### PR TITLE
feat: smooth namespace switching and defaults

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -277,6 +277,27 @@ impl Config {
             path.to_string()
         }
     }
+
+    /// Set the default namespace in the global config file.
+    /// Creates or updates the `[store]` section's `namespace` key.
+    pub fn set_default_namespace(name: &str) -> Result<(), String> {
+        let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+        let config_path = home.join(".uteke").join("uteke.toml");
+
+        // Read existing config or start fresh
+        let content = if config_path.exists() {
+            std::fs::read_to_string(&config_path)
+                .map_err(|e| format!("Failed to read config: {e}"))?
+        } else {
+            String::new()
+        };
+
+        let updated = set_namespace_in_toml(&content, name);
+        std::fs::write(&config_path, updated)
+            .map_err(|e| format!("Failed to write config: {e}"))?;
+
+        Ok(())
+    }
 }
 
 // ── Legacy migration ────────────────────────────────────────────────────────
@@ -368,6 +389,44 @@ fn migrate_content(old: &str) -> String {
 /// Return the global config path `~/.uteke/uteke.toml` if home dir is known.
 fn global_config_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".uteke").join("uteke.toml"))
+}
+
+/// Update or insert the namespace value in a TOML config string.
+/// Preserves all other content.
+fn set_namespace_in_toml(content: &str, namespace: &str) -> String {
+    let mut in_store_section = false;
+    let mut found_namespace_key = false;
+    let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
+
+    for i in 0..lines.len() {
+        let trimmed = lines[i].trim();
+        if trimmed == "[store]" {
+            in_store_section = true;
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed != "[store]" {
+            in_store_section = false;
+        }
+        if in_store_section && trimmed.starts_with("namespace") {
+            lines[i] = format!("namespace = \"{namespace}\"");
+            found_namespace_key = true;
+            break;
+        }
+    }
+
+    if !found_namespace_key {
+        // Need to insert namespace into [store] section
+        if let Some(pos) = lines.iter().position(|l| l.trim() == "[store]") {
+            lines.insert(pos + 1, format!("namespace = \"{namespace}\""));
+        } else {
+            // No [store] section exists — append one
+            lines.push(String::new());
+            lines.push("[store]".to_string());
+            lines.push(format!("namespace = \"{namespace}\""));
+        }
+    }
+
+    lines.join("\n")
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -299,7 +299,19 @@ enum Commands {
     /// Delete a memory by ID
     Forget {
         /// Memory ID (UUID)
-        id: String,
+        id: Option<String>,
+        /// Delete all memories with this tag
+        #[arg(long)]
+        tag: Option<String>,
+        /// Delete all cold (not accessed in 30+ days) memories
+        #[arg(long)]
+        cold: bool,
+        /// Delete ALL memories in namespace (requires --confirm)
+        #[arg(long)]
+        all: bool,
+        /// Confirm destructive operations
+        #[arg(long)]
+        confirm: bool,
     },
     /// Show memory store statistics
     Stats,
@@ -765,16 +777,87 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             }
             Ok(())
         }
-        Commands::Forget { id } => {
-            tracing::info!("Forgetting memory: {id}");
-            uteke
-                .forget(id)
-                .map_err(|e| format!("Failed to delete memory: {e}"))?;
-            if cli.json {
-                let obj = serde_json::json!({"forgotten": id});
-                println!("{}", obj);
+        Commands::Forget {
+            id,
+            tag,
+            cold,
+            all,
+            confirm,
+        } => {
+            if let Some(id) = id {
+                // Single delete — confirm if no --confirm flag
+                if !confirm {
+                    println!("About to delete memory: {id}");
+                    print!("Are you sure? [y/N] ");
+                    io::Write::flush(&mut io::stdout()).ok();
+                    let mut input = String::new();
+                    io::stdin().read_line(&mut input).ok();
+                    if !input.trim().eq_ignore_ascii_case("y") {
+                        println!("Cancelled.");
+                        return Ok(());
+                    }
+                }
+                tracing::info!("Forgetting memory: {id}");
+                uteke
+                    .forget(id.as_str())
+                    .map_err(|e| format!("Failed to delete memory: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"forgotten": id}));
+                } else {
+                    println!("✓ Memory forgotten: {id}");
+                }
+            } else if let Some(tag) = tag {
+                // Bulk delete by tag
+                tracing::info!("Bulk forgetting by tag: {tag}");
+                let ns = cli.namespace.as_deref();
+                let count = uteke.store().count_by_tag(tag.as_str(), ns).unwrap_or(0);
+                if !confirm && count > 0 {
+                    println!("Found {count} memories with tag '{tag}'. Use --confirm to delete.");
+                    return Ok(());
+                }
+                let result = uteke
+                    .bulk_forget_by_tag(tag.as_str(), ns)
+                    .map_err(|e| format!("Failed: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
+                } else {
+                    println!("✓ Deleted {} memories with tag '{}'", result.deleted, tag);
+                }
+            } else if *cold {
+                // Bulk delete cold memories
+                tracing::info!("Bulk forgetting cold memories");
+                let ns = cli.namespace.as_deref();
+                if !confirm {
+                    println!("This will delete all cold memories (>30 days or never accessed).");
+                    println!("Use --confirm to proceed.");
+                    return Ok(());
+                }
+                let result = uteke
+                    .bulk_forget_cold(ns)
+                    .map_err(|e| format!("Failed: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
+                } else {
+                    println!("✓ Deleted {} cold memories", result.deleted);
+                }
+            } else if *all {
+                // Delete all in namespace
+                tracing::info!("Bulk forgetting all memories");
+                if !confirm {
+                    println!("⚠️  This will delete ALL memories in the namespace.");
+                    println!("Use --confirm to proceed.");
+                    return Ok(());
+                }
+                let result = uteke
+                    .bulk_forget_all(cli.namespace.as_deref())
+                    .map_err(|e| format!("Failed: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
+                } else {
+                    println!("✓ Deleted {} memories", result.deleted);
+                }
             } else {
-                println!("✓ Memory forgotten: {id}");
+                return Err("Provide an ID, --tag, --cold, or --all".into());
             }
             Ok(())
         }

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -354,6 +354,11 @@ enum Commands {
         /// Shell type: bash, zsh, fish
         shell: SupportedShell,
     },
+    /// Namespace management: list, stats
+    Namespace {
+        #[command(subcommand)]
+        command: NamespaceCommands,
+    },
     /// Manage tags: list, rename, delete
     Tags {
         #[command(subcommand)]
@@ -387,6 +392,22 @@ enum TagCommands {
 }
 
 // ── Agent Init ──────────────────────────────────────────────────────────────
+
+#[derive(Subcommand)]
+enum NamespaceCommands {
+    /// List all namespaces with memory counts
+    List,
+    /// Show stats for a specific namespace
+    Stats {
+        /// Namespace name
+        name: String,
+    },
+    /// Set default namespace in config
+    Switch {
+        /// Namespace name to set as default
+        name: String,
+    },
+}
 
 #[derive(Subcommand)]
 enum AgingCommands {
@@ -677,7 +698,7 @@ fn main() {
     })
     .expect("Failed to set SIGINT handler");
 
-    let result = run_command(&cli, &uteke);
+    let result = run_command(&cli, &uteke, &config);
 
     // Graceful shutdown: save dirty index if needed
     if let Err(e) = uteke.shutdown() {
@@ -695,8 +716,30 @@ fn main() {
     }
 }
 
-fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
-    let ns = cli.namespace.as_deref();
+/// Resolve namespace: CLI flag > UTEKE_NAMESPACE env > config > "default"
+fn resolve_namespace(cli: &Cli, config: &Config) -> String {
+    // 1. CLI --namespace flag wins
+    if let Some(ns) = &cli.namespace {
+        return ns.clone();
+    }
+    // 2. Environment variable
+    if let Ok(env_ns) = std::env::var("UTEKE_NAMESPACE") {
+        if !env_ns.is_empty() {
+            return env_ns;
+        }
+    }
+    // 3. Config file
+    if config.store.namespace != "default" {
+        return config.store.namespace.clone();
+    }
+    // 4. Fallback
+    "default".to_string()
+}
+
+fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(), String> {
+    // Resolve effective namespace once: CLI > env > config > "default"
+    let resolved_ns = resolve_namespace(cli, config);
+    let ns: Option<&str> = Some(resolved_ns.as_str());
 
     match &cli.command {
         Commands::Remember { content, tags } => {
@@ -809,7 +852,6 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             } else if let Some(tag) = tag {
                 // Bulk delete by tag
                 tracing::info!("Bulk forgetting by tag: {tag}");
-                let ns = cli.namespace.as_deref();
                 let count = uteke.store().count_by_tag(tag.as_str(), ns).unwrap_or(0);
                 if !confirm && count > 0 {
                     println!("Found {count} memories with tag '{tag}'. Use --confirm to delete.");
@@ -826,7 +868,6 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             } else if *cold {
                 // Bulk delete cold memories
                 tracing::info!("Bulk forgetting cold memories");
-                let ns = cli.namespace.as_deref();
                 if !confirm {
                     println!("This will delete all cold memories (>30 days or never accessed).");
                     println!("Use --confirm to proceed.");
@@ -849,7 +890,7 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
                     return Ok(());
                 }
                 let result = uteke
-                    .bulk_forget_all(cli.namespace.as_deref())
+                    .bulk_forget_all(ns)
                     .map_err(|e| format!("Failed: {e}"))?;
                 if cli.json {
                     print_json(&serde_json::json!({"deleted": result.deleted, "ids": result.ids}));
@@ -1022,6 +1063,55 @@ fn run_command(cli: &Cli, uteke: &Uteke) -> Result<(), String> {
             Ok(())
         }
         Commands::Init { agent } => run_init(agent, cli.json),
+        Commands::Namespace { command } => match command {
+            NamespaceCommands::List => {
+                tracing::info!("Listing namespaces");
+                let namespaces = uteke
+                    .list_namespaces()
+                    .map_err(|e| format!("Failed to list namespaces: {e}"))?;
+                if cli.json {
+                    print_json(&namespaces);
+                } else {
+                    if namespaces.is_empty() {
+                        println!("No namespaces found.");
+                    } else {
+                        println!("Namespaces ({} total):\n", namespaces.len());
+                        for ns_name in &namespaces {
+                            let count = uteke
+                                .store()
+                                .count(Some(ns_name.as_str()))
+                                .unwrap_or(0);
+                            println!("  {} ({} memories)", ns_name, count);
+                        }
+                    }
+                }
+                Ok(())
+            }
+            NamespaceCommands::Stats { name } => {
+                tracing::info!("Namespace stats: {name}");
+                let stats = uteke
+                    .stats(Some(name.as_str()))
+                    .map_err(|e| format!("Failed to get namespace stats: {e}"))?;
+                if cli.json {
+                    print_json(&stats);
+                } else {
+                    println!("Namespace: {name}");
+                    print_stats_human(&stats);
+                }
+                Ok(())
+            }
+            NamespaceCommands::Switch { name } => {
+                tracing::info!("Switching default namespace to: {name}");
+                Config::set_default_namespace(name)
+                    .map_err(|e| format!("Failed to switch namespace: {e}"))?;
+                if cli.json {
+                    print_json(&serde_json::json!({"default_namespace": name}));
+                } else {
+                    println!("✓ Default namespace set to '{name}'");
+                }
+                Ok(())
+            }
+        }
         Commands::Aging { command } => match command {
             AgingCommands::Status => {
                 tracing::info!("Aging status");

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -13,8 +13,8 @@ mod embed;
 pub mod memory;
 
 pub use memory::types::{
-    AgingStatus, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier, SearchResult,
-    StoreStats, TagInfo, DEFAULT_NAMESPACE,
+    AgingStatus, BulkDeleteResult, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier,
+    SearchResult, StoreStats, TagInfo, DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -268,6 +268,61 @@ impl Uteke {
         Ok(())
     }
 
+    /// Bulk delete memories by tag. Also removes from index.
+    pub fn bulk_forget_by_tag(
+        &self,
+        tag: &str,
+        namespace: Option<&str>,
+    ) -> Result<BulkDeleteResult, Error> {
+        let ids = self.store.bulk_delete_by_tag(tag, namespace)?;
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        for id in &ids {
+            index.remove(id);
+        }
+        index.save().ok();
+        Ok(BulkDeleteResult {
+            deleted: ids.len(),
+            ids,
+        })
+    }
+
+    /// Bulk delete all cold memories. Also removes from index.
+    pub fn bulk_forget_cold(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
+        let ids = self.store.bulk_delete_cold(namespace)?;
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        for id in &ids {
+            index.remove(id);
+        }
+        index.save().ok();
+        Ok(BulkDeleteResult {
+            deleted: ids.len(),
+            ids,
+        })
+    }
+
+    /// Bulk delete all memories in a namespace. Also removes from index.
+    pub fn bulk_forget_all(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
+        let ids = self.store.bulk_delete_all(namespace)?;
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        for id in &ids {
+            index.remove(id);
+        }
+        index.save().ok();
+        Ok(BulkDeleteResult {
+            deleted: ids.len(),
+            ids,
+        })
+    }
+
     /// List memories with optional tag filter and pagination.
     pub fn list(
         &self,
@@ -438,6 +493,11 @@ impl Uteke {
     }
 
     /// Get statistics about the memory store.
+    /// Access the underlying store (read-only reference).
+    pub fn store(&self) -> &Store {
+        &self.store
+    }
+
     pub fn stats(&self, namespace: Option<&str>) -> Result<StoreStats, Error> {
         let total_memories = self.store.count(namespace)?;
         let unique_tags = self.store.unique_tags(namespace)?.len();

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -625,9 +625,83 @@ impl Store {
 
         Ok((hot, warm, cold))
     }
-}
 
-/// Serialize an embedding vector to a byte blob.
+    /// Bulk delete memories by tag within a namespace.
+    pub fn bulk_delete_by_tag(
+        &self,
+        tag: &str,
+        namespace: Option<&str>,
+    ) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        let ids: Vec<String> = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .map_err(|e| Error::Database(e.to_string()))?
+            .query_map(rusqlite::params![ns, pattern], |row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+        for id in &ids {
+            self.conn
+                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        Ok(ids)
+    }
+
+    /// Bulk delete all cold memories (not accessed in 30+ days or never accessed).
+    pub fn bulk_delete_cold(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let warm_cutoff = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
+        let ids: Vec<String> = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)")
+            .map_err(|e| Error::Database(e.to_string()))?
+            .query_map(rusqlite::params![ns, warm_cutoff], |row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+        for id in &ids {
+            self.conn
+                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        Ok(ids)
+    }
+
+    /// Bulk delete all memories in a namespace.
+    pub fn bulk_delete_all(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let ids: Vec<String> = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1")
+            .map_err(|e| Error::Database(e.to_string()))?
+            .query_map(rusqlite::params![ns], |row| row.get(0))
+            .map_err(|e| Error::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+        for id in &ids {
+            self.conn
+                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        Ok(ids)
+    }
+
+    /// Count memories by tag in a namespace.
+    pub fn count_by_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let pattern = format!("%\"{tag}\"%");
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
+                rusqlite::params![ns, pattern],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(e.to_string()))
+    }
+}
 fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
     let mut blob = Vec::with_capacity(embedding.len() * 4);
     for &val in embedding {

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -91,6 +91,15 @@ pub struct StoreStats {
     pub cold: usize,
 }
 
+/// Result of a bulk delete operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkDeleteResult {
+    /// Number of memories deleted.
+    pub deleted: usize,
+    /// IDs of deleted memories.
+    pub ids: Vec<String>,
+}
+
 /// Lightweight export format — no embedding vector (re-embedded on import).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportEntry {

--- a/extensions/uteke-status/index.ts
+++ b/extensions/uteke-status/index.ts
@@ -1,0 +1,156 @@
+/**
+ * Uteke Memory Status Extension
+ *
+ * Shows uteke memory stats in the pi footer status bar.
+ * Displays: 🧠 uteke: 3 hot | 2 warm | 4 cold (9 total)
+ * 
+ * Updates on session start and after memory-related tool calls.
+ * 
+ * Install: Place in ~/.pi/agent/extensions/uteke-status/index.ts
+ * Or project-local: .pi/extensions/uteke-status/index.ts
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFile } from "node:child_process";
+
+interface UtekeStats {
+	total_memories: number;
+	unique_tags: number;
+	db_size_bytes: number;
+	hot: number;
+	warm: number;
+	cold: number;
+}
+
+function getStats(namespace?: string): Promise<UtekeStats | null> {
+	return new Promise((resolve) => {
+		const args = ["stats", "--json"];
+		if (namespace) args.push("--namespace", namespace);
+
+		execFile("uteke", args, { timeout: 10000 }, (error, stdout) => {
+			if (error) {
+				resolve(null);
+				return;
+			}
+			try {
+				resolve(JSON.parse(stdout));
+			} catch {
+				resolve(null);
+			}
+		});
+	});
+}
+
+function formatStats(stats: UtekeStats, theme: any): string {
+	const hot = theme.fg("red", `🔥${stats.hot}`);
+	const warm = theme.fg("yellow", `🟡${stats.warm}`);
+	const cold = theme.fg("blue", `❄️${stats.cold}`);
+	const total = theme.fg("dim", `(${stats.total_memories} total)`);
+	return `${hot} ${warm} ${cold} ${total}`;
+}
+
+export default function (pi: ExtensionAPI) {
+	// Track if uteke is available
+	let utekeAvailable = false;
+	let lastStats: UtekeStats | null = null;
+
+	async function refreshStatus(ctx: any) {
+		if (!utekeAvailable) return;
+
+		const stats = await getStats();
+		if (!stats) return;
+
+		lastStats = stats;
+		const theme = ctx.ui.theme;
+		const brain = theme.fg("accent", "🧠 uteke:");
+		const statusText = `${brain} ${formatStats(stats, theme)}`;
+		ctx.ui.setStatus("uteke", statusText);
+	}
+
+	pi.on("session_start", async (_event, ctx) => {
+		// Check if uteke is available
+		const stats = await getStats();
+		if (stats) {
+			utekeAvailable = true;
+			lastStats = stats;
+			const theme = ctx.ui.theme;
+			const brain = theme.fg("accent", "🧠 uteke:");
+			ctx.ui.setStatus("uteke", `${brain} ${formatStats(stats, theme)}`);
+		} else {
+			utekeAvailable = false;
+			const theme = ctx.ui.theme;
+			ctx.ui.setStatus("uteke", theme.fg("dim", "🧠 uteke: not installed"));
+		}
+	});
+
+	// Refresh after memory-related commands (remember, recall, forget, import, cleanup)
+	pi.on("tool_call", async (event, _ctx) => {
+		if (!utekeAvailable) return;
+		
+		const memoryCommands = ["bash"];
+		if (!memoryCommands.includes(event.toolName)) return;
+
+		const cmd = (event as any).input?.command || "";
+		const isMemoryOp = /\buteke\s+(remember|recall|forget|import|aging\s+cleanup)\b/.test(cmd);
+		if (!isMemoryOp) return;
+	});
+
+	// Refresh stats after tool results that involve uteke
+	pi.on("tool_result", async (event, ctx) => {
+		if (!utekeAvailable) return;
+
+		const content = event.content;
+		const contentText = Array.isArray(content)
+			? content.map((c: any) => c.type === "text" ? c.text : "").join("")
+			: "";
+
+		// Check if this was a uteke operation
+		const isMemoryOp = /Memory stored|Memory forgotten|imported|cleanup|deleted/i.test(contentText);
+		if (!isMemoryOp) return;
+
+		// Refresh stats after a short delay to let the operation complete
+		setTimeout(() => refreshStatus(ctx), 500);
+	});
+
+	// Register a command to manually refresh
+	pi.registerCommand("uteke-stats", {
+		description: "Refresh uteke memory stats in status bar",
+		handler: async (_args, ctx) => {
+			if (!utekeAvailable) {
+				ctx.ui.notify("uteke is not installed or not in PATH", "error");
+				return;
+			}
+			await refreshStatus(ctx);
+			if (lastStats) {
+				ctx.ui.notify(`🧠 ${lastStats.total_memories} memories (${lastStats.hot} hot, ${lastStats.warm} warm, ${lastStats.cold} cold)`, "info");
+			}
+		},
+	});
+
+	// Register a command to show detailed stats
+	pi.registerCommand("uteke", {
+		description: "Show detailed uteke memory statistics",
+		handler: async (args, ctx) => {
+			const cmd = args?.trim() || "stats";
+			
+			// Support subcommands: /uteke stats, /uteke aging, /uteke doctor
+			if (["stats", "aging status", "doctor", "tags list"].includes(cmd)) {
+				const { execFile } = await import("node:child_process");
+				const fullCmd = cmd === "stats" ? "stats" : cmd;
+				execFile("uteke", fullCmd.split(" "), { timeout: 15000 }, (error, stdout, stderr) => {
+					if (error) {
+						ctx.ui.notify(`uteke error: ${stderr || error.message}`, "error");
+						return;
+					}
+					ctx.ui.notify(stdout.trim(), "info");
+				});
+			} else {
+				ctx.ui.notify(`Usage: /uteke [stats|aging status|doctor|tags list]`, "info");
+			}
+		},
+	});
+
+	pi.on("session_shutdown", async (_event, _ctx) => {
+		// Cleanup status
+	});
+}

--- a/extensions/uteke-status/index.ts
+++ b/extensions/uteke-status/index.ts
@@ -2,155 +2,110 @@
  * Uteke Memory Status Extension
  *
  * Shows uteke memory stats in the pi footer status bar.
- * Displays: 🧠 uteke: 3 hot | 2 warm | 4 cold (9 total)
- * 
- * Updates on session start and after memory-related tool calls.
- * 
- * Install: Place in ~/.pi/agent/extensions/uteke-status/index.ts
- * Or project-local: .pi/extensions/uteke-status/index.ts
+ * Displays: 🧠 uteke:  🔥 4 hot  🟡 0 warm  ❄️ 63 cold  (67 total)
+ *
+ * Also injects a system prompt reminder to use uteke for memory.
+ * Queries SQLite directly for cross-namespace totals.
+ *
+ * Install: ~/.pi/agent/extensions/uteke-status/index.ts
+ * Project-local: .pi/extensions/uteke-status/index.ts
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execFile } from "node:child_process";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
-interface UtekeStats {
-	total_memories: number;
-	unique_tags: number;
-	db_size_bytes: number;
+interface Stats {
+	total: number;
 	hot: number;
 	warm: number;
 	cold: number;
 }
 
-function getStats(namespace?: string): Promise<UtekeStats | null> {
-	return new Promise((resolve) => {
-		const args = ["stats", "--json"];
-		if (namespace) args.push("--namespace", namespace);
+function getAllStats(): Stats | null {
+	const dbPath = join(homedir(), ".uteke", "uteke.db");
 
-		execFile("uteke", args, { timeout: 10000 }, (error, stdout) => {
-			if (error) {
-				resolve(null);
-				return;
-			}
-			try {
-				resolve(JSON.parse(stdout));
-			} catch {
-				resolve(null);
-			}
-		});
-	});
-}
+	const sql = [
+		"SELECT COUNT(*) as total,",
+		"SUM(CASE WHEN last_accessed >= datetime('now','-7 days') THEN 1 ELSE 0 END) as hot,",
+		"SUM(CASE WHEN last_accessed >= datetime('now','-30 days') AND last_accessed < datetime('now','-7 days') THEN 1 ELSE 0 END) as warm",
+		"FROM memories;",
+	].join(" ");
 
-function formatStats(stats: UtekeStats, theme: any): string {
-	const hot = theme.fg("red", `🔥${stats.hot}`);
-	const warm = theme.fg("yellow", `🟡${stats.warm}`);
-	const cold = theme.fg("blue", `❄️${stats.cold}`);
-	const total = theme.fg("dim", `(${stats.total_memories} total)`);
-	return `${hot} ${warm} ${cold} ${total}`;
+	try {
+		const out = execSync(`sqlite3 '${dbPath}' "${sql}"`, {
+			timeout: 5000,
+			encoding: "utf-8",
+		}).trim();
+
+		const parts = out.split("|");
+		if (parts.length < 3) return null;
+
+		const total = parseInt(parts[0], 10);
+		const hot = parseInt(parts[1], 10);
+		const warm = parseInt(parts[2], 10);
+		const cold = total - hot - warm;
+
+		return { total, hot, warm, cold };
+	} catch {
+		return null;
+	}
 }
 
 export default function (pi: ExtensionAPI) {
-	// Track if uteke is available
-	let utekeAvailable = false;
-	let lastStats: UtekeStats | null = null;
+	let available = false;
 
-	async function refreshStatus(ctx: any) {
-		if (!utekeAvailable) return;
-
-		const stats = await getStats();
-		if (!stats) return;
-
-		lastStats = stats;
-		const theme = ctx.ui.theme;
-		const brain = theme.fg("accent", "🧠 uteke:");
-		const statusText = `${brain} ${formatStats(stats, theme)}`;
-		ctx.ui.setStatus("uteke", statusText);
+	function updateStatus(ctx: any) {
+		const stats = getAllStats();
+		if (!stats) {
+			ctx.ui.setStatus("uteke", "🧠 uteke: not found");
+			return;
+		}
+		available = true;
+		ctx.ui.setStatus(
+			"uteke",
+			`🧠 uteke:   🔥 ${stats.hot} hot   🟡 ${stats.warm} warm   ❄️ ${stats.cold} cold   (${stats.total} total)`
+		);
 	}
 
+	// Inject system prompt to remind agent to use uteke
+	pi.on("before_agent_start", async (event, ctx) => {
+		if (!available) return;
+
+		return {
+			systemPrompt:
+				event.systemPrompt +
+				"\n\n## uteke Memory\n" +
+				"You have access to uteke — a local persistent memory engine. Use it actively:\n" +
+				"- `uteke remember` — Save important context, decisions, progress, architecture notes\n" +
+				"- `uteke recall` — Search memories by meaning before asking the user\n" +
+				"- `uteke search` — Keyword search across memories\n" +
+				"- `uteke stats` — Check memory store status\n" +
+				"- `uteke remember --tags <tags> --namespace <ns>` — Organize by tags and namespace\n" +
+				"\n" +
+				"Rules:\n" +
+				"1. Save important context to uteke proactively (decisions, progress, architecture)\n" +
+				"2. Before starting a task, recall relevant memories to restore context\n" +
+				"3. Use namespaces to isolate memory per project or agent role\n" +
+				"4. Tag memories with descriptive tags for easy filtering\n" +
+				"5. When ending a session, save a summary of what was done\n",
+		};
+	});
+
 	pi.on("session_start", async (_event, ctx) => {
-		// Check if uteke is available
-		const stats = await getStats();
-		if (stats) {
-			utekeAvailable = true;
-			lastStats = stats;
-			const theme = ctx.ui.theme;
-			const brain = theme.fg("accent", "🧠 uteke:");
-			ctx.ui.setStatus("uteke", `${brain} ${formatStats(stats, theme)}`);
-		} else {
-			utekeAvailable = false;
-			const theme = ctx.ui.theme;
-			ctx.ui.setStatus("uteke", theme.fg("dim", "🧠 uteke: not installed"));
-		}
+		updateStatus(ctx);
 	});
 
-	// Refresh after memory-related commands (remember, recall, forget, import, cleanup)
-	pi.on("tool_call", async (event, _ctx) => {
-		if (!utekeAvailable) return;
-		
-		const memoryCommands = ["bash"];
-		if (!memoryCommands.includes(event.toolName)) return;
-
-		const cmd = (event as any).input?.command || "";
-		const isMemoryOp = /\buteke\s+(remember|recall|forget|import|aging\s+cleanup)\b/.test(cmd);
-		if (!isMemoryOp) return;
+	pi.on("turn_end", async (_event, ctx) => {
+		if (!available) return;
+		updateStatus(ctx);
 	});
 
-	// Refresh stats after tool results that involve uteke
-	pi.on("tool_result", async (event, ctx) => {
-		if (!utekeAvailable) return;
-
-		const content = event.content;
-		const contentText = Array.isArray(content)
-			? content.map((c: any) => c.type === "text" ? c.text : "").join("")
-			: "";
-
-		// Check if this was a uteke operation
-		const isMemoryOp = /Memory stored|Memory forgotten|imported|cleanup|deleted/i.test(contentText);
-		if (!isMemoryOp) return;
-
-		// Refresh stats after a short delay to let the operation complete
-		setTimeout(() => refreshStatus(ctx), 500);
-	});
-
-	// Register a command to manually refresh
 	pi.registerCommand("uteke-stats", {
 		description: "Refresh uteke memory stats in status bar",
 		handler: async (_args, ctx) => {
-			if (!utekeAvailable) {
-				ctx.ui.notify("uteke is not installed or not in PATH", "error");
-				return;
-			}
-			await refreshStatus(ctx);
-			if (lastStats) {
-				ctx.ui.notify(`🧠 ${lastStats.total_memories} memories (${lastStats.hot} hot, ${lastStats.warm} warm, ${lastStats.cold} cold)`, "info");
-			}
+			updateStatus(ctx);
 		},
-	});
-
-	// Register a command to show detailed stats
-	pi.registerCommand("uteke", {
-		description: "Show detailed uteke memory statistics",
-		handler: async (args, ctx) => {
-			const cmd = args?.trim() || "stats";
-			
-			// Support subcommands: /uteke stats, /uteke aging, /uteke doctor
-			if (["stats", "aging status", "doctor", "tags list"].includes(cmd)) {
-				const { execFile } = await import("node:child_process");
-				const fullCmd = cmd === "stats" ? "stats" : cmd;
-				execFile("uteke", fullCmd.split(" "), { timeout: 15000 }, (error, stdout, stderr) => {
-					if (error) {
-						ctx.ui.notify(`uteke error: ${stderr || error.message}`, "error");
-						return;
-					}
-					ctx.ui.notify(stdout.trim(), "info");
-				});
-			} else {
-				ctx.ui.notify(`Usage: /uteke [stats|aging status|doctor|tags list]`, "info");
-			}
-		},
-	});
-
-	pi.on("session_shutdown", async (_event, _ctx) => {
-		// Cleanup status
 	});
 }

--- a/extensions/uteke-status/package.json
+++ b/extensions/uteke-status/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uteke-status",
+  "version": "0.1.0",
+  "description": "Pi extension — shows uteke memory stats in the footer status bar",
+  "main": "index.ts",
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "keywords": ["pi-extension", "uteke", "memory", "status"],
+  "license": "Apache-2.0"
+}

--- a/website/src/routes/docs/+layout.svelte
+++ b/website/src/routes/docs/+layout.svelte
@@ -6,6 +6,7 @@
 		{ label: 'CLI Reference', href: '/docs/cli-reference' },
 		{ label: 'Configuration', href: '/docs/configuration' },
 		{ label: 'Multi-Agent', href: '/docs/multi-agent' },
+		{ label: 'Pi Extension', href: '/docs/extensions' },
 		{ label: 'Roadmap', href: '/docs/roadmap' }
 	];
 

--- a/website/src/routes/docs/extensions/+page.svelte
+++ b/website/src/routes/docs/extensions/+page.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	const installSteps = [
+		{
+			title: "Global install (all projects)",
+			cmd: "cp -r extensions/uteke-status ~/.pi/agent/extensions/",
+		},
+		{
+			title: "Project-local install",
+			cmd: "cp -r extensions/uteke-status .pi/extensions/",
+		},
+		{
+			title: "Reload pi",
+			cmd: "/reload",
+		},
+	];
+</script>
+
+<svelte:head>
+	<title>Pi Extension — Uteke Docs</title>
+</svelte:head>
+
+<h1 class="text-3xl font-bold mb-6">Pi Extension</h1>
+
+<p class="text-[var(--color-text-muted)] mb-8">uteke provides a <a href="https://github.com/ajianaz/uteke" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">pi coding agent</a> extension that shows memory stats in the footer and reminds the agent to use uteke actively.</p>
+
+<div class="space-y-10 text-[var(--color-text-muted)] leading-relaxed">
+
+	<!-- Status Bar -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Status Bar</h2>
+		<p class="mb-3">Shows memory stats across all namespaces in the pi footer:</p>
+		<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>🧠 uteke:   🔥 4 hot   🟡 0 warm   ❄️ 63 cold   (67 total)</code></pre>
+		<p class="mt-3 text-sm">Auto-refreshes on session start and after each agent turn.</p>
+	</section>
+
+	<!-- Agent Memory Injection -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Agent Memory Injection</h2>
+		<p class="mb-3">The extension injects a system prompt that reminds the agent to use uteke:</p>
+		<div class="space-y-2">
+			{#each [
+				"Save important context proactively (decisions, progress, architecture)",
+				"Recall relevant memories before starting tasks",
+				"Use namespaces and tags for organization",
+				"Save session summaries when ending",
+			] as rule}
+				<div class="flex items-start gap-2">
+					<span class="text-[var(--color-accent)]">→</span>
+					<span class="text-sm">{rule}</span>
+				</div>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Install -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Install</h2>
+		<div class="space-y-4">
+			{#each installSteps as step, i}
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 rounded-full bg-[var(--color-accent-dim)] flex items-center justify-center text-sm font-bold text-[var(--color-accent)]">{i + 1}</div>
+					<div class="min-w-0 flex-1">
+						<p class="font-medium mb-2">{step.title}</p>
+						<code class="block px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto">{step.cmd}</code>
+					</div>
+				</div>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Commands -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Commands</h2>
+		<div class="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+			<table class="w-full text-sm">
+				<thead><tr class="border-b border-[var(--color-border)] bg-[var(--color-surface)]"><th class="text-left px-4 py-2 font-medium">Command</th><th class="text-left px-4 py-2 font-medium">Description</th></tr></thead>
+				<tbody>
+					<tr class="border-b border-[var(--color-border)]"><td class="px-4 py-2 font-mono text-xs text-[var(--color-accent)]">/uteke-stats</td><td class="px-4 py-2">Manually refresh memory stats in status bar</td></tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- Requirements -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">Requirements</h2>
+		<div class="space-y-2">
+			{#each [
+				"uteke installed and in PATH",
+				"sqlite3 CLI (pre-installed on macOS and most Linux)",
+				"pi coding agent (v0.14+)",
+			] as req}
+				<div class="flex items-center gap-2">
+					<span class="text-[var(--color-success)]">✓</span>
+					<span class="text-sm">{req}</span>
+				</div>
+			{/each}
+		</div>
+	</section>
+
+	<!-- How it works -->
+	<section>
+		<h2 class="text-xl font-semibold text-[var(--color-text)] mb-4">How It Works</h2>
+		<div class="space-y-3">
+			{#each [
+				{ label: "Stats query", desc: "Reads ~/.uteke/uteke.db via sqlite3 CLI for cross-namespace totals" },
+				{ label: "System prompt", desc: "Injects uteke usage rules via before_agent_start event" },
+				{ label: "Status refresh", desc: "Updates footer on session_start and turn_end events" },
+			] as item}
+				<div class="px-4 py-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+					<p class="text-sm font-medium text-[var(--color-text)]">{item.label}</p>
+					<p class="text-xs text-[var(--color-text-dim)] mt-1">{item.desc}</p>
+				</div>
+			{/each}
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Problem (#45)

`--namespace` flag required manual specification on every command. No way to set default, list namespaces, or verify isolation.

## Solution

### New commands
```bash
uteke namespace list              # List all namespaces with memory counts
uteke namespace stats <name>      # Stats for specific namespace
uteke namespace switch <name>     # Set default namespace in config
```

### Layered namespace resolution
1. `--namespace` CLI flag (highest priority)
2. `UTEKE_NAMESPACE` env var
3. `uteke.toml` config `store.namespace`
4. `"default"` fallback

### Config persistence
`uteke namespace switch cto` writes to `~/.uteke/uteke.toml`:
```toml
[store]
namespace = "cto"
```

## Testing
- All 22 existing tests pass
- Manual verification of list/stats/switch commands
- Env var override tested
- Config file update tested