### PR TITLE
fix: Windows release build — chrono wasm deps + VS dev cmd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
+      - name: Setup Windows VS environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.target == 'aarch64-pc-windows-msvc' && 'amd64_arm64' || 'amd64' }}
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,10 +182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }
 usearch = "2"
 uuid = { version = "1", features = ["v4"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 thiserror = "1"
 ort = { version = "2.0.0-rc.12", features = ["download-binaries"] }
 ndarray = "0.17"


### PR DESCRIPTION
## Problem
Windows builds fail in release CI:
1. **x86_64**: `chrono 0.4.44` pulls `js-sys`/`wasm-bindgen` (default `wasmbind` feature)
2. **ARM64**: `numkong` (usearch) C compile fails — `VCINSTALLDIR = None`

## Fix
- `chrono`: disable default features, only enable `serde` + `clock`
- `release.yml`: add `ilammy/msvc-dev-cmd@v1` for Windows C compiler setup

## Verification
- ✅ 15/15 tests pass
- ✅ `cargo build --release` succeeds locally
- ⏳ Windows CI will validate after merge