### PR TITLE
feat: tag-based filtering and management commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +450,15 @@ checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1262,6 +1280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1475,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1999,6 +2029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2134,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2281,6 +2348,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2531,7 @@ dependencies = [
  "serde_json",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uteke-core",
 ]

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -20,6 +20,17 @@ fn print_json<T: serde::Serialize>(value: &T) {
 
 // ── Human-readable output helpers ───────────────────────────────────────────
 
+fn print_tags_human(tags: &[uteke_core::TagInfo], _by_count: bool) {
+    if tags.is_empty() {
+        println!("No tags found.");
+        return;
+    }
+    println!("Tags ({} total):\n", tags.len());
+    for t in tags {
+        println!("  {} ({})", t.name, t.count);
+    }
+}
+
 fn print_remember_human(id: &str) {
     println!("✓ Memory stored");
     println!("  ID: {id}");
@@ -274,6 +285,36 @@ enum Commands {
         /// Agent type: pi, claude, cursor, copilot, codex
         #[arg(long, default_value = "pi")]
         agent: String,
+    },
+    /// Manage tags: list, rename, delete
+    Tags {
+        #[command(subcommand)]
+        command: TagCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum TagCommands {
+    /// List all tags with usage counts
+    List {
+        /// Sort by count (descending) instead of alphabetical
+        #[arg(long)]
+        by_count: bool,
+    },
+    /// Rename a tag across all memories
+    Rename {
+        /// Current tag name
+        old: String,
+        /// New tag name
+        new: String,
+    },
+    /// Delete a tag from all memories
+    Delete {
+        /// Tag name to delete
+        tag: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        confirm: bool,
     },
 }
 
@@ -669,6 +710,73 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 print_json(&report);
             } else {
                 print_repair_human(&report);
+            }
+            Ok(())
+        }
+        Commands::Tags { command } => {
+            match command {
+                TagCommands::List { by_count } => {
+                    tracing::info!("Listing tags (by_count: {by_count})");
+                    let mut tags = uteke
+                        .tags_with_counts(ns)
+                        .map_err(|e| format!("Failed to list tags: {e}"))?;
+                    if *by_count {
+                        tags.sort_by_key(|b| std::cmp::Reverse(b.count));
+                    } else {
+                        tags.sort_by(|a, b| a.name.cmp(&b.name));
+                    }
+                    if cli.json {
+                        print_json(&tags);
+                    } else {
+                        print_tags_human(&tags, *by_count);
+                    }
+                }
+                TagCommands::Rename { old, new } => {
+                    tracing::info!("Renaming tag: {old} -> {new}");
+                    let count = uteke
+                        .rename_tag(old, new, ns)
+                        .map_err(|e| format!("Failed to rename tag: {e}"))?;
+                    if cli.json {
+                        print_json(
+                            &serde_json::json!({"renamed": count, "tag": old, "new_tag": new}),
+                        );
+                    } else {
+                        println!("✓ Tag '{old}' renamed to '{new}' ({count} memories updated)");
+                    }
+                }
+                TagCommands::Delete { tag, confirm } => {
+                    if !confirm {
+                        // Check if tag exists and show count
+                        let tags = uteke
+                            .tags_with_counts(ns)
+                            .map_err(|e| format!("Failed to list tags: {e}"))?;
+                        let info = tags.iter().find(|t| t.name == *tag);
+                        match info {
+                            Some(info) => {
+                                println!(
+                                    "Tag '{}' is used by {} memory(ies).",
+                                    info.name, info.count
+                                );
+                                println!("Use --confirm to proceed with deletion.");
+                                return Err(
+                                    "Tag deletion not confirmed. Use --confirm flag.".to_string()
+                                );
+                            }
+                            None => {
+                                return Err(format!("Tag '{}' not found.", tag));
+                            }
+                        }
+                    }
+                    tracing::info!("Deleting tag: {tag}");
+                    let count = uteke
+                        .delete_tag(tag, ns)
+                        .map_err(|e| format!("Failed to delete tag: {e}"))?;
+                    if cli.json {
+                        print_json(&serde_json::json!({"deleted": count, "tag": tag}));
+                    } else {
+                        println!("✓ Tag '{tag}' deleted ({count} memories updated)");
+                    }
+                }
             }
             Ok(())
         }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -13,7 +13,8 @@ mod embed;
 pub mod memory;
 
 pub use memory::types::{
-    ExportEntry, ImportResult, Memory, MemoryTier, SearchResult, StoreStats, DEFAULT_NAMESPACE,
+    ExportEntry, ImportResult, Memory, MemoryTier, SearchResult, StoreStats, TagInfo,
+    DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -427,6 +428,26 @@ impl Uteke {
             warm,
             cold,
         })
+    }
+
+    /// List all tags with their usage counts.
+    pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
+        self.store.tags_with_counts(namespace)
+    }
+
+    /// Rename a tag across all memories. Returns count of memories updated.
+    pub fn rename_tag(
+        &self,
+        old: &str,
+        new: &str,
+        namespace: Option<&str>,
+    ) -> Result<usize, Error> {
+        self.store.rename_tag(old, new, namespace)
+    }
+
+    /// Delete a tag from all memories. Returns count of memories updated.
+    pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        self.store.delete_tag(tag, namespace)
     }
 
     /// Export all memories to JSONL format (one JSON object per line).

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -1,6 +1,6 @@
 //! SQLite-backed persistence for memories.
 
-use crate::memory::types::Memory;
+use crate::memory::types::{Memory, TagInfo};
 use crate::Error;
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -388,6 +388,125 @@ impl Store {
         Ok(())
     }
 
+    /// Get all tags with their usage counts, optionally filtered by namespace.
+    pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
+        let tags = self.unique_tags(namespace)?;
+        let mut result = Vec::new();
+        for tag in &tags {
+            let count = self.count_tag(tag, namespace)?;
+            result.push(TagInfo {
+                name: tag.clone(),
+                count,
+            });
+        }
+        Ok(result)
+    }
+
+    /// Count how many memories use a specific tag.
+    fn count_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        let count: usize = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
+                rusqlite::params![ns, pattern],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(count)
+    }
+
+    /// Rename a tag across all memories (optionally filtered by namespace).
+    /// Returns the number of memories updated.
+    pub fn rename_tag(
+        &self,
+        old: &str,
+        new: &str,
+        namespace: Option<&str>,
+    ) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{old}\"%");
+        let sql = "SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2";
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let rows: Vec<(String, String)> = stmt
+            .query_map(rusqlite::params![ns, pattern], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut updated = 0;
+        for (id, tags_str) in &rows {
+            let mut tags: Vec<String> = serde_json::from_str(tags_str).unwrap_or_default();
+            let mut changed = false;
+            for t in &mut tags {
+                if t == old {
+                    *t = new.to_string();
+                    changed = true;
+                }
+            }
+            if changed {
+                let new_tags_json =
+                    serde_json::to_string(&tags).map_err(|e| Error::Database(e.to_string()))?;
+                let now = chrono::Utc::now().to_rfc3339();
+                self.conn
+                    .execute(
+                        "UPDATE memories SET tags = ?1, updated_at = ?2 WHERE id = ?3",
+                        rusqlite::params![new_tags_json, now, id],
+                    )
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                updated += 1;
+            }
+        }
+        Ok(updated)
+    }
+
+    /// Delete a tag from all memories (optionally filtered by namespace).
+    /// Returns the number of memories updated.
+    pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        let sql = "SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2";
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let rows: Vec<(String, String)> = stmt
+            .query_map(rusqlite::params![ns, pattern], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut updated = 0;
+        for (id, tags_str) in &rows {
+            let mut tags: Vec<String> = serde_json::from_str(tags_str).unwrap_or_default();
+            let before_len = tags.len();
+            tags.retain(|t| t != tag);
+            if tags.len() != before_len {
+                let new_tags_json =
+                    serde_json::to_string(&tags).map_err(|e| Error::Database(e.to_string()))?;
+                let now = chrono::Utc::now().to_rfc3339();
+                self.conn
+                    .execute(
+                        "UPDATE memories SET tags = ?1, updated_at = ?2 WHERE id = ?3",
+                        rusqlite::params![new_tags_json, now, id],
+                    )
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                updated += 1;
+            }
+        }
+        Ok(updated)
+    }
+
     /// Count memories by tier (hot/warm/cold) for a namespace.
     pub fn tier_counts(&self, namespace: Option<&str>) -> Result<(usize, usize, usize), Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
@@ -675,5 +794,74 @@ mod tests {
         assert_eq!(ns.len(), 2);
         assert!(ns.contains(&"hermes".to_string()));
         assert!(ns.contains(&"pi".to_string()));
+    }
+
+    #[test]
+    fn test_tags_with_counts() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rust", "web"]))
+            .unwrap();
+        store.insert(&make_test_memory("3", "c", &["ai"])).unwrap();
+
+        let mut tags = store.tags_with_counts(None).unwrap();
+        tags.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(tags.len(), 3);
+        assert_eq!(tags[0].name, "ai");
+        assert_eq!(tags[0].count, 2);
+        assert_eq!(tags[1].name, "rust");
+        assert_eq!(tags[1].count, 2);
+        assert_eq!(tags[2].name, "web");
+        assert_eq!(tags[2].count, 1);
+    }
+
+    #[test]
+    fn test_rename_tag() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rust"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["python"]))
+            .unwrap();
+
+        let count = store.rename_tag("rust", "systems", None).unwrap();
+        assert_eq!(count, 2);
+
+        let m1 = store.get_by_id("1").unwrap().unwrap();
+        assert_eq!(m1.tags, vec!["systems", "ai"]);
+
+        let m2 = store.get_by_id("2").unwrap().unwrap();
+        assert_eq!(m2.tags, vec!["systems"]);
+
+        let m3 = store.get_by_id("3").unwrap().unwrap();
+        assert_eq!(m3.tags, vec!["python"]);
+    }
+
+    #[test]
+    fn test_delete_tag() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rust"]))
+            .unwrap();
+
+        let count = store.delete_tag("rust", None).unwrap();
+        assert_eq!(count, 2);
+
+        let m1 = store.get_by_id("1").unwrap().unwrap();
+        assert_eq!(m1.tags, vec!["ai"]);
+
+        let m2 = store.get_by_id("2").unwrap().unwrap();
+        assert!(m2.tags.is_empty());
     }
 }

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -112,3 +112,12 @@ pub struct ImportResult {
     /// Number of entries skipped (duplicate or invalid).
     pub skipped: usize,
 }
+
+/// A tag with its usage count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagInfo {
+    /// Tag name.
+    pub name: String,
+    /// Number of memories using this tag.
+    pub count: usize,
+}


### PR DESCRIPTION
Closes #42

## Changes

### New Type
- `TagInfo { name: String, count: usize }` in `memory/types.rs`

### Store Methods (`memory/store.rs`)
- `tags_with_counts()` — aggregate all tags with usage counts
- `rename_tag(old, new)` — rename a tag across all matching memories
- `delete_tag(tag)` — remove a tag from all matching memories

### Uteke Wrappers (`lib.rs`)
- `tags_with_counts()`, `rename_tag()`, `delete_tag()` delegate to store

### CLI (`main.rs`)
- `uteke tags list [--by-count]` — list tags alphabetically or by count
- `uteke tags rename <old> <new>` — rename tag across memories
- `uteke tags delete <tag> [--confirm]` — delete tag (requires --confirm)

### Tests
- `test_tags_with_counts` — verifies count aggregation
- `test_rename_tag` — verifies tag rename propagates
- `test_delete_tag` — verifies tag removal from memories

All checks pass: cargo check, clippy, test (18/18), fmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag management commands including list (with sort-by-count option), rename, and delete operations.
  * Tags now display usage counts in human-readable format.
  * Tag deletion requires explicit `--confirm` flag for safety.
  * Support for both JSON and human-readable output formats across tag operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajianaz/uteke/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->