### PR TITLE
feat: tiered memory with hot/warm/cold access tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Auto-migration of existing databases (zero data loss)
   - Each namespace is fully isolated: recall, search, list, stats scoped
   - Default namespace: `"default"` (backward compatible)
+- **Tiered memory** — access-based scoring with Hot/Warm/Cold tiers
+  - `access_count` and `last_accessed` tracked per memory
+  - Hot memories (accessed within 7 days) get +0.1 score boost in recall
+  - Warm (30 days) and Cold (>30 days) tiers for visibility
+  - `uteke stats` shows tier breakdown: 🔥 Hot / 🟡 Warm / ❄️ Cold
+  - Auto-migration: columns added to existing databases
 - **Removed old deps:** `hnsw`, `rand_pcg`, `space` (replaced by `usearch`)
 - **Added deps:** `usearch`, `tracing`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ crates/
 ├── uteke-core/         # Memory engine library
 │   └── src/
 │       ├── lib.rs      # Uteke struct — main API
-│       ├── memory/     # SQLite store + HNSW vector index
+│       ├── memory/     # SQLite store + usearch vector index
 │       └── embed/      # ONNX embedding engine
 └── uteke-cli/          # CLI binary
     └── src/main.rs     # clap commands

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Existing databases are auto-migrated — the `namespace` column is added on firs
 │                  uteke-cli crate                     │
 ├─────────────────────────────────────────────────────┤
 │                    Uteke API                         │
-│                  uteke-core crate                    │
+│          uteke-core crate (lib)                      │
 ├──────────┬──────────────────┬────────────────────────┤
 │   ONNX   │     usearch      │       SQLite           │
 │ Embedding│  Vector Index    │    Metadata Store      │
@@ -155,11 +155,12 @@ Existing databases are auto-migrated — the `namespace` column is added on firs
 | Storage | SQLite (rusqlite) | Embedded, zero-config, battle-tested |
 | Embedding | EmbeddingGemma Q4 ONNX | 768d vectors, multilingual, downloaded on first run |
 | Namespaces | SQLite column | Multi-agent isolation, zero overhead |
+| Tiered Memory | Access tracking | Hot/Warm/Cold scoring boost |
 | CLI | clap | Standard Rust CLI framework |
 
 **How it works:**
 1. `remember` → text is embedded into a 768d vector via ONNX → stored in SQLite + indexed in usearch
-2. `recall` → query is embedded → usearch finds nearest neighbors → returns ranked results (scoped to namespace)
+2. `recall` → query is embedded → usearch finds nearest neighbors → hot memories get +0.1 score boost → returns ranked results
 3. `search` → SQLite LIKE-based keyword search (fast, deterministic, scoped to namespace)
 4. `forget` → incremental delete from usearch + SQLite (no rebuild)
 5. Everything lives in `~/.uteke/` — fully local, fully yours

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -147,6 +147,9 @@ fn print_stats_human(stats: &uteke_core::StoreStats) {
     println!("Memory Store Statistics");
     println!("──────────────────────");
     println!("  Total memories: {}", stats.total_memories);
+    println!("  🔥 Hot (7d):    {}", stats.hot);
+    println!("  🟡 Warm (30d):  {}", stats.warm);
+    println!("  ❄️  Cold (>30d):  {}", stats.cold);
     println!("  Unique tags:    {}", stats.unique_tags);
     let size_str = if stats.db_size_bytes < 1024 {
         format!("{} B", stats.db_size_bytes)

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -13,7 +13,7 @@ mod embed;
 pub mod memory;
 
 pub use memory::types::{
-    ExportEntry, ImportResult, Memory, SearchResult, StoreStats, DEFAULT_NAMESPACE,
+    ExportEntry, ImportResult, Memory, MemoryTier, SearchResult, StoreStats, DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -121,6 +121,8 @@ impl Uteke {
             created_at: now,
             updated_at: now,
             namespace: namespace.unwrap_or(DEFAULT_NAMESPACE).to_string(),
+            access_count: 0,
+            last_accessed: None,
         };
 
         self.store.insert(&memory)?;
@@ -191,7 +193,18 @@ impl Uteke {
             }
 
             let score = euclidean_to_cosine(distance);
-            results.push(SearchResult { memory, score });
+
+            // Boost hot memories (+0.1 bonus)
+            let tier = MemoryTier::from_last_accessed(memory.last_accessed);
+            let boosted_score = match tier {
+                MemoryTier::Hot => (score + 0.1).min(1.0),
+                _ => score,
+            };
+
+            results.push(SearchResult {
+                memory,
+                score: boosted_score,
+            });
         }
 
         // Sort by score descending
@@ -200,6 +213,11 @@ impl Uteke {
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
+
+        // Touch access for returned results
+        for r in &results {
+            self.store.touch_access(&r.memory.id).ok();
+        }
 
         Ok(results)
     }
@@ -251,9 +269,12 @@ impl Uteke {
 
     /// Get a single memory by ID.
     pub fn get(&self, id: &str) -> Result<Memory, Error> {
-        self.store
+        let memory = self
+            .store
             .get_by_id(id)?
-            .ok_or_else(|| Error::Database(format!("Memory not found: {id}")))
+            .ok_or_else(|| Error::Database(format!("Memory not found: {id}")))?;
+        self.store.touch_access(id).ok();
+        Ok(memory)
     }
 
     /// List all namespaces.
@@ -265,6 +286,7 @@ impl Uteke {
     pub fn stats(&self, namespace: Option<&str>) -> Result<StoreStats, Error> {
         let total_memories = self.store.count(namespace)?;
         let unique_tags = self.store.unique_tags(namespace)?.len();
+        let (hot, warm, cold) = self.store.tier_counts(namespace)?;
 
         let db_size_bytes = self
             .store
@@ -277,6 +299,9 @@ impl Uteke {
             total_memories,
             unique_tags,
             db_size_bytes,
+            hot,
+            warm,
+            cold,
         })
     }
 
@@ -351,6 +376,8 @@ impl Uteke {
                 created_at: entry.created_at,
                 updated_at: now,
                 namespace: namespace.unwrap_or(DEFAULT_NAMESPACE).to_string(),
+                access_count: 0,
+                last_accessed: None,
             };
 
             self.store.insert(&memory)?;
@@ -412,6 +439,8 @@ mod tests {
             created_at: now,
             updated_at: now,
             namespace: DEFAULT_NAMESPACE.to_string(),
+            access_count: 0,
+            last_accessed: None,
         };
 
         let json = serde_json::to_string(&m).unwrap();
@@ -434,6 +463,8 @@ mod tests {
             created_at: now,
             updated_at: now,
             namespace: DEFAULT_NAMESPACE.to_string(),
+            access_count: 0,
+            last_accessed: None,
         };
 
         let sr = SearchResult {
@@ -450,6 +481,9 @@ mod tests {
             total_memories: 42,
             unique_tags: 5,
             db_size_bytes: 1024,
+            hot: 10,
+            warm: 15,
+            cold: 17,
         };
 
         let json = serde_json::to_string(&stats).unwrap();

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -14,7 +14,9 @@ CREATE TABLE IF NOT EXISTS memories (
     metadata TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    namespace TEXT NOT NULL DEFAULT 'default'
+    namespace TEXT NOT NULL DEFAULT 'default',
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
@@ -71,7 +73,28 @@ impl Store {
             )
             .map_err(|e| Error::Database(e.to_string()))?;
 
+        // Migration: add access tracking columns
+        if !self.column_exists("access_count") {
+            self.conn
+                .execute_batch(
+                    "ALTER TABLE memories ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0;",
+                )
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        if !self.column_exists("last_accessed") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN last_accessed TEXT;")
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+
         Ok(())
+    }
+
+    fn column_exists(&self, column: &str) -> bool {
+        self.conn
+            .prepare("SELECT * FROM memories LIMIT 0")
+            .map(|stmt| stmt.column_names().iter().any(|n| n == &column))
+            .unwrap_or(false)
     }
 
     /// Insert a new memory. Returns the inserted memory's ID.
@@ -84,8 +107,8 @@ impl Store {
 
         self.conn
             .execute(
-                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                 params![
                     memory.id,
                     memory.content,
@@ -95,6 +118,8 @@ impl Store {
                     memory.created_at.to_rfc3339(),
                     memory.updated_at.to_rfc3339(),
                     memory.namespace,
+                    memory.access_count,
+                    memory.last_accessed.map(|t| t.to_rfc3339()),
                 ],
             )
             .map_err(|e| Error::Database(e.to_string()))?;
@@ -106,7 +131,7 @@ impl Store {
     pub fn get_by_id(&self, id: &str) -> Result<Option<Memory>, Error> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE id = ?1")
+            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE id = ?1")
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let result = stmt
@@ -164,8 +189,8 @@ impl Store {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
 
         let sql = match tag {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE namespace = ?1 AND tags LIKE ?2 ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE namespace = ?1 AND tags LIKE ?2 ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
         };
 
         let mut memories = Vec::new();
@@ -236,8 +261,8 @@ impl Store {
     /// Load all memories for index rebuilding, optionally filtered by namespace.
     pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
         let sql = match namespace {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories WHERE namespace = ?1 ORDER BY created_at",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace FROM memories ORDER BY created_at",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE namespace = ?1 ORDER BY created_at",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories ORDER BY created_at",
         };
 
         let mut memories = Vec::new();
@@ -350,6 +375,55 @@ impl Store {
     pub fn path(&self) -> Option<std::path::PathBuf> {
         self.conn.path().map(std::path::PathBuf::from)
     }
+
+    /// Increment access count and update last_accessed for a memory.
+    pub fn touch_access(&self, id: &str) -> Result<(), Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "UPDATE memories SET access_count = access_count + 1, last_accessed = ?1 WHERE id = ?2",
+                params![now, id],
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Count memories by tier (hot/warm/cold) for a namespace.
+    pub fn tier_counts(&self, namespace: Option<&str>) -> Result<(usize, usize, usize), Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let now = chrono::Utc::now();
+        let hot_cutoff = (now - chrono::Duration::days(7)).to_rfc3339();
+        let warm_cutoff = (now - chrono::Duration::days(30)).to_rfc3339();
+
+        let hot: usize = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed >= ?2",
+                params![ns, hot_cutoff],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let warm: usize = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed >= ?2 AND last_accessed < ?3",
+                params![ns, warm_cutoff, hot_cutoff],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let cold: usize = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)",
+                params![ns, warm_cutoff],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        Ok((hot, warm, cold))
+    }
 }
 
 /// Serialize an embedding vector to a byte blob.
@@ -402,6 +476,12 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
     let namespace: String = row
         .get(7)
         .unwrap_or_else(|_| crate::memory::types::DEFAULT_NAMESPACE.to_string());
+    let access_count: u32 = row.get(8).unwrap_or(0);
+    let last_accessed_str: Option<String> = row.get(9).ok().flatten();
+    let last_accessed = last_accessed_str
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.to_utc());
 
     Ok(Memory {
         id,
@@ -412,6 +492,8 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
         created_at,
         updated_at,
         namespace,
+        access_count,
+        last_accessed,
     })
 }
 
@@ -431,6 +513,8 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             namespace: crate::memory::types::DEFAULT_NAMESPACE.to_string(),
+            access_count: 0,
+            last_accessed: None,
         }
     }
 
@@ -444,6 +528,8 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             namespace: namespace.to_string(),
+            access_count: 0,
+            last_accessed: None,
         }
     }
 

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -25,6 +25,12 @@ pub struct Memory {
     /// Namespace for multi-agent isolation.
     #[serde(default = "default_namespace")]
     pub namespace: String,
+    /// How many times this memory has been accessed (recall, get).
+    #[serde(default)]
+    pub access_count: u32,
+    /// When this memory was last accessed.
+    #[serde(default)]
+    pub last_accessed: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 fn default_namespace() -> String {
@@ -40,6 +46,34 @@ pub struct SearchResult {
     pub score: f32,
 }
 
+/// Memory tier based on access recency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryTier {
+    /// Accessed within last 7 days — boosted in recall.
+    Hot,
+    /// Accessed within last 30 days — normal recall.
+    Warm,
+    /// Not accessed in 30+ days — lower priority.
+    Cold,
+}
+
+impl MemoryTier {
+    /// Determine tier from last_accessed timestamp.
+    pub fn from_last_accessed(last_accessed: Option<chrono::DateTime<chrono::Utc>>) -> Self {
+        let Some(la) = last_accessed else {
+            return MemoryTier::Cold;
+        };
+        let age = chrono::Utc::now() - la;
+        if age.num_days() <= 7 {
+            MemoryTier::Hot
+        } else if age.num_days() <= 30 {
+            MemoryTier::Warm
+        } else {
+            MemoryTier::Cold
+        }
+    }
+}
+
 /// Statistics about the memory store.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoreStats {
@@ -49,6 +83,12 @@ pub struct StoreStats {
     pub unique_tags: usize,
     /// Database file size in bytes.
     pub db_size_bytes: u64,
+    /// Number of hot memories (accessed within 7 days).
+    pub hot: usize,
+    /// Number of warm memories (accessed within 30 days).
+    pub warm: usize,
+    /// Number of cold memories (not accessed in 30+ days).
+    pub cold: usize,
 }
 
 /// Lightweight export format — no embedding vector (re-embedded on import).


### PR DESCRIPTION
## Problem

All memories have equal priority regardless of access frequency. 1000 old memories that are rarely accessed compete equally with 10 frequently-used important memories in recall results.

## Solution

Tiered memory with access-based scoring:

| Tier | Criteria | Recall Behavior |
|------|----------|-----------------|
| 🔥 Hot | Accessed within 7 days | +0.1 score boost |
| 🟡 Warm | Accessed within 30 days | Normal score |
| ❄️ Cold | >30 days or never accessed | Normal score |

```bash
uteke stats
# Memory Store Statistics
# ──────────────────────
#   Total memories: 42
#   🔥 Hot (7d):    10
#   🟡 Warm (30d):  15
#   ❄️  Cold (>30d):  17
```

## Changes

- **Access tracking**: `access_count` (INTEGER) + `last_accessed` (TEXT) columns
- **Score boost**: Hot memories get +0.1 bonus in recall results
- **Touch on access**: `recall` and `get` automatically update access tracking
- **Tier display**: `uteke stats` shows Hot/Warm/Cold breakdown
- **Auto-migration**: Columns added to existing databases, zero data loss
- **`MemoryTier` enum**: `from_last_accessed()` helper for tier determination

## Docs Updated

- README: architecture table, tiered memory in "How it works"
- CHANGELOG: [Unreleased] section updated
- CONTRIBUTING.md: HNSW → usearch reference fix

## Verification

- ✅ 15/15 unit tests pass
- ✅ Zero clippy warnings, zero fmt issues
- ✅ CLI smoke test: stats shows tier counts, recall boosts hot memories
- ✅ Auto-migration tested: old DB → new schema with access tracking columns

## CTO Evaluation Gap Addressed

> 🔴 **Tiered memory lifecycle** — ✅ Partially solved (access tracking + scoring, TTL pending)