### PR TITLE
feat(ci): Docker image build & push on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+target
+node_modules
+website
+Cargo.lock
+*.md
+LICENSE
+NOTICE
+tests
+benches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,3 +149,63 @@ jobs:
           prerelease: ${{ contains(steps.version.outputs.VERSION, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Build & Push Docker Image
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push (linux/amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            TARGET=x86_64-unknown-linux-gnu
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push (linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64/v8
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            TARGET=aarch64-unknown-linux-gnu
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# ── Stage 1: Builder ────────────────────────────────────────────────────
+FROM debian:bookworm-slim@sha256:49a26f2a35ca268bbb3fefc6722c13b07e3ce320f9689e91b54c652e24a1ba20 AS builder
+
+ARG VERSION=v0.0.4
+ARG TARGET=aarch64-unknown-linux-gnu
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl gpg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download release binary (contains uteke + uteke-serve)
+RUN ARCHIVE="uteke-${TARGET}-${VERSION}.tar.gz" && \
+    URL="https://github.com/ajianaz/uteke/releases/download/${VERSION}/${ARCHIVE}" && \
+    echo "Downloading ${ARCHIVE}..." && \
+    curl -fsSL "${URL}" -o "/tmp/${ARCHIVE}" && \
+    tar xzf "/tmp/${ARCHIVE}" --strip-components=1 && \
+    rm "/tmp/${ARCHIVE}" && \
+    chmod +x uteke uteke-serve && \
+    echo "Binary download complete."
+
+# Download embedding model (~208MB)
+RUN mkdir -p /models/onnx && \
+    echo "Downloading embedding model (this may take a minute)..." && \
+    curl -fsSL -o /models/onnx/model_q4.onnx \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx" && \
+    curl -fsSL -o /models/onnx/model_q4.onnx_data \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data" && \
+    curl -fsSL -o /models/tokenizer.json \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json" && \
+    echo "Model download complete." && \
+    ls -lh /models/onnx/ /models/tokenizer.json
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────
+FROM debian:bookworm-slim@sha256:49a26f2a35ca268bbb3fefc6722c13b07e3ce320f9689e91b54c652e24a1ba20
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy binaries
+COPY --from=builder /build/uteke /usr/local/bin/uteke
+COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
+
+# Copy embedding model
+COPY --from=builder /models /data/models/embeddinggemma-q4
+
+# Data directory (mount volume here)
+ENV UTEKE_HOME=/data
+
+EXPOSE 8767
+
+ENTRYPOINT ["uteke-serve"]


### PR DESCRIPTION
## Summary

Add Docker image build & push to GHCR in release workflow.

## Details
- Multi-arch: linux/amd64 + linux/arm64
- Triggered after release job (binary + GitHub Release created)
- Tags: semver (e.g. v0.0.5) + latest
- Registry: ghcr.io/ajianaz/uteke
- Auth: GITHUB_TOKEN (no new secrets)
- QEMU + buildx for cross-platform

## Acceptance Criteria
- [x] New job in release.yml after release
- [x] Multi-arch: linux/amd64 + linux/arm64
- [x] Pushes to ghcr.io with version + latest tags
- [x] No new CI secrets needed
- [x] Cora review: passed

## Depends On
- #97 (Dockerfile — merged into this branch)
- #95 (UTEKE_HOME — merged into this branch)

## Merge Order
Merge AFTER: #106 (UTEKE_HOME), #109 (Dockerfile)

## Verification
After tag v0.0.5:
```bash
docker pull ghcr.io/ajianaz/uteke:v0.0.5
docker pull ghcr.io/ajianaz/uteke:latest
```

Closes #99