### PR TITLE
fix(ci): workaround numkong v7.7.0 Windows ARM64 build failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli
+        env:
+          # numkong v7.7.0 bug: types.h auto-detects x86 features via _MSC_VER on non-x86 MSVC targets.
+          # Defining these to 0 prevents the broken auto-detect path from including immintrin.h.
+          CFLAGS_aarch64_pc_windows_msvc: "-DNK_TARGET_HASWELL=0 -DNK_TARGET_SKYLAKE=0"
 
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Problem

CI job `Build aarch64-pc-windows-msvc` fails on v0.0.2 release because `numkong v7.7.0` (transitive dep via `usearch` → `ort`) has a bug in `types.h` auto-detect.

On `aarch64-pc-windows-msvc`, `types.h` checks `!defined(NK_TARGET_HASWELL) || ...` → enters x86 auto-detect block → `defined(_MSC_VER) && _MSC_VER >= 1900` = TRUE (MSVC ARM64 also defines \`_MSC_VER\`) → sets `NK_TARGET_HASWELL=1` → includes `immintrin.h` (x86-only) → fatal error.

## Fix

Pass target-specific `CFLAGS_aarch64_pc_windows_msvc` with `-DNK_TARGET_HASWELL=0 -DNK_TARGET_SKYLAKE=0` to prevent the broken auto-detect path.

cc-rs automatically picks up `CFLAGS_<target>` env vars and passes \`-D\` flags to all compilations, so `types.h` sees `NK_TARGET_HASWELL` as defined(0) → skips auto-detect → build succeeds.

## Test

This is a CI-only change. Will verify on next tag push / manual workflow trigger.

## Upstream

Bug report should be filed at https://github.com/ashvardanian/NumKong — the \`types.h\` auto-detect condition needs an arch guard:
```c
#if (!defined(NK_TARGET_HASWELL) || (NK_TARGET_HASWELL && !NK_TARGET_X8664_)) \
    && (defined(__x86_64__) || defined(_M_X64))
```