### PR TITLE
feat: bulk memory operations (#43)

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -299,7 +299,19 @@ enum Commands {
     /// Delete a memory by ID
     Forget {
         /// Memory ID (UUID)
-        id: String,
+        id: Option<String>,
+        /// Delete all memories with this tag
+        #[arg(long)]
+        tag: Option<String>,
+        /// Delete all cold (not accessed in 30+ days) memories
+        #[arg(long)]
+        cold: bool,
+        /// Delete ALL memories in namespace (requires --confirm)
+        #[arg(long)]
+        all: bool,
+        /// Confirm destructive operations
+        #[arg(long)]
+        confirm: bool,
     },
     /// Show memory store statistics
     Stats,
@@ -765,16 +777,87 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             }
             Ok(())
         }
-        Commands::Forget { id } => {
-            tracing::info!("Forgetting memory: {id}");
-            uteke
-                .forget(id)
-                .map_err(|e| format!("Failed to delete memory: {e}"))?;
-            if cli.json {
-                let obj = serde_json::json!({"forgotten": id});
-                println!("{}", obj);
+        Commands::Forget {
+            id,
+            tag,
+            cold,
+            all,
+            confirm,
+        } => {
+            if let Some(id) = id {
+                // Single delete — confirm if no --confirm flag
+                if !confirm {
+                    println!("About to delete memory: {id}");
+                    print!("Are you sure? [y/N] ");
+                    io::Write::flush(&mut io::stdout()).ok();
+                    let mut input = String::new();
+                    io::stdin().read_line(&mut input).ok();
+                    if !input.trim().eq_ignore_ascii_case("y") {
+                        println!("Cancelled.");
+                        return Ok(());
+                    }
+                }
+                tracing::info!("Forgetting memory: {id}");
+                uteke
+                    .forget(id.as_str())
+                    .map_err(|e| format!("Failed to delete memory: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"forgotten": id}));
+                } else {
+                    println!("✓ Memory forgotten: {id}");
+                }
+            } else if let Some(tag) = tag {
+                // Bulk delete by tag
+                tracing::info!("Bulk forgetting by tag: {tag}");
+                let ns = cli.namespace.as_deref();
+                let count = uteke.store().count_by_tag(tag.as_str(), ns).unwrap_or(0);
+                if !confirm && count > 0 {
+                    println!("Found {count} memories with tag '{tag}'. Use --confirm to delete.");
+                    return Ok(());
+                }
+                let result = uteke
+                    .bulk_forget_by_tag(tag.as_str(), ns)
+                    .map_err(|e| format!("Failed: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
+                } else {
+                    println!("✓ Deleted {} memories with tag '{}'", result.deleted, tag);
+                }
+            } else if *cold {
+                // Bulk delete cold memories
+                tracing::info!("Bulk forgetting cold memories");
+                let ns = cli.namespace.as_deref();
+                if !confirm {
+                    println!("This will delete all cold memories (>30 days or never accessed).");
+                    println!("Use --confirm to proceed.");
+                    return Ok(());
+                }
+                let result = uteke
+                    .bulk_forget_cold(ns)
+                    .map_err(|e| format!("Failed: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
+                } else {
+                    println!("✓ Deleted {} cold memories", result.deleted);
+                }
+            } else if *all {
+                // Delete all in namespace
+                tracing::info!("Bulk forgetting all memories");
+                if !confirm {
+                    println!("⚠️  This will delete ALL memories in the namespace.");
+                    println!("Use --confirm to proceed.");
+                    return Ok(());
+                }
+                let result = uteke
+                    .bulk_forget_all(cli.namespace.as_deref())
+                    .map_err(|e| format!("Failed: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
+                } else {
+                    println!("✓ Deleted {} memories", result.deleted);
+                }
             } else {
-                println!("✓ Memory forgotten: {id}");
+                return Err("Provide an ID, --tag, --cold, or --all".into());
             }
             Ok(())
         }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -13,8 +13,8 @@ mod embed;
 pub mod memory;
 
 pub use memory::types::{
-    AgingStatus, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier, SearchResult,
-    StoreStats, TagInfo, DEFAULT_NAMESPACE,
+    AgingStatus, BulkDeleteResult, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier,
+    SearchResult, StoreStats, TagInfo, DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -268,6 +268,61 @@ impl Uteke {
         Ok(())
     }
 
+    /// Bulk delete memories by tag. Also removes from index.
+    pub fn bulk_forget_by_tag(
+        &self,
+        tag: &str,
+        namespace: Option<&str>,
+    ) -> Result<BulkDeleteResult, Error> {
+        let ids = self.store.bulk_delete_by_tag(tag, namespace)?;
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        for id in &ids {
+            index.remove(id);
+        }
+        index.save().ok();
+        Ok(BulkDeleteResult {
+            deleted: ids.len(),
+            ids,
+        })
+    }
+
+    /// Bulk delete all cold memories. Also removes from index.
+    pub fn bulk_forget_cold(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
+        let ids = self.store.bulk_delete_cold(namespace)?;
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        for id in &ids {
+            index.remove(id);
+        }
+        index.save().ok();
+        Ok(BulkDeleteResult {
+            deleted: ids.len(),
+            ids,
+        })
+    }
+
+    /// Bulk delete all memories in a namespace. Also removes from index.
+    pub fn bulk_forget_all(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
+        let ids = self.store.bulk_delete_all(namespace)?;
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        for id in &ids {
+            index.remove(id);
+        }
+        index.save().ok();
+        Ok(BulkDeleteResult {
+            deleted: ids.len(),
+            ids,
+        })
+    }
+
     /// List memories with optional tag filter and pagination.
     pub fn list(
         &self,
@@ -438,6 +493,11 @@ impl Uteke {
     }
 
     /// Get statistics about the memory store.
+    /// Access the underlying store (read-only reference).
+    pub fn store(&self) -> &Store {
+        &self.store
+    }
+
     pub fn stats(&self, namespace: Option<&str>) -> Result<StoreStats, Error> {
         let total_memories = self.store.count(namespace)?;
         let unique_tags = self.store.unique_tags(namespace)?.len();

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -625,9 +625,83 @@ impl Store {
 
         Ok((hot, warm, cold))
     }
-}
 
-/// Serialize an embedding vector to a byte blob.
+    /// Bulk delete memories by tag within a namespace.
+    pub fn bulk_delete_by_tag(
+        &self,
+        tag: &str,
+        namespace: Option<&str>,
+    ) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        let ids: Vec<String> = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .map_err(|e| Error::Database(e.to_string()))?
+            .query_map(rusqlite::params![ns, pattern], |row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+        for id in &ids {
+            self.conn
+                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        Ok(ids)
+    }
+
+    /// Bulk delete all cold memories (not accessed in 30+ days or never accessed).
+    pub fn bulk_delete_cold(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let warm_cutoff = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
+        let ids: Vec<String> = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)")
+            .map_err(|e| Error::Database(e.to_string()))?
+            .query_map(rusqlite::params![ns, warm_cutoff], |row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+        for id in &ids {
+            self.conn
+                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        Ok(ids)
+    }
+
+    /// Bulk delete all memories in a namespace.
+    pub fn bulk_delete_all(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let ids: Vec<String> = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1")
+            .map_err(|e| Error::Database(e.to_string()))?
+            .query_map(rusqlite::params![ns], |row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+        for id in &ids {
+            self.conn
+                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        Ok(ids)
+    }
+
+    /// Count memories by tag in a namespace.
+    pub fn count_by_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
+                rusqlite::params![ns, pattern],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))
+    }
+}
 fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
     let mut blob = Vec::with_capacity(embedding.len() * 4);
     for &val in embedding {

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -91,6 +91,15 @@ pub struct StoreStats {
     pub cold: usize,
 }
 
+/// Result of a bulk delete operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkDeleteResult {
+    /// Number of memories deleted.
+    pub deleted: usize,
+    /// IDs of deleted memories.
+    pub ids: Vec<String>,
+}
+
 /// Lightweight export format — no embedding vector (re-embedded on import).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportEntry {


### PR DESCRIPTION
## Changes

Implements #43 — bulk memory operations for store maintenance.

### New Commands
```bash
uteke forget <id>              # Now prompts: Are you sure? [y/N]
uteke forget --tag ci          # Delete all memories tagged "ci"  
uteke forget --cold            # Delete cold memories (>30d / never accessed)
uteke forget --all             # Delete ALL in namespace
```

All bulk ops require `--confirm` flag. Without it, shows preview/warning.

### New Types
- `BulkDeleteResult { deleted: usize, ids: Vec<String> }`

### Store Methods
- `bulk_delete_by_tag(tag, namespace)`
- `bulk_delete_cold(namespace)`
- `bulk_delete_all(namespace)`
- `count_by_tag(tag, namespace)`

### Verification
- [x] `cargo check` ✓
- [x] `cargo clippy -D warnings` ✓
- [x] `cargo test` — 15/15 ✓
- [x] `cargo fmt` ✓
- [x] Manual test: single delete confirms, --cold/--all show preview, --tag works