### PR TITLE
ci: drop macOS Intel from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,6 @@ jobs:
             target: aarch64-apple-darwin
             artifact: uteke-aarch64-apple-darwin
             ext: tar.gz
-          # macOS Intel
-          - os: macos-13
-            target: x86_64-apple-darwin
-            artifact: uteke-x86_64-apple-darwin
-            ext: tar.gz
           # Windows x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -130,7 +125,6 @@ jobs:
           | Platform | File |
           |----------|------|
           | macOS (Apple Silicon) | `uteke-VERSION-aarch64-apple-darwin.tar.gz` |
-          | macOS (Intel) | `uteke-VERSION-x86_64-apple-darwin.tar.gz` |
           | Linux (x86_64) | `uteke-VERSION-x86_64-unknown-linux-gnu.tar.gz` |
           | Linux (ARM64) | `uteke-VERSION-aarch64-unknown-linux-gnu.tar.gz` |
           | Windows (x86_64) | `uteke-VERSION-x86_64-pc-windows-msvc.zip` |


### PR DESCRIPTION
Drop  /  — was blocking releases (run 26636833671). 4 platforms remain: Linux x64, Linux ARM64, macOS ARM64, Windows x64.