### PR TITLE
ci: add Windows + Linux ARM64 to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,22 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact: uteke-x86_64-linux
+            artifact: uteke-x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: uteke-aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact: uteke-x86_64-macos
+            artifact: uteke-x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact: uteke-aarch64-macos
+            artifact: uteke-aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: uteke-x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            artifact: uteke-aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v4
@@ -32,23 +41,41 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli
 
-      - name: Strip binary (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: strip target/${{ matrix.target }}/release/uteke
+      - name: Strip binary (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: strip target/${{ matrix.target }}/release/uteke${{ matrix.os == 'windows-latest' && '.exe' || '' }}
 
-      - name: Rename binary
+      - name: Prepare artifact (Unix)
+        if: runner.os != 'Windows'
         run: |
           mkdir -p release
           cp target/${{ matrix.target }}/release/uteke release/${{ matrix.artifact }}
+          cd release
+          tar czf ${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
+
+      - name: Prepare artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          mkdir release
+          cp target/${{ matrix.target }}/release/uteke.exe release/${{ matrix.artifact }}.exe
+          cd release
+          7z a ${{ matrix.artifact }}.zip ${{ matrix.artifact }}.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: release/${{ matrix.artifact }}
+          path: release/${{ matrix.artifact }}.*
 
   release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Add **Windows x86_64** and **Windows ARM64** (MSVC) build targets
- Add **Linux ARM64** (aarch64-unknown-linux-gnu) build target
- Windows binaries packaged as `.zip`, Unix as `.tar.gz`
- Install cross-compilation toolchain for ARM64 Linux

## Platforms (was 3, now 6)
| Platform | Target |
|----------|--------|
| Linux x86_64 | `x86_64-unknown-linux-gnu` |
| Linux ARM64 | `aarch64-unknown-linux-gnu` ✨ |
| macOS Intel | `x86_64-apple-darwin` |
| macOS Apple Silicon | `aarch64-apple-darwin` |
| Windows x86_64 | `x86_64-pc-windows-msvc` ✨ |
| Windows ARM64 | `aarch64-pc-windows-msvc` ✨ |

## Test Plan
- [ ] Will verify on next `v*` tag push