### PR TITLE
fix: address CodeRabbit review — shell hook improvements

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -319,6 +319,11 @@ enum Commands {
         #[command(subcommand)]
         command: AgingCommands,
     },
+    /// Output shell hook script for auto-context loading
+    Hook {
+        /// Shell type: bash, zsh, fish
+        shell: String,
+    },
 }
 
 // ── Agent Init ──────────────────────────────────────────────────────────────
@@ -895,5 +900,57 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 Ok(())
             }
         },
+        Commands::Hook { shell } => {
+            match shell.as_str() {
+                "bash" => print!(
+                    r#"# Uteke shell hook for Bash
+# Add to ~/.bashrc: eval "$(uteke hook bash)"
+_uteke_prev_dir="$PWD"
+uteke_prompt_hook() {{
+    if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
+        _uteke_prev_dir="$PWD"
+        if [[ -f ".uteke/uteke.db" ]]; then
+            export UTEKE_PROJECT_STORE="$PWD/.uteke"
+        else
+            unset UTEKE_PROJECT_STORE
+        fi
+    fi
+}}
+PROMPT_COMMAND="uteke_prompt_hook;${{PROMPT_COMMAND}}"
+"#
+                ),
+                "zsh" => print!(
+                    r#"# Uteke shell hook for Zsh
+# Add to ~/.zshrc: eval "$(uteke hook zsh)"
+chpwd_functions+=(uteke_chpwd)
+uteke_chpwd() {{
+    if [[ -f ".uteke/uteke.db" ]]; then
+        export UTEKE_PROJECT_STORE="$PWD/.uteke"
+    else
+        unset UTEKE_PROJECT_STORE
+    fi
+}}
+"#
+                ),
+                "fish" => print!(
+                    r#"# Uteke shell hook for Fish
+# Add to ~/.config/fish/config.fish: uteke hook fish | source
+function __uteke_directory_change --on-variable PWD
+    if test -f .uteke/uteke.db
+        set -gx UTEKE_PROJECT_STORE "$PWD/.uteke"
+    else
+        set -e UTEKE_PROJECT_STORE
+    fi
+end
+"#
+                ),
+                other => {
+                    return Err(format!(
+                        "Unknown shell: {other}. Supported shells: bash, zsh, fish"
+                    ))
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -229,6 +229,13 @@ struct Cli {
     command: Commands,
 }
 
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum SupportedShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Store a new memory
@@ -322,7 +329,7 @@ enum Commands {
     /// Output shell hook script for auto-context loading
     Hook {
         /// Shell type: bash, zsh, fish
-        shell: String,
+        shell: SupportedShell,
     },
 }
 
@@ -901,55 +908,12 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             }
         },
         Commands::Hook { shell } => {
-            match shell.as_str() {
-                "bash" => print!(
-                    r#"# Uteke shell hook for Bash
-# Add to ~/.bashrc: eval "$(uteke hook bash)"
-_uteke_prev_dir="$PWD"
-uteke_prompt_hook() {{
-    if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
-        _uteke_prev_dir="$PWD"
-        if [[ -f ".uteke/uteke.db" ]]; then
-            export UTEKE_PROJECT_STORE="$PWD/.uteke"
-        else
-            unset UTEKE_PROJECT_STORE
-        fi
-    fi
-}}
-PROMPT_COMMAND="uteke_prompt_hook;${{PROMPT_COMMAND}}"
-"#
-                ),
-                "zsh" => print!(
-                    r#"# Uteke shell hook for Zsh
-# Add to ~/.zshrc: eval "$(uteke hook zsh)"
-chpwd_functions+=(uteke_chpwd)
-uteke_chpwd() {{
-    if [[ -f ".uteke/uteke.db" ]]; then
-        export UTEKE_PROJECT_STORE="$PWD/.uteke"
-    else
-        unset UTEKE_PROJECT_STORE
-    fi
-}}
-"#
-                ),
-                "fish" => print!(
-                    r#"# Uteke shell hook for Fish
-# Add to ~/.config/fish/config.fish: uteke hook fish | source
-function __uteke_directory_change --on-variable PWD
-    if test -f .uteke/uteke.db
-        set -gx UTEKE_PROJECT_STORE "$PWD/.uteke"
-    else
-        set -e UTEKE_PROJECT_STORE
-    fi
-end
-"#
-                ),
-                other => {
-                    return Err(format!(
-                        "Unknown shell: {other}. Supported shells: bash, zsh, fish"
-                    ))
-                }
-            }
+            let script = match shell {
+                SupportedShell::Bash => include_str!("../../../scripts/shell/uteke-hook.bash"),
+                SupportedShell::Zsh => include_str!("../../../scripts/shell/uteke-hook.zsh"),
+                SupportedShell::Fish => include_str!("../../../scripts/shell/uteke-hook.fish"),
+            };
+            print!("{script}");
             Ok(())
         }
     }

--- a/scripts/shell/uteke-hook.bash
+++ b/scripts/shell/uteke-hook.bash
@@ -1,11 +1,24 @@
 # Uteke shell hook for Bash
 # Add to ~/.bashrc: eval "$(uteke hook bash)"
+_uteke_find_project() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.uteke/uteke.db" ]]; then
+            echo "$dir/.uteke"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
 _uteke_prev_dir="$PWD"
 uteke_prompt_hook() {
     if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
         _uteke_prev_dir="$PWD"
-        if [[ -f ".uteke/uteke.db" ]]; then
-            export UTEKE_PROJECT_STORE="$PWD/.uteke"
+        local project_store
+        if project_store="$(_uteke_find_project)"; then
+            export UTEKE_PROJECT_STORE="$project_store"
         else
             unset UTEKE_PROJECT_STORE
         fi

--- a/scripts/shell/uteke-hook.bash
+++ b/scripts/shell/uteke-hook.bash
@@ -1,0 +1,14 @@
+# Uteke shell hook for Bash
+# Add to ~/.bashrc: eval "$(uteke hook bash)"
+_uteke_prev_dir="$PWD"
+uteke_prompt_hook() {
+    if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
+        _uteke_prev_dir="$PWD"
+        if [[ -f ".uteke/uteke.db" ]]; then
+            export UTEKE_PROJECT_STORE="$PWD/.uteke"
+        else
+            unset UTEKE_PROJECT_STORE
+        fi
+    fi
+}
+PROMPT_COMMAND="uteke_prompt_hook;${PROMPT_COMMAND}"

--- a/scripts/shell/uteke-hook.fish
+++ b/scripts/shell/uteke-hook.fish
@@ -1,0 +1,9 @@
+# Uteke shell hook for Fish
+# Add to ~/.config/fish/config.fish: uteke hook fish | source
+function __uteke_directory_change --on-variable PWD
+    if test -f .uteke/uteke.db
+        set -gx UTEKE_PROJECT_STORE "$PWD/.uteke"
+    else
+        set -e UTEKE_PROJECT_STORE
+    end
+end

--- a/scripts/shell/uteke-hook.fish
+++ b/scripts/shell/uteke-hook.fish
@@ -1,8 +1,21 @@
 # Uteke shell hook for Fish
 # Add to ~/.config/fish/config.fish: uteke hook fish | source
+function __uteke_find_project
+    set -l dir $PWD
+    while test "$dir" != "/"
+        if test -f "$dir/.uteke/uteke.db"
+            echo "$dir/.uteke"
+            return 0
+        end
+        set dir (dirname "$dir")
+    end
+    return 1
+end
+
 function __uteke_directory_change --on-variable PWD
-    if test -f .uteke/uteke.db
-        set -gx UTEKE_PROJECT_STORE "$PWD/.uteke"
+    set -l project_store (__uteke_find_project)
+    if test -n "$project_store"
+        set -gx UTEKE_PROJECT_STORE "$project_store"
     else
         set -e UTEKE_PROJECT_STORE
     end

--- a/scripts/shell/uteke-hook.zsh
+++ b/scripts/shell/uteke-hook.zsh
@@ -1,0 +1,10 @@
+# Uteke shell hook for Zsh
+# Add to ~/.zshrc: eval "$(uteke hook zsh)"
+chpwd_functions+=(uteke_chpwd)
+uteke_chpwd() {
+    if [[ -f ".uteke/uteke.db" ]]; then
+        export UTEKE_PROJECT_STORE="$PWD/.uteke"
+    else
+        unset UTEKE_PROJECT_STORE
+    fi
+}

--- a/scripts/shell/uteke-hook.zsh
+++ b/scripts/shell/uteke-hook.zsh
@@ -1,10 +1,23 @@
 # Uteke shell hook for Zsh
 # Add to ~/.zshrc: eval "$(uteke hook zsh)"
-chpwd_functions+=(uteke_chpwd)
+_uteke_find_project() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.uteke/uteke.db" ]]; then
+            echo "$dir/.uteke"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
 uteke_chpwd() {
-    if [[ -f ".uteke/uteke.db" ]]; then
-        export UTEKE_PROJECT_STORE="$PWD/.uteke"
+    local project_store
+    if project_store="$(_uteke_find_project)"; then
+        export UTEKE_PROJECT_STORE="$project_store"
     else
         unset UTEKE_PROJECT_STORE
     fi
 }
+chpwd_functions+=(uteke_chpwd)


### PR DESCRIPTION
## Changes
Addresses all CodeRabbit review comments on PR #72:

1. **Parent directory search** — hooks now walk up from cwd to root looking for `.uteke/uteke.db`, not just checking current dir
2. **include_str!** — shell scripts loaded from canonical `scripts/shell/` files, no more duplication
3. **SupportedShell enum** — `String` → `clap::ValueEnum` enum, invalid shells rejected at parse time
4. **Zsh ordering** — function defined before `chpwd_functions+=()` registration

## Verification
- [x] `cargo check` ✓
- [x] `cargo clippy` ✓
- [x] `cargo test` — 18/18 ✓
- [x] `cargo fmt` ✓

Closes #47 (completes shell hook feature)