### PR TITLE
fix(ci): CFLAGS for numkong.c HASWELL/SKYLAKE on Windows ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,10 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli
+        env:
+          # numkong v7.7.0: types.h auto-detects x86 HASWELL/SKYLAKE via _MSC_VER
+          # on non-x86 MSVC targets. Inject -D flags to bypass the broken auto-detect.
+          CFLAGS_aarch64_pc_windows_msvc: "-DNK_TARGET_HASWELL=0 -DNK_TARGET_SKYLAKE=0"
 
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Two-part fix needed for numkong v7.7.0 on aarch64-pc-windows-msvc:

1. Env vars (already merged) - skip probe compilation via #error directives
2. CFLAGS (this PR) - inject -DNK_TARGET_HASWELL=0 -DNK_TARGET_SKYLAKE=0 into numkong.c cl.exe invocation, because build.rs never calls build.define() for x86 features on aarch64, so types.h auto-detect via defined(_MSC_VER) still fires during main compilation.