### PR TITLE
fix(ci): correct tar extraction in cora-review action

### DIFF
--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -49,6 +49,18 @@ runs:
         env-slug: ${{ inputs.infisical-env }}
         domain: ${{ inputs.infisical-domain }}
 
+    - name: Resolve cora-cli version
+      id: resolve
+      shell: bash
+      run: |
+        if [ "${{ inputs.cora-version }}" = "latest" ]; then
+          VERSION=$(curl -sL https://api.github.com/repos/ajianaz/cora-cli/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
+        else
+          VERSION="${{ inputs.cora-version }}"
+        fi
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Resolved cora-cli version: $VERSION"
+
     - name: Install cora-cli
       shell: bash
       run: |
@@ -61,7 +73,7 @@ runs:
           echo "Unsupported architecture: $ARCH"
           exit 1
         fi
-        curl -sL "https://github.com/ajianaz/cora-cli/releases/download/${{ inputs.cora-version }}/${ASSET}-${{ inputs.cora-version }}.tar.gz" | tar xz -C /usr/local/bin cora
+        curl -sL "https://github.com/ajianaz/cora-cli/releases/download/${{ steps.resolve.outputs.VERSION }}/${ASSET}-${{ steps.resolve.outputs.VERSION }}.tar.gz" | tar xz -C /usr/local/bin cora
         chmod +x /usr/local/bin/cora
         cora --version
 

--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -13,7 +13,7 @@ inputs:
   cora-version:
     description: 'cora-cli version tag (default: latest release)'
     required: false
-    default: 'v0.1.1'
+    default: 'latest'
   upload-sarif:
     description: 'Upload SARIF to GitHub Code Scanning (default: false)'
     required: false

--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -1,5 +1,5 @@
 name: 'Cora AI Code Review'
-description: 'Run cora AI code review on a PR diff — uploads SARIF to Code Scanning and posts a PR comment.'
+description: 'Run cora AI code review on a PR diff — posts a PR comment with findings. SARIF upload is optional.'
 
 inputs:
   base-branch:
@@ -14,6 +14,10 @@ inputs:
     description: 'cora-cli version tag (default: latest release)'
     required: false
     default: 'v0.1.1'
+  upload-sarif:
+    description: 'Upload SARIF to GitHub Code Scanning (default: false)'
+    required: false
+    default: 'false'
   infisical-identity-id:
     description: 'Infisical OIDC identity ID (from secret INFISICAL_IDENTITY_ID)'
     required: true
@@ -62,6 +66,7 @@ runs:
         cora --version
 
     - name: Run cora review
+      id: review
       shell: bash
       env:
         CORA_API_KEY: ${{ env.CORA_API_KEY }}
@@ -77,7 +82,8 @@ runs:
         echo "Cora review complete ($(wc -c < cora-results.sarif) bytes)"
 
     - name: Upload SARIF to GitHub Code Scanning
-      if: always() && hashFiles('cora-results.sarif') != ''
+      if: inputs.upload-sarif == 'true'
+      continue-on-error: true
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: cora-results.sarif
@@ -185,7 +191,7 @@ runs:
           " 2>/dev/null || echo "0")
 
           if [ "$ERRORS" -gt 0 ]; then
-            echo "::error::Cora found $ERRORS blocking issue(s). Review the Code Scanning results."
+            echo "::error::Cora found $ERRORS blocking issue(s)."
             exit 1
           fi
         fi


### PR DESCRIPTION
Release archive contains `cora-x86_64-unknown-linux-gnu` not `cora`. Extract to temp dir then rename.