### PR TITLE
ci: fix double v prefix in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Generate release notes
         run: |
           cat > release-notes.md << 'EOF'
-          ## What's New in vVERSION
+          ## What's New in VERSION
 
           ### 🔧 Features
 
@@ -139,10 +139,10 @@ jobs:
 
           | Platform | File |
           |----------|------|
-          | Linux (x86_64) | `uteke-vVERSION-x86_64-unknown-linux-gnu.tar.gz` |
-          | Linux (ARM64) | `uteke-vVERSION-aarch64-unknown-linux-gnu.tar.gz` |
-          | macOS (Apple Silicon) | `uteke-vVERSION-aarch64-apple-darwin.tar.gz` |
-          | Windows (x86_64) | `uteke-vVERSION-x86_64-pc-windows-msvc.zip` |
+          | Linux (x86_64) | `uteke-VERSION-x86_64-unknown-linux-gnu.tar.gz` |
+          | Linux (ARM64) | `uteke-VERSION-aarch64-unknown-linux-gnu.tar.gz` |
+          | macOS (Apple Silicon) | `uteke-VERSION-aarch64-apple-darwin.tar.gz` |
+          | Windows (x86_64) | `uteke-VERSION-x86_64-pc-windows-msvc.zip` |
 
           ### 🚀 Quick Start
 


### PR DESCRIPTION
VERSION already includes v prefix, template was adding another.