### PR TITLE
fix(website): import app.css in layout — CSS not loading

### DIFF
--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import '../app.css';
+
 	let { children } = $props();
 </script>
 


### PR DESCRIPTION
## Problem
CSS was never loaded on the live site (uteke.pages.dev). Page rendered unstyled — white background, default fonts, no dark theme.

## Root Cause
`app.css` (containing `@import tailwindcss` + all custom styles) was never imported by any Svelte component. `@tailwindcss/vite` only processes CSS in Vite module graph.

## Fix
Added `import "../app.css"` to `+layout.svelte`.

## Verification
- `find build/ -name "*.css"` → `build/_app/immutable/assets/0.CM6bO5iJ.css` (17KB)
- HTML includes `<link rel="stylesheet" href="...">` ✅
- Dark theme, typography, hover effects all render correctly ✅