### PR TITLE
fix(ci): use build artifacts + lazy runtime model download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
 
   docker:
     name: Build & Push Docker Image
-    needs: [release]
+    needs: [build-release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -174,24 +174,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download release binaries
+      - name: Download Linux binaries from build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: uteke-*-${{ github.ref_name }}
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Extract binaries for Docker context
         run: |
           mkdir -p binaries
-          VERSION="${{ github.ref_name }}"
-          # Download amd64 binary
-          curl -fSL --retry 3 --retry-delay 5 \
-            "https://github.com/ajianaz/uteke/releases/download/${VERSION}/uteke-x86_64-unknown-linux-gnu-${VERSION}.tar.gz" \
-            | tar xz -C binaries --strip-components=1
-          mv binaries/uteke binaries/uteke-amd64
-          mv binaries/uteke-serve binaries/uteke-serve-amd64
-          # Download arm64 binary
-          curl -fSL --retry 3 --retry-delay 5 \
-            "https://github.com/ajianaz/uteke/releases/download/${VERSION}/uteke-aarch64-unknown-linux-gnu-${VERSION}.tar.gz" \
-            | tar xz -C binaries --strip-components=1
-          mv binaries/uteke binaries/uteke-arm64
-          mv binaries/uteke-serve binaries/uteke-serve-arm64
-          chmod +x binaries/*
-          ls -lh binaries/
+          cd release-artifacts
+          # Extract amd64
+          tar xzf uteke-x86_64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz -C ../binaries --strip-components=1
+          mv ../binaries/uteke ../binaries/uteke-amd64
+          mv ../binaries/uteke-serve ../binaries/uteke-serve-amd64
+          # Extract arm64
+          tar xzf uteke-aarch64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz -C ../binaries --strip-components=1
+          mv ../binaries/uteke ../binaries/uteke-arm64
+          mv ../binaries/uteke-serve ../binaries/uteke-serve-arm64
+          chmod +x ../binaries/*
+          ls -lh ../binaries/
 
       - name: Download embedding model
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ ARG TARGETARCH
 ARG VERSION=v0.0.5
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates && \
+    ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
-# Select correct binary for target architecture
-# TARGETARCH is set by Docker buildx: amd64 or arm64
+# Copy CI-downloaded binaries (preferred).
 COPY binaries/ ./
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
       mv uteke-arm64 uteke && mv uteke-serve-arm64 uteke-serve && \
@@ -26,19 +25,23 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 && \
+    ca-certificates libssl3 curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy binaries
 COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
 
-# Copy embedding model (downloaded in CI)
+# Copy embedding model (pre-baked by CI)
 COPY models/ /data/models/embeddinggemma-q4
 
-# Data directory (mount volume here)
+# Copy entrypoint script (handles lazy model download)
+COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Data directory (mount volume here for persistence)
 ENV UTEKE_HOME=/data
 
 EXPOSE 8767
 
-ENTRYPOINT ["uteke-serve"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+MODEL_DIR="/data/models/embeddinggemma-q4"
+MODEL_FILE="${MODEL_DIR}/onnx/model_q4.onnx"
+
+# Lazy download: only if model not pre-baked by CI
+if [ ! -f "$MODEL_FILE" ]; then
+  echo "Model not found, downloading embedding model (~208MB)..."
+  mkdir -p "${MODEL_DIR}/onnx"
+  curl -fSL --retry 3 -o "${MODEL_DIR}/onnx/model_q4.onnx" \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx"
+  curl -fSL --retry 3 -o "${MODEL_DIR}/onnx/model_q4.onnx_data" \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data"
+  curl -fSL --retry 3 -o "${MODEL_DIR}/tokenizer.json" \
+    "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json"
+  echo "Model download complete."
+fi
+
+exec uteke-serve "$@"


### PR DESCRIPTION
## Problem

Docker build consistently fails downloading files:
1. Buildx `docker-container` driver isolates network — curl inside Dockerfile fails
2. Even moving downloads to host runner, curl to github.com releases failed

## Solution — Two-Layer Approach

### Primary: CI Artifacts (no network in Dockerfile)
- Docker job `needs: [build-release]` — parallel with release job
- Binaries via `actions/download-artifact@v4` — internal GitHub network, 100% reliable
- Model still downloaded on host (huggingface.co accessible from runner)
- No `RUN curl` in Dockerfile at all

### Fallback: Lazy Runtime Download
- `docker-entrypoint.sh` checks if model exists at container start
- If model missing (e.g. custom build, volume override), downloads before starting
- Uses `exec` form entrypoint — proper signal handling (SIGTERM, SIGINT)

### Other Fixes
- Replaced `sh -c` with exec form entrypoint (Cora CRITICAL)
- Model download writes to UTEKE_HOME (volume), not read-only image layer (Cora MAJOR)
- `.dockerignore` excludes build artifacts from context

## Trade-offs
- **Pro**: No network in Dockerfile = deterministic builds
- **Pro**: Artifact sharing = faster (no re-download ~44MB binaries)
- **Pro**: Lazy fallback = self-healing containers
- **Con**: Model still downloaded in CI step (~208MB from huggingface)