### PR TITLE
feat: memory aging with auto-cleanup policy

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -24,17 +24,6 @@ fn print_json<T: serde::Serialize>(value: &T) {
 
 // ── Human-readable output helpers ───────────────────────────────────────────
 
-fn print_tags_human(tags: &[uteke_core::TagInfo], _by_count: bool) {
-    if tags.is_empty() {
-        println!("No tags found.");
-        return;
-    }
-    println!("Tags ({} total):\n", tags.len());
-    for t in tags {
-        println!("  {} ({})", t.name, t.count);
-    }
-}
-
 fn print_remember_human(id: &str) {
     println!("✓ Memory stored");
     println!("  ID: {id}");
@@ -179,6 +168,38 @@ fn print_repair_human(report: &uteke_core::RepairReport) {
     }
 }
 
+fn print_aging_status_human(status: &uteke_core::AgingStatus) {
+    println!("Memory Aging Status");
+    println!("────────────────────");
+    println!("  Total:          {}", status.total);
+    println!("  🔥 Hot (7d):    {}", status.hot);
+    println!("  🟡 Warm (30d):  {}", status.warm);
+    println!("  ❄️  Cold (>30d):  {}", status.cold);
+    println!("  🚫 Never accessed: {}", status.never_accessed);
+}
+
+fn print_aging_preview_human(memories: &[uteke_core::Memory]) {
+    if memories.is_empty() {
+        println!("No aged memories eligible for cleanup.");
+        return;
+    }
+    println!("Aged Memories ({} eligible for cleanup):\n", memories.len());
+    for (i, m) in memories.iter().enumerate() {
+        let accessed = m
+            .last_accessed
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_else(|| "never".to_string());
+        println!(
+            "  {}. {}",
+            i + 1,
+            m.content.chars().take(80).collect::<String>()
+        );
+        println!("     ID: {}", m.id);
+        println!("     Created: {}", m.created_at.to_rfc3339());
+        println!("     Accessed: {} (count: {})", accessed, m.access_count);
+    }
+}
+
 // ── CLI definition ──────────────────────────────────────────────────────────
 
 #[derive(Parser)]
@@ -290,39 +311,41 @@ enum Commands {
         #[arg(long, default_value = "pi")]
         agent: String,
     },
-    /// Manage tags: list, rename, delete
-    Tags {
+    /// Memory aging: status, preview cleanup, cleanup
+    Aging {
         #[command(subcommand)]
-        command: TagCommands,
-    },
-}
-
-#[derive(Subcommand)]
-enum TagCommands {
-    /// List all tags with usage counts
-    List {
-        /// Sort by count (descending) instead of alphabetical
-        #[arg(long)]
-        by_count: bool,
-    },
-    /// Rename a tag across all memories
-    Rename {
-        /// Current tag name
-        old: String,
-        /// New tag name
-        new: String,
-    },
-    /// Delete a tag from all memories
-    Delete {
-        /// Tag name to delete
-        tag: String,
-        /// Skip confirmation prompt
-        #[arg(long)]
-        confirm: bool,
+        command: AgingCommands,
     },
 }
 
 // ── Agent Init ──────────────────────────────────────────────────────────────
+
+#[derive(Subcommand)]
+enum AgingCommands {
+    /// Show aging status: hot, warm, cold, never-accessed counts
+    Status,
+    /// Preview memories eligible for cleanup (dry-run)
+    Preview {
+        /// Minimum age in days for a memory to be considered aged
+        #[arg(long, default_value = "180")]
+        older_than_days: u32,
+        /// Maximum access count threshold
+        #[arg(long, default_value = "1")]
+        max_access_count: u32,
+    },
+    /// Delete aged memories (use --yes to skip confirmation)
+    Cleanup {
+        /// Minimum age in days for a memory to be considered aged
+        #[arg(long, default_value = "180")]
+        older_than_days: u32,
+        /// Maximum access count threshold
+        #[arg(long, default_value = "1")]
+        max_access_count: u32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+}
 
 fn run_init_command(cli: &Cli) -> Result<(), String> {
     if let Commands::Init { agent } = &cli.command {
@@ -735,73 +758,6 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             }
             Ok(())
         }
-        Commands::Tags { command } => {
-            match command {
-                TagCommands::List { by_count } => {
-                    tracing::info!("Listing tags (by_count: {by_count})");
-                    let mut tags = uteke
-                        .tags_with_counts(ns)
-                        .map_err(|e| format!("Failed to list tags: {e}"))?;
-                    if *by_count {
-                        tags.sort_by_key(|b| std::cmp::Reverse(b.count));
-                    } else {
-                        tags.sort_by(|a, b| a.name.cmp(&b.name));
-                    }
-                    if cli.json {
-                        print_json(&tags);
-                    } else {
-                        print_tags_human(&tags, *by_count);
-                    }
-                }
-                TagCommands::Rename { old, new } => {
-                    tracing::info!("Renaming tag: {old} -> {new}");
-                    let count = uteke
-                        .rename_tag(old, new, ns)
-                        .map_err(|e| format!("Failed to rename tag: {e}"))?;
-                    if cli.json {
-                        print_json(
-                            &serde_json::json!({"renamed": count, "tag": old, "new_tag": new}),
-                        );
-                    } else {
-                        println!("✓ Tag '{old}' renamed to '{new}' ({count} memories updated)");
-                    }
-                }
-                TagCommands::Delete { tag, confirm } => {
-                    if !confirm {
-                        // Check if tag exists and show count
-                        let tags = uteke
-                            .tags_with_counts(ns)
-                            .map_err(|e| format!("Failed to list tags: {e}"))?;
-                        let info = tags.iter().find(|t| t.name == *tag);
-                        match info {
-                            Some(info) => {
-                                println!(
-                                    "Tag '{}' is used by {} memory(ies).",
-                                    info.name, info.count
-                                );
-                                println!("Use --confirm to proceed with deletion.");
-                                return Err(
-                                    "Tag deletion not confirmed. Use --confirm flag.".to_string()
-                                );
-                            }
-                            None => {
-                                return Err(format!("Tag '{}' not found.", tag));
-                            }
-                        }
-                    }
-                    tracing::info!("Deleting tag: {tag}");
-                    let count = uteke
-                        .delete_tag(tag, ns)
-                        .map_err(|e| format!("Failed to delete tag: {e}"))?;
-                    if cli.json {
-                        print_json(&serde_json::json!({"deleted": count, "tag": tag}));
-                    } else {
-                        println!("✓ Tag '{tag}' deleted ({count} memories updated)");
-                    }
-                }
-            }
-            Ok(())
-        }
         Commands::Export { output } => {
             tracing::info!("Exporting memories to {output}");
             let jsonl = uteke
@@ -854,5 +810,81 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             Ok(())
         }
         Commands::Init { agent } => run_init(agent, cli.json),
+        Commands::Aging { command } => match command {
+            AgingCommands::Status => {
+                tracing::info!("Aging status");
+                let status = uteke
+                    .aging_status(ns)
+                    .map_err(|e| format!("Failed to get aging status: {e}"))?;
+                if cli.json {
+                    print_json(&status);
+                } else {
+                    print_aging_status_human(&status);
+                }
+                Ok(())
+            }
+            AgingCommands::Preview {
+                older_than_days,
+                max_access_count,
+            } => {
+                tracing::info!(
+                    "Aging preview (older_than: {}d, max_access: {})",
+                    older_than_days,
+                    max_access_count
+                );
+                let memories = uteke
+                    .aging_preview(*older_than_days, *max_access_count, ns)
+                    .map_err(|e| format!("Failed to preview aged memories: {e}"))?;
+                if cli.json {
+                    print_json(&memories);
+                } else {
+                    print_aging_preview_human(&memories);
+                }
+                Ok(())
+            }
+            AgingCommands::Cleanup {
+                older_than_days,
+                max_access_count,
+                yes,
+            } => {
+                // Preview first
+                let preview = uteke
+                    .aging_preview(*older_than_days, *max_access_count, ns)
+                    .map_err(|e| format!("Failed to preview aged memories: {e}"))?;
+
+                if preview.is_empty() {
+                    if cli.json {
+                        print_json(&uteke_core::CleanupResult { deleted: 0 });
+                    } else {
+                        println!("No aged memories to clean up.");
+                    }
+                    return Ok(());
+                }
+
+                if !yes {
+                    if !cli.json {
+                        print_aging_preview_human(&preview);
+                        println!();
+                        println!(
+                            "⚠ About to delete {} memory(ies). Use --yes to confirm.",
+                            preview.len()
+                        );
+                    }
+                    return Err("Cleanup not confirmed. Use --yes flag to proceed.".to_string());
+                }
+
+                let count = preview.len();
+                let result = uteke
+                    .aging_cleanup(*older_than_days, *max_access_count, ns)
+                    .map_err(|e| format!("Failed to cleanup aged memories: {e}"))?;
+                if cli.json {
+                    print_json(&result);
+                } else {
+                    println!("✓ Cleaned up {} aged memory(ies)", result.deleted);
+                }
+                let _ = count;
+                Ok(())
+            }
+        },
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -13,8 +13,8 @@ mod embed;
 pub mod memory;
 
 pub use memory::types::{
-    ExportEntry, ImportResult, Memory, MemoryTier, SearchResult, StoreStats, TagInfo,
-    DEFAULT_NAMESPACE,
+    AgingStatus, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier, SearchResult,
+    StoreStats, DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -430,24 +430,67 @@ impl Uteke {
         })
     }
 
-    /// List all tags with their usage counts.
-    pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
-        self.store.tags_with_counts(namespace)
+    /// Get aging status — breakdown of memories by access tier.
+    pub fn aging_status(&self, namespace: Option<&str>) -> Result<AgingStatus, Error> {
+        let total = self.store.count(namespace)?;
+        let (hot, warm, cold) = self.store.tier_counts(namespace)?;
+        let never_accessed = self.store.count_never_accessed(namespace)?;
+
+        Ok(AgingStatus {
+            total,
+            hot,
+            warm,
+            cold,
+            never_accessed,
+        })
     }
 
-    /// Rename a tag across all memories. Returns count of memories updated.
-    pub fn rename_tag(
+    /// Preview aged memories eligible for cleanup (dry-run).
+    pub fn aging_preview(
         &self,
-        old: &str,
-        new: &str,
+        older_than_days: u32,
+        max_access_count: u32,
         namespace: Option<&str>,
-    ) -> Result<usize, Error> {
-        self.store.rename_tag(old, new, namespace)
+    ) -> Result<Vec<Memory>, Error> {
+        self.store
+            .find_aged(older_than_days, max_access_count, namespace)
     }
 
-    /// Delete a tag from all memories. Returns count of memories updated.
-    pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        self.store.delete_tag(tag, namespace)
+    /// Cleanup aged memories — deletes from SQLite AND removes from vector index.
+    pub fn aging_cleanup(
+        &self,
+        older_than_days: u32,
+        max_access_count: u32,
+        namespace: Option<&str>,
+    ) -> Result<CleanupResult, Error> {
+        // Find aged memories first to get IDs for vector index removal
+        let aged = self
+            .store
+            .find_aged(older_than_days, max_access_count, namespace)?;
+        let ids: Vec<String> = aged.into_iter().map(|m| m.id).collect();
+
+        if ids.is_empty() {
+            return Ok(CleanupResult { deleted: 0 });
+        }
+
+        // Delete from SQLite
+        let deleted = self
+            .store
+            .cleanup_aged(older_than_days, max_access_count, namespace)?;
+
+        // Remove from vector index
+        {
+            let mut index = self
+                .index
+                .lock()
+                .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+            for id in &ids {
+                index.remove(id);
+            }
+            index.save().ok();
+        }
+
+        Ok(CleanupResult { deleted })
     }
 
     /// Export all memories to JSONL format (one JSON object per line).

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -1,6 +1,6 @@
 //! SQLite-backed persistence for memories.
 
-use crate::memory::types::{Memory, TagInfo};
+use crate::memory::types::Memory;
 use crate::Error;
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -388,123 +388,87 @@ impl Store {
         Ok(())
     }
 
-    /// Get all tags with their usage counts, optionally filtered by namespace.
-    pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
-        let tags = self.unique_tags(namespace)?;
-        let mut result = Vec::new();
-        for tag in &tags {
-            let count = self.count_tag(tag, namespace)?;
-            result.push(TagInfo {
-                name: tag.clone(),
-                count,
-            });
+    /// Find aged memories eligible for cleanup.
+    ///
+    /// Returns memories matching: older than `older_than_days`, access_count <= max_access_count,
+    /// and last_accessed older than `older_than_days` (or never accessed).
+    pub fn find_aged(
+        &self,
+        older_than_days: u32,
+        max_access_count: u32,
+        namespace: Option<&str>,
+    ) -> Result<Vec<Memory>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let sql = r#"
+            SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed
+            FROM memories
+            WHERE namespace = ?1
+              AND created_at < datetime('now', '-' || ?2 || ' days')
+              AND access_count <= ?3
+              AND (last_accessed IS NULL OR last_accessed < datetime('now', '-' || ?4 || ' days'))
+            ORDER BY created_at ASC
+        "#;
+
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(
+                params![ns, older_than_days, max_access_count, older_than_days],
+                row_to_memory,
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let mut memories = Vec::new();
+        for row in rows {
+            let m = row.map_err(|e| Error::Database(e.to_string()))?;
+            memories.push(m);
         }
-        Ok(result)
+        Ok(memories)
     }
 
-    /// Count how many memories use a specific tag.
-    fn count_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+    /// Delete aged memories from SQLite. Returns count of deleted rows.
+    ///
+    /// Same criteria as `find_aged`. Does NOT touch the vector index.
+    pub fn cleanup_aged(
+        &self,
+        older_than_days: u32,
+        max_access_count: u32,
+        namespace: Option<&str>,
+    ) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{tag}\"%");
+        let sql = r#"
+            DELETE FROM memories
+            WHERE namespace = ?1
+              AND created_at < datetime('now', '-' || ?2 || ' days')
+              AND access_count <= ?3
+              AND (last_accessed IS NULL OR last_accessed < datetime('now', '-' || ?4 || ' days'))
+        "#;
+
+        let deleted = self
+            .conn
+            .execute(
+                sql,
+                params![ns, older_than_days, max_access_count, older_than_days],
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(deleted)
+    }
+
+    /// Count memories never accessed in a namespace.
+    pub fn count_never_accessed(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
         let count: usize = self
             .conn
             .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
-                rusqlite::params![ns, pattern],
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed IS NULL",
+                params![ns],
                 |row| row.get(0),
             )
             .map_err(|e| Error::Database(e.to_string()))?;
         Ok(count)
-    }
-
-    /// Rename a tag across all memories (optionally filtered by namespace).
-    /// Returns the number of memories updated.
-    pub fn rename_tag(
-        &self,
-        old: &str,
-        new: &str,
-        namespace: Option<&str>,
-    ) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{old}\"%");
-        let sql = "SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2";
-        let mut stmt = self
-            .conn
-            .prepare(sql)
-            .map_err(|e| Error::Database(e.to_string()))?;
-
-        let rows: Vec<(String, String)> = stmt
-            .query_map(rusqlite::params![ns, pattern], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(|e| Error::Database(e.to_string()))?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        let mut updated = 0;
-        for (id, tags_str) in &rows {
-            let mut tags: Vec<String> = serde_json::from_str(tags_str).unwrap_or_default();
-            let mut changed = false;
-            for t in &mut tags {
-                if t == old {
-                    *t = new.to_string();
-                    changed = true;
-                }
-            }
-            if changed {
-                let new_tags_json =
-                    serde_json::to_string(&tags).map_err(|e| Error::Database(e.to_string()))?;
-                let now = chrono::Utc::now().to_rfc3339();
-                self.conn
-                    .execute(
-                        "UPDATE memories SET tags = ?1, updated_at = ?2 WHERE id = ?3",
-                        rusqlite::params![new_tags_json, now, id],
-                    )
-                    .map_err(|e| Error::Database(e.to_string()))?;
-                updated += 1;
-            }
-        }
-        Ok(updated)
-    }
-
-    /// Delete a tag from all memories (optionally filtered by namespace).
-    /// Returns the number of memories updated.
-    pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{tag}\"%");
-        let sql = "SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2";
-        let mut stmt = self
-            .conn
-            .prepare(sql)
-            .map_err(|e| Error::Database(e.to_string()))?;
-
-        let rows: Vec<(String, String)> = stmt
-            .query_map(rusqlite::params![ns, pattern], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(|e| Error::Database(e.to_string()))?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        let mut updated = 0;
-        for (id, tags_str) in &rows {
-            let mut tags: Vec<String> = serde_json::from_str(tags_str).unwrap_or_default();
-            let before_len = tags.len();
-            tags.retain(|t| t != tag);
-            if tags.len() != before_len {
-                let new_tags_json =
-                    serde_json::to_string(&tags).map_err(|e| Error::Database(e.to_string()))?;
-                let now = chrono::Utc::now().to_rfc3339();
-                self.conn
-                    .execute(
-                        "UPDATE memories SET tags = ?1, updated_at = ?2 WHERE id = ?3",
-                        rusqlite::params![new_tags_json, now, id],
-                    )
-                    .map_err(|e| Error::Database(e.to_string()))?;
-                updated += 1;
-            }
-        }
-        Ok(updated)
     }
 
     /// Count memories by tier (hot/warm/cold) for a namespace.
@@ -794,74 +758,5 @@ mod tests {
         assert_eq!(ns.len(), 2);
         assert!(ns.contains(&"hermes".to_string()));
         assert!(ns.contains(&"pi".to_string()));
-    }
-
-    #[test]
-    fn test_tags_with_counts() {
-        let store = Store::open(":memory:").unwrap();
-        store
-            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
-            .unwrap();
-        store
-            .insert(&make_test_memory("2", "b", &["rust", "web"]))
-            .unwrap();
-        store.insert(&make_test_memory("3", "c", &["ai"])).unwrap();
-
-        let mut tags = store.tags_with_counts(None).unwrap();
-        tags.sort_by(|a, b| a.name.cmp(&b.name));
-
-        assert_eq!(tags.len(), 3);
-        assert_eq!(tags[0].name, "ai");
-        assert_eq!(tags[0].count, 2);
-        assert_eq!(tags[1].name, "rust");
-        assert_eq!(tags[1].count, 2);
-        assert_eq!(tags[2].name, "web");
-        assert_eq!(tags[2].count, 1);
-    }
-
-    #[test]
-    fn test_rename_tag() {
-        let store = Store::open(":memory:").unwrap();
-        store
-            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
-            .unwrap();
-        store
-            .insert(&make_test_memory("2", "b", &["rust"]))
-            .unwrap();
-        store
-            .insert(&make_test_memory("3", "c", &["python"]))
-            .unwrap();
-
-        let count = store.rename_tag("rust", "systems", None).unwrap();
-        assert_eq!(count, 2);
-
-        let m1 = store.get_by_id("1").unwrap().unwrap();
-        assert_eq!(m1.tags, vec!["systems", "ai"]);
-
-        let m2 = store.get_by_id("2").unwrap().unwrap();
-        assert_eq!(m2.tags, vec!["systems"]);
-
-        let m3 = store.get_by_id("3").unwrap().unwrap();
-        assert_eq!(m3.tags, vec!["python"]);
-    }
-
-    #[test]
-    fn test_delete_tag() {
-        let store = Store::open(":memory:").unwrap();
-        store
-            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
-            .unwrap();
-        store
-            .insert(&make_test_memory("2", "b", &["rust"]))
-            .unwrap();
-
-        let count = store.delete_tag("rust", None).unwrap();
-        assert_eq!(count, 2);
-
-        let m1 = store.get_by_id("1").unwrap().unwrap();
-        assert_eq!(m1.tags, vec!["ai"]);
-
-        let m2 = store.get_by_id("2").unwrap().unwrap();
-        assert!(m2.tags.is_empty());
     }
 }

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -113,11 +113,24 @@ pub struct ImportResult {
     pub skipped: usize,
 }
 
-/// A tag with its usage count.
+/// Aging status — breakdown of memories by access tier.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TagInfo {
-    /// Tag name.
-    pub name: String,
-    /// Number of memories using this tag.
-    pub count: usize,
+pub struct AgingStatus {
+    /// Total memories in namespace.
+    pub total: usize,
+    /// Hot memories (accessed within 7 days).
+    pub hot: usize,
+    /// Warm memories (accessed within 30 days but not hot).
+    pub warm: usize,
+    /// Cold memories (not accessed in 30+ days).
+    pub cold: usize,
+    /// Memories that have never been accessed.
+    pub never_accessed: usize,
+}
+
+/// Result of a cleanup operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CleanupResult {
+    /// Number of memories deleted.
+    pub deleted: usize,
 }


### PR DESCRIPTION
Closes #44

## Changes

- ****: Add  (total, hot, warm, cold, never_accessed) and  (deleted count)
- ****: Add  (SQL query with age/access filters),  (delete matching rows), 
- ****: Add , ,  — cleanup also removes from vector index
- ****: Add  subcommand with , ,  variants

## CLI shape
```
uteke aging status
uteke aging preview [--older-than-days 180] [--max-access-count 1]
uteke aging cleanup [--older-than-days 180] [--max-access-count 1] [--yes]
```

## Verification
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (15 tests pass)
- [x] `cargo fmt --all -- --check`