### PR TITLE
chore(docs): update roadmap with v0.0.5-v0.0.7 milestones

### DIFF
--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -13,7 +13,7 @@ inputs:
   cora-version:
     description: 'cora-cli version tag (default: latest release)'
     required: false
-    default: 'v0.1.2'
+    default: 'latest'
   upload-sarif:
     description: 'Upload SARIF to GitHub Code Scanning (default: false)'
     required: false

--- a/website/src/routes/docs/roadmap/+page.svelte
+++ b/website/src/routes/docs/roadmap/+page.svelte
@@ -102,17 +102,20 @@
 		</div>
 	</section>
 
-	<!-- Next -->
+	<!-- v0.0.5 — In Progress -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-amber-500/20 text-amber-400">Next</span>
-			Integrations & Performance
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-amber-500/20 text-amber-400">v0.0.5</span>
+			Docker & Deployment
 		</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">Containerize uteke-serve with multi-stage build, flexible data paths, and automated image publishing.</p>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Import from external knowledge sources', issue: 46, status: 'open' },
-				{ title: 'Benchmark and performance metrics', issue: 49, status: 'open' },
-				{ title: 'Hermes plugin for uteke integration', issue: 55, status: 'open' },
+				{ title: 'UTEKE_HOME env var for custom data directory', issue: 95 },
+				{ title: 'uteke-serve reads uteke.toml, default host 0.0.0.0', issue: 96 },
+				{ title: 'Dockerfile (multi-stage build, model baked in)', issue: 97 },
+				{ title: 'Cora review always use latest version', issue: 98 },
+				{ title: 'Docker image build & push on release', issue: 99 },
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -130,25 +133,94 @@
 		</div>
 	</section>
 
-	<!-- Future -->
+	<!-- v0.0.6 — Planned -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-500/20 text-blue-400">Future</span>
-			Scale & Ecosystem
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-500/20 text-blue-400">v0.0.6</span>
+			Network & Auth
 		</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">Secure remote access with TLS, API key auth, and cloud routing.</p>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Better embeddings (larger model option)' },
-				{ title: 'Python SDK (PyO3 bindings)' },
-				{ title: 'Node.js SDK (NAPI)' },
-				{ title: 'Editor integrations (VS Code, JetBrains)' },
-				{ title: 'Team features & cloud sync (opt-in)' },
+				{ title: 'TLS support & reverse proxy documentation', issue: 100 },
+				{ title: 'API key authentication for uteke-serve', issue: 101 },
+				{ title: '--remote flag for cloud API routing', issue: 102 },
+				{ title: 'Hermes plugin for uteke integration', issue: 55 },
+			] as item}
+				<a
+					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+					target="_blank"
+					rel="noopener"
+					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+				>
+					<div class="flex items-center gap-3">
+						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+						<span class="text-sm">{item.title}</span>
+					</div>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">Planned</span>
+				</a>
+			{/each}
+		</div>
+	</section>
+
+	<!-- v0.0.7 — Cloud MVP -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-purple-500/20 text-purple-400">v0.0.7</span>
+			Cloud MVP
+		</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">Managed cloud API with billing and multi-tenant namespaces — open core with optional paid tier.</p>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Managed cloud API (uteke.ajianaz.dev)' },
+				{ title: 'Multi-tenant namespace isolation' },
+				{ title: 'Usage-based billing (Stripe/Lynk)' },
+				{ title: 'Web dashboard (usage, namespaces, settings)' },
 			] as item}
 				<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
 					<span class="text-sm">{item.title}</span>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">Planned</span>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-400">Future</span>
 				</div>
 			{/each}
 		</div>
 	</section>
+
+	<!-- Backlog -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-zinc-500/20 text-zinc-400">Backlog</span>
+			Nice-to-haves
+		</h2>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Import from external knowledge sources', issue: 46 },
+				{ title: 'Benchmark and performance metrics', issue: 49 },
+				{ title: 'Better embeddings (larger model option)' },
+				{ title: 'Python SDK (PyO3 bindings)' },
+				{ title: 'Node.js SDK (NAPI)' },
+				{ title: 'Editor integrations (VS Code, JetBrains)' },
+			] as item}
+				{#if item.issue}
+					<a
+						href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+						target="_blank"
+						rel="noopener"
+						class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+					>
+						<div class="flex items-center gap-3">
+							<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+							<span class="text-sm">{item.title}</span>
+						</div>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-zinc-500/20 text-zinc-400">Backlog</span>
+					</a>
+				{:else}
+					<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
+						<span class="text-sm">{item.title}</span>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-zinc-500/20 text-zinc-400">Backlog</span>
+					</div>
+				{/if}
+			{/each}
+		</div>
+	</section>
+
 </div>


### PR DESCRIPTION
## Summary

Update roadmap page to reflect planned milestones v0.0.5 through v0.0.7.

### Changes

- **v0.0.5 — Docker & Deployment** (amber, 5 issues: #95-#99)
- **v0.0.6 — Network & Auth** (blue, 4 issues: #55, #100-#102)
- **v0.0.7 — Cloud MVP** (purple, 4 future items)
- **Backlog** reorganized (6 items including #46, #49)

### Also created on GitHub

- **4 milestones** — v0.0.5, v0.0.6, v0.0.7, Backlog
- **6 new labels** — `scope:docker`, `scope:cloud`, `type:breaking`, `effort:low`, `effort:high`, `status:deferred`
- **8 new issues** — all assigned to appropriate milestones

### No GitHub Project

Repo has 11 open issues — too small for project board. Milestones + labels sufficient for now.