### PR TITLE
fix: v0.0.6 patch & hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-release:
@@ -43,10 +44,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-
-      - name: Install Linux dependencies
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build release binaries
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli -p uteke-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Uteke will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.0.6] — 2026-06-02
+
+### Fixed
+
+- **JSON output omits embedding vector** — `Memory.embedding` now uses `#[serde(skip_serializing, default)]`
+  - Reduces JSON response size by ~3KB per memory
+  - Embeddings are populated programmatically via ONNX, not from JSON
+- **`import()` now persists vector index** — previously imported memories were lost on restart because the index was never saved
+- **CI: Node.js 24 enforcement** — added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to all workflows
+- **Docker: non-root container** — added `USER uteke` directive (uid/gid 1000) with owned `/data` directory
+- **CI: removed unused `musl-tools`** install — targets are glibc only
+
+### Added
+
+- **Dependabot** — automated dependency updates for cargo, GitHub Actions, and Docker
+
 ## [0.0.5] — 2026-06-01
 
 ### Added
@@ -42,8 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pre-existing format issue: `.to_string_lossy().to_string()` chain cleaned up
-
-[0.0.5]: https://github.com/ajianaz/uteke/releases/tag/v0.0.5
 
 ## [0.0.4] — 2026-05-31
 
@@ -93,7 +109,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Server warm (112 ops) | 112/112 | ✅ (avg ~35ms/op) |
 | Full functional retest | 15 phases | ✅ All pass |
 
-[0.0.4]: https://github.com/ajianaz/uteke/releases/tag/v0.0.4
+## [0.0.3] — 2026-05-30
+
+### Added
+
+- **Graceful shutdown** — SIGINT (Ctrl+C) handler via `ctrlc` crate
+  - Saves usearch index to disk before exit
+  - Prevents index corruption on interrupt
+- **File logging with daily rotation** — via `tracing-appender`
+  - Logs written to `~/.uteke/logs/uteke.log`
+  - Automatic daily rotation (`uteke.log.YYYY-MM-DD`)
+  - Non-blocking async writer
+- **Configuration file** — `uteke.toml` with layered resolution
+  - Search order: `./uteke.toml` → parent dirs → `~/.config/uteke/uteke.toml` → defaults
+  - Configurable: `store_path`, `log_level`, `log_dir`, `default_namespace`
+  - New `--config` flag to override config file path
+- **Tag management commands** — `tags list`, `tags rename`, `tags delete`
+  - `tags list [--by-count]` — list all tags with usage counts
+  - `tags rename <old> <new>` — rename tag across all memories
+  - `tags delete <tag>` — remove tag from all memories
+- **`--tags` filter for search** — filter search results by tags
+  - `uteke search "query" --tags "rust,cli"`
+- **Memory aging with auto-cleanup** — `aging status`, `aging preview`, `aging cleanup`
+  - `aging status` — show hot/warm/cold/never-accessed breakdown
+  - `aging preview --days N` — preview memories older than N days
+  - `aging cleanup --days N [--confirm]` — delete stale memories
+- **Shell hook for auto-context loading** — `hook install`
+  - Supports bash, zsh, fish
+  - Walks up from cwd to find `.uteke/uteke.db`
+  - Auto-loads project-scoped context on shell init
+  - Shell scripts loaded via `include_str!` from canonical files
+  - `SupportedShell` enum for parse-time shell validation
+- **Node.js 24** — CI upgraded from Node.js 20 → 24
+
+### Changed
+
+- Version bumped from 0.0.2 → 0.0.3
+
+### Stress Test Results (50 memories)
+
+| Phase | Result | Time |
+|---|---|---|
+| WRITE (50 memories) | 50/50 ✅ | 49.6s (~1.0/s) |
+| RECALL (5 queries) | 5/5 ✅ | 4.8s |
+| SEARCH (5 queries) | 5/5 ✅ | 4.7s |
+| EXPORT/IMPORT | 51/51 ✅ | - |
+| TAGS (list/rename/delete) | ✅ | - |
+| AGING | ✅ | - |
+| VERIFY + DOCTOR | ✅ All pass | - |
+| CLEANUP (50 delete) | 50/50 ✅ | 50.2s |
 
 ## [0.0.2] — 2026-05-29
 
@@ -149,60 +213,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CONTRIBUTING.md:** HNSW → usearch references updated
 - **README:** architecture table, tiered memory, health check commands
 
-## [0.0.3] — 2026-05-30
-
-### Added
-
-- **Graceful shutdown** — SIGINT (Ctrl+C) handler via `ctrlc` crate
-  - Saves usearch index to disk before exit
-  - Prevents index corruption on interrupt
-- **File logging with daily rotation** — via `tracing-appender`
-  - Logs written to `~/.uteke/logs/uteke.log`
-  - Automatic daily rotation (`uteke.log.YYYY-MM-DD`)
-  - Non-blocking async writer
-- **Configuration file** — `uteke.toml` with layered resolution
-  - Search order: `./uteke.toml` → parent dirs → `~/.config/uteke/uteke.toml` → defaults
-  - Configurable: `store_path`, `log_level`, `log_dir`, `default_namespace`
-  - New `--config` flag to override config file path
-- **Tag management commands** — `tags list`, `tags rename`, `tags delete`
-  - `tags list [--by-count]` — list all tags with usage counts
-  - `tags rename <old> <new>` — rename tag across all memories
-  - `tags delete <tag>` — remove tag from all memories
-- **`--tags` filter for search** — filter search results by tags
-  - `uteke search "query" --tags "rust,cli"`
-- **Memory aging with auto-cleanup** — `aging status`, `aging preview`, `aging cleanup`
-  - `aging status` — show hot/warm/cold/never-accessed breakdown
-  - `aging preview --days N` — preview memories older than N days
-  - `aging cleanup --days N [--confirm]` — delete stale memories
-- **Shell hook for auto-context loading** — `hook install`
-  - Supports bash, zsh, fish
-  - Walks up from cwd to find `.uteke/uteke.db`
-  - Auto-loads project-scoped context on shell init
-  - Shell scripts loaded via `include_str!` from canonical files
-  - `SupportedShell` enum for parse-time shell validation
-- **Node.js 24** — CI upgraded from Node.js 20 → 24
-
-### Changed
-
-- Version bumped from 0.0.2 → 0.0.3
-
-### Stress Test Results (50 memories)
-
-| Phase | Result | Time |
-|---|---|---|
-| WRITE (50 memories) | 50/50 ✅ | 49.6s (~1.0/s) |
-| RECALL (5 queries) | 5/5 ✅ | 4.8s |
-| SEARCH (5 queries) | 5/5 ✅ | 4.7s |
-| EXPORT/IMPORT | 51/51 ✅ | - |
-| TAGS (list/rename/delete) | ✅ | - |
-| AGING | ✅ | - |
-| VERIFY + DOCTOR | ✅ All pass | - |
-| CLEANUP (50 delete) | 50/50 ✅ | 50.2s |
-
-[0.0.3]: https://github.com/ajianaz/uteke/releases/tag/v0.0.3
-
-## [Unreleased]
-
 ## [0.0.1] — 2026-05-29
 
 ### Added
@@ -237,5 +247,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Binary name:** `uteke`
 - **Minimum Rust version:** 1.75+
 
+[0.0.6]: https://github.com/ajianaz/uteke/releases/tag/v0.0.6
+[0.0.5]: https://github.com/ajianaz/uteke/releases/tag/v0.0.5
+[0.0.4]: https://github.com/ajianaz/uteke/releases/tag/v0.0.4
+[0.0.3]: https://github.com/ajianaz/uteke/releases/tag/v0.0.3
 [0.0.2]: https://github.com/ajianaz/uteke/releases/tag/v0.0.2
 [0.0.1]: https://github.com/ajianaz/uteke/releases/tag/v0.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ajianaz/uteke"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 curl && \
     rm -rf /var/lib/apt/lists/*
 
+# Create non-root user
+RUN groupadd --system --gid 1000 uteke && \
+    useradd --system --uid 1000 --gid uteke --home /data uteke
+
 # Copy binaries
 COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
@@ -41,6 +45,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Data directory (mount volume here for persistence)
 ENV UTEKE_HOME=/data
+
+# Create data directory with correct ownership
+RUN mkdir -p /data && chown uteke:uteke /data
+
+USER uteke
 
 EXPOSE 8767
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1081,11 +1081,25 @@ mod tests {
         };
 
         let json = serde_json::to_string(&m).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Embedding is skipped in JSON output (skip_serializing)
+        assert!(
+            !v.get("embedding").is_some(),
+            "embedding should not be in JSON output"
+        );
+
+        // Other fields should serialize correctly
+        assert_eq!(v["id"], m.id);
+        assert_eq!(v["content"], m.content);
+        assert_eq!(v["tags"].as_array().unwrap().len(), 2);
+
+        // Deserialization produces empty embedding (expected — populated programmatically)
         let restored: Memory = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.id, m.id);
         assert_eq!(restored.content, m.content);
         assert_eq!(restored.tags, m.tags);
-        assert_eq!(restored.embedding.len(), 768);
+        assert!(restored.embedding.is_empty());
     }
 
     #[test]

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1085,7 +1085,7 @@ mod tests {
 
         // Embedding is skipped in JSON output (skip_serializing)
         assert!(
-            !v.get("embedding").is_some(),
+            v.get("embedding").is_none(),
             "embedding should not be in JSON output"
         );
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -935,6 +935,15 @@ impl Uteke {
             imported += 1;
         }
 
+        // Persist vector index after import completes
+        if imported > 0 {
+            let mut index = self
+                .index
+                .lock()
+                .map_err(|_| Error::Database("Failed to acquire index lock".into()))?;
+            index.save()?;
+        }
+
         Ok(ImportResult { imported, skipped })
     }
 }

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -13,7 +13,7 @@ pub struct Memory {
     /// The text content of the memory.
     pub content: String,
     /// 768-dimensional embedding vector.
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, default)]
     pub embedding: Vec<f32>,
     /// Tags for categorization.
     pub tags: Vec<String>,

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -13,6 +13,7 @@ pub struct Memory {
     /// The text content of the memory.
     pub content: String,
     /// 768-dimensional embedding vector.
+    #[serde(skip_serializing)]
     pub embedding: Vec<f32>,
     /// Tags for categorization.
     pub tags: Vec<String>,

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -248,7 +248,10 @@ impl VectorIndex {
             ..Default::default()
         };
 
-        Index::new(&options).expect("Failed to create usearch index")
+        match Index::new(&options) {
+            Ok(idx) => idx,
+            Err(e) => panic!("FATAL: Failed to create usearch index (dims={dims}): {e}. This is likely an out-of-memory condition."),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Quick fixes for milestone **v0.0.6 — Patch & Hardening**. No new features — stability and correctness only.

## Changes

| File | What | Issue |
|------|------|-------|
| `ci.yml` | Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` | #125 |
| `release.yml` | Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` | #125 |
| `release.yml` | Remove unused `musl-tools` install (glibc targets only) | #145 |
| `Dockerfile` | Add non-root `uteke` user + USER directive | #126 |
| `types.rs` | Add `#[serde(skip_serializing)]` on `Memory.embedding` | #124 |
| `lib.rs` | Persist vector index after `import()` completes | #124 |
| `vector.rs` | Improve panic message with dims + root cause hint | #124 |
| `.github/dependabot.yml` | New: Dependabot for cargo, github-actions, docker | #122 |

## Cora Review Notes

Cora flagged 2 issues (both false positives for this change):
- **musl-tools removal**: Intentional — targets are glibc, not musl
- **skip_serializing on embedding**: By design — JSON output excludes 3KB vector; import uses `ExportEntry` (no embedding, re-embeds on import)

## Closes

#122, #124, #125, #126, #145 (#123 already resolved on develop)

## Testing

- `cargo fmt --check` ✅
- Full `cargo check` / `cargo test` blocked on this server (missing `pkg-config` for ort-sys build dep) — will run in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Dependabot for automated dependency updates
  * Docker container now runs as non-root user for improved security

* **Bug Fixes**
  * Vector index now persists after importing data
  * Embedding vectors excluded from JSON output
  * Enhanced error messages for vector operations

* **Chores**
  * Version bumped to 0.0.6
  * Updated GitHub Actions workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->