### PR TITLE
fix: missing docs pages (404), roadmap update, CI Node.js fix

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -16,6 +16,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/website/src/routes/docs/+layout.svelte
+++ b/website/src/routes/docs/+layout.svelte
@@ -10,14 +10,16 @@
 	];
 
 	let currentPath = $derived($page.url.pathname);
+
+	let { children } = $props();
 </script>
 
 <div class="max-w-6xl mx-auto px-6">
 	<div class="flex gap-8">
 		<!-- Sidebar -->
-		<aside class="hidden md:block w-56 flex-shrink-0">
+		<aside class="hidden md:block w-56 flex-shrink-0 pt-8">
 			<nav class="sticky top-20 space-y-1">
-				<p class="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-3">Documentation</p>
+				<p class="text-xs font-semibold text-[var(--color-text-dim)] uppercase tracking-wider mb-3">Documentation</p>
 				{#each docsNav as item}
 					<a
 						href={item.href}
@@ -32,16 +34,14 @@
 			</nav>
 
 			<div class="mt-8 px-3 py-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
-				<p class="text-xs text-[var(--color-text-muted)] mb-2">On this page</p>
-				<div class="text-xs text-[var(--color-text-muted)]">
-					<slot name="toc" />
-				</div>
+				<p class="text-xs text-[var(--color-text-dim)] mb-1">Version</p>
+				<p class="text-xs text-[var(--color-accent)] font-mono">v0.0.3</p>
 			</div>
 		</aside>
 
 		<!-- Content -->
-		<div class="flex-1 min-w-0">
-			<slot />
+		<div class="flex-1 min-w-0 py-8">
+			{@render children()}
 		</div>
 	</div>
 </div>

--- a/website/src/routes/docs/+page.svelte
+++ b/website/src/routes/docs/+page.svelte
@@ -7,11 +7,11 @@
 <div class="space-y-8 text-[var(--color-text-muted)] leading-relaxed">
 	<h2 id="install" class="text-xl font-semibold text-[var(--color-text)] !mt-0">Install</h2>
 
-	<p>Download from <a href="https://github.com/ajianaz/uteke/releases" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Releases</a> or use the install script:</p>
+	<p>Install from source (requires <a href="https://rustup.rs" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">Rust</a>):</p>
 
-	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>curl -fsSL https://uteke.dev/install.sh | sh</code></pre>
+	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>cargo install --git https://github.com/ajianaz/uteke</code></pre>
 
-	<p>Available for Linux (x64/ARM64), macOS (Intel/ARM64), and Windows (x64).</p>
+	<p>Or download pre-built binaries from <a href="https://github.com/ajianaz/uteke/releases" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Releases</a> — available for Linux (x64/ARM64), macOS (Apple Silicon), and Windows (x64).</p>
 
 	<h2 id="first-memory" class="text-xl font-semibold text-[var(--color-text)]">Your First Memory</h2>
 
@@ -21,14 +21,36 @@ uteke remember --tags project "My app uses SvelteKit 5 with Tailwind"
 # Recall by meaning (semantic search)
 uteke recall "What frontend framework do I use?"
 
-# Text search
-uteke search "SvelteKit"
+# Text search with tag filter
+uteke search "SvelteKit" --tags project
 
 # List all memories
 uteke list
 
 # Check system health
 uteke doctor</code></pre>
+
+	<h2 id="tags" class="text-xl font-semibold text-[var(--color-text)]">Tag Management</h2>
+
+	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># List all tags with usage counts
+uteke tags list --by-count
+
+# Rename a tag across all memories
+uteke tags rename old-name new-name
+
+# Delete a tag from all memories
+uteke tags delete unused-tag</code></pre>
+
+	<h2 id="aging" class="text-xl font-semibold text-[var(--color-text)]">Memory Aging</h2>
+
+	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># Show hot/warm/cold/never-accessed breakdown
+uteke aging status
+
+# Preview memories older than 90 days
+uteke aging preview --days 90
+
+# Delete stale memories older than 180 days
+uteke aging cleanup --days 180 --confirm</code></pre>
 
 	<h2 id="multi-agent" class="text-xl font-semibold text-[var(--color-text)]">Multi-Agent Isolation</h2>
 
@@ -44,15 +66,25 @@ uteke --namespace dev remember "Database connection string: postgres://localhost
 uteke --namespace architect recall "database"
 uteke --namespace dev recall "database"</code></pre>
 
+	<h2 id="shell-hooks" class="text-xl font-semibold text-[var(--color-text)]">Shell Hooks</h2>
+
+	<p>Auto-load project-scoped memory when you cd into a project directory:</p>
+
+	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># Install hook for your shell
+uteke hook install bash   # or zsh, fish
+
+# Now when you cd into a project with .uteke/uteke.db,
+# uteke auto-discovers it</code></pre>
+
 	<h2 id="export-import" class="text-xl font-semibold text-[var(--color-text)]">Export & Import</h2>
 
 	<p>Port your memories anywhere:</p>
 
 	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># Export to JSONL (no embeddings — small, portable)
-uteke export --output memories.jsonl
+uteke export > memories.jsonl
 
 # Import on another machine
-uteke import --input memories.jsonl</code></pre>
+uteke import memories.jsonl</code></pre>
 
 	<h2 id="troubleshooting" class="text-xl font-semibold text-[var(--color-text)]">Troubleshooting</h2>
 
@@ -72,10 +104,13 @@ uteke repair</code></pre>
 	<p>All data lives in <code class="px-1.5 py-0.5 rounded bg-[var(--color-surface)] border border-[var(--color-border)] text-xs">~/.uteke/</code>:</p>
 
 	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>~/.uteke/
-├── uteke.db          # SQLite (memories + metadata)
-├── embeddings/       # Vector index
-├── model/            # Local ONNX embedding model
-└── uteke.log         # Rotated logs</code></pre>
+├── uteke.db                    # SQLite (memories + metadata)
+├── uteke_index.usearch         # Persistent vector index
+├── uteke_index.keys            # Index key mapping
+├── models/embeddinggemma/      # Local ONNX embedding model
+└── logs/
+    ├── uteke.log               # Current log
+    └── uteke.log.YYYY-MM-DD    # Rotated logs</code></pre>
 
 	<p>Copy the entire folder to back up or transfer to another machine.</p>
 </div>

--- a/website/src/routes/docs/cli-reference/+page.svelte
+++ b/website/src/routes/docs/cli-reference/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	const globalFlags = [
+		{ flag: '--store <path>', desc: 'Override store location', def: '~/.uteke' },
+		{ flag: '--namespace <name>', desc: 'Namespace for multi-agent isolation', def: 'default' },
+		{ flag: '--config <path>', desc: 'Override config file path', def: 'auto-resolved' },
+		{ flag: '--json', desc: 'Output as JSON', def: 'off' },
+		{ flag: '--verbose', desc: 'Enable debug logging', def: 'off' },
+	];
+
+	const rememberFlags = [
+		{ f: '--tags <tags>', d: 'Comma-separated tags' },
+		{ f: '--metadata <json>', d: 'Arbitrary JSON metadata' },
+		{ f: '--json', d: 'Output stored memory as JSON' },
+	];
+
+	const recallFlags = [
+		{ f: '--limit <n>', d: 'Max results (default: 5)' },
+		{ f: '--json', d: 'Output as JSON array' },
+	];
+
+	const searchFlags = [
+		{ f: '--tags <tags>', d: 'Filter by comma-separated tags' },
+		{ f: '--limit <n>', d: 'Max results (default: 20)' },
+		{ f: '--json', d: 'Output as JSON' },
+	];
+
+	const listFlags = [
+		{ f: '--tag <tag>', d: 'Filter by single tag' },
+		{ f: '--limit <n>', d: 'Max results (default: 20)' },
+		{ f: '--offset <n>', d: 'Skip first N results' },
+		{ f: '--json', d: 'Output as JSON' },
+	];
+
+	const otherCommands = [
+		{ c: 'uteke get <id>', d: 'Retrieve a single memory by UUID' },
+		{ c: 'uteke forget <id>', d: 'Delete a memory by UUID' },
+		{ c: 'uteke stats', d: 'Show store statistics with tier breakdown' },
+		{ c: 'uteke export', d: 'Export memories to JSONL (no embeddings)' },
+		{ c: 'uteke import <file>', d: 'Import memories from JSONL' },
+		{ c: 'uteke doctor', d: 'Health check (DB, index, model, consistency)' },
+		{ c: 'uteke verify', d: 'Verify DB and index consistency' },
+		{ c: 'uteke repair', d: 'Rebuild index from SQLite' },
+		{ c: 'uteke hook install <shell>', d: 'Install shell hook (bash/zsh/fish)' },
+		{ c: 'uteke completions <shell>', d: 'Generate shell completions' },
+	];
+</script>
+
+<svelte:head>
+	<title>CLI Reference — Uteke Docs</title>
+</svelte:head>
+
+<h1 class="text-3xl font-bold mb-6">CLI Reference</h1>
+
+<p class="text-[var(--color-text-muted)] mb-8">Complete reference for all uteke commands. Version <strong>0.0.3</strong>.</p>
+
+<div class="space-y-10 text-[var(--color-text-muted)] leading-relaxed">
+
+	<!-- Global Flags -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Global Flags</h2>
+		<div class="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead>
+					<tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+						<th class="text-left px-4 py-2 font-medium">Flag</th>
+						<th class="text-left px-4 py-2 font-medium">Description</th>
+						<th class="text-left px-4 py-2 font-medium">Default</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each globalFlags as row}
+						<tr class="border-b border-[var(--color-border)]">
+							<td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{row.flag}</td>
+							<td class="px-4 py-2">{row.desc}</td>
+							<td class="px-4 py-2 text-[var(--color-text-dim)]">{row.def}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- remember -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">uteke remember</h2>
+		<p class="mb-3">Store a new memory with optional tags and metadata.</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>uteke remember "Deploy v2.1 to staging Friday" --tags deploy,staging
+uteke remember "API key for prod" --tags secret
+uteke remember "User prefers dark mode" --tags pref --namespace my-agent</code></pre>
+		<div class="mt-3 overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Flag</th><th class="text-left px-4 py-2 font-medium">Description</th></tr></thead>
+				<tbody>
+					{#each rememberFlags as r}
+						<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{r.f}</td><td class="px-4 py-2">{r.d}</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- recall -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">uteke recall</h2>
+		<p class="mb-3">Semantic search using vector similarity. Hot memories (accessed within 7 days) get a score boost.</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>uteke recall "What framework does the API use?"
+uteke recall "deployment" --limit 10
+uteke recall "database config" --namespace hermes --json</code></pre>
+		<div class="mt-3 overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Flag</th><th class="text-left px-4 py-2 font-medium">Description</th></tr></thead>
+				<tbody>
+					{#each recallFlags as r}
+						<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{r.f}</td><td class="px-4 py-2">{r.d}</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- search -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">uteke search</h2>
+		<p class="mb-3">Keyword text search with tag filtering.</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>uteke search "monorepo"
+uteke search "deploy" --tags staging,prod --limit 20
+uteke search "api" --namespace backend --json</code></pre>
+		<div class="mt-3 overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Flag</th><th class="text-left px-4 py-2 font-medium">Description</th></tr></thead>
+				<tbody>
+					{#each searchFlags as r}
+						<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{r.f}</td><td class="px-4 py-2">{r.d}</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- list -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">uteke list</h2>
+		<p class="mb-3">List memories with optional tag filter and pagination.</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>uteke list --limit 20
+uteke list --tag deploy --offset 10 --json
+uteke list --namespace hermes</code></pre>
+		<div class="mt-3 overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Flag</th><th class="text-left px-4 py-2 font-medium">Description</th></tr></thead>
+				<tbody>
+					{#each listFlags as r}
+						<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{r.f}</td><td class="px-4 py-2">{r.d}</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- tags -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">uteke tags</h2>
+		<p class="mb-3">Manage tags across all memories.</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># List all tags with counts
+uteke tags list --by-count
+
+# Rename a tag
+uteke tags rename old-tag new-tag
+
+# Delete a tag from all memories
+uteke tags delete unused-tag</code></pre>
+	</section>
+
+	<!-- aging -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">uteke aging</h2>
+		<p class="mb-3">Memory aging management with auto-cleanup.</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># Show hot/warm/cold breakdown
+uteke aging status
+
+# Preview memories older than 90 days
+uteke aging preview --days 90
+
+# Delete memories older than 180 days
+uteke aging cleanup --days 180 --confirm</code></pre>
+	</section>
+
+	<!-- Other commands -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Other Commands</h2>
+		<div class="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Command</th><th class="text-left px-4 py-2 font-medium">Description</th></tr></thead>
+				<tbody>
+					{#each otherCommands as r}
+						<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{r.c}</td><td class="px-4 py-2">{r.d}</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>

--- a/website/src/routes/docs/configuration/+page.svelte
+++ b/website/src/routes/docs/configuration/+page.svelte
@@ -1,0 +1,87 @@
+<svelte:head>
+	<title>Configuration — Uteke Docs</title>
+</svelte:head>
+
+<h1 class="text-3xl font-bold mb-6">Configuration</h1>
+
+<p class="text-[var(--color-text-muted)] mb-8">Uteke supports <code class="px-1.5 py-0.5 rounded bg-[var(--color-surface)] border border-[var(--color-border)] text-xs">uteke.toml</code> configuration with layered resolution.</p>
+
+<div class="space-y-10 text-[var(--color-text-muted)] leading-relaxed">
+
+	<!-- Resolution Order -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Resolution Order</h2>
+		<p class="mb-4">Uteke searches for config in this order. First match wins:</p>
+		<div class="space-y-2">
+			{#each [
+				{ n: '1', path: './uteke.toml', desc: 'Current directory' },
+				{ n: '2', path: '../uteke.toml', desc: 'Parent directories (walks up to root)' },
+				{ n: '3', path: '~/.config/uteke/uteke.toml', desc: 'User-level config' },
+				{ n: '4', path: '(built-in defaults)', desc: 'Hardcoded defaults' },
+			] as item}
+				<div class="flex items-start gap-3 px-4 py-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+					<span class="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--color-accent-dim)] flex items-center justify-center text-xs font-bold text-[var(--color-accent)]">{item.n}</span>
+					<div>
+						<code class="text-sm text-[var(--color-accent)]">{item.path}</code>
+						<p class="text-xs text-[var(--color-text-dim)] mt-0.5">{item.desc}</p>
+					</div>
+				</div>
+			{/each}
+		</div>
+		<p class="mt-3 text-sm">Override the config file path with the <code class="px-1.5 py-0.5 rounded bg-[var(--color-surface)] border border-[var(--color-border)] text-xs">--config</code> flag.</p>
+	</section>
+
+	<!-- Config File -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Config File Format</h2>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># uteke.toml
+
+# Store location (default: ~/.uteke)
+store_path = "~/.uteke"
+
+# Log level: trace, debug, info, warn, error
+log_level = "info"
+
+# Log directory (default: ~/.uteke/logs)
+log_dir = "~/.uteke/logs"
+
+# Default namespace (default: "default")
+default_namespace = "default"</code></pre>
+	</section>
+
+	<!-- Examples -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Per-Project Config</h2>
+		<p class="mb-3">Place a <code class="px-1.5 py-0.5 rounded bg-[var(--color-surface)] border border-[var(--color-border)] text-xs">uteke.toml</code> in your project root to override defaults for that project:</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># my-project/uteke.toml
+store_path = "./.uteke"
+default_namespace = "my-project"
+log_level = "warn"</code></pre>
+		<p class="mt-3 text-sm">Combined with shell hooks, this enables automatic project-scoped memory — each project gets its own isolated memory store.</p>
+	</section>
+
+	<!-- Environment Variables -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">CLI Flag Override</h2>
+		<p class="mb-3">CLI flags always take precedence over config file values:</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># Override store path
+uteke --store /path/to/project/.uteke remember "project note"
+
+# Override config file
+uteke --config ./my-config.toml stats
+
+# Override namespace
+uteke --namespace agent-1 recall "context"</code></pre>
+	</section>
+
+	<!-- File Logging -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">File Logging</h2>
+		<p class="mb-3">Logs are written to <code class="px-1.5 py-0.5 rounded bg-[var(--color-surface)] border border-[var(--color-border)] text-xs">~/.uteke/logs/uteke.log</code> with daily rotation:</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>~/.uteke/logs/
+├── uteke.log              # Current log
+├── uteke.log.2026-05-29   # Yesterday's log
+└── uteke.log.2026-05-28   # Two days ago</code></pre>
+		<p class="mt-3 text-sm">Non-blocking async writer — logging never blocks memory operations. Rotated files are kept until manually deleted.</p>
+	</section>
+</div>

--- a/website/src/routes/docs/multi-agent/+page.svelte
+++ b/website/src/routes/docs/multi-agent/+page.svelte
@@ -1,0 +1,113 @@
+<svelte:head>
+	<title>Multi-Agent — Uteke Docs</title>
+</svelte:head>
+
+<h1 class="text-3xl font-bold mb-6">Multi-Agent Isolation</h1>
+
+<p class="text-[var(--color-text-muted)] mb-8">Uteke provides first-class namespace support for running multiple AI agents, each with fully isolated memory.</p>
+
+<div class="space-y-10 text-[var(--color-text-muted)] leading-relaxed">
+
+	<!-- Concept -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">How Namespaces Work</h2>
+		<p class="mb-3">Every memory belongs to exactly one namespace. Namespaces are fully isolated — a recall in one namespace never returns results from another.</p>
+		<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+			{#each [
+				{ name: 'default', desc: 'Used when no --namespace flag is provided. Backward compatible with v0.0.1 databases.' },
+				{ name: 'hermes', desc: 'Example: a planning agent that remembers architecture decisions.' },
+				{ name: 'pi-agent', desc: 'Example: a coding agent that remembers project-specific context.' },
+			] as ns}
+				<div class="px-4 py-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+					<code class="text-sm text-[var(--color-accent)]">{ns.name}</code>
+					<p class="text-xs text-[var(--color-text-dim)] mt-1">{ns.desc}</p>
+				</div>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Usage -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Usage</h2>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code># Agent "architect" stores its context
+uteke --namespace architect remember "We chose PostgreSQL for ACID compliance" --tags db,decision
+
+# Agent "dev" has its own separate memory
+uteke --namespace dev remember "Database connection string: postgres://localhost:5432/app" --tags db,config
+
+# Each only sees its own memories
+uteke --namespace architect recall "database"
+# → Finds "We chose PostgreSQL for ACID compliance"
+
+uteke --namespace dev recall "database"
+# → Finds "Database connection string: postgres://localhost:5432/app"
+
+# Without --namespace, uses "default"
+uteke remember "General knowledge" --tags misc</code></pre>
+	</section>
+
+	<!-- Auto-migration -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Auto-Migration</h2>
+		<p class="mb-3">Existing databases from v0.0.1 are automatically migrated on first run:</p>
+		<div class="space-y-2">
+			{#each [
+				'namespace column added to SQLite',
+				'All existing memories assigned to "default" namespace',
+				'Zero data loss — your memories are preserved',
+			] as item}
+				<div class="flex items-center gap-2">
+					<span class="text-[var(--color-success)]">✓</span>
+					<span class="text-sm">{item}</span>
+				</div>
+			{/each}
+		</div>
+	</section>
+
+	<!-- All commands scoped -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">All Commands Are Scoped</h2>
+		<p class="mb-3">The <code class="px-1.5 py-0.5 rounded bg-[var(--color-surface)] border border-[var(--color-border)] text-xs">--namespace</code> flag works on every command:</p>
+		<div class="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Command</th><th class="text-left px-4 py-2 font-medium">Scoped Behavior</th></tr></thead>
+				<tbody>
+					{#each [
+						{c:'remember',d:'Store in namespace'},
+						{c:'recall',d:'Search within namespace'},
+						{c:'search',d:'Text search within namespace'},
+						{c:'list',d:'List memories in namespace'},
+						{c:'tags list',d:'Tags for namespace'},
+						{c:'tags rename',d:'Rename tag in namespace'},
+						{c:'tags delete',d:'Delete tag in namespace'},
+						{c:'aging status',d:'Aging breakdown for namespace'},
+						{c:'aging cleanup',d:'Cleanup in namespace'},
+						{c:'stats',d:'Statistics for namespace'},
+						{c:'export',d:'Export from namespace'},
+						{c:'import',d:'Import to namespace'},
+					] as r}
+						<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">{r.c}</td><td class="px-4 py-2">{r.d}</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- Best Practices -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Best Practices</h2>
+		<div class="space-y-4">
+			{#each [
+				{ title: 'One namespace per agent role', desc: 'Use descriptive names like "planner", "coder", "reviewer" instead of "agent-1", "agent-2".' },
+				{ title: 'Use config files for defaults', desc: 'Set default_namespace in uteke.toml per project so agents don\'t need --namespace on every call.' },
+				{ title: 'Shell hooks for project isolation', desc: 'Install shell hooks (uteke hook install) to auto-discover .uteke/ in parent directories — each project gets isolated memory.' },
+				{ title: 'Export for backup', desc: 'uteke export --namespace my-agent > backup.jsonl — backup per-agent memory independently.' },
+			] as bp}
+				<div class="px-4 py-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+					<p class="text-sm font-medium text-[var(--color-text)]">{bp.title}</p>
+					<p class="text-xs text-[var(--color-text-dim)] mt-1">{bp.desc}</p>
+				</div>
+			{/each}
+		</div>
+	</section>
+</div>

--- a/website/src/routes/docs/roadmap/+page.svelte
+++ b/website/src/routes/docs/roadmap/+page.svelte
@@ -7,74 +7,81 @@
 <p class="text-[var(--color-text-muted)] mb-10">Track our progress on <a href="https://github.com/ajianaz/uteke/issues" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Issues</a>.</p>
 
 <div class="space-y-10">
-	<!-- P1 Core -->
+
+	<!-- Completed v0.0.2 -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-red-500/20 text-red-400">P1</span>
-			Core Memory
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">v0.0.2</span>
+			Core Engine
 		</h2>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Tag-based filtering and management', issue: 42, status: 'open' },
+				{ title: 'Persistent vector index (usearch)', issue: 40, status: 'done' },
+				{ title: 'Multi-agent namespaces', issue: 39, status: 'done' },
+				{ title: 'Tiered memory (Hot/Warm/Cold)', issue: 38, status: 'done' },
+				{ title: 'Health checks (doctor, verify, repair)', issue: 37, status: 'done' },
+				{ title: 'Website (landing + docs)', issue: 53, status: 'done' },
+			] as item}
+				<a
+					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+					target="_blank"
+					rel="noopener"
+					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+				>
+					<div class="flex items-center gap-3">
+						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+						<span class="text-sm">{item.title}</span>
+					</div>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
+				</a>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Completed v0.0.3 -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">v0.0.3</span>
+			Tag Management & Operations
+		</h2>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Tag-based filtering and management', issue: 42, status: 'done' },
+				{ title: 'Memory aging with auto-cleanup', issue: 44, status: 'done' },
+				{ title: 'Shell hook for auto-context loading', issue: 47, status: 'done' },
+				{ title: 'Configuration file (uteke.toml)', issue: 48, status: 'done' },
+				{ title: 'Graceful shutdown (SIGINT handler)', issue: 31, status: 'done' },
+				{ title: 'File logging with daily rotation', issue: 32, status: 'done' },
+				{ title: 'Upgrade Node.js 20→24 in CI', issue: 41, status: 'done' },
+			] as item}
+				<a
+					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+					target="_blank"
+					rel="noopener"
+					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+				>
+					<div class="flex items-center gap-3">
+						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+						<span class="text-sm">{item.title}</span>
+					</div>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
+				</a>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Next -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-amber-500/20 text-amber-400">Next</span>
+			Operations & Performance
+		</h2>
+		<div class="space-y-3">
+			{#each [
 				{ title: 'Bulk memory operations', issue: 43, status: 'open' },
-				{ title: 'Memory aging with auto-cleanup policy', issue: 44, status: 'open' },
-				{ title: 'Smooth namespace switching and defaults', issue: 45, status: 'open' }
-			] as item}
-				<a
-					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
-					target="_blank"
-					rel="noopener"
-					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors group"
-				>
-					<div class="flex items-center gap-3">
-						<span class="text-xs text-[var(--color-text-muted)] font-mono">#{item.issue}</span>
-						<span class="text-sm">{item.title}</span>
-					</div>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-yellow-500/20 text-yellow-400">Open</span>
-				</a>
-			{/each}
-		</div>
-	</section>
-
-	<!-- P2 Intelligence -->
-	<section>
-		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-yellow-500/20 text-yellow-400">P2</span>
-			Intelligence
-		</h2>
-		<div class="space-y-3">
-			{#each [
-				{ title: 'Adopt Supermemory auto-forget & temporal facts', issue: 51, status: 'open' },
-				{ title: 'Adopt MCP Memory knowledge graph & consolidation', issue: 52, status: 'open' },
-				{ title: 'Import from external knowledge sources', issue: 46, status: 'open' }
-			] as item}
-				<a
-					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
-					target="_blank"
-					rel="noopener"
-					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
-				>
-					<div class="flex items-center gap-3">
-						<span class="text-xs text-[var(--color-text-muted)] font-mono">#{item.issue}</span>
-						<span class="text-sm">{item.title}</span>
-					</div>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-yellow-500/20 text-yellow-400">Open</span>
-				</a>
-			{/each}
-		</div>
-	</section>
-
-	<!-- Infrastructure -->
-	<section>
-		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-500/20 text-blue-400">INFRA</span>
-			Infrastructure
-		</h2>
-		<div class="space-y-3">
-			{#each [
+				{ title: 'Smooth namespace switching and defaults', issue: 45, status: 'open' },
+				{ title: 'Benchmark and performance metrics', issue: 49, status: 'open' },
 				{ title: 'Daemon/server mode for warm recall (<50ms)', issue: 54, status: 'open' },
-				{ title: 'Hermes plugin for uteke integration (optional)', issue: 55, status: 'open' },
-				{ title: 'uteke website (landing + docs + blog)', issue: 53, status: 'in-progress' }
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -83,29 +90,27 @@
 					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
 				>
 					<div class="flex items-center gap-3">
-						<span class="text-xs text-[var(--color-text-muted)] font-mono">#{item.issue}</span>
+						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
 						<span class="text-sm">{item.title}</span>
 					</div>
-					<span class="text-xs px-2 py-0.5 rounded-full {item.status === 'in-progress'
-						? 'bg-cyan-500/20 text-cyan-400'
-						: 'bg-yellow-500/20 text-yellow-400'
-					}">{item.status === 'in-progress' ? 'In Progress' : 'Open'}</span>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400">Open</span>
 				</a>
 			{/each}
 		</div>
 	</section>
 
-	<!-- DX -->
+	<!-- Future -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">DX</span>
-			Developer Experience
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-500/20 text-blue-400">Future</span>
+			Intelligence & Integrations
 		</h2>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Shell hook for auto-context loading', issue: 47, status: 'open' },
-				{ title: 'Configuration file (uteke.toml)', issue: 48, status: 'open' },
-				{ title: 'Benchmark and performance metrics', issue: 49, status: 'open' }
+				{ title: 'Import from external knowledge sources', issue: 46, status: 'open' },
+				{ title: 'Adopt MCP Memory Service knowledge graph', issue: 52, status: 'open' },
+				{ title: 'Adopt Supermemory auto-forget & temporal facts', issue: 51, status: 'open' },
+				{ title: 'Hermes plugin for uteke integration', issue: 55, status: 'open' },
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -114,10 +119,10 @@
 					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
 				>
 					<div class="flex items-center gap-3">
-						<span class="text-xs text-[var(--color-text-muted)] font-mono">#{item.issue}</span>
+						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
 						<span class="text-sm">{item.title}</span>
 					</div>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-yellow-500/20 text-yellow-400">Open</span>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400">Open</span>
 				</a>
 			{/each}
 		</div>


### PR DESCRIPTION
## Changes

### Bug Fixes
- **404 pages fixed** — Created missing docs pages that were linked in sidebar:
  - `/docs/cli-reference` — Complete CLI reference with all commands and flags
  - `/docs/configuration` — uteke.toml layered resolution docs
  - `/docs/multi-agent` — Namespace isolation documentation
- **Docs layout** — Fixed Svelte 5 `{@render}` syntax (was using `<slot>`)
- **CI warning** — Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to deploy workflow

### Content Updates
- **Getting Started** — Added sections for tags, aging, shell hooks
- **Roadmap** — Marked v0.0.2 (5 issues) and v0.0.3 (7 issues) as done, reorganized remaining into Next/Future
- **Docs sidebar** — Added version badge (v0.0.3)