### PR TITLE
fix(docker): add curl retry and timeout for CI reliability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ WORKDIR /build
 # Download release binary (contains uteke + uteke-serve)
 RUN ARCHIVE="uteke-${TARGET}-${VERSION}.tar.gz" && \
     URL="https://github.com/ajianaz/uteke/releases/download/${VERSION}/${ARCHIVE}" && \
-    echo "Downloading ${ARCHIVE}..." && \
-    curl -fsSL "${URL}" -o "/tmp/${ARCHIVE}" && \
+    echo "Downloading ${ARCHIVE} from ${URL}..." && \
+    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL "${URL}" -o "/tmp/${ARCHIVE}" && \
+    echo "Extracting..." && \
     tar xzf "/tmp/${ARCHIVE}" --strip-components=1 && \
     rm "/tmp/${ARCHIVE}" && \
     chmod +x uteke uteke-serve && \
@@ -23,12 +24,15 @@ RUN ARCHIVE="uteke-${TARGET}-${VERSION}.tar.gz" && \
 # Download embedding model (~208MB)
 RUN mkdir -p /models/onnx && \
     echo "Downloading embedding model (this may take a minute)..." && \
-    curl -fsSL -o /models/onnx/model_q4.onnx \
-    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx" && \
-    curl -fsSL -o /models/onnx/model_q4.onnx_data \
-    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data" && \
-    curl -fsSL -o /models/tokenizer.json \
-    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json" && \
+    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL \
+        -o /models/onnx/model_q4.onnx \
+        "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx" && \
+    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL \
+        -o /models/onnx/model_q4.onnx_data \
+        "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data" && \
+    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL \
+        -o /models/tokenizer.json \
+        "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json" && \
     echo "Model download complete." && \
     ls -lh /models/onnx/ /models/tokenizer.json
 


### PR DESCRIPTION
Docker build consistently fails with `exit code: 1` on curl download step in GitHub Actions.

**Root cause:** buildx `docker-container` driver has network restrictions that cause intermittent curl failures to github.com and huggingface.co.

**Fix:**
- Add `--retry 3 --retry-delay 5 --connect-timeout 30` to all curl commands
- Add debug logging (URL echo, extract step echo)

Note: Cora flagged checksum verification as MAJOR — valid concern, tracked as future improvement (needs CI to compute checksums from release assets and pass as build-arg).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process resilience with enhanced error handling and retry logic for downloading external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->