### PR TITLE
fix(ci): remove --strip-components from tar extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,10 +193,10 @@ jobs:
             echo "Available files:" && find . -type f | head -20
             exit 1
           fi
-          tar xzf "$AMD64" -C ../binaries --strip-components=1
+          tar xzf "$AMD64" -C ../binaries
           mv ../binaries/uteke ../binaries/uteke-amd64
           mv ../binaries/uteke-serve ../binaries/uteke-serve-amd64
-          tar xzf "$ARM64" -C ../binaries --strip-components=1
+          tar xzf "$ARM64" -C ../binaries
           mv ../binaries/uteke ../binaries/uteke-arm64
           mv ../binaries/uteke-serve ../binaries/uteke-serve-arm64
           chmod +x ../binaries/*


### PR DESCRIPTION
## Root Cause

`uteke-*.tar.gz` archives contain `uteke` + `uteke-serve` at **root level** (no directory prefix). `--strip-components=1` was stripping the filenames themselves → empty extraction → `mv: No such file`.

## Fix
Remove `--strip-components=1` from both tar extractions. Verified archive structure from build step:
```
tar czf archive.tar.gz uteke uteke-serve  # no dir prefix
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build process for release artifact extraction and binary packaging to improve the release build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->