### PR TITLE
feat(server): read uteke.toml config + smart server fallback

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -704,12 +704,17 @@ fn main() {
 
     if server_available {
         tracing::info!("Server detected at {server_url}, routing via HTTP");
-        let result = run_via_server(&cli, &server_url);
-        if let Err(e) = result {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
+        match run_via_server(&cli, &server_url) {
+            Ok(()) => return,
+            Err(e) if e == "unsupported" => {
+                tracing::info!("Command not supported via server, using local store");
+                // Fall through to local store
+            }
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
         }
-        return;
     }
 
     // Fallback: open local store (cold start ~1s)
@@ -930,7 +935,7 @@ fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> {
         }
         // Commands not supported via server fall through to local
         _ => {
-            return Err("This command requires local store. Disable server mode to use it.".into());
+            return Err("unsupported".into());
         }
     }
     Ok(())

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 uteke-core = { path = "../uteke-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 tiny_http = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -278,10 +278,10 @@ fn route(
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
 fn main() {
-    // Parse CLI args
+    // Parse CLI args — these override config
     let args: Vec<String> = std::env::args().collect();
-    let mut host = "127.0.0.1".to_string();
-    let mut port: u16 = 8767;
+    let mut cli_host: Option<String> = None;
+    let mut cli_port: Option<u16> = None;
 
     let mut i = 1;
     while i < args.len() {
@@ -289,16 +289,16 @@ fn main() {
             "--host" => {
                 i += 1;
                 if i < args.len() {
-                    host = args[i].clone();
+                    cli_host = Some(args[i].clone());
                 }
             }
             "--port" => {
                 i += 1;
                 if i < args.len() {
-                    port = args[i].parse().unwrap_or_else(|e| {
+                    cli_port = Some(args[i].parse().unwrap_or_else(|e| {
                         eprintln!("Invalid port: {e}");
                         std::process::exit(1);
-                    });
+                    }));
                 }
             }
             "--help" | "-h" => {
@@ -307,9 +307,15 @@ fn main() {
                 println!("Usage: uteke-serve [OPTIONS]");
                 println!();
                 println!("Options:");
-                println!("  --host <HOST>  Bind address (default: 127.0.0.1)");
+                println!("  --host <HOST>  Bind address (default: 0.0.0.0)");
                 println!("  --port <PORT>  Port number (default: 8767)");
                 println!("  -h, --help     Show this help");
+                println!();
+                println!("Config: reads [server] section from uteke.toml");
+                println!("  CLI args override config values.");
+                println!();
+                println!("Environment:");
+                println!("  UTEKE_HOME    Data directory (default: ~/.uteke)");
                 println!();
                 println!("API:");
                 println!("  GET  /health              → {{ status, memories }}");
@@ -332,6 +338,16 @@ fn main() {
         }
         i += 1;
     }
+
+    // Load config: defaults → uteke.toml → CLI args
+    let config = load_uteke_toml();
+    let config_host = config.server.as_ref().and_then(|s| s.host.clone())
+        .unwrap_or_else(|| "0.0.0.0".to_string());
+    let config_port = config.server.as_ref().and_then(|s| s.port)
+        .unwrap_or(8767);
+
+    let host = cli_host.unwrap_or(config_host);
+    let port = cli_port.unwrap_or(config_port);
 
     // Logging
     tracing_subscriber::fmt()
@@ -399,3 +415,44 @@ fn main() {
 
     info!("Goodbye.");
 }
+
+// ── Config Loading ────────────────────────────────────────────────────────
+
+/// Minimal [server] config section for parsing uteke.toml.
+#[derive(serde::Deserialize, Default)]
+struct ServerFileConfig {
+    server: Option<ServerFileSection>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ServerFileSection {
+    host: Option<String>,
+    port: Option<u16>,
+}
+
+/// Find and parse the nearest uteke.toml, looking at:
+/// 1. $UTEKE_HOME/uteke.toml (or ~/.uteke/uteke.toml)
+/// 2. $CWD/.uteke/uteke.toml
+fn load_uteke_toml() -> ServerFileConfig {
+    let mut config = ServerFileConfig::default();
+
+    let paths = [
+        uteke_core::uteke_home().join("uteke.toml"),
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.join(".uteke").join("uteke.toml")),
+    ];
+
+    for path in paths.into_iter().flatten() {
+        if path.exists() {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Ok(parsed) = toml::from_str::<ServerFileConfig>(&content) {
+                    config = parsed;
+                }
+            }
+        }
+    }
+
+    config
+}
+

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -343,10 +343,12 @@ fn main() {
 
     // Load config: defaults → uteke.toml → CLI args
     let config = load_uteke_toml();
-    let config_host = config.server.as_ref().and_then(|s| s.host.clone())
+    let config_host = config
+        .server
+        .as_ref()
+        .and_then(|s| s.host.clone())
         .unwrap_or_else(|| "0.0.0.0".to_string());
-    let config_port = config.server.as_ref().and_then(|s| s.port)
-        .unwrap_or(8767);
+    let config_port = config.server.as_ref().and_then(|s| s.port).unwrap_or(8767);
 
     let host = cli_host.unwrap_or(config_host);
     let port = cli_port.unwrap_or(config_port);
@@ -438,9 +440,7 @@ struct ServerFileSection {
 fn load_uteke_toml() -> ServerFileConfig {
     let mut config = ServerFileConfig::default();
 
-    let mut paths: Vec<PathBuf> = vec![
-        uteke_core::uteke_home().join("uteke.toml"),
-    ];
+    let mut paths: Vec<PathBuf> = vec![uteke_core::uteke_home().join("uteke.toml")];
     if let Ok(cwd) = std::env::current_dir() {
         paths.push(cwd.join(".uteke").join("uteke.toml"));
     }
@@ -457,4 +457,3 @@ fn load_uteke_toml() -> ServerFileConfig {
 
     config
 }
-

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -6,6 +6,8 @@
 use std::io::{Cursor, Read as IoRead};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 use tiny_http::{Header, Method, Response, Server, StatusCode};
 use tracing::{error, info, warn};
@@ -436,14 +438,14 @@ struct ServerFileSection {
 fn load_uteke_toml() -> ServerFileConfig {
     let mut config = ServerFileConfig::default();
 
-    let paths = [
+    let mut paths: Vec<PathBuf> = vec![
         uteke_core::uteke_home().join("uteke.toml"),
-        std::env::current_dir()
-            .ok()
-            .map(|cwd| cwd.join(".uteke").join("uteke.toml")),
     ];
+    if let Ok(cwd) = std::env::current_dir() {
+        paths.push(cwd.join(".uteke").join("uteke.toml"));
+    }
 
-    for path in paths.into_iter().flatten() {
+    for path in paths {
         if path.exists() {
             if let Ok(content) = std::fs::read_to_string(&path) {
                 if let Ok(parsed) = toml::from_str::<ServerFileConfig>(&content) {


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Server reads uteke.toml (#96)
- Server now reads `[server]` section from `uteke.toml`
- Layered resolution: `UTEKE_HOME/uteke.toml` → `cwd/.uteke/uteke.toml`
- Default host: `0.0.0.0` (Docker-compatible, was `127.0.0.1`)
- CLI `--host`/`--port` override config values
- Single config parse (Cora feedback addressed)

### 2. Smart server fallback (#104)
- CLI commands not supported via HTTP auto-fallback to local store
- Before: `uteke doctor` → ERROR when server enabled
- After: `uteke doctor` → logs fallback, runs locally

## Acceptance Criteria
- [x] Server reads uteke.toml [server] section
- [x] Default host 0.0.0.0
- [x] CLI args override config
- [x] UTEKE_HOME respected for config lookup
- [x] Unsupported commands auto-fallback to local (no error)
- [x] Cora review: no issues

## Depends On
- #95 (UTEKE_HOME — cherry-picked into this branch)

Closes #96
Closes #104