### PR TITLE
fix: add --tags filter to search command

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -236,6 +236,9 @@ enum Commands {
         /// Maximum results to return
         #[arg(long, default_value = "10")]
         limit: usize,
+        /// Filter by tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
     },
     /// List memories, optionally filtered by tag
     List {
@@ -641,10 +644,16 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             }
             Ok(())
         }
-        Commands::Search { query, limit } => {
+        Commands::Search { query, limit, tags } => {
             tracing::info!("Searching: {query} (limit: {limit})");
+            let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+            let tags_filter = if tag_refs.is_empty() {
+                None
+            } else {
+                Some(tag_refs.as_slice())
+            };
             let results = uteke
-                .search(query, *limit, ns)
+                .search(query, *limit, tags_filter, ns)
                 .map_err(|e| format!("Failed to search: {e}"))?;
             if cli.json {
                 print_json(&results);

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -229,12 +229,22 @@ impl Uteke {
         &self,
         query: &str,
         limit: usize,
+        tags_filter: Option<&[&str]>,
         namespace: Option<&str>,
     ) -> Result<Vec<SearchResult>, Error> {
         let memories = self.store.search_content(query, namespace, limit)?;
 
         let results = memories
             .into_iter()
+            .filter(|memory| {
+                if let Some(filter_tags) = tags_filter {
+                    filter_tags
+                        .iter()
+                        .any(|ft| memory.tags.iter().any(|t| t == ft))
+                } else {
+                    true
+                }
+            })
             .map(|memory| SearchResult {
                 memory,
                 score: 1.0, // Text search doesn't have meaningful scores


### PR DESCRIPTION
## Changes
- Add `--tags` option to `uteke search` command (comma-separated)
- Update `Uteke::search()` to accept `tags_filter` parameter
- Filter text search results by tags, matching existing recall behavior

## Why
CodeRabbit noted on PR #69 that tag-aware filtering for search was missing from the #42 implementation. This completes it.

## Verification
- [x] `cargo check --workspace` ✓
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✓
- [x] `cargo test --workspace` — 18/18 tests pass ✓
- [x] `cargo fmt --all -- --check` ✓

See: #42