### PR TITLE
feat: auto-forget, temporal facts & contradiction detection

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -256,6 +256,12 @@ enum Commands {
         /// Tags for categorization (comma-separated)
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
+        /// Memory type: fact, procedure, preference, decision, context
+        #[arg(long, default_value = "fact")]
+        r#type: String,
+        /// Enable contradiction detection (auto-deprecate conflicting memories)
+        #[arg(long)]
+        detect_contradiction: bool,
     },
     /// Recall memories relevant to a query (semantic search)
     Recall {
@@ -363,6 +369,15 @@ enum Commands {
     Tags {
         #[command(subcommand)]
         command: TagCommands,
+    },
+    /// Prune deprecated memories (auto-forget with TTL)
+    Prune {
+        /// TTL in days — deprecate memories older than this
+        #[arg(long, default_value = "30")]
+        ttl: u32,
+        /// Dry run — show what would be pruned without deleting
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -742,18 +757,44 @@ fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(), String> 
     let ns: Option<&str> = Some(resolved_ns.as_str());
 
     match &cli.command {
-        Commands::Remember { content, tags } => {
-            tracing::info!("Remembering: {content}");
+        Commands::Remember { content, tags, r#type, detect_contradiction } => {
+            tracing::info!("Remembering: {content} (type: {type}, contradiction: {detect_contradiction})");
             let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
-            let id = uteke
-                .remember(content, &tag_refs, None, ns)
-                .map_err(|e| format!("Failed to store memory: {e}"))?;
-            tracing::info!("Memory stored with ID: {id}");
-            if cli.json {
-                let obj = serde_json::json!({"id": id});
-                println!("{}", obj);
+
+            if *detect_contradiction {
+                let (id, contradiction) = uteke
+                    .remember_with_contradiction(content, &tag_refs, ns, Some(r#type.as_str()), true)
+                    .map_err(|e| format!("Failed to store memory: {e}"))?;
+                tracing::info!("Memory stored with ID: {id}");
+                if cli.json {
+                    let obj = serde_json::json!({
+                        "id": id,
+                        "contradiction": {
+                            "detected": contradiction.contradicted,
+                            "deprecated_id": contradiction.deprecated_id,
+                            "similarity": contradiction.similarity
+                        }
+                    });
+                    println!("{}", obj);
+                } else {
+                    print_remember_human(&id);
+                    if contradiction.contradicted {
+                        if let Some(dep_id) = &contradiction.deprecated_id {
+                            println!("  \u{26a0} Contradiction detected (sim: {:.3}): deprecated {}", contradiction.similarity, &dep_id[..8]);
+                        }
+                    }
+                }
             } else {
-                print_remember_human(&id);
+                let id = uteke
+                    .remember(content, &tag_refs, None, ns)
+                    .map_err(|e| format!("Failed to store memory: {e}"))?;
+                tracing::info!("Memory stored with ID: {id}");
+                if cli.json {
+                    let obj = serde_json::json!({"id": id});
+                    println!("{}", obj);
+                } else {
+                    print_remember_human(&id);
+                }
             }
             Ok(())
         }
@@ -1007,6 +1048,27 @@ fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(), String> 
                     } else {
                         println!("✓ Tag '{tag}' deleted ({count} memories updated)");
                     }
+                }
+            }
+            Ok(())
+        }
+        Commands::Prune { ttl, dry_run } => {
+            tracing::info!("Pruning with TTL={ttl}d (dry_run={dry_run})");
+            let result = uteke
+                .prune(*ttl, ns, *dry_run)
+                .map_err(|e| format!("Failed to prune: {e}"))?;
+            if cli.json {
+                print_json(&result);
+            } else {
+                if result.deprecated_ids.is_empty() && result.pruned == 0 {
+                    println!("No deprecated memories to prune.");
+                } else if *dry_run {
+                    println!("Dry run — {} deprecated memories would be pruned (TTL: {ttl}d):", result.deprecated);
+                    for id in &result.deprecated_ids {
+                        println!("  {}", id);
+                    }
+                } else {
+                    println!("\u{2713} Pruned {} deprecated memories (TTL: {ttl}d)", result.pruned);
                 }
             }
             Ok(())

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -13,8 +13,9 @@ mod embed;
 pub mod memory;
 
 pub use memory::types::{
-    AgingStatus, BulkDeleteResult, CleanupResult, ExportEntry, ImportResult, Memory, MemoryTier,
-    SearchResult, StoreStats, TagInfo, DEFAULT_NAMESPACE,
+    AgingStatus, BulkDeleteResult, CleanupResult, ContradictionResult, ExportEntry, ImportResult,
+    Memory, MemoryTier, MemoryType, PruneResult, SearchResult, StoreStats, TagInfo,
+    DEFAULT_NAMESPACE,
 };
 
 use embed::EmbeddingEngine;
@@ -125,6 +126,10 @@ impl Uteke {
             namespace: namespace.unwrap_or(DEFAULT_NAMESPACE).to_string(),
             access_count: 0,
             last_accessed: None,
+            deprecated: false,
+            valid_from: Some(now),
+            valid_until: None,
+            memory_type: "fact".to_string(),
         };
 
         self.store.insert(&memory)?;
@@ -583,6 +588,159 @@ impl Uteke {
         Ok(CleanupResult { deleted })
     }
 
+    /// Check for contradictions when storing a new memory.
+    ///
+    /// Compares new embedding against existing memories in the same namespace.
+    /// If similarity > threshold (0.65), marks the old memory as deprecated.
+    pub fn check_contradiction(
+        &self,
+        content: &str,
+        embedding: &[f32],
+        namespace: &str,
+        threshold: f32,
+    ) -> Result<ContradictionResult, Error> {
+        let index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+
+        let results = index.search(embedding, 5, 50);
+
+        for (id, distance) in &results {
+            let similarity = 1.0 - distance;
+            if similarity > threshold {
+                if let Ok(Some(memory)) = self.store.get_by_id(id) {
+                    if memory.namespace == namespace && !memory.deprecated {
+                        self.store.deprecate(id)?;
+                        tracing::info!(
+                            "Contradiction detected (sim={:.3}): deprecating '{}' → replaced by '{}'",
+                            similarity,
+                            memory.content.chars().take(60).collect::<String>(),
+                            content.chars().take(60).collect::<String>()
+                        );
+                        return Ok(ContradictionResult {
+                            contradicted: true,
+                            deprecated_id: Some(id.clone()),
+                            similarity,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(ContradictionResult {
+            contradicted: false,
+            deprecated_id: None,
+            similarity: 0.0,
+        })
+    }
+
+    /// Store a memory with contradiction detection and temporal metadata.
+    ///
+    /// Returns the ID of the new memory and any contradiction result.
+    pub fn remember_with_contradiction(
+        &self,
+        content: &str,
+        tags: &[&str],
+        namespace: Option<&str>,
+        memory_type: Option<&str>,
+        check_contradiction: bool,
+    ) -> Result<(String, ContradictionResult), Error> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let embedding = self
+            .embedder
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire embedder lock".into()))?
+            .embed(content)?;
+
+        // Check for contradictions before inserting
+        let contradiction = if check_contradiction {
+            // Release embedder lock first, then check
+            self.check_contradiction(content, &embedding, ns, 0.65)?
+        } else {
+            ContradictionResult {
+                contradicted: false,
+                deprecated_id: None,
+                similarity: 0.0,
+            }
+        };
+
+        let memory = Memory {
+            id: id.clone(),
+            content: content.to_string(),
+            embedding: embedding.clone(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            metadata: serde_json::Value::Null,
+            created_at: now,
+            updated_at: now,
+            namespace: ns.to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: Some(now),
+            valid_until: None,
+            memory_type: memory_type.unwrap_or("fact").to_string(),
+        };
+
+        self.store.insert(&memory)?;
+
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+        index.insert(&id, &embedding);
+        index.save().ok();
+
+        Ok((id, contradiction))
+    }
+
+    /// Prune deprecated memories older than TTL days.
+    ///
+    /// Deletes from both SQLite and vector index.
+    pub fn prune(
+        &self,
+        ttl_days: u32,
+        namespace: Option<&str>,
+        dry_run: bool,
+    ) -> Result<PruneResult, Error> {
+        let deprecated = self.store.find_deprecated_for_prune(ttl_days, namespace)?;
+        let ids: Vec<String> = deprecated.iter().map(|m| m.id.clone()).collect();
+        let count = ids.len();
+
+        if dry_run || count == 0 {
+            return Ok(PruneResult {
+                pruned: 0,
+                ids: vec![],
+                deprecated: count,
+                deprecated_ids: ids,
+            });
+        }
+
+        // Delete from SQLite
+        let pruned = self.store.prune_ttl(ttl_days, namespace)?;
+
+        // Remove from vector index
+        {
+            let mut index = self
+                .index
+                .lock()
+                .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+            for id in &ids {
+                index.remove(id);
+            }
+            index.save().ok();
+        }
+
+        Ok(PruneResult {
+            pruned,
+            ids: ids.clone(),
+            deprecated: count,
+            deprecated_ids: ids,
+        })
+    }
+
     /// Export all memories to JSONL format (one JSON object per line).
     ///
     /// Embeddings are NOT exported — they will be re-computed on import.
@@ -668,6 +826,10 @@ impl Uteke {
                 namespace: namespace.unwrap_or(DEFAULT_NAMESPACE).to_string(),
                 access_count: 0,
                 last_accessed: None,
+                deprecated: false,
+                valid_from: Some(entry.created_at),
+                valid_until: None,
+                memory_type: "fact".to_string(),
             };
 
             self.store.insert(&memory)?;
@@ -790,6 +952,10 @@ mod tests {
             namespace: DEFAULT_NAMESPACE.to_string(),
             access_count: 0,
             last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
         };
 
         let json = serde_json::to_string(&m).unwrap();
@@ -814,6 +980,10 @@ mod tests {
             namespace: DEFAULT_NAMESPACE.to_string(),
             access_count: 0,
             last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
         };
 
         let sr = SearchResult {

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -16,7 +16,11 @@ CREATE TABLE IF NOT EXISTS memories (
     updated_at TEXT NOT NULL,
     namespace TEXT NOT NULL DEFAULT 'default',
     access_count INTEGER NOT NULL DEFAULT 0,
-    last_accessed TEXT
+    last_accessed TEXT,
+    deprecated INTEGER NOT NULL DEFAULT 0,
+    valid_from TEXT,
+    valid_until TEXT,
+    memory_type TEXT NOT NULL DEFAULT 'fact'
 );
 CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
@@ -87,6 +91,33 @@ impl Store {
                 .map_err(|e| Error::Database(e.to_string()))?;
         }
 
+        // Migration: add temporal/deprecation columns
+        if !self.column_exists("deprecated") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN deprecated INTEGER NOT NULL DEFAULT 0;")
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        if !self.column_exists("valid_from") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN valid_from TEXT;")
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        if !self.column_exists("valid_until") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN valid_until TEXT;")
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+        if !self.column_exists("memory_type") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN memory_type TEXT NOT NULL DEFAULT 'fact';")
+                .map_err(|e| Error::Database(e.to_string()))?;
+        }
+
+        // Create deprecation index
+        self.conn
+            .execute_batch("CREATE INDEX IF NOT EXISTS idx_memories_deprecated ON memories(deprecated);")
+            .map_err(|e| Error::Database(e.to_string()))?;
+
         Ok(())
     }
 
@@ -107,8 +138,8 @@ impl Store {
 
         self.conn
             .execute(
-                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 params![
                     memory.id,
                     memory.content,
@@ -120,6 +151,10 @@ impl Store {
                     memory.namespace,
                     memory.access_count,
                     memory.last_accessed.map(|t| t.to_rfc3339()),
+                    memory.deprecated as i32,
+                    memory.valid_from.map(|t| t.to_rfc3339()),
+                    memory.valid_until.map(|t| t.to_rfc3339()),
+                    memory.memory_type,
                 ],
             )
             .map_err(|e| Error::Database(e.to_string()))?;
@@ -131,7 +166,7 @@ impl Store {
     pub fn get_by_id(&self, id: &str) -> Result<Option<Memory>, Error> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE id = ?1")
+            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE id = ?1")
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let result = stmt
@@ -189,8 +224,8 @@ impl Store {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
 
         let sql = match tag {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE namespace = ?1 AND tags LIKE ?2 ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE namespace = ?1 AND tags LIKE ?2 ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
         };
 
         let mut memories = Vec::new();
@@ -240,7 +275,7 @@ impl Store {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
                  FROM memories WHERE namespace = ?1 AND content LIKE ?2
                  ORDER BY created_at DESC LIMIT ?3",
             )
@@ -261,8 +296,8 @@ impl Store {
     /// Load all memories for index rebuilding, optionally filtered by namespace.
     pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
         let sql = match namespace {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories WHERE namespace = ?1 ORDER BY created_at",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed FROM memories ORDER BY created_at",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE namespace = ?1 ORDER BY created_at",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories ORDER BY created_at",
         };
 
         let mut memories = Vec::new();
@@ -400,9 +435,10 @@ impl Store {
     ) -> Result<Vec<Memory>, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
         let sql = r#"
-            SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed
+            SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
             FROM memories
             WHERE namespace = ?1
+              AND deprecated = 0
               AND created_at < datetime('now', '-' || ?2 || ' days')
               AND access_count <= ?3
               AND (last_accessed IS NULL OR last_accessed < datetime('now', '-' || ?4 || ' days'))
@@ -701,6 +737,85 @@ impl Store {
             )
             .map_err(|e| Error::Database(e.to_string()))
     }
+
+    /// Deprecate a memory by ID. Sets deprecated=1 and valid_until=now.
+    pub fn deprecate(&self, id: &str) -> Result<(), Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "UPDATE memories SET deprecated = 1, valid_until = ?1, updated_at = ?1 WHERE id = ?2",
+                params![now, id],
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Find memories that contradict a new embedding (high similarity, same namespace).
+    /// Returns memories with cosine similarity > threshold that are not already deprecated.
+    pub fn find_similar(
+        &self,
+        namespace: &str,
+        limit: usize,
+    ) -> Result<Vec<Memory>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
+                 FROM memories WHERE namespace = ?1 AND deprecated = 0 ORDER BY created_at DESC LIMIT ?2",
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![namespace, limit], row_to_memory)
+            .map_err(|e| Error::Database(e.to_string()))?;
+        let mut memories = Vec::new();
+        for row in rows {
+            memories.push(row.map_err(|e| Error::Database(e.to_string()))?);
+        }
+        Ok(memories)
+    }
+
+    /// Prune (delete) cold, deprecated, or expired memories based on TTL.
+    /// Returns count of pruned memories.
+    pub fn prune_ttl(&self, ttl_days: u32, namespace: Option<&str>) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let deleted = self
+            .conn
+            .execute(
+                "DELETE FROM memories WHERE namespace = ?1
+                 AND deprecated = 1
+                 AND datetime(updated_at) < datetime('now', '-' || ?2 || ' days')",
+                params![ns, ttl_days],
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(deleted)
+    }
+
+    /// Find deprecated memories eligible for pruning (dry-run).
+    pub fn find_deprecated_for_prune(
+        &self,
+        ttl_days: u32,
+        namespace: Option<&str>,
+    ) -> Result<Vec<Memory>, Error> {
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
+                 FROM memories WHERE namespace = ?1
+                 AND deprecated = 1
+                 AND datetime(updated_at) < datetime('now', '-' || ?2 || ' days')
+                 ORDER BY updated_at ASC",
+            )
+            .map_err(|e| Error::Database(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![ns, ttl_days], row_to_memory)
+            .map_err(|e| Error::Database(e.to_string()))?;
+        let mut memories = Vec::new();
+        for row in rows {
+            memories.push(row.map_err(|e| Error::Database(e.to_string()))?);
+        }
+        Ok(memories)
+    }
 }
 fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
     let mut blob = Vec::with_capacity(embedding.len() * 4);
@@ -757,6 +872,18 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
         .as_deref()
         .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.to_utc());
+    let deprecated: bool = row.get(10).unwrap_or(false);
+    let valid_from_str: Option<String> = row.get(11).ok().flatten();
+    let valid_from = valid_from_str
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.to_utc());
+    let valid_until_str: Option<String> = row.get(12).ok().flatten();
+    let valid_until = valid_until_str
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.to_utc());
+    let memory_type: String = row.get(13).unwrap_or_else(|_| "fact".to_string());
 
     Ok(Memory {
         id,
@@ -769,6 +896,10 @@ fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
         namespace,
         access_count,
         last_accessed,
+        deprecated,
+        valid_from,
+        valid_until,
+        memory_type,
     })
 }
 
@@ -790,6 +921,10 @@ mod tests {
             namespace: crate::memory::types::DEFAULT_NAMESPACE.to_string(),
             access_count: 0,
             last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
         }
     }
 
@@ -805,6 +940,10 @@ mod tests {
             namespace: namespace.to_string(),
             access_count: 0,
             last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
         }
     }
 

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -31,10 +31,26 @@ pub struct Memory {
     /// When this memory was last accessed.
     #[serde(default)]
     pub last_accessed: Option<chrono::DateTime<chrono::Utc>>,
+    /// Whether this memory has been superseded by a newer one.
+    #[serde(default)]
+    pub deprecated: bool,
+    /// When this fact became valid (temporal metadata).
+    #[serde(default)]
+    pub valid_from: Option<chrono::DateTime<chrono::Utc>>,
+    /// When this fact was invalidated (temporal metadata).
+    #[serde(default)]
+    pub valid_until: Option<chrono::DateTime<chrono::Utc>>,
+    /// Memory type: fact, procedure, preference, decision, context.
+    #[serde(default = "default_memory_type")]
+    pub memory_type: String,
 }
 
 fn default_namespace() -> String {
     DEFAULT_NAMESPACE.to_string()
+}
+
+fn default_memory_type() -> String {
+    "fact".to_string()
 }
 
 /// A search result with relevance score.
@@ -151,4 +167,73 @@ pub struct AgingStatus {
 pub struct CleanupResult {
     /// Number of memories deleted.
     pub deleted: usize,
+}
+
+/// Result of a prune operation (auto-forget with decay policy).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PruneResult {
+    /// Number of memories pruned.
+    pub pruned: usize,
+    /// IDs of pruned memories.
+    pub ids: Vec<String>,
+    /// Number of memories deprecated (contradicted).
+    pub deprecated: usize,
+    /// IDs of deprecated memories.
+    pub deprecated_ids: Vec<String>,
+}
+
+/// Result of a contradiction check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContradictionResult {
+    /// Whether a contradiction was detected.
+    pub contradicted: bool,
+    /// ID of the existing memory that was deprecated.
+    pub deprecated_id: Option<String>,
+    /// Similarity score that triggered the contradiction.
+    pub similarity: f32,
+}
+
+/// Memory type classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryType {
+    /// A factual statement (has temporal validity).
+    Fact,
+    /// A procedure or how-to (doesn't expire).
+    Procedure,
+    /// A user preference (doesn't expire).
+    Preference,
+    /// A design or architecture decision (may be superseded).
+    Decision,
+    /// Contextual information (session-scoped, may expire).
+    Context,
+}
+
+impl MemoryType {
+    /// Parse from string.
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "fact" => Some(Self::Fact),
+            "procedure" => Some(Self::Procedure),
+            "preference" => Some(Self::Preference),
+            "decision" => Some(Self::Decision),
+            "context" => Some(Self::Context),
+            _ => None,
+        }
+    }
+
+    /// Convert to string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fact => "fact",
+            Self::Procedure => "procedure",
+            Self::Preference => "preference",
+            Self::Decision => "decision",
+            Self::Context => "context",
+        }
+    }
+
+    /// Whether this memory type has temporal validity.
+    pub fn has_temporal_validity(&self) -> bool {
+        matches!(self, Self::Fact | Self::Decision | Self::Context)
+    }
 }


### PR DESCRIPTION
## Problem (#51)

Agents store contradictory facts without noticing. No temporal validity. No auto-forget policy.

## Solution

### 1. Contradiction Detection
```bash
uteke remember "Server runs on port 8080" --detect-contradiction
# → ⚠ Contradiction detected (sim: 0.71): deprecated 8cd69b14
```
- Vector similarity check against existing memories in same namespace
- Auto-deprecates old conflicting memories
- Returns deprecated ID + similarity score in JSON

### 2. Temporal Facts
```bash
uteke remember "Project uses React" --type fact
uteke remember "Deploy process" --type procedure
uteke remember "User likes dark mode" --type preference
```
- Memory types: `fact`, `procedure`, `preference`, `decision`, `context`
- Deprecated memories get `valid_until` timestamp
- New memories get `valid_from` timestamp

### 3. Prune (Auto-Forget)
```bash
uteke prune --ttl 30 --dry-run   # Preview
uteke prune --ttl 30              # Delete deprecated >30d old
```

### Schema Changes
| Column | Type | Default | Description |
|--------|------|---------|-------------|
| `deprecated` | INTEGER | 0 | 1=superseded by newer memory |
| `valid_from` | TEXT | NULL | When fact became valid |
| `valid_until` | TEXT | NULL | When fact was invalidated |
| `memory_type` | TEXT | 'fact' | fact/procedure/preference/decision/context |

### Backward Compatibility
- Auto-migration adds new columns to existing DB
- All existing memories work unchanged
- New features are opt-in via flags

## Testing
- All 22 tests pass
- Manual verification: contradiction detection, prune, memory types