### PR TITLE
feat: shell hook for auto-context loading

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -319,6 +319,11 @@ enum Commands {
         #[command(subcommand)]
         command: AgingCommands,
     },
+    /// Output shell hook script for auto-context loading
+    Hook {
+        /// Shell type: bash, zsh, fish
+        shell: String,
+    },
 }
 
 // ── Agent Init ──────────────────────────────────────────────────────────────
@@ -895,5 +900,57 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 Ok(())
             }
         },
+        Commands::Hook { shell } => {
+            match shell.as_str() {
+                "bash" => print!(
+                    r#"# Uteke shell hook for Bash
+# Add to ~/.bashrc: eval "$(uteke hook bash)"
+_uteke_prev_dir="$PWD"
+uteke_prompt_hook() {{
+    if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
+        _uteke_prev_dir="$PWD"
+        if [[ -f ".uteke/uteke.db" ]]; then
+            export UTEKE_PROJECT_STORE="$PWD/.uteke"
+        else
+            unset UTEKE_PROJECT_STORE
+        fi
+    fi
+}}
+PROMPT_COMMAND="uteke_prompt_hook;${{PROMPT_COMMAND}}"
+"#
+                ),
+                "zsh" => print!(
+                    r#"# Uteke shell hook for Zsh
+# Add to ~/.zshrc: eval "$(uteke hook zsh)"
+chpwd_functions+=(uteke_chpwd)
+uteke_chpwd() {{
+    if [[ -f ".uteke/uteke.db" ]]; then
+        export UTEKE_PROJECT_STORE="$PWD/.uteke"
+    else
+        unset UTEKE_PROJECT_STORE
+    fi
+}}
+"#
+                ),
+                "fish" => print!(
+                    r#"# Uteke shell hook for Fish
+# Add to ~/.config/fish/config.fish: uteke hook fish | source
+function __uteke_directory_change --on-variable PWD
+    if test -f .uteke/uteke.db
+        set -gx UTEKE_PROJECT_STORE "$PWD/.uteke"
+    else
+        set -e UTEKE_PROJECT_STORE
+    fi
+end
+"#
+                ),
+                other => {
+                    return Err(format!(
+                        "Unknown shell: {other}. Supported shells: bash, zsh, fish"
+                    ))
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/scripts/shell/uteke-hook.bash
+++ b/scripts/shell/uteke-hook.bash
@@ -1,0 +1,14 @@
+# Uteke shell hook for Bash
+# Add to ~/.bashrc: eval "$(uteke hook bash)"
+_uteke_prev_dir="$PWD"
+uteke_prompt_hook() {
+    if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
+        _uteke_prev_dir="$PWD"
+        if [[ -f ".uteke/uteke.db" ]]; then
+            export UTEKE_PROJECT_STORE="$PWD/.uteke"
+        else
+            unset UTEKE_PROJECT_STORE
+        fi
+    fi
+}
+PROMPT_COMMAND="uteke_prompt_hook;${PROMPT_COMMAND}"

--- a/scripts/shell/uteke-hook.fish
+++ b/scripts/shell/uteke-hook.fish
@@ -1,0 +1,9 @@
+# Uteke shell hook for Fish
+# Add to ~/.config/fish/config.fish: uteke hook fish | source
+function __uteke_directory_change --on-variable PWD
+    if test -f .uteke/uteke.db
+        set -gx UTEKE_PROJECT_STORE "$PWD/.uteke"
+    else
+        set -e UTEKE_PROJECT_STORE
+    end
+end

--- a/scripts/shell/uteke-hook.zsh
+++ b/scripts/shell/uteke-hook.zsh
@@ -1,0 +1,10 @@
+# Uteke shell hook for Zsh
+# Add to ~/.zshrc: eval "$(uteke hook zsh)"
+chpwd_functions+=(uteke_chpwd)
+uteke_chpwd() {
+    if [[ -f ".uteke/uteke.db" ]]; then
+        export UTEKE_PROJECT_STORE="$PWD/.uteke"
+    else
+        unset UTEKE_PROJECT_STORE
+    fi
+}


### PR DESCRIPTION
## Changes
- Add `scripts/shell/uteke-hook.bash` — Bash PROMPT_COMMAND hook
- Add `scripts/shell/uteke-hook.zsh` — Zsh chpwd_functions hook  
- Add `scripts/shell/uteke-hook.fish` — Fish --on-variable PWD hook
- Add `uteke hook <bash|zsh|fish>` CLI subcommand
- Hooks detect `.uteke/uteke.db` in cwd, set/unset `UTEKE_PROJECT_STORE`

## Usage
```bash
# Bash — add to ~/.bashrc
eval "$(uteke hook bash)"

# Zsh — add to ~/.zshrc
eval "$(uteke hook zsh)"

# Fish — add to ~/.config/fish/config.fish
uteke hook fish | source
```

## Verification
- [x] `cargo check` ✓
- [x] `cargo clippy` ✓
- [x] `cargo test` — 18/18 ✓
- [x] `cargo fmt` ✓

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell hook support via `uteke hook <shell>` command for bash, zsh, and fish.
  * Hooks automatically manage environment configuration based on project directory detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajianaz/uteke/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->