### PR TITLE
feat(core): UTEKE_HOME env var for custom data directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,16 +530,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -550,20 +541,8 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.6",
+ "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1762,17 +1741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,7 +2622,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "ctrlc",
- "dirs 5.0.1",
+ "dirs",
  "reqwest",
  "serde",
  "serde_json",
@@ -2671,7 +2639,7 @@ name = "uteke-core"
 version = "0.0.4"
 dependencies = [
  "chrono",
- "dirs 5.0.1",
+ "dirs",
  "ndarray",
  "ort",
  "reqwest",
@@ -2691,7 +2659,6 @@ name = "uteke-server"
 version = "0.0.4"
 dependencies = [
  "ctrlc",
- "dirs 6.0.0",
  "serde",
  "serde_json",
  "tiny_http",

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -124,9 +124,7 @@ impl EmbeddingEngine {
     }
 
     fn model_dir() -> Result<PathBuf, Error> {
-        let home = dirs::home_dir()
-            .ok_or_else(|| Error::Embedding("Cannot determine home directory".into()))?;
-        Ok(home.join(".uteke").join("models").join(MODEL_DIR_NAME))
+        Ok(crate::uteke_home().join("models").join(MODEL_DIR_NAME))
     }
 }
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -24,8 +24,28 @@ use memory::vector::euclidean_to_cosine;
 use memory::VectorIndex;
 
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
+/// Resolve uteke data directory.
+///
+/// Uses `UTEKE_HOME` environment variable when set, otherwise falls back to
+/// `~/.uteke`. This allows Docker containers and custom deployments to
+/// override the default storage location.
+///
+/// ```text
+/// UTEKE_HOME=/data   → /data
+/// (not set)           → ~/.uteke
+/// ```
+pub fn uteke_home() -> PathBuf {
+    if let Ok(home) = std::env::var("UTEKE_HOME") {
+        PathBuf::from(home)
+    } else {
+        dirs::home_dir()
+            .expect("Cannot determine home directory. Set UTEKE_HOME or HOME.")
+            .join(".uteke")
+    }
+}
 
 /// Uteke — AI agent memory engine.
 ///
@@ -423,9 +443,7 @@ impl Uteke {
         }
 
         // 4. Embedding model
-        let model_dir = dirs::home_dir()
-            .map(|h| h.join(".uteke").join("models").join("embeddinggemma-q4"))
-            .unwrap_or_default();
+        let model_dir = uteke_home().join("models").join("embeddinggemma-q4");
         let model_file = model_dir.join("onnx").join("model_q4.onnx");
         let tokenizer_file = model_dir.join("tokenizer.json");
         let model_exists = model_file.exists() && tokenizer_file.exists();

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -18,4 +18,3 @@ tiny_http = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ctrlc = "3"
-dirs = "6.0.0"

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -342,12 +342,8 @@ fn main() {
         .init();
 
     // Open store
-    let home = dirs::home_dir().expect("Cannot determine home directory");
-    let db_path = home
-        .join(".uteke")
-        .join("uteke.db")
-        .to_string_lossy()
-        .to_string();
+    let home = uteke_core::uteke_home();
+    let db_path = home.join("uteke.db").to_string_lossy().to_string();
 
     info!("Opening store at: {db_path}");
     let uteke = match Uteke::open(&db_path) {


### PR DESCRIPTION
## Summary

Add `UTEKE_HOME` environment variable to override default data directory.

```
UTEKE_HOME=/data   → /data/uteke.db, /data/models/
(not set)           → ~/.uteke/uteke.db, ~/.uteke/models/  (no change)
```

## Changes
- `uteke_core::uteke_home()` — public function, resolves data dir
- `engine.rs` — model download path uses `uteke_home()`
- `lib.rs` — doctor model check uses `uteke_home()`
- `uteke-server` — DB path uses `uteke_core::uteke_home()`
- Remove unused `dirs` dep from uteke-server

## Acceptance Criteria
- [x] UTEKE_HOME env var takes precedence over dirs::home_dir()
- [x] dirs::home_dir() remains fallback (zero breaking change)
- [x] Model path respects UTEKE_HOME
- [x] Doctor model check respects UTEKE_HOME
- [x] Server DB path respects UTEKE_HOME
- [x] No new dependencies

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `UTEKE_HOME` environment variable support to customize where Uteke stores its data, with fallback to `~/.uteke`.
  * Unified directory path resolution across models and database management for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->