### PR TITLE
feat: add export/import commands (JSONL)

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Shell};
-use std::io;
+use std::io::{self, Read};
 use std::path::PathBuf;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
@@ -236,6 +236,18 @@ enum Commands {
     },
     /// Show memory store statistics
     Stats,
+    /// Export all memories to JSONL file (no embeddings — portable)
+    Export {
+        /// Output file path (use - for stdout)
+        #[arg(default_value = "-")]
+        output: String,
+    },
+    /// Import memories from JSONL file (re-embeds content)
+    Import {
+        /// Input file path (use - for stdin)
+        #[arg(default_value = "-")]
+        input: String,
+    },
     /// Generate shell completions
     Completions {
         /// Shell type
@@ -403,6 +415,53 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 print_json(&stats);
             } else {
                 print_stats_human(&stats);
+            }
+            Ok(())
+        }
+        Commands::Export { output } => {
+            tracing::info!("Exporting memories to {output}");
+            let jsonl = uteke
+                .export()
+                .map_err(|e| format!("Failed to export: {e}"))?;
+
+            if output == "-" {
+                println!("{jsonl}");
+            } else {
+                std::fs::write(output, &jsonl)
+                    .map_err(|e| format!("Failed to write export file: {e}"))?;
+                let count = jsonl.lines().filter(|l| !l.trim().is_empty()).count();
+                if cli.json {
+                    print_json(&serde_json::json!({"exported": count}));
+                } else {
+                    println!("✓ Exported {count} memories");
+                }
+            }
+            Ok(())
+        }
+        Commands::Import { input } => {
+            tracing::info!("Importing memories from {input}");
+            let jsonl = if input == "-" {
+                let mut buf = String::new();
+                io::stdin()
+                    .read_to_string(&mut buf)
+                    .map_err(|e| format!("Failed to read stdin: {e}"))?;
+                buf
+            } else {
+                std::fs::read_to_string(input)
+                    .map_err(|e| format!("Failed to read import file: {e}"))?
+            };
+
+            let result = uteke
+                .import(&jsonl)
+                .map_err(|e| format!("Failed to import: {e}"))?;
+
+            if cli.json {
+                print_json(&result);
+            } else {
+                println!(
+                    "✓ Imported {} memories ({} skipped)",
+                    result.imported, result.skipped
+                );
             }
             Ok(())
         }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -12,7 +12,7 @@
 mod embed;
 pub mod memory;
 
-pub use memory::types::{Memory, SearchResult, StoreStats};
+pub use memory::types::{ExportEntry, ImportResult, Memory, SearchResult, StoreStats};
 
 use embed::EmbeddingEngine;
 use memory::store::Store;
@@ -249,6 +249,92 @@ impl Uteke {
             unique_tags,
             db_size_bytes,
         })
+    }
+
+    /// Export all memories to JSONL format (one JSON object per line).
+    ///
+    /// Embeddings are NOT exported — they will be re-computed on import.
+    /// This keeps export files small and portable.
+    pub fn export(&self) -> Result<String, Error> {
+        let memories = self.store.load_all()?;
+        let entries: Vec<ExportEntry> = memories
+            .into_iter()
+            .map(|m| ExportEntry {
+                content: m.content,
+                tags: m.tags,
+                metadata: m.metadata,
+                created_at: m.created_at,
+            })
+            .collect();
+
+        let mut lines = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            let line = serde_json::to_string(entry).map_err(|e| Error::Database(e.to_string()))?;
+            lines.push(line);
+        }
+
+        Ok(lines.join("\n"))
+    }
+
+    /// Import memories from JSONL format.
+    ///
+    /// Each line should be a valid JSON object with `content`, `tags`, `metadata`, `created_at`.
+    /// Embeddings are re-computed during import.
+    pub fn import(&self, jsonl: &str) -> Result<ImportResult, Error> {
+        let mut imported = 0;
+        let mut skipped = 0;
+
+        for line in jsonl.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let entry: ExportEntry = match serde_json::from_str(line) {
+                Ok(e) => e,
+                Err(_) => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+
+            if entry.content.is_empty() {
+                skipped += 1;
+                continue;
+            }
+
+            // Re-embed the content
+            let embedding = self
+                .embedder
+                .lock()
+                .map_err(|_| Error::Database("Failed to acquire embedder lock".into()))?
+                .embed(&entry.content)?;
+
+            let id = uuid::Uuid::new_v4().to_string();
+            let now = chrono::Utc::now();
+
+            let memory = Memory {
+                id: id.clone(),
+                content: entry.content,
+                embedding: embedding.clone(),
+                tags: entry.tags,
+                metadata: entry.metadata,
+                created_at: entry.created_at,
+                updated_at: now,
+            };
+
+            self.store.insert(&memory)?;
+
+            let mut index = self
+                .index
+                .lock()
+                .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+            index.insert(&id, &embedding);
+
+            imported += 1;
+        }
+
+        Ok(ImportResult { imported, skipped })
     }
 }
 

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -40,3 +40,25 @@ pub struct StoreStats {
     /// Database file size in bytes.
     pub db_size_bytes: u64,
 }
+
+/// Lightweight export format — no embedding vector (re-embedded on import).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportEntry {
+    /// The text content.
+    pub content: String,
+    /// Tags for categorization.
+    pub tags: Vec<String>,
+    /// Arbitrary JSON metadata.
+    pub metadata: serde_json::Value,
+    /// When this memory was originally created.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Result of an import operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportResult {
+    /// Number of memories imported.
+    pub imported: usize,
+    /// Number of entries skipped (duplicate or invalid).
+    pub skipped: usize,
+}


### PR DESCRIPTION
## Summary
- Add `uteke export [file]` — export all memories as JSONL (no embeddings, portable)
- Add `uteke import [file]` — import from JSONL, re-embeds content with new IDs
- Supports `stdin`/`stdout` with `-` as file argument
- Supports `--json` flag for both commands

## Why
Local-only users need backup and portability. Export creates small JSONL files (~100 bytes/memory) that can be version controlled, shared, or imported into any uteke store.

## Usage
```bash
# Export to file
uteke export memories.jsonl

# Import into another store
uteke --store /new/path import memories.jsonl

# Pipe between stores
uteke export - | uteke --store /new/path import -
```

## Test Plan
- [x] `cargo test --workspace` — 12/12 pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [x] E2E: export 3 memories → import into new store → recall works with semantic search
- [x] JSON output works for both commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Export` subcommand to retrieve and save stored memories to stdout or file in JSONL format, with optional JSON summary output.
  * Added `Import` subcommand to restore memories from JSONL data via stdin or file, reporting imported and skipped entry counts.
  * Enables portable backup and restoration of persistent memory across different instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajianaz/uteke/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->