### PR TITLE
feat(docker): add multi-stage Dockerfile with baked-in model

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+target
+node_modules
+website
+Cargo.lock
+*.md
+LICENSE
+NOTICE
+tests
+benches

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# ── Stage 1: Builder ────────────────────────────────────────────────────
+FROM debian:bookworm-slim@sha256:49a26f2a35ca268bbb3fefc6722c13b07e3ce320f9689e91b54c652e24a1ba20 AS builder
+
+ARG VERSION=v0.0.4
+ARG TARGET=aarch64-unknown-linux-gnu
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl gpg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download release binary (contains uteke + uteke-serve)
+RUN ARCHIVE="uteke-${TARGET}-${VERSION}.tar.gz" && \
+    URL="https://github.com/ajianaz/uteke/releases/download/${VERSION}/${ARCHIVE}" && \
+    echo "Downloading ${ARCHIVE}..." && \
+    curl -fsSL "${URL}" -o "/tmp/${ARCHIVE}" && \
+    tar xzf "/tmp/${ARCHIVE}" --strip-components=1 && \
+    rm "/tmp/${ARCHIVE}" && \
+    chmod +x uteke uteke-serve && \
+    echo "Binary download complete."
+
+# Download embedding model (~208MB)
+RUN mkdir -p /models/onnx && \
+    echo "Downloading embedding model (this may take a minute)..." && \
+    curl -fsSL -o /models/onnx/model_q4.onnx \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx" && \
+    curl -fsSL -o /models/onnx/model_q4.onnx_data \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data" && \
+    curl -fsSL -o /models/tokenizer.json \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json" && \
+    echo "Model download complete." && \
+    ls -lh /models/onnx/ /models/tokenizer.json
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────
+FROM debian:bookworm-slim@sha256:49a26f2a35ca268bbb3fefc6722c13b07e3ce320f9689e91b54c652e24a1ba20
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy binaries
+COPY --from=builder /build/uteke /usr/local/bin/uteke
+COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
+
+# Copy embedding model
+COPY --from=builder /models /data/models/embeddinggemma-q4
+
+# Data directory (mount volume here)
+ENV UTEKE_HOME=/data
+
+EXPOSE 8767
+
+ENTRYPOINT ["uteke-serve"]


### PR DESCRIPTION
## Summary

Multi-stage Dockerfile for uteke-serve:
- Stage 1: download release binary + HuggingFace model
- Stage 2: runtime only (debian:bookworm-slim)
- Model baked in (~208MB) — no runtime download
- ENV UTEKE_HOME=/data for volume mount
- Pinned base image digest
- .dockerignore for clean build context

## Acceptance Criteria
- [x] Multi-stage build
- [x] Pre-built binary from GitHub release
- [x] Model baked in
- [x] ENV UTEKE_HOME=/data
- [x] EXPOSE 8767, ENTRYPOINT uteke-serve
- [x] .dockerignore excludes fluff
- [x] Pinned base image digest
- [x] Cora review: passed

## Depends On
- #95 (UTEKE_HOME — cherry-picked into this branch)

## Usage

```bash
docker build --build-arg VERSION=v0.0.5 --build-arg TARGET=aarch64-unknown-linux-gnu -t uteke:v0.0.5 .
docker run -d -p 8767:8767 -v uteke-data:/data uteke:v0.0.5
curl http://localhost:8767/health
```

Closes #97