### PR TITLE
fix(ci): skip numkong ARM probes on Windows ARM64 (v2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,22 @@ jobs:
         with:
           arch: ${{ matrix.target == 'aarch64-pc-windows-msvc' && 'amd64_arm64' || 'amd64' }}
 
+      # numkong v7.7.0 bug: on aarch64-pc-windows-msvc, probe .c files use #error
+      # directives that crash MSVC try_compile() instead of returning Err.
+      # build.rs respects NK_TARGET_* env vars — setting to "0" skips the probe.
+      - name: Disable unsupported numkong ARM features (Windows ARM64)
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: bash
+        run: |
+          for feature in NEONHALF NEONBFDOT NEONFHM NEONFP8 \
+            SVE SVEHALF SVEBFDOT SVESDOT SVE2 SVE2P1 \
+            SME SME2 SME2P1 SMEF64 SMEHALF SMEBF16 SMEBI32 SMELUT2 SMEFA64 \
+            HASWELL SKYLAKE; do
+            echo "NK_TARGET_${feature}=0" >> $GITHUB_ENV
+          done
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli
-        env:
-          # numkong v7.7.0 bug: types.h auto-detects x86 features via _MSC_VER on non-x86 MSVC targets.
-          # Defining these to 0 prevents the broken auto-detect path from including immintrin.h.
-          CFLAGS_aarch64_pc_windows_msvc: "-DNK_TARGET_HASWELL=0 -DNK_TARGET_SKYLAKE=0"
 
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Fix v2: use NK_TARGET_* env vars to skip probe compilation. Previous CFLAGS approach did not work because probe .c files use #error directives that crash MSVC try_compile(). See PR #36 for context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows ARM64 release build pipeline with improved feature configuration management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajianaz/uteke/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->