### PR TITLE
feat: multi-agent namespace isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,32 @@ All notable changes to Uteke will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] — 2026-05-29
+## [Unreleased]
+
+### Added
+
+- **Persistent vector index** — replaced in-memory HNSW with usearch (persistent HNSW)
+  - Cold start: loads from disk (~5ms) instead of rebuilding from SQLite (~5s at 10K memories)
+  - Incremental delete: `remove()` in ~0.1ms instead of full index rebuild
+  - Index persisted as `uteke_index.usearch` + `uteke_index.keys` sidecar
+  - Auto-migration: builds usearch index from SQLite on first load
+- **Multi-agent namespaces** — isolated memory spaces per agent
+  - `--namespace` global flag on all commands
+  - SQLite `namespace` column with index
+  - Auto-migration of existing databases (zero data loss)
+  - Each namespace is fully isolated: recall, search, list, stats scoped
+  - Default namespace: `"default"` (backward compatible)
+- **Removed old deps:** `hnsw`, `rand_pcg`, `space` (replaced by `usearch`)
+- **Added deps:** `usearch`, `tracing`
+
+### Changed
+
+- **Vector index:** HNSW (in-memory) → usearch (persistent, incremental)
+- **Delete:** rebuild-based → incremental `remove()` + save
+- **Startup:** rebuild from SQLite → `restore()` from disk
+- **Binary size:** 20MB → 21MB (+1MB from usearch)
+
+## [0.0.1] — 2026-05-29
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ cargo install --path crates/uteke-cli
 # Store a memory
 uteke remember "Deploy v2.1 to staging on Friday" --tags deploy,staging
 
-# Semantic search
-uteke recall "what deployment is coming up?"
+# Store in a specific namespace (multi-agent isolation)
+uteke --namespace hermes remember "Prod server on AWS us-east-1" --tags deploy
+
+# Semantic search (scoped to namespace)
+uteke --namespace hermes recall "server deployment"
 
 # Get stats
 uteke stats
@@ -86,6 +89,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 | Flag | Description |
 |------|-------------|
 | `--store <path>` | Override store location (default: `~/.uteke`) |
+| `--namespace <name>` | Namespace for multi-agent isolation (default: `"default"`) |
 | `--json` | Output as JSON (all commands) |
 | `--verbose` | Enable debug logging |
 
@@ -104,6 +108,25 @@ uteke stats --json
 # {"total_memories":42,"unique_tags":5,"db_size_bytes":102400}
 ```
 
+### Multi-Agent Namespaces
+
+Isolate memories per agent using `--namespace`:
+
+```bash
+# Each agent gets its own memory space
+uteke --namespace hermes remember "Prod deploy config" --tags deploy
+uteke --namespace pi remember "User prefers dark mode" --tags pref
+
+# Search is scoped to the namespace
+uteke --namespace hermes recall "deployment"  # Only finds hermes memories
+uteke --namespace pi recall "preferences"    # Only finds pi memories
+
+# Without --namespace, uses "default" namespace
+uteke remember "General knowledge" --tags misc
+```
+
+Existing databases are auto-migrated — the `namespace` column is added on first run with zero data loss.
+
 ---
 
 ## Architecture
@@ -116,28 +139,30 @@ uteke stats --json
 │                    Uteke API                         │
 │                  uteke-core crate                    │
 ├──────────┬──────────────────┬────────────────────────┤
-│   ONNX   │      HNSW        │       SQLite           │
+│   ONNX   │     usearch      │       SQLite           │
 │ Embedding│  Vector Index    │    Metadata Store      │
-│ (768d)   │  (Fast ANN)      │    (rusqlite)          │
+│ (768d)   │ (Persistent HNSW)│    (rusqlite)          │
 ├──────────┴──────────────────┴────────────────────────┤
 │              ~/.uteke/ (local storage)               │
-│   uteke.db  │  config.toml  │ models/embeddinggemma/ │
+│ uteke.db │ uteke_index.usearch │ models/embeddinggemma/ │
 └─────────────────────────────────────────────────────┘
 ```
 
 | Component | Technology | Detail |
 |-----------|-----------|--------|
 | Language | Rust (no unsafe) | Memory-safe, fast, single binary |
-| Vector Index | HNSW | Fast approximate nearest neighbor search |
+| Vector Index | usearch | Persistent HNSW with incremental updates |
 | Storage | SQLite (rusqlite) | Embedded, zero-config, battle-tested |
 | Embedding | EmbeddingGemma Q4 ONNX | 768d vectors, multilingual, downloaded on first run |
+| Namespaces | SQLite column | Multi-agent isolation, zero overhead |
 | CLI | clap | Standard Rust CLI framework |
 
 **How it works:**
-1. `remember` → text is embedded into a 768d vector via ONNX → stored in SQLite + indexed in HNSW
-2. `recall` → query is embedded → HNSW finds nearest neighbors → returns ranked results
-3. `search` → SQLite LIKE-based keyword search (fast, deterministic)
-4. Everything lives in `~/.uteke/` — fully local, fully yours
+1. `remember` → text is embedded into a 768d vector via ONNX → stored in SQLite + indexed in usearch
+2. `recall` → query is embedded → usearch finds nearest neighbors → returns ranked results (scoped to namespace)
+3. `search` → SQLite LIKE-based keyword search (fast, deterministic, scoped to namespace)
+4. `forget` → incremental delete from usearch + SQLite (no rebuild)
+5. Everything lives in `~/.uteke/` — fully local, fully yours
 
 ---
 
@@ -224,7 +249,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
 
 Uteke follows a demand-gated roadmap — we build what people actually use.
 
-**Now (v0.1.0):** Core engine — store, recall, search, CLI, Python wrapper
+**Now (v0.0.1):** Core engine — store, recall, search, CLI, Python wrapper, persistent vector index, multi-agent namespaces
 **Phase A (100+ stars):** Better embeddings, dedup, import/export, remote embedding opt-in
 **Phase B (500+ stars):** Python SDK (PyO3), Node.js SDK, editor integrations
 **Phase C (1000+ stars):** Team features, cloud sync (opt-in), knowledge graph

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -171,6 +171,10 @@ struct Cli {
     #[arg(long, global = true)]
     store: Option<String>,
 
+    /// Namespace for multi-agent isolation (default: "default")
+    #[arg(long, global = true)]
+    namespace: Option<String>,
+
     /// Output as JSON
     #[arg(long, global = true)]
     json: bool,
@@ -521,12 +525,14 @@ fn main() {
 }
 
 fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
+    let ns = cli.namespace.as_deref();
+
     match &cli.command {
         Commands::Remember { content, tags } => {
             tracing::info!("Remembering: {content}");
             let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
             let id = uteke
-                .remember(content, &tag_refs, None)
+                .remember(content, &tag_refs, None, ns)
                 .map_err(|e| format!("Failed to store memory: {e}"))?;
             tracing::info!("Memory stored with ID: {id}");
             if cli.json {
@@ -546,7 +552,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 Some(tag_refs.as_slice())
             };
             let results = uteke
-                .recall(query, *limit, tags_filter)
+                .recall(query, *limit, tags_filter, ns)
                 .map_err(|e| format!("Failed to recall: {e}"))?;
             if cli.json {
                 print_json(&results);
@@ -558,7 +564,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
         Commands::Search { query, limit } => {
             tracing::info!("Searching: {query} (limit: {limit})");
             let results = uteke
-                .search(query, *limit)
+                .search(query, *limit, ns)
                 .map_err(|e| format!("Failed to search: {e}"))?;
             if cli.json {
                 print_json(&results);
@@ -573,7 +579,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 tag
             );
             let results = uteke
-                .list(tag.as_deref(), *limit, *offset)
+                .list(tag.as_deref(), *limit, *offset, ns)
                 .map_err(|e| format!("Failed to list: {e}"))?;
             if cli.json {
                 print_json(&results);
@@ -610,7 +616,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
         Commands::Stats => {
             tracing::info!("Getting stats");
             let stats = uteke
-                .stats()
+                .stats(ns)
                 .map_err(|e| format!("Failed to get stats: {e}"))?;
             if cli.json {
                 print_json(&stats);
@@ -622,7 +628,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
         Commands::Export { output } => {
             tracing::info!("Exporting memories to {output}");
             let jsonl = uteke
-                .export()
+                .export(ns)
                 .map_err(|e| format!("Failed to export: {e}"))?;
 
             if output == "-" {
@@ -653,7 +659,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             };
 
             let result = uteke
-                .import(&jsonl)
+                .import(&jsonl, ns)
                 .map_err(|e| format!("Failed to import: {e}"))?;
 
             if cli.json {

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -12,7 +12,7 @@
 mod embed;
 pub mod memory;
 
-pub use memory::types::{ExportEntry, ImportResult, Memory, SearchResult, StoreStats};
+pub use memory::types::{DEFAULT_NAMESPACE, ExportEntry, ImportResult, Memory, SearchResult, StoreStats};
 
 use embed::EmbeddingEngine;
 use memory::store::Store;
@@ -74,7 +74,7 @@ impl Uteke {
 
         // If index is empty but SQLite has memories, build from SQLite (migration)
         if index.is_empty() {
-            let all_memories = store.load_all()?;
+            let all_memories = store.load_all(None)?;
             if !all_memories.is_empty() {
                 let items: Vec<(String, Vec<f32>)> = all_memories
                     .into_iter()
@@ -100,6 +100,7 @@ impl Uteke {
         content: &str,
         tags: &[&str],
         metadata: Option<serde_json::Value>,
+        namespace: Option<&str>,
     ) -> Result<String, Error> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now();
@@ -117,6 +118,7 @@ impl Uteke {
             metadata: metadata.unwrap_or(serde_json::Value::Null),
             created_at: now,
             updated_at: now,
+            namespace: namespace.unwrap_or(DEFAULT_NAMESPACE).to_string(),
         };
 
         self.store.insert(&memory)?;
@@ -134,13 +136,15 @@ impl Uteke {
 
     /// Recall memories relevant to a query using vector similarity.
     ///
-    /// Optionally filter by tags.
+    /// Optionally filter by tags and namespace.
     pub fn recall(
         &self,
         query: &str,
         limit: usize,
         tags_filter: Option<&[&str]>,
+        namespace: Option<&str>,
     ) -> Result<Vec<SearchResult>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         let query_embedding = self
             .embedder
             .lock()
@@ -169,6 +173,11 @@ impl Uteke {
                 None => continue,
             };
 
+            // Apply namespace filter
+            if memory.namespace != ns {
+                continue;
+            }
+
             // Apply tag filter
             if let Some(filter_tags) = tags_filter {
                 let has_tag = filter_tags
@@ -194,8 +203,8 @@ impl Uteke {
     }
 
     /// Search memories by content text (LIKE-based for v2).
-    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>, Error> {
-        let memories = self.store.search_content(query, limit)?;
+    pub fn search(&self, query: &str, limit: usize, namespace: Option<&str>) -> Result<Vec<SearchResult>, Error> {
+        let memories = self.store.search_content(query, namespace, limit)?;
 
         let results = memories
             .into_iter()
@@ -228,8 +237,9 @@ impl Uteke {
         tag: Option<&str>,
         limit: usize,
         offset: usize,
+        namespace: Option<&str>,
     ) -> Result<Vec<Memory>, Error> {
-        self.store.list(tag, limit, offset)
+        self.store.list(tag, namespace, limit, offset)
     }
 
     /// Get a single memory by ID.
@@ -239,10 +249,15 @@ impl Uteke {
             .ok_or_else(|| Error::Database(format!("Memory not found: {id}")))
     }
 
+    /// List all namespaces.
+    pub fn list_namespaces(&self) -> Result<Vec<String>, Error> {
+        self.store.list_namespaces()
+    }
+
     /// Get statistics about the memory store.
-    pub fn stats(&self) -> Result<StoreStats, Error> {
-        let total_memories = self.store.count()?;
-        let unique_tags = self.store.unique_tags()?.len();
+    pub fn stats(&self, namespace: Option<&str>) -> Result<StoreStats, Error> {
+        let total_memories = self.store.count(namespace)?;
+        let unique_tags = self.store.unique_tags(namespace)?.len();
 
         let db_size_bytes = self
             .store
@@ -262,8 +277,8 @@ impl Uteke {
     ///
     /// Embeddings are NOT exported — they will be re-computed on import.
     /// This keeps export files small and portable.
-    pub fn export(&self) -> Result<String, Error> {
-        let memories = self.store.load_all()?;
+    pub fn export(&self, namespace: Option<&str>) -> Result<String, Error> {
+        let memories = self.store.load_all(namespace)?;
         let entries: Vec<ExportEntry> = memories
             .into_iter()
             .map(|m| ExportEntry {
@@ -287,7 +302,7 @@ impl Uteke {
     ///
     /// Each line should be a valid JSON object with `content`, `tags`, `metadata`, `created_at`.
     /// Embeddings are re-computed during import.
-    pub fn import(&self, jsonl: &str) -> Result<ImportResult, Error> {
+    pub fn import(&self, jsonl: &str, namespace: Option<&str>) -> Result<ImportResult, Error> {
         let mut imported = 0;
         let mut skipped = 0;
 
@@ -328,6 +343,7 @@ impl Uteke {
                 metadata: entry.metadata,
                 created_at: entry.created_at,
                 updated_at: now,
+                namespace: namespace.unwrap_or(DEFAULT_NAMESPACE).to_string(),
             };
 
             self.store.insert(&memory)?;
@@ -388,6 +404,7 @@ mod tests {
             metadata: serde_json::json!({"key": "value"}),
             created_at: now,
             updated_at: now,
+            namespace: DEFAULT_NAMESPACE.to_string(),
         };
 
         let json = serde_json::to_string(&m).unwrap();
@@ -409,6 +426,7 @@ mod tests {
             metadata: serde_json::Value::Null,
             created_at: now,
             updated_at: now,
+            namespace: DEFAULT_NAMESPACE.to_string(),
         };
 
         let sr = SearchResult {

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -12,7 +12,9 @@
 mod embed;
 pub mod memory;
 
-pub use memory::types::{DEFAULT_NAMESPACE, ExportEntry, ImportResult, Memory, SearchResult, StoreStats};
+pub use memory::types::{
+    ExportEntry, ImportResult, Memory, SearchResult, StoreStats, DEFAULT_NAMESPACE,
+};
 
 use embed::EmbeddingEngine;
 use memory::store::Store;
@@ -203,7 +205,12 @@ impl Uteke {
     }
 
     /// Search memories by content text (LIKE-based for v2).
-    pub fn search(&self, query: &str, limit: usize, namespace: Option<&str>) -> Result<Vec<SearchResult>, Error> {
+    pub fn search(
+        &self,
+        query: &str,
+        limit: usize,
+        namespace: Option<&str>,
+    ) -> Result<Vec<SearchResult>, Error> {
         let memories = self.store.search_content(query, namespace, limit)?;
 
         let results = memories

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS memories (
     tags TEXT,
     metadata TEXT,
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    namespace TEXT NOT NULL DEFAULT 'default'
 );
 CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
@@ -49,6 +50,25 @@ impl Store {
         self.conn
             .execute_batch(SCHEMA)
             .map_err(|e| Error::Database(e.to_string()))?;
+
+        // Migration: add namespace column if missing (existing DBs)
+        let has_namespace: bool = self
+            .conn
+            .prepare("SELECT namespace FROM memories LIMIT 1")
+            .is_ok();
+        if !has_namespace {
+            self.conn
+                .execute_batch(
+                    "ALTER TABLE memories ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';",
+                )
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+
+        // Create namespace index (safe after column exists)
+        self.conn
+            .execute_batch("CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);")
+            .map_err(|e| Error::Database(e.to_string()))?;
+
         Ok(())
     }
 
@@ -62,8 +82,8 @@ impl Store {
 
         self.conn
             .execute(
-                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     memory.id,
                     memory.content,
@@ -72,6 +92,7 @@ impl Store {
                     metadata_json,
                     memory.created_at.to_rfc3339(),
                     memory.updated_at.to_rfc3339(),
+                    memory.namespace,
                 ],
             )
             .map_err(|e| Error::Database(e.to_string()))?;
@@ -83,7 +104,7 @@ impl Store {
     pub fn get_by_id(&self, id: &str) -> Result<Option<Memory>, Error> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at FROM memories WHERE id = ?1")
+            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE id = ?1")
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let result = stmt
@@ -114,7 +135,7 @@ impl Store {
 
         self.conn
             .execute(
-                "UPDATE memories SET content = ?2, embedding = ?3, tags = ?4, metadata = ?5, updated_at = ?6
+                "UPDATE memories SET content = ?2, embedding = ?3, tags = ?4, metadata = ?5, updated_at = ?6, namespace = ?7
                  WHERE id = ?1",
                 params![
                     memory.id,
@@ -123,22 +144,26 @@ impl Store {
                     tags_json,
                     metadata_json,
                     memory.updated_at.to_rfc3339(),
+                    memory.namespace,
                 ],
             )
             .map_err(|e| Error::Database(e.to_string()))?;
         Ok(())
     }
 
-    /// List memories with optional tag filter and pagination.
+    /// List memories with optional tag filter, namespace filter, and pagination.
     pub fn list(
         &self,
         tag: Option<&str>,
+        namespace: Option<&str>,
         limit: usize,
         offset: usize,
     ) -> Result<Vec<Memory>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+
         let sql = match tag {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at FROM memories WHERE tags LIKE ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at FROM memories ORDER BY created_at DESC LIMIT ?1 OFFSET ?2",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE namespace = ?1 AND tags LIKE ?2 ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
         };
 
         let mut memories = Vec::new();
@@ -149,7 +174,7 @@ impl Store {
                     .prepare(sql)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 let rows = stmt
-                    .query_map(params![format!("%\"{t}\"%"), limit, offset], row_to_memory)
+                    .query_map(params![ns, format!("%\"{t}\"%"), limit, offset], row_to_memory)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 for row in rows {
                     let m = row.map_err(|e| Error::Database(e.to_string()))?;
@@ -162,7 +187,7 @@ impl Store {
                     .prepare(sql)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 let rows = stmt
-                    .query_map(params![limit, offset], row_to_memory)
+                    .query_map(params![ns, limit, offset], row_to_memory)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 for row in rows {
                     let m = row.map_err(|e| Error::Database(e.to_string()))?;
@@ -174,19 +199,20 @@ impl Store {
     }
 
     /// Search memories by content using LIKE (simple full-text for v2).
-    pub fn search_content(&self, query: &str, limit: usize) -> Result<Vec<Memory>, Error> {
+    pub fn search_content(&self, query: &str, namespace: Option<&str>, limit: usize) -> Result<Vec<Memory>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
         let pattern = format!("%{query}%");
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at
-                 FROM memories WHERE content LIKE ?1
-                 ORDER BY created_at DESC LIMIT ?2",
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace
+                 FROM memories WHERE namespace = ?1 AND content LIKE ?2
+                 ORDER BY created_at DESC LIMIT ?3",
             )
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let rows = stmt
-            .query_map(params![pattern, limit], row_to_memory)
+            .query_map(params![ns, pattern, limit], row_to_memory)
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let mut memories = Vec::new();
@@ -197,48 +223,82 @@ impl Store {
         Ok(memories)
     }
 
-    /// Load all memories (for index rebuilding).
-    pub fn load_all(&self) -> Result<Vec<Memory>, Error> {
-        let mut stmt = self
-            .conn
-            .prepare(
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at FROM memories ORDER BY created_at",
-            )
-            .map_err(|e| Error::Database(e.to_string()))?;
-
-        let rows = stmt
-            .query_map([], row_to_memory)
-            .map_err(|e| Error::Database(e.to_string()))?;
+    /// Load all memories for index rebuilding, optionally filtered by namespace.
+    pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
+        let sql = match namespace {
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE namespace = ?1 ORDER BY created_at",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories ORDER BY created_at",
+        };
 
         let mut memories = Vec::new();
-        for row in rows {
-            let m = row.map_err(|e| Error::Database(e.to_string()))?;
-            memories.push(m);
+        match namespace {
+            Some(ns) => {
+                let mut stmt = self
+                    .conn
+                    .prepare(sql)
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                let rows = stmt
+                    .query_map(params![ns], row_to_memory)
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                for row in rows {
+                    let m = row.map_err(|e| Error::Database(e.to_string()))?;
+                    memories.push(m);
+                }
+            }
+            None => {
+                let mut stmt = self
+                    .conn
+                    .prepare(sql)
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                let rows = stmt
+                    .query_map([], row_to_memory)
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                for row in rows {
+                    let m = row.map_err(|e| Error::Database(e.to_string()))?;
+                    memories.push(m);
+                }
+            }
         }
         Ok(memories)
     }
 
-    /// Count total memories.
-    pub fn count(&self) -> Result<usize, Error> {
-        let count: usize = self
-            .conn
-            .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
-            .map_err(|e| Error::Database(e.to_string()))?;
+    /// Count total memories, optionally filtered by namespace.
+    pub fn count(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let count: usize = match namespace {
+            Some(ns) => self
+                .conn
+                .query_row("SELECT COUNT(*) FROM memories WHERE namespace = ?1", params![ns], |row| row.get(0))
+                .map_err(|e| Error::Database(e.to_string()))?,
+            None => self
+                .conn
+                .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
+                .map_err(|e| Error::Database(e.to_string()))?,
+        };
         Ok(count)
     }
 
-    /// Get all unique tags across all memories.
-    pub fn unique_tags(&self) -> Result<Vec<String>, Error> {
+    /// Get all unique tags, optionally filtered by namespace.
+    pub fn unique_tags(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+        let sql = match namespace {
+            Some(_) => "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL AND namespace = ?1",
+            None => "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL",
+        };
+
         let mut stmt = self
             .conn
-            .prepare("SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL")
+            .prepare(sql)
             .map_err(|e| Error::Database(e.to_string()))?;
 
-        let rows = stmt
-            .query_map([], |row: &rusqlite::Row| -> rusqlite::Result<String> {
-                row.get(0)
-            })
-            .map_err(|e| Error::Database(e.to_string()))?;
+        let rows: Vec<Result<String, rusqlite::Error>> = match namespace {
+            Some(ns) => stmt
+                .query_map(params![ns], |row: &rusqlite::Row| row.get(0))
+                .map_err(|e| Error::Database(e.to_string()))?
+                .collect(),
+            None => stmt
+                .query_map([], |row: &rusqlite::Row| row.get(0))
+                .map_err(|e| Error::Database(e.to_string()))?
+                .collect(),
+        };
 
         let mut all_tags = std::collections::HashSet::new();
         for row in rows {
@@ -250,6 +310,24 @@ impl Store {
             }
         }
         Ok(all_tags.into_iter().collect())
+    }
+
+    /// List all distinct namespaces.
+    pub fn list_namespaces(&self) -> Result<Vec<String>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT namespace FROM memories ORDER BY namespace")
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let rows = stmt
+            .query_map([], |row: &rusqlite::Row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let mut namespaces = Vec::new();
+        for row in rows {
+            namespaces.push(row.map_err(|e| Error::Database(e.to_string()))?);
+        }
+        Ok(namespaces)
     }
 
     /// Get the underlying database path, if file-based.
@@ -305,6 +383,7 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e))
         })?;
+    let namespace: String = row.get(7).unwrap_or_else(|_| crate::memory::types::DEFAULT_NAMESPACE.to_string());
 
     Ok(Memory {
         id,
@@ -314,6 +393,7 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
         metadata,
         created_at,
         updated_at,
+        namespace,
     })
 }
 
@@ -332,6 +412,20 @@ mod tests {
             metadata: serde_json::json!({}),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            namespace: crate::memory::types::DEFAULT_NAMESPACE.to_string(),
+        }
+    }
+
+    fn make_test_memory_ns(id: &str, content: &str, tags: &[&str], namespace: &str) -> Memory {
+        Memory {
+            id: id.to_string(),
+            content: content.to_string(),
+            embedding: vec![0.1; 768],
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            metadata: serde_json::json!({}),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            namespace: namespace.to_string(),
         }
     }
 
@@ -368,10 +462,10 @@ mod tests {
             .insert(&make_test_memory("3", "c", &["rust", "ai"]))
             .unwrap();
 
-        let rust_memories = store.list(Some("rust"), 10, 0).unwrap();
+        let rust_memories = store.list(Some("rust"), None, 10, 0).unwrap();
         assert_eq!(rust_memories.len(), 2);
 
-        let all = store.list(None, 10, 0).unwrap();
+        let all = store.list(None, None, 10, 0).unwrap();
         assert_eq!(all.len(), 3);
     }
 
@@ -386,7 +480,7 @@ mod tests {
             .insert(&make_test_memory("2", "python machine learning", &[]))
             .unwrap();
 
-        let results = store.search_content("rust", 10).unwrap();
+        let results = store.search_content("rust", None, 10).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "1");
     }
@@ -423,7 +517,43 @@ mod tests {
             .insert(&make_test_memory("2", "b", &["rust", "web"]))
             .unwrap();
 
-        let tags = store.unique_tags().unwrap();
+        let tags = store.unique_tags(None).unwrap();
         assert_eq!(tags.len(), 3);
+    }
+
+    #[test]
+    fn test_namespace_isolation() {
+        let store = Store::open(":memory:").unwrap();
+
+        // Insert into different namespaces
+        store.insert(&make_test_memory_ns("a1", "hermes deploy", &["deploy"], "hermes")).unwrap();
+        store.insert(&make_test_memory_ns("a2", "hermes config", &["config"], "hermes")).unwrap();
+        store.insert(&make_test_memory_ns("b1", "pi preference", &["pref"], "pi")).unwrap();
+
+        // Count per namespace
+        assert_eq!(store.count(Some("hermes")).unwrap(), 2);
+        assert_eq!(store.count(Some("pi")).unwrap(), 1);
+        assert_eq!(store.count(None).unwrap(), 3);
+
+        // List per namespace
+        let hermes_list = store.list(None, Some("hermes"), 10, 0).unwrap();
+        assert_eq!(hermes_list.len(), 2);
+
+        let pi_list = store.list(None, Some("pi"), 10, 0).unwrap();
+        assert_eq!(pi_list.len(), 1);
+        assert_eq!(pi_list[0].content, "pi preference");
+
+        // Search per namespace
+        let hermes_search = store.search_content("deploy", Some("hermes"), 10).unwrap();
+        assert_eq!(hermes_search.len(), 1);
+
+        let pi_search = store.search_content("deploy", Some("pi"), 10).unwrap();
+        assert_eq!(pi_search.len(), 0);
+
+        // List namespaces
+        let ns = store.list_namespaces().unwrap();
+        assert_eq!(ns.len(), 2);
+        assert!(ns.contains(&"hermes".to_string()));
+        assert!(ns.contains(&"pi".to_string()));
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -66,7 +66,9 @@ impl Store {
 
         // Create namespace index (safe after column exists)
         self.conn
-            .execute_batch("CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);")
+            .execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);",
+            )
             .map_err(|e| Error::Database(e.to_string()))?;
 
         Ok(())
@@ -174,7 +176,10 @@ impl Store {
                     .prepare(sql)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 let rows = stmt
-                    .query_map(params![ns, format!("%\"{t}\"%"), limit, offset], row_to_memory)
+                    .query_map(
+                        params![ns, format!("%\"{t}\"%"), limit, offset],
+                        row_to_memory,
+                    )
                     .map_err(|e| Error::Database(e.to_string()))?;
                 for row in rows {
                     let m = row.map_err(|e| Error::Database(e.to_string()))?;
@@ -199,7 +204,12 @@ impl Store {
     }
 
     /// Search memories by content using LIKE (simple full-text for v2).
-    pub fn search_content(&self, query: &str, namespace: Option<&str>, limit: usize) -> Result<Vec<Memory>, Error> {
+    pub fn search_content(
+        &self,
+        query: &str,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<Memory>, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
         let pattern = format!("%{query}%");
         let mut stmt = self
@@ -267,7 +277,11 @@ impl Store {
         let count: usize = match namespace {
             Some(ns) => self
                 .conn
-                .query_row("SELECT COUNT(*) FROM memories WHERE namespace = ?1", params![ns], |row| row.get(0))
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1",
+                    params![ns],
+                    |row| row.get(0),
+                )
                 .map_err(|e| Error::Database(e.to_string()))?,
             None => self
                 .conn
@@ -280,7 +294,9 @@ impl Store {
     /// Get all unique tags, optionally filtered by namespace.
     pub fn unique_tags(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
         let sql = match namespace {
-            Some(_) => "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL AND namespace = ?1",
+            Some(_) => {
+                "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL AND namespace = ?1"
+            }
             None => "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL",
         };
 
@@ -383,7 +399,9 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e))
         })?;
-    let namespace: String = row.get(7).unwrap_or_else(|_| crate::memory::types::DEFAULT_NAMESPACE.to_string());
+    let namespace: String = row
+        .get(7)
+        .unwrap_or_else(|_| crate::memory::types::DEFAULT_NAMESPACE.to_string());
 
     Ok(Memory {
         id,
@@ -526,9 +544,25 @@ mod tests {
         let store = Store::open(":memory:").unwrap();
 
         // Insert into different namespaces
-        store.insert(&make_test_memory_ns("a1", "hermes deploy", &["deploy"], "hermes")).unwrap();
-        store.insert(&make_test_memory_ns("a2", "hermes config", &["config"], "hermes")).unwrap();
-        store.insert(&make_test_memory_ns("b1", "pi preference", &["pref"], "pi")).unwrap();
+        store
+            .insert(&make_test_memory_ns(
+                "a1",
+                "hermes deploy",
+                &["deploy"],
+                "hermes",
+            ))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns(
+                "a2",
+                "hermes config",
+                &["config"],
+                "hermes",
+            ))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("b1", "pi preference", &["pref"], "pi"))
+            .unwrap();
 
         // Count per namespace
         assert_eq!(store.count(Some("hermes")).unwrap(), 2);

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -2,6 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Default namespace for memories without explicit namespace.
+pub const DEFAULT_NAMESPACE: &str = "default";
+
 /// A stored memory with content, embedding, tags, and metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Memory {
@@ -19,6 +22,13 @@ pub struct Memory {
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// When this memory was last updated.
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    /// Namespace for multi-agent isolation.
+    #[serde(default = "default_namespace")]
+    pub namespace: String,
+}
+
+fn default_namespace() -> String {
+    DEFAULT_NAMESPACE.to_string()
 }
 
 /// A search result with relevance score.


### PR DESCRIPTION
## Problem

All memories share one pool. Agent A can see Agent B's memories. No isolation for multi-agent setups like Hermes fleet.

Also includes the usearch persistent index from the previous work (was not documented in its own PR).

## Solution

Add namespace-based isolation per agent:

```bash
# Each agent gets its own memory space
uteke --namespace hermes remember "Prod deploy config" --tags deploy
uteke --namespace pi remember "User prefers dark mode" --tags pref

# Search is scoped to namespace
uteke --namespace hermes recall "deployment"  # Only finds hermes memories
uteke --namespace pi recall "preferences"    # Only finds pi memories
```

## Changes

### Multi-agent namespaces
- **`--namespace` global flag** on all CLI commands
- **SQLite `namespace` column** with index
- **Auto-migration** of existing databases (zero data loss)
- **Namespace-scoped** queries: recall, search, list, stats, export, import
- **Default namespace**: `"default"` (fully backward compatible)
- **`list_namespaces()`** API to discover all namespaces

### Persistent vector index (usearch)
- Replaced in-memory HNSW with usearch (persistent HNSW)
- Cold start: ~5ms (was ~5s rebuild from SQLite)
- Incremental delete: ~0.1ms (was full rebuild)
- Index files: `uteke_index.usearch` + `uteke_index.keys`

### Docs
- README updated: namespace usage, architecture diagram, command table
- CHANGELOG updated with [Unreleased] section

## Verification

- ✅ 15/15 unit tests pass (including new `test_namespace_isolation`)
- ✅ Zero clippy warnings
- ✅ CLI smoke test: namespace isolation works correctly
- ✅ Auto-migration tested: old DB schema → new schema with namespace
- ✅ Binary size: 21MB

## CTO Evaluation Gaps Addressed

> 🔴 **Persistent HNSW** — ✅ Solved (usearch)
> 🔴 **Multi-agent isolation** — ✅ Solved (namespace)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--namespace` flag to isolate memories across multiple agents with automatic per-namespace scoping
  * Replaced in-memory vector index with persistent, disk-backed index for faster cold start and incremental deletes
  * Automatic database migration for existing installations with backward-compatible default namespace

* **Documentation**
  * Updated README with multi-agent namespace examples and revised architecture diagram
  * Updated CHANGELOG for v0.0.1 release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajianaz/uteke/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->