### PR TITLE
fix(ci): move downloads to host runner — buildx cannot access network

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,39 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download release binaries
+        run: |
+          mkdir -p binaries
+          VERSION="${{ github.ref_name }}"
+          # Download amd64 binary
+          curl -fSL --retry 3 --retry-delay 5 \
+            "https://github.com/ajianaz/uteke/releases/download/${VERSION}/uteke-x86_64-unknown-linux-gnu-${VERSION}.tar.gz" \
+            | tar xz -C binaries --strip-components=1
+          mv binaries/uteke binaries/uteke-amd64
+          mv binaries/uteke-serve binaries/uteke-serve-amd64
+          # Download arm64 binary
+          curl -fSL --retry 3 --retry-delay 5 \
+            "https://github.com/ajianaz/uteke/releases/download/${VERSION}/uteke-aarch64-unknown-linux-gnu-${VERSION}.tar.gz" \
+            | tar xz -C binaries --strip-components=1
+          mv binaries/uteke binaries/uteke-arm64
+          mv binaries/uteke-serve binaries/uteke-serve-arm64
+          chmod +x binaries/*
+          ls -lh binaries/
+
+      - name: Download embedding model
+        run: |
+          mkdir -p models/onnx
+          curl -fSL --retry 3 --retry-delay 5 \
+            -o models/onnx/model_q4.onnx \
+            "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx"
+          curl -fSL --retry 3 --retry-delay 5 \
+            -o models/onnx/model_q4.onnx_data \
+            "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data"
+          curl -fSL --retry 3 --retry-delay 5 \
+            -o models/tokenizer.json \
+            "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json"
+          ls -lh models/onnx/ models/tokenizer.json
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -184,28 +217,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push (linux/amd64)
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64/v8
           build-args: |
             VERSION=${{ github.ref_name }}
-            TARGET=x86_64-unknown-linux-gnu
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push (linux/arm64)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/arm64/v8
-          build-args: |
-            VERSION=${{ github.ref_name }}
-            TARGET=aarch64-unknown-linux-gnu
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,26 @@
 # ── Stage 1: Builder ────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS builder
 
+ARG TARGETARCH
 ARG VERSION=v0.0.5
-ARG TARGET=aarch64-unknown-linux-gnu
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl gpg && \
+    ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
-# Download release binary (contains uteke + uteke-serve)
-RUN ARCHIVE="uteke-${TARGET}-${VERSION}.tar.gz" && \
-    URL="https://github.com/ajianaz/uteke/releases/download/${VERSION}/${ARCHIVE}" && \
-    echo "Downloading ${ARCHIVE} from ${URL}..." && \
-    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL "${URL}" -o "/tmp/${ARCHIVE}" && \
-    echo "Extracting..." && \
-    tar xzf "/tmp/${ARCHIVE}" --strip-components=1 && \
-    rm "/tmp/${ARCHIVE}" && \
-    chmod +x uteke uteke-serve && \
-    echo "Binary download complete."
-
-# Download embedding model (~208MB)
-RUN mkdir -p /models/onnx && \
-    echo "Downloading embedding model (this may take a minute)..." && \
-    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL \
-        -o /models/onnx/model_q4.onnx \
-        "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx" && \
-    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL \
-        -o /models/onnx/model_q4.onnx_data \
-        "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data" && \
-    curl --retry 3 --retry-delay 5 --connect-timeout 30 -fSL \
-        -o /models/tokenizer.json \
-        "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json" && \
-    echo "Model download complete." && \
-    ls -lh /models/onnx/ /models/tokenizer.json
+# Select correct binary for target architecture
+# TARGETARCH is set by Docker buildx: amd64 or arm64
+COPY binaries/ ./
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      mv uteke-arm64 uteke && mv uteke-serve-arm64 uteke-serve && \
+      rm -f uteke-amd64 uteke-serve-amd64; \
+    else \
+      mv uteke-amd64 uteke && mv uteke-serve-amd64 uteke-serve && \
+      rm -f uteke-arm64 uteke-serve-arm64; \
+    fi && \
+    chmod +x uteke uteke-serve
 
 # ── Stage 2: Runtime ────────────────────────────────────────────────────
 FROM debian:bookworm-slim
@@ -47,8 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
 
-# Copy embedding model
-COPY --from=builder /models /data/models/embeddinggemma-q4
+# Copy embedding model (downloaded in CI)
+COPY models/ /data/models/embeddinggemma-q4
 
 # Data directory (mount volume here)
 ENV UTEKE_HOME=/data


### PR DESCRIPTION
## Problem

Docker build with buildx `docker-container` driver consistently fails downloading from github.com and huggingface.co:
```
curl: exit code: 1 (instant failure — not timeout)
```
The `docker-container` driver isolates network, preventing outbound HTTP from build steps.

## Solution

Move ALL downloads from `Dockerfile RUN` steps to CI host runner steps, then pass files via Docker context `COPY`.

**Dockerfile changes:**
- Remove `RUN curl...` for both binaries and models
- `COPY binaries/` + `COPY models/` from context
- Select correct arch binary via `TARGETARCH` (Docker buildx auto-set)

**release.yml changes:**
- Add `Download release binaries` step — downloads amd64 + arm64
- Add `Download embedding model` step — downloads 3 files (~208MB)
- Merge 2 separate build-push steps into 1 multi-platform step
- Consistent `--strip-components=1` for both arches

## Trade-offs
- **Pro**: Downloads run on host with full network access — no buildx isolation issue
- **Con**: Build context includes ~500MB of binaries + models (acceptable for CI, not for development)