### PR TITLE
fix: restore Tags subcommand + bump v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ajianaz/uteke"

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -24,6 +24,17 @@ fn print_json<T: serde::Serialize>(value: &T) {
 
 // ── Human-readable output helpers ───────────────────────────────────────────
 
+fn print_tags_human(tags: &[uteke_core::TagInfo], _by_count: bool) {
+    if tags.is_empty() {
+        println!("No tags found.");
+        return;
+    }
+    println!("Tags ({} total):\n", tags.len());
+    for t in tags {
+        println!("  {} ({})", t.name, t.count);
+    }
+}
+
 fn print_remember_human(id: &str) {
     println!("✓ Memory stored");
     println!("  ID: {id}");
@@ -330,6 +341,36 @@ enum Commands {
     Hook {
         /// Shell type: bash, zsh, fish
         shell: SupportedShell,
+    },
+    /// Manage tags: list, rename, delete
+    Tags {
+        #[command(subcommand)]
+        command: TagCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum TagCommands {
+    /// List all tags with usage counts
+    List {
+        /// Sort by count (descending) instead of alphabetical
+        #[arg(long)]
+        by_count: bool,
+    },
+    /// Rename a tag across all memories
+    Rename {
+        /// Current tag name
+        old: String,
+        /// New tag name
+        new: String,
+    },
+    /// Delete a tag from all memories
+    Delete {
+        /// Tag name to delete
+        tag: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        confirm: bool,
     },
 }
 
@@ -776,6 +817,73 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                 print_json(&report);
             } else {
                 print_repair_human(&report);
+            }
+            Ok(())
+        }
+        Commands::Tags { command } => {
+            match command {
+                TagCommands::List { by_count } => {
+                    tracing::info!("Listing tags (by_count: {by_count})");
+                    let mut tags = uteke
+                        .tags_with_counts(ns)
+                        .map_err(|e| format!("Failed to list tags: {e}"))?;
+                    if *by_count {
+                        tags.sort_by_key(|b| std::cmp::Reverse(b.count));
+                    } else {
+                        tags.sort_by(|a, b| a.name.cmp(&b.name));
+                    }
+                    if cli.json {
+                        print_json(&tags);
+                    } else {
+                        print_tags_human(&tags, *by_count);
+                    }
+                }
+                TagCommands::Rename { old, new } => {
+                    tracing::info!("Renaming tag: {old} -> {new}");
+                    let count = uteke
+                        .rename_tag(old, new, ns)
+                        .map_err(|e| format!("Failed to rename tag: {e}"))?;
+                    if cli.json {
+                        print_json(
+                            &serde_json::json!({"renamed": count, "tag": old, "new_tag": new}),
+                        );
+                    } else {
+                        println!("✓ Tag '{old}' renamed to '{new}' ({count} memories updated)");
+                    }
+                }
+                TagCommands::Delete { tag, confirm } => {
+                    if !confirm {
+                        // Check if tag exists and show count
+                        let tags = uteke
+                            .tags_with_counts(ns)
+                            .map_err(|e| format!("Failed to list tags: {e}"))?;
+                        let info = tags.iter().find(|t| t.name == *tag);
+                        match info {
+                            Some(info) => {
+                                println!(
+                                    "Tag '{}' is used by {} memory(ies).",
+                                    info.name, info.count
+                                );
+                                println!("Use --confirm to proceed with deletion.");
+                                return Err(
+                                    "Tag deletion not confirmed. Use --confirm flag.".to_string()
+                                );
+                            }
+                            None => {
+                                return Err(format!("Tag '{}' not found.", tag));
+                            }
+                        }
+                    }
+                    tracing::info!("Deleting tag: {tag}");
+                    let count = uteke
+                        .delete_tag(tag, ns)
+                        .map_err(|e| format!("Failed to delete tag: {e}"))?;
+                    if cli.json {
+                        print_json(&serde_json::json!({"deleted": count, "tag": tag}));
+                    } else {
+                        println!("✓ Tag '{tag}' deleted ({count} memories updated)");
+                    }
+                }
             }
             Ok(())
         }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod memory;
 
 pub use memory::types::{
     AgingStatus, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier, SearchResult,
-    StoreStats, DEFAULT_NAMESPACE,
+    StoreStats, TagInfo, DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -292,6 +292,26 @@ impl Uteke {
     /// List all namespaces.
     pub fn list_namespaces(&self) -> Result<Vec<String>, Error> {
         self.store.list_namespaces()
+    }
+
+    /// List all tags with their usage counts.
+    pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
+        self.store.tags_with_counts(namespace)
+    }
+
+    /// Rename a tag across all memories in a namespace.
+    pub fn rename_tag(
+        &self,
+        old: &str,
+        new: &str,
+        namespace: Option<&str>,
+    ) -> Result<usize, Error> {
+        self.store.rename_tag(old, new, namespace)
+    }
+
+    /// Delete a tag from all memories in a namespace.
+    pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        self.store.delete_tag(tag, namespace)
     }
 
     /// Check system health: DB, index, model, consistency.

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -472,6 +472,124 @@ impl Store {
     }
 
     /// Count memories by tier (hot/warm/cold) for a namespace.
+    /// List all tags with their usage counts.
+    pub fn tags_with_counts(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<crate::memory::types::TagInfo>, Error> {
+        let tags = self.unique_tags(namespace)?;
+        let mut result = Vec::new();
+        for tag in &tags {
+            let count = self.count_tag(tag, namespace)?;
+            result.push(crate::memory::types::TagInfo {
+                name: tag.clone(),
+                count,
+            });
+        }
+        Ok(result)
+    }
+
+    /// Count how many memories use a specific tag.
+    fn count_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        let count: usize = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
+                rusqlite::params![ns, pattern],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(count)
+    }
+
+    /// Rename a tag across all memories. Returns number updated.
+    pub fn rename_tag(
+        &self,
+        old: &str,
+        new: &str,
+        namespace: Option<&str>,
+    ) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{old}\"%");
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let rows: Vec<(String, String)> = stmt
+            .query_map(rusqlite::params![ns, pattern], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut updated = 0;
+        for (id, tags_str) in &rows {
+            let mut tags: Vec<String> = serde_json::from_str(tags_str).unwrap_or_default();
+            let mut changed = false;
+            for t in &mut tags {
+                if t == old {
+                    *t = new.to_string();
+                    changed = true;
+                }
+            }
+            if changed {
+                let new_tags_json =
+                    serde_json::to_string(&tags).map_err(|e| Error::Database(e.to_string()))?;
+                let now = chrono::Utc::now().to_rfc3339();
+                self.conn
+                    .execute(
+                        "UPDATE memories SET tags = ?1, updated_at = ?2 WHERE id = ?3",
+                        rusqlite::params![new_tags_json, now, id],
+                    )
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                updated += 1;
+            }
+        }
+        Ok(updated)
+    }
+
+    /// Delete a tag from all memories. Returns number updated.
+    pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let rows: Vec<(String, String)> = stmt
+            .query_map(rusqlite::params![ns, pattern], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut updated = 0;
+        for (id, tags_str) in &rows {
+            let mut tags: Vec<String> = serde_json::from_str(tags_str).unwrap_or_default();
+            let before_len = tags.len();
+            tags.retain(|t| t != tag);
+            if tags.len() != before_len {
+                let new_tags_json =
+                    serde_json::to_string(&tags).map_err(|e| Error::Database(e.to_string()))?;
+                let now = chrono::Utc::now().to_rfc3339();
+                self.conn
+                    .execute(
+                        "UPDATE memories SET tags = ?1, updated_at = ?2 WHERE id = ?3",
+                        rusqlite::params![new_tags_json, now, id],
+                    )
+                    .map_err(|e| Error::Database(e.to_string()))?;
+                updated += 1;
+            }
+        }
+        Ok(updated)
+    }
+
     pub fn tier_counts(&self, namespace: Option<&str>) -> Result<(usize, usize, usize), Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
         let now = chrono::Utc::now();

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -113,6 +113,15 @@ pub struct ImportResult {
     pub skipped: usize,
 }
 
+/// A tag with its usage count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagInfo {
+    /// Tag name.
+    pub name: String,
+    /// Number of memories using this tag.
+    pub count: usize,
+}
+
 /// Aging status — breakdown of memories by access tier.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgingStatus {


### PR DESCRIPTION
## Changes
Tags subcommand was accidentally dropped during PR #72 rebase conflict resolution.

Restores:
- `TagInfo` type with name/count
- `tags_with_counts()`, `rename_tag()`, `delete_tag()` store methods
- `Tags` CLI subcommand (list/rename/delete)
- Uteke wrapper methods

Also bumps version to 0.0.3.

## Stress Test Results (50 memories)
| Phase | Result | Time |
|---|---|---|
| WRITE (50) | 50/50 ✅ | 49.6s |
| RECALL (5 queries) | 5/5 ✅ | 4.8s |
| SEARCH (5 queries) | 5/5 ✅ | 4.7s |
| EXPORT/IMPORT | 51/51 ✅ | - |
| TAGS (list/rename/delete) | ✅ | - |
| AGING | ✅ | - |
| VERIFY + DOCTOR | ✅ All pass | - |
| CLEANUP (50 delete) | 50/50 ✅ | 50.2s |

## Verification
- [x] `cargo check` ✓
- [x] `cargo clippy` ✓
- [x] `cargo test` — 15/15 ✓
- [x] `cargo fmt` ✓
- [x] Stress test — all phases passed