### PR TITLE
docs: update CHANGELOG + fix license refs MIT → Apache 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Website** — https://uteke.ajianaz.dev (SvelteKit 5 + Tailwind)
+  - Landing page, docs, roadmap
+  - Auto-deploy via CF Pages + Infisical OIDC
+- **Release matrix** — 4 platforms: Linux x64, Linux ARM64, macOS ARM64, Windows x64
 - **Persistent vector index** — replaced in-memory HNSW with usearch (persistent HNSW)
   - Cold start: loads from disk (~5ms) instead of rebuilding from SQLite (~5s at 10K memories)
   - Incremental delete: `remove()` in ~0.1ms instead of full index rebuild
@@ -34,16 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **License:** MIT → Apache 2.0
 - **Vector index:** HNSW (in-memory) → usearch (persistent, incremental)
 - **Delete:** rebuild-based → incremental `remove()` + save
 - **Startup:** rebuild from SQLite → `restore()` from disk
-- **Binary size:** 20MB → 21MB (+1MB from usearch)
+- **Binary size:** 26MB (v0.0.1) → 28MB (v0.0.2, +usearch)
 - **CI:** only runs on PR to develop and push to main (eliminates duplicate runs)
 - **Release:** versioned artifact filenames (`uteke-{version}-{target}.tar.gz`)
+- **CI secrets:** Infisical OIDC for CF Pages deploy (website workflow)
 
 ### Removed
 
 - Old deps: `hnsw`, `rand_pcg`, `space` (replaced by `usearch`)
+- macOS Intel (`x86_64-apple-darwin`) from release matrix
+- Windows ARM64 (`aarch64-pc-windows-msvc`) from release matrix (numkong incompatibility)
 
 ### Docs
 

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -42,7 +42,7 @@
 			<div class="flex items-center gap-4">
 				<a href="https://github.com/ajianaz/uteke" target="_blank" rel="noopener" class="hover:text-[var(--color-text)] transition-colors">GitHub</a>
 				<a href="https://discord.gg/uteke" target="_blank" rel="noopener" class="hover:text-[var(--color-text)] transition-colors">Discord</a>
-				<a href="https://github.com/ajianaz/uteke/blob/main/LICENSE" class="hover:text-[var(--color-text)] transition-colors">MIT License</a>
+				<a href="https://github.com/ajianaz/uteke/blob/main/LICENSE" class="hover:text-[var(--color-text)] transition-colors">Apache 2.0 License</a>
 			</div>
 		</div>
 	</footer>

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -54,7 +54,7 @@
 		{ feature: 'Speed (warm)', uteke: '~23ms*', mem0: '~50ms', letta: '~100ms', cognee: '~200ms' },
 		{ feature: 'Knowledge Graph', uteke: '🔮 Planned', mem0: '❌', letta: '❌', cognee: '✅ GraphRAG' },
 		{ feature: 'Auto-Forget', uteke: '🔮 Planned', mem0: '✅', letta: '✅ Core memory', cognee: '✅ TTL-based' },
-		{ feature: 'License', uteke: 'MIT', mem0: 'MIT', letta: 'Apache-2.0', cognee: 'Apache-2.0' }
+		{ feature: 'License', uteke: 'Apache-2.0', mem0: 'MIT', letta: 'Apache-2.0', cognee: 'Apache-2.0' }
 	];
 
 	const audiences: Feature[] = [
@@ -259,7 +259,7 @@
 <!-- CTA -->
 <section class="max-w-6xl mx-auto px-6 py-16 md:py-20 text-center">
 	<h2 class="text-2xl md:text-3xl font-bold mb-4">Ready to give your AI a brain?</h2>
-	<p class="text-[var(--color-text-muted)] mb-8">Open source, MIT licensed. Start in 30 seconds.</p>
+	<p class="text-[var(--color-text-muted)] mb-8">Open source, Apache 2.0 licensed. Start in 30 seconds.</p>
 	<a
 		href="https://github.com/ajianaz/uteke"
 		target="_blank"


### PR DESCRIPTION
CHANGELOG: add website, release matrix, Infisical, license change, platform drops.
Website: fix 3 remaining MIT references → Apache 2.0 (comparison table, CTA, footer).