### PR TITLE
feat: v0.0.7 — core stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 |------|-------------|
 | `--store <path>` | Override store location (default: `~/.uteke`) |
 | `--namespace <name>` | Namespace for multi-agent isolation (default: `"default"`) |
-| `--config <path>` | Override config file path |
 | `--json` | Output as JSON (all commands) |
 | `--verbose` | Enable debug logging |
 
@@ -244,22 +243,31 @@ uteke completions fish  > ~/.config/fish/completions/uteke.fish
 
 Uteke supports `uteke.toml` configuration with layered resolution:
 
-1. `./uteke.toml` (current directory)
-2. Parent directories up to root
-3. `~/.config/uteke/uteke.toml` (user-level)
-4. Built-in defaults
+1. `.uteke/uteke.toml` (project-level, in cwd)
+2. `~/.uteke/uteke.toml` (global user-level)
+3. Built-in defaults
 
 ```toml
-store_path = "~/.uteke"
-log_level = "info"
-log_dir = "~/.uteke/logs"
-default_namespace = "default"
-```
+[store]
+path = "~/.uteke"
+namespace = "default"
 
-Override config file path with `--config`:
+[embedding]
+model = "embeddinggemma-q4"
+max_seq_length = 256
 
-```bash
-uteke --config ./my-config.toml remember "project-specific note"
+[tier]
+hot_days = 7
+warm_days = 30
+hot_boost = 0.1
+
+[logging]
+level = "warn"
+
+[server]
+enabled = false
+host = "127.0.0.1"
+port = 8767
 ```
 
 ---

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -605,4 +605,119 @@ namespace = "agent1"
         assert!(migrated.contains("path = \"/data/mem\""));
         assert!(migrated.contains("namespace = \"agent1\""));
     }
+
+    #[test]
+    fn set_namespace_in_toml_existing_section() {
+        let content = "[store]\npath = \"~/.uteke\"\n# namespace = \"default\"\n\n[logging]\nlevel = \"warn\"\n";
+        let result = set_namespace_in_toml(content, "my-agent");
+        assert!(result.contains("namespace = \"my-agent\""));
+        assert!(result.contains("[store]"));
+        assert!(result.contains("[logging]"));
+    }
+
+    #[test]
+    fn set_namespace_in_toml_no_store_section() {
+        let content = "[logging]\nlevel = \"warn\"\n";
+        let result = set_namespace_in_toml(content, "new-ns");
+        assert!(result.contains("[store]"));
+        assert!(result.contains("namespace = \"new-ns\""));
+        assert!(result.contains("[logging]"));
+    }
+
+    #[test]
+    fn set_namespace_in_toml_empty_content() {
+        let content = "";
+        let result = set_namespace_in_toml(content, "empty-ns");
+        assert!(result.contains("[store]"));
+        assert!(result.contains("namespace = \"empty-ns\""));
+    }
+
+    #[test]
+    fn set_namespace_in_toml_update_existing() {
+        let content = "[store]\nnamespace = \"old-ns\"\npath = \"~/.uteke\"\n";
+        let result = set_namespace_in_toml(content, "new-ns");
+        assert!(result.contains("namespace = \"new-ns\""));
+        assert!(!result.contains("namespace = \"old-ns\""));
+    }
+
+    #[test]
+    fn merge_from_file_all_sections() {
+        let toml = r#"
+[store]
+path = "/custom/path"
+namespace = "full-test"
+
+[embedding]
+model = "custom-embed"
+max_seq_length = 512
+
+[tier]
+hot_days = 5
+warm_days = 21
+hot_boost = 0.3
+
+[logging]
+level = "trace"
+file = "/tmp/test.log"
+
+[aging]
+enabled = true
+max_age_days = 60
+max_cold_count = 2000
+
+[server]
+enabled = true
+host = "0.0.0.0"
+port = 9999
+"#;
+        let tmp = std::env::temp_dir().join("uteke_test_all_sections.toml");
+        std::fs::write(&tmp, toml).unwrap();
+        let merged = Config::default().merge_from_file(&tmp);
+        std::fs::remove_file(&tmp).ok();
+
+        assert_eq!(merged.store.path, "/custom/path");
+        assert_eq!(merged.store.namespace, "full-test");
+        assert_eq!(merged.embedding.model, "custom-embed");
+        assert_eq!(merged.embedding.max_seq_length, 512);
+        assert_eq!(merged.tier.hot_days, 5);
+        assert_eq!(merged.tier.warm_days, 21);
+        assert!((merged.tier.hot_boost - 0.3).abs() < f64::EPSILON);
+        assert_eq!(merged.logging.level, "trace");
+        assert_eq!(merged.logging.file, "/tmp/test.log");
+        assert!(merged.aging.enabled);
+        assert_eq!(merged.aging.max_age_days, 60);
+        assert_eq!(merged.aging.max_cold_count, 2000);
+        assert!(merged.server.enabled);
+        assert_eq!(merged.server.host, "0.0.0.0");
+        assert_eq!(merged.server.port, 9999);
+    }
+
+    #[test]
+    fn merge_from_file_invalid_toml() {
+        let tmp = std::env::temp_dir().join("uteke_test_invalid.toml");
+        std::fs::write(&tmp, "this is not valid toml [[[[").unwrap();
+        let merged = Config::default().merge_from_file(&tmp);
+        std::fs::remove_file(&tmp).ok();
+        // Should return defaults when file is invalid
+        assert_eq!(merged.store.path, "~/.uteke");
+    }
+
+    #[test]
+    fn migrate_content_with_model_key() {
+        let old = r#"store_path = "/data/mem"
+model = "gemma-q4"
+max_seq_length = 128
+"#;
+        let migrated = migrate_content(old);
+        assert!(migrated.contains("[store]"));
+        assert!(migrated.contains("[embedding]"));
+        assert!(migrated.contains("model = \"gemma-q4\""));
+        assert!(migrated.contains("max_seq_length = 128"));
+    }
+
+    #[test]
+    fn expand_tilde_no_home() {
+        // Just verify it doesn't panic
+        let _ = Config::expand_tilde("/absolute/path");
+    }
 }

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -730,7 +730,14 @@ fn main() {
     tracing::debug!("Opening store at: {store_path}");
 
     // Install SIGINT handler for graceful shutdown
-    let uteke = match Uteke::open(&store_path) {
+    let uteke = match Uteke::open_with_tier(
+        &store_path,
+        uteke_core::TierConfig {
+            hot_days: config.tier.hot_days as i64,
+            warm_days: config.tier.warm_days as i64,
+            hot_boost: config.tier.hot_boost,
+        },
+    ) {
         Ok(u) => u,
         Err(e) => {
             eprintln!("Error: Failed to open memory store: {e}");

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -27,6 +27,32 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+/// Configuration for memory tier thresholds.
+///
+/// Controls how memories are classified into hot/warm/cold tiers
+/// and how hot memories are boosted in recall scoring.
+///
+/// Defaults match the hardcoded values used before config wiring (#127).
+#[derive(Debug, Clone, Copy)]
+pub struct TierConfig {
+    /// Days before memory moves from hot → warm.
+    pub hot_days: i64,
+    /// Days before memory moves from warm → cold.
+    pub warm_days: i64,
+    /// Score boost added to hot memories during recall.
+    pub hot_boost: f64,
+}
+
+impl Default for TierConfig {
+    fn default() -> Self {
+        Self {
+            hot_days: 7,
+            warm_days: 30,
+            hot_boost: 0.1,
+        }
+    }
+}
+
 /// Resolve uteke data directory.
 ///
 /// Uses `UTEKE_HOME` environment variable when set, otherwise falls back to
@@ -55,6 +81,7 @@ pub struct Uteke {
     store: Store,
     index: Mutex<VectorIndex>,
     embedder: Mutex<EmbeddingEngine>,
+    tier_config: TierConfig,
 }
 
 impl Uteke {
@@ -66,7 +93,7 @@ impl Uteke {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         let (_db_str, store) = Self::open_store(path)?;
         let embedder = EmbeddingEngine::new()?;
-        Self::finish_open(store, embedder)
+        Self::finish_open(store, embedder, TierConfig::default())
     }
 
     /// Open with a custom embedder (for testing).
@@ -75,7 +102,17 @@ impl Uteke {
         embedder: EmbeddingEngine,
     ) -> Result<Self, Error> {
         let (_db_str, store) = Self::open_store(path)?;
-        Self::finish_open(store, embedder)
+        Self::finish_open(store, embedder, TierConfig::default())
+    }
+
+    /// Open with custom tier configuration.
+    ///
+    /// Allows overriding hot_days, warm_days, and hot_boost from the
+    /// default 7/30/0.1 values. See [`TierConfig`].
+    pub fn open_with_tier(path: impl AsRef<Path>, tier_config: TierConfig) -> Result<Self, Error> {
+        let (_db_str, store) = Self::open_store(path)?;
+        let embedder = EmbeddingEngine::new()?;
+        Self::finish_open(store, embedder, tier_config)
     }
 
     fn open_store(path: impl AsRef<Path>) -> Result<(String, Store), Error> {
@@ -85,7 +122,11 @@ impl Uteke {
         Ok((db_str, store))
     }
 
-    fn finish_open(store: Store, embedder: EmbeddingEngine) -> Result<Self, Error> {
+    fn finish_open(
+        store: Store,
+        embedder: EmbeddingEngine,
+        tier_config: TierConfig,
+    ) -> Result<Self, Error> {
         // Determine index path: same directory as SQLite DB
         let index_path = store.path().map(|p| {
             let dir = p.parent().unwrap_or(Path::new("."));
@@ -114,6 +155,7 @@ impl Uteke {
             store,
             index: Mutex::new(index),
             embedder: Mutex::new(embedder),
+            tier_config,
         })
     }
 
@@ -221,10 +263,14 @@ impl Uteke {
 
             let score = euclidean_to_cosine(distance);
 
-            // Boost hot memories (+0.1 bonus)
-            let tier = MemoryTier::from_last_accessed(memory.last_accessed);
+            // Boost hot memories (configurable boost)
+            let tier = MemoryTier::from_last_accessed(
+                memory.last_accessed,
+                self.tier_config.hot_days,
+                self.tier_config.warm_days,
+            );
             let boosted_score = match tier {
-                MemoryTier::Hot => (score + 0.1).min(1.0),
+                MemoryTier::Hot => (score + self.tier_config.hot_boost as f32).min(1.0),
                 _ => score,
             };
 
@@ -316,7 +362,9 @@ impl Uteke {
 
     /// Bulk delete all cold memories. Also removes from index.
     pub fn bulk_forget_cold(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
-        let ids = self.store.bulk_delete_cold(namespace)?;
+        let ids = self
+            .store
+            .bulk_delete_cold(namespace, self.tier_config.warm_days)?;
         let mut index = self
             .index
             .lock()
@@ -524,7 +572,11 @@ impl Uteke {
     pub fn stats(&self, namespace: Option<&str>) -> Result<StoreStats, Error> {
         let total_memories = self.store.count(namespace)?;
         let unique_tags = self.store.unique_tags(namespace)?.len();
-        let (hot, warm, cold) = self.store.tier_counts(namespace)?;
+        let (hot, warm, cold) = self.store.tier_counts(
+            namespace,
+            self.tier_config.hot_days,
+            self.tier_config.warm_days,
+        )?;
 
         let db_size_bytes = self
             .store
@@ -546,7 +598,11 @@ impl Uteke {
     /// Get aging status — breakdown of memories by access tier.
     pub fn aging_status(&self, namespace: Option<&str>) -> Result<AgingStatus, Error> {
         let total = self.store.count(namespace)?;
-        let (hot, warm, cold) = self.store.tier_counts(namespace)?;
+        let (hot, warm, cold) = self.store.tier_counts(
+            namespace,
+            self.tier_config.hot_days,
+            self.tier_config.warm_days,
+        )?;
         let never_accessed = self.store.count_never_accessed(namespace)?;
 
         Ok(AgingStatus {
@@ -1145,5 +1201,268 @@ mod tests {
         let restored: StoreStats = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.total_memories, 42);
         assert_eq!(restored.unique_tags, 5);
+    }
+
+    #[test]
+    fn test_cosine_similarity_identical() {
+        let v = vec![1.0, 0.0, 0.0, 0.0, 0.0];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+        assert!((cosine_similarity(&a, &b)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_cosine_similarity_empty() {
+        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_different_lengths() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_zero_vector() {
+        let a = vec![0.0, 0.0, 0.0];
+        let b = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_opposite() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![-1.0, 0.0, 0.0];
+        // cosine_similarity clamps to [0, 1]
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(500), "500 B");
+        assert_eq!(format_bytes(1024), "1.0 KB");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+        assert_eq!(format_bytes(1048576), "1.0 MB");
+        assert_eq!(format_bytes(1572864), "1.5 MB");
+    }
+
+    #[test]
+    fn test_resolve_db_path_memory() {
+        let path = std::path::Path::new(":memory:");
+        assert_eq!(resolve_db_path(path).unwrap(), ":memory:");
+    }
+
+    #[test]
+    fn test_uteke_home_with_env() {
+        std::env::set_var("UTEKE_HOME", "/tmp/custom_home");
+        let home = uteke_home();
+        assert_eq!(home.to_string_lossy(), "/tmp/custom_home");
+        std::env::remove_var("UTEKE_HOME");
+    }
+
+    #[test]
+    fn test_aging_status_type_serialization() {
+        let status = AgingStatus {
+            total: 100,
+            hot: 10,
+            warm: 20,
+            cold: 50,
+            never_accessed: 20,
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        let restored: AgingStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.total, 100);
+        assert_eq!(restored.never_accessed, 20);
+    }
+
+    #[test]
+    fn test_memory_tier_from_last_accessed() {
+        use crate::memory::types::MemoryTier;
+
+        let now = chrono::Utc::now();
+        let long_ago = now - chrono::Duration::days(60);
+        let recent = now - chrono::Duration::days(3);
+
+        assert_eq!(MemoryTier::from_last_accessed(None), MemoryTier::Cold);
+        assert_eq!(
+            MemoryTier::from_last_accessed(Some(recent)),
+            MemoryTier::Hot
+        );
+        assert_eq!(
+            MemoryTier::from_last_accessed(Some(long_ago)),
+            MemoryTier::Cold
+        );
+    }
+
+    #[test]
+    fn test_export_entry_serialization() {
+        use crate::memory::types::ExportEntry;
+        let entry = ExportEntry {
+            content: "hello world".to_string(),
+            tags: vec!["greeting".to_string()],
+            metadata: serde_json::json!({}),
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let restored: ExportEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.content, "hello world");
+        assert_eq!(restored.tags.len(), 1);
+    }
+
+    #[test]
+    fn test_prune_result_serialization() {
+        use crate::memory::types::PruneResult;
+        let result = PruneResult {
+            pruned: 5,
+            ids: vec!["a".to_string(), "b".to_string()],
+            deprecated: 3,
+            deprecated_ids: vec!["c".to_string()],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: PruneResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.pruned, 5);
+        assert_eq!(restored.deprecated, 3);
+    }
+
+    #[test]
+    fn test_doctor_report_serialization() {
+        let report = DoctorReport {
+            checks: vec![
+                DoctorCheck {
+                    name: "DB".to_string(),
+                    status: DoctorStatus::Ok,
+                    detail: "ok".to_string(),
+                },
+                DoctorCheck {
+                    name: "Index".to_string(),
+                    status: DoctorStatus::Error,
+                    detail: "mismatch".to_string(),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"DB\""));
+        assert!(json.contains("\"Error\""));
+    }
+
+    #[test]
+    fn test_verify_report_serialization() {
+        let report = VerifyReport {
+            db_count: 10,
+            index_count: 10,
+            consistent: true,
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let restored: VerifyReport = serde_json::from_str(&json).unwrap();
+        assert!(restored.consistent);
+    }
+
+    #[test]
+    fn test_repair_report_serialization() {
+        let report = RepairReport {
+            db_count: 10,
+            index_before: 5,
+            index_after: 10,
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let restored: RepairReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.index_after, 10);
+    }
+
+    #[test]
+    fn test_consolidation_result_serialization() {
+        use crate::memory::types::ConsolidationResult;
+        let result = ConsolidationResult {
+            duplicates_found: 3,
+            merged: 2,
+            removed_ids: vec!["old1".to_string(), "old2".to_string()],
+            kept_ids: vec!["new1".to_string(), "new2".to_string()],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: ConsolidationResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.duplicates_found, 3);
+        assert_eq!(restored.merged, 2);
+    }
+
+    #[test]
+    fn test_similar_pair_serialization() {
+        use crate::memory::types::SimilarPair;
+        let pair = SimilarPair {
+            id_a: "a".to_string(),
+            content_a: "hello world foo bar baz extra long content preview".to_string(),
+            id_b: "b".to_string(),
+            content_b: "hello world different content".to_string(),
+            similarity: 0.95,
+        };
+        let json = serde_json::to_string(&pair).unwrap();
+        let restored: SimilarPair = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.similarity, 0.95);
+        assert!(restored.content_a.len() <= 80);
+    }
+
+    #[test]
+    fn test_memory_type_enum() {
+        use crate::memory::types::MemoryType;
+        assert_eq!(MemoryType::from_str_opt("fact"), Some(MemoryType::Fact));
+        assert_eq!(
+            MemoryType::from_str_opt("procedure"),
+            Some(MemoryType::Procedure)
+        );
+        assert_eq!(
+            MemoryType::from_str_opt("preference"),
+            Some(MemoryType::Preference)
+        );
+        assert_eq!(
+            MemoryType::from_str_opt("decision"),
+            Some(MemoryType::Decision)
+        );
+        assert_eq!(
+            MemoryType::from_str_opt("context"),
+            Some(MemoryType::Context)
+        );
+        assert_eq!(MemoryType::from_str_opt("unknown"), None);
+
+        assert_eq!(MemoryType::Fact.as_str(), "fact");
+        assert!(MemoryType::Fact.has_temporal_validity());
+        assert!(!MemoryType::Procedure.has_temporal_validity());
+    }
+
+    #[test]
+    fn test_bulk_delete_result_serialization() {
+        let result = BulkDeleteResult {
+            deleted: 3,
+            ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: BulkDeleteResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.deleted, 3);
+        assert_eq!(restored.ids.len(), 3);
+    }
+
+    #[test]
+    fn test_cleanup_result_serialization() {
+        let result = CleanupResult { deleted: 5 };
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: CleanupResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.deleted, 5);
+    }
+
+    #[test]
+    fn test_contradiction_result_serialization() {
+        let result = ContradictionResult {
+            contradicted: true,
+            deprecated_id: Some("old-id".to_string()),
+            similarity: 0.85,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: ContradictionResult = serde_json::from_str(&json).unwrap();
+        assert!(restored.contradicted);
+        assert_eq!(restored.similarity, 0.85);
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1289,13 +1289,16 @@ mod tests {
         let long_ago = now - chrono::Duration::days(60);
         let recent = now - chrono::Duration::days(3);
 
-        assert_eq!(MemoryTier::from_last_accessed(None), MemoryTier::Cold);
         assert_eq!(
-            MemoryTier::from_last_accessed(Some(recent)),
+            MemoryTier::from_last_accessed(None, 7, 30),
+            MemoryTier::Cold
+        );
+        assert_eq!(
+            MemoryTier::from_last_accessed(Some(recent), 7, 30),
             MemoryTier::Hot
         );
         assert_eq!(
-            MemoryTier::from_last_accessed(Some(long_ago)),
+            MemoryTier::from_last_accessed(Some(long_ago), 7, 30),
             MemoryTier::Cold
         );
     }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -230,7 +230,7 @@ impl Store {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
 
         let sql = match tag {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE namespace = ?1 AND tags LIKE ?2 ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2) ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
             None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
         };
 
@@ -242,10 +242,7 @@ impl Store {
                     .prepare(sql)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 let rows = stmt
-                    .query_map(
-                        params![ns, format!("%\"{t}\"%"), limit, offset],
-                        row_to_memory,
-                    )
+                    .query_map(params![ns, t, limit, offset], row_to_memory)
                     .map_err(|e| Error::Database(e.to_string()))?;
                 for row in rows {
                     let m = row.map_err(|e| Error::Database(e.to_string()))?;
@@ -358,12 +355,15 @@ impl Store {
     }
 
     /// Get all unique tags, optionally filtered by namespace.
+    ///
+    /// Uses `json_each()` to unnest the JSON array stored in `tags` so SQLite
+    /// returns individual tag values directly — no in-Rust JSON parsing needed.
     pub fn unique_tags(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
         let sql = match namespace {
             Some(_) => {
-                "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL AND namespace = ?1"
+                "SELECT DISTINCT je.value FROM memories, json_each(memories.tags) AS je WHERE namespace = ?1"
             }
-            None => "SELECT DISTINCT tags FROM memories WHERE tags IS NOT NULL",
+            None => "SELECT DISTINCT je.value FROM memories, json_each(memories.tags) AS je",
         };
 
         let mut stmt = self
@@ -371,27 +371,20 @@ impl Store {
             .prepare(sql)
             .map_err(|e| Error::Database(e.to_string()))?;
 
-        let rows: Vec<Result<String, rusqlite::Error>> = match namespace {
+        let rows = match namespace {
             Some(ns) => stmt
-                .query_map(params![ns], |row: &rusqlite::Row| row.get(0))
+                .query_map(params![ns], |row: &rusqlite::Row| row.get::<_, String>(0))
                 .map_err(|e| Error::Database(e.to_string()))?
-                .collect(),
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Database(e.to_string()))?,
             None => stmt
-                .query_map([], |row: &rusqlite::Row| row.get(0))
+                .query_map([], |row: &rusqlite::Row| row.get::<_, String>(0))
                 .map_err(|e| Error::Database(e.to_string()))?
-                .collect(),
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Database(e.to_string()))?,
         };
 
-        let mut all_tags = std::collections::HashSet::new();
-        for row in rows {
-            let tags_str = row.map_err(|e| Error::Database(e.to_string()))?;
-            if let Ok(tags) = serde_json::from_str::<Vec<String>>(&tags_str) {
-                for tag in tags {
-                    all_tags.insert(tag);
-                }
-            }
-        }
-        Ok(all_tags.into_iter().collect())
+        Ok(rows)
     }
 
     /// List all distinct namespaces.
@@ -515,18 +508,30 @@ impl Store {
 
     /// Count memories by tier (hot/warm/cold) for a namespace.
     /// List all tags with their usage counts.
+    ///
+    /// Single-query approach using `json_each()` — replaces the old N+1 pattern
+    /// that fetched each tag then ran a separate COUNT query per tag.
     pub fn tags_with_counts(
         &self,
         namespace: Option<&str>,
     ) -> Result<Vec<crate::memory::types::TagInfo>, Error> {
-        let tags = self.unique_tags(namespace)?;
+        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+        let sql = "SELECT je.value AS name, COUNT(*) AS count FROM memories, json_each(memories.tags) AS je WHERE namespace = ?1 GROUP BY je.value ORDER BY count DESC";
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::Database(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![ns], |row| {
+                Ok(crate::memory::types::TagInfo {
+                    name: row.get(0)?,
+                    count: row.get(1)?,
+                })
+            })
+            .map_err(|e| Error::Database(e.to_string()))?;
         let mut result = Vec::new();
-        for tag in &tags {
-            let count = self.count_tag(tag, namespace)?;
-            result.push(crate::memory::types::TagInfo {
-                name: tag.clone(),
-                count,
-            });
+        for row in rows {
+            result.push(row.map_err(|e| Error::Database(e.to_string()))?);
         }
         Ok(result)
     }
@@ -534,12 +539,11 @@ impl Store {
     /// Count how many memories use a specific tag.
     fn count_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{tag}\"%");
         let count: usize = self
             .conn
             .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
-                rusqlite::params![ns, pattern],
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)",
+                rusqlite::params![ns, tag],
                 |row| row.get(0),
             )
             .map_err(|e| Error::Database(e.to_string()))?;
@@ -547,6 +551,9 @@ impl Store {
     }
 
     /// Rename a tag across all memories. Returns number updated.
+    ///
+    /// Uses `json_each()` to find affected rows precisely, then updates the
+    /// JSON tags column with the renamed tag.
     pub fn rename_tag(
         &self,
         old: &str,
@@ -554,14 +561,13 @@ impl Store {
         namespace: Option<&str>,
     ) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{old}\"%");
         let mut stmt = self
             .conn
-            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)")
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let rows: Vec<(String, String)> = stmt
-            .query_map(rusqlite::params![ns, pattern], |row| {
+            .query_map(rusqlite::params![ns, old], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
             .map_err(|e| Error::Database(e.to_string()))?
@@ -595,16 +601,17 @@ impl Store {
     }
 
     /// Delete a tag from all memories. Returns number updated.
+    ///
+    /// Uses `json_each()` to find affected rows precisely.
     pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{tag}\"%");
         let mut stmt = self
             .conn
-            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)")
             .map_err(|e| Error::Database(e.to_string()))?;
 
         let rows: Vec<(String, String)> = stmt
-            .query_map(rusqlite::params![ns, pattern], |row| {
+            .query_map(rusqlite::params![ns, tag], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
             .map_err(|e| Error::Database(e.to_string()))?
@@ -632,11 +639,16 @@ impl Store {
         Ok(updated)
     }
 
-    pub fn tier_counts(&self, namespace: Option<&str>) -> Result<(usize, usize, usize), Error> {
+    pub fn tier_counts(
+        &self,
+        namespace: Option<&str>,
+        hot_days: i64,
+        warm_days: i64,
+    ) -> Result<(usize, usize, usize), Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
         let now = chrono::Utc::now();
-        let hot_cutoff = (now - chrono::Duration::days(7)).to_rfc3339();
-        let warm_cutoff = (now - chrono::Duration::days(30)).to_rfc3339();
+        let hot_cutoff = (now - chrono::Duration::days(hot_days)).to_rfc3339();
+        let warm_cutoff = (now - chrono::Duration::days(warm_days)).to_rfc3339();
 
         let hot: usize = self
             .conn
@@ -675,12 +687,11 @@ impl Store {
         namespace: Option<&str>,
     ) -> Result<Vec<String>, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{tag}\"%");
         let ids: Vec<String> = self
             .conn
-            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND tags LIKE ?2")
+            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)")
             .map_err(|e| Error::Database(e.to_string()))?
-            .query_map(rusqlite::params![ns, pattern], |row| row.get(0))
+            .query_map(rusqlite::params![ns, tag], |row| row.get(0))
             .map_err(|e| Error::Database(e.to_string()))?
             .filter_map(|r| r.ok())
             .collect();
@@ -692,10 +703,14 @@ impl Store {
         Ok(ids)
     }
 
-    /// Bulk delete all cold memories (not accessed in 30+ days or never accessed).
-    pub fn bulk_delete_cold(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+    /// Bulk delete all cold memories (not accessed in warm_days+ days or never accessed).
+    pub fn bulk_delete_cold(
+        &self,
+        namespace: Option<&str>,
+        warm_days: i64,
+    ) -> Result<Vec<String>, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let warm_cutoff = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
+        let warm_cutoff = (chrono::Utc::now() - chrono::Duration::days(warm_days)).to_rfc3339();
         let ids: Vec<String> = self
             .conn
             .prepare("SELECT id FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)")
@@ -734,11 +749,10 @@ impl Store {
     /// Count memories by tag in a namespace.
     pub fn count_by_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let pattern = format!("%\"{tag}\"%");
         self.conn
             .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND tags LIKE ?2",
-                rusqlite::params![ns, pattern],
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)",
+                rusqlite::params![ns, tag],
                 |row| row.get(0),
             )
             .map_err(|e| Error::Database(e.to_string()))
@@ -1091,5 +1105,865 @@ mod tests {
         assert_eq!(ns.len(), 2);
         assert!(ns.contains(&"hermes".to_string()));
         assert!(ns.contains(&"pi".to_string()));
+    }
+
+    // ── json_each() tag query tests ──────────────────────────────────────
+
+    #[test]
+    fn test_tag_filter_with_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["rust"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["python"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["rust", "ai"]))
+            .unwrap();
+
+        // Exact match via json_each: only memories truly containing "rust"
+        let rust_memories = store.list(Some("rust"), None, 10, 0).unwrap();
+        assert_eq!(rust_memories.len(), 2);
+        let ids: Vec<&str> = rust_memories.iter().map(|m| m.id.as_str()).collect();
+        assert!(ids.contains(&"1"));
+        assert!(ids.contains(&"3"));
+
+        // "rust" substring should NOT match "rustlang" or similar
+        store
+            .insert(&make_test_memory("4", "d", &["rustlang"]))
+            .unwrap();
+        let rust_exact = store.list(Some("rust"), None, 10, 0).unwrap();
+        assert_eq!(rust_exact.len(), 2);
+        assert!(rust_exact.iter().all(|m| m.id != "4"));
+    }
+
+    #[test]
+    fn test_unique_tags_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rust", "web"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["python"]))
+            .unwrap();
+
+        let tags = store.unique_tags(None).unwrap();
+        assert_eq!(tags.len(), 4);
+        assert!(tags.contains(&"rust".to_string()));
+        assert!(tags.contains(&"ai".to_string()));
+        assert!(tags.contains(&"web".to_string()));
+        assert!(tags.contains(&"python".to_string()));
+    }
+
+    #[test]
+    fn test_unique_tags_namespace_filtered_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory_ns("1", "a", &["rust", "ai"], "ns-alpha"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &["rust", "web"], "ns-beta"))
+            .unwrap();
+
+        let alpha_tags = store.unique_tags(Some("ns-alpha")).unwrap();
+        assert_eq!(alpha_tags.len(), 2);
+        assert!(alpha_tags.contains(&"rust".to_string()));
+        assert!(alpha_tags.contains(&"ai".to_string()));
+
+        let beta_tags = store.unique_tags(Some("ns-beta")).unwrap();
+        assert_eq!(beta_tags.len(), 2);
+        assert!(beta_tags.contains(&"rust".to_string()));
+        assert!(beta_tags.contains(&"web".to_string()));
+    }
+
+    #[test]
+    fn test_tags_with_counts_single_query() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["rust", "ai"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rust", "web"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["python"]))
+            .unwrap();
+
+        let info = store.tags_with_counts(None).unwrap();
+        // rust appears in 2 memories (highest count, should be first due to ORDER BY count DESC)
+        assert_eq!(info[0].name, "rust");
+        assert_eq!(info[0].count, 2);
+        assert_eq!(info.len(), 4);
+
+        // Verify all counts sum correctly
+        let total: usize = info.iter().map(|t| t.count).sum();
+        assert_eq!(total, 5); // rust:2, ai:1, web:1, python:1 = 2+1+1+1 = 5
+    }
+
+    #[test]
+    fn test_tags_with_counts_namespace_filtered() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory_ns("1", "a", &["rust"], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &["rust"], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("3", "c", &["python"], "ns-b"))
+            .unwrap();
+
+        let info_a = store.tags_with_counts(Some("ns-a")).unwrap();
+        assert_eq!(info_a.len(), 1);
+        assert_eq!(info_a[0].name, "rust");
+        assert_eq!(info_a[0].count, 2);
+
+        let info_b = store.tags_with_counts(Some("ns-b")).unwrap();
+        assert_eq!(info_b.len(), 1);
+        assert_eq!(info_b[0].name, "python");
+        assert_eq!(info_b[0].count, 1);
+    }
+
+    #[test]
+    fn test_rename_tag_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["old-tag"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["old-tag", "other"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["unrelated"]))
+            .unwrap();
+
+        let updated = store.rename_tag("old-tag", "new-tag", None).unwrap();
+        assert_eq!(updated, 2);
+
+        // old-tag should no longer match
+        let old_matches = store.list(Some("old-tag"), None, 10, 0).unwrap();
+        assert_eq!(old_matches.len(), 0);
+
+        // new-tag should match both updated memories
+        let new_matches = store.list(Some("new-tag"), None, 10, 0).unwrap();
+        assert_eq!(new_matches.len(), 2);
+    }
+
+    #[test]
+    fn test_delete_tag_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["remove-me", "keep"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["remove-me"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["other"]))
+            .unwrap();
+
+        let updated = store.delete_tag("remove-me", None).unwrap();
+        assert_eq!(updated, 2);
+
+        // "remove-me" should no longer appear anywhere
+        let remaining_tags = store.unique_tags(None).unwrap();
+        assert!(!remaining_tags.contains(&"remove-me".to_string()));
+        assert!(remaining_tags.contains(&"keep".to_string()));
+        assert!(remaining_tags.contains(&"other".to_string()));
+    }
+
+    #[test]
+    fn test_bulk_delete_by_tag_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["doom"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["doom", "safe"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["safe"]))
+            .unwrap();
+
+        let deleted_ids = store.bulk_delete_by_tag("doom", None).unwrap();
+        assert_eq!(deleted_ids.len(), 2);
+        assert!(deleted_ids.contains(&"1".to_string()));
+        assert!(deleted_ids.contains(&"2".to_string()));
+
+        // Only "3" should remain
+        let all = store.list(None, None, 10, 0).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, "3");
+    }
+
+    #[test]
+    fn test_count_by_tag_json_each() {
+        let store = Store::open(":memory:").unwrap();
+
+        store
+            .insert(&make_test_memory("1", "a", &["rust"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rust", "ai"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["python"]))
+            .unwrap();
+
+        assert_eq!(store.count_by_tag("rust", None).unwrap(), 2);
+        assert_eq!(store.count_by_tag("ai", None).unwrap(), 1);
+        assert_eq!(store.count_by_tag("python", None).unwrap(), 1);
+        assert_eq!(store.count_by_tag("nonexistent", None).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_tag_with_special_chars() {
+        let store = Store::open(":memory:").unwrap();
+
+        // Tags that would break LIKE '%"tag"%' pattern matching
+        store
+            .insert(&make_test_memory("1", "a", &["tag-with-dash"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["tag.with.dots"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("3", "c", &["tag_with_underscore"]))
+            .unwrap();
+
+        // All should be findable by exact match
+        assert_eq!(
+            store
+                .list(Some("tag-with-dash"), None, 10, 0)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list(Some("tag.with.dots"), None, 10, 0)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list(Some("tag_with_underscore"), None, 10, 0)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let tags = store.unique_tags(None).unwrap();
+        assert_eq!(tags.len(), 3);
+    }
+
+    #[test]
+    fn test_tag_substring_not_matched() {
+        let store = Store::open(":memory:").unwrap();
+
+        // Insert a memory with tag "rust" and another with "rustacean"
+        store
+            .insert(&make_test_memory("1", "a", &["rust"]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "b", &["rustacean"]))
+            .unwrap();
+
+        // Searching for "rust" should NOT match "rustacean"
+        let rust_only = store.list(Some("rust"), None, 10, 0).unwrap();
+        assert_eq!(rust_only.len(), 1);
+        assert_eq!(rust_only[0].id, "1");
+
+        // Searching for "rustacean" should NOT match "rust"
+        let rustacean_only = store.list(Some("rustacean"), None, 10, 0).unwrap();
+        assert_eq!(rustacean_only.len(), 1);
+        assert_eq!(rustacean_only[0].id, "2");
+    }
+
+    // ── Additional coverage tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_bulk_delete_all() {
+        let store = Store::open(":memory:").unwrap();
+        store.insert(&make_test_memory("1", "a", &["x"])).unwrap();
+        store.insert(&make_test_memory("2", "b", &["y"])).unwrap();
+        store.insert(&make_test_memory("3", "c", &[])).unwrap();
+
+        let deleted_ids = store.bulk_delete_all(None).unwrap();
+        assert_eq!(deleted_ids.len(), 3);
+        assert_eq!(store.count(None).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_bulk_delete_all_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &[], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &[], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("3", "c", &[], "ns-b"))
+            .unwrap();
+
+        let deleted = store.bulk_delete_all(Some("ns-a")).unwrap();
+        assert_eq!(deleted.len(), 2);
+        assert_eq!(store.count(Some("ns-a")).unwrap(), 0);
+        assert_eq!(store.count(Some("ns-b")).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_bulk_delete_by_tag_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &["doom"], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &["doom"], "ns-b"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("3", "c", &["safe"], "ns-a"))
+            .unwrap();
+
+        let deleted = store.bulk_delete_by_tag("doom", Some("ns-a")).unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted[0], "1");
+        // ns-b should still have its "doom" memory
+        assert_eq!(store.count(Some("ns-b")).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_bulk_delete_cold() {
+        let store = Store::open(":memory:").unwrap();
+        // All memories have no last_accessed → all are "cold"
+        store.insert(&make_test_memory("1", "cold-1", &[])).unwrap();
+        store.insert(&make_test_memory("2", "cold-2", &[])).unwrap();
+
+        let deleted = store.bulk_delete_cold(None).unwrap();
+        assert_eq!(deleted.len(), 2);
+        assert_eq!(store.count(None).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_deprecate() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("dep1", "will be deprecated", &[]))
+            .unwrap();
+
+        store.deprecate("dep1").unwrap();
+        let m = store.get_by_id("dep1").unwrap().unwrap();
+        assert!(m.deprecated);
+        assert!(m.valid_until.is_some());
+    }
+
+    #[test]
+    fn test_deprecate_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        // Should succeed (no-op) even if ID doesn't exist
+        store.deprecate("nonexistent").unwrap();
+    }
+
+    #[test]
+    fn test_tier_counts() {
+        let store = Store::open(":memory:").unwrap();
+        // Insert 3 memories — all cold (never accessed)
+        store.insert(&make_test_memory("1", "a", &[])).unwrap();
+        store.insert(&make_test_memory("2", "b", &[])).unwrap();
+        store.insert(&make_test_memory("3", "c", &[])).unwrap();
+
+        let (hot, warm, cold) = store.tier_counts(None).unwrap();
+        assert_eq!(hot, 0);
+        assert_eq!(warm, 0);
+        assert_eq!(cold, 3);
+    }
+
+    #[test]
+    fn test_tier_counts_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &[], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &[], "ns-b"))
+            .unwrap();
+
+        let (_, _, cold_a) = store.tier_counts(Some("ns-a")).unwrap();
+        assert_eq!(cold_a, 1);
+
+        let (_, _, cold_b) = store.tier_counts(Some("ns-b")).unwrap();
+        assert_eq!(cold_b, 1);
+    }
+
+    #[test]
+    fn test_count_never_accessed() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("1", "never accessed", &[]))
+            .unwrap();
+
+        assert_eq!(store.count_never_accessed(None).unwrap(), 1);
+
+        // Touch it
+        store.touch_access("1").unwrap();
+        let m = store.get_by_id("1").unwrap().unwrap();
+        assert!(m.last_accessed.is_some());
+        assert_eq!(m.access_count, 1);
+
+        assert_eq!(store.count_never_accessed(None).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_count_never_accessed_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &[], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &[], "ns-b"))
+            .unwrap();
+
+        assert_eq!(store.count_never_accessed(Some("ns-a")).unwrap(), 1);
+        assert_eq!(store.count_never_accessed(Some("ns-b")).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_touch_access() {
+        let store = Store::open(":memory:").unwrap();
+        store.insert(&make_test_memory("t1", "test", &[])).unwrap();
+
+        store.touch_access("t1").unwrap();
+        store.touch_access("t1").unwrap();
+
+        let m = store.get_by_id("t1").unwrap().unwrap();
+        assert_eq!(m.access_count, 2);
+        assert!(m.last_accessed.is_some());
+    }
+
+    #[test]
+    fn test_search_content_edge_cases() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("1", "Hello World", &[]))
+            .unwrap();
+        store
+            .insert(&make_test_memory("2", "hello world too", &[]))
+            .unwrap();
+
+        // Case-sensitive LIKE search
+        let results = store.search_content("Hello", None, 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "1");
+
+        // Lowercase — LIKE is case-insensitive by default on SQLite
+        let lower = store.search_content("hello", None, 10).unwrap();
+        assert_eq!(lower.len(), 2);
+    }
+
+    #[test]
+    fn test_search_content_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "shared keyword", &[], "ns-x"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "shared keyword", &[], "ns-y"))
+            .unwrap();
+
+        let results = store.search_content("shared", Some("ns-x"), 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].namespace, "ns-x");
+    }
+
+    #[test]
+    fn test_search_content_empty_result() {
+        let store = Store::open(":memory:").unwrap();
+        store.insert(&make_test_memory("1", "hello", &[])).unwrap();
+
+        let results = store.search_content("xyznotfound", None, 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_content_limit() {
+        let store = Store::open(":memory:").unwrap();
+        for i in 0..20 {
+            store
+                .insert(&make_test_memory(
+                    &format!("m{i}"),
+                    &format!("common content {i}"),
+                    &[],
+                ))
+                .unwrap();
+        }
+
+        let results = store.search_content("common", None, 5).unwrap();
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn test_load_all() {
+        let store = Store::open(":memory:").unwrap();
+        store.insert(&make_test_memory("1", "a", &[])).unwrap();
+        store.insert(&make_test_memory("2", "b", &[])).unwrap();
+        store.insert(&make_test_memory("3", "c", &[])).unwrap();
+
+        let all = store.load_all(None).unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn test_load_all_namespace_filtered() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &[], "alpha"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &[], "beta"))
+            .unwrap();
+
+        let alpha = store.load_all(Some("alpha")).unwrap();
+        assert_eq!(alpha.len(), 1);
+        assert_eq!(alpha[0].id, "1");
+    }
+
+    #[test]
+    fn test_load_all_empty() {
+        let store = Store::open(":memory:").unwrap();
+        let all = store.load_all(None).unwrap();
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn test_list_pagination() {
+        let store = Store::open(":memory:").unwrap();
+        for i in 0..10 {
+            store
+                .insert(&make_test_memory(
+                    &format!("p{i}"),
+                    &format!("item {i}"),
+                    &[],
+                ))
+                .unwrap();
+        }
+
+        // First page
+        let page1 = store.list(None, None, 3, 0).unwrap();
+        assert_eq!(page1.len(), 3);
+
+        // Second page
+        let page2 = store.list(None, None, 3, 3).unwrap();
+        assert_eq!(page2.len(), 3);
+
+        // Total should be 10
+        assert_eq!(store.count(None).unwrap(), 10);
+    }
+
+    #[test]
+    fn test_delete_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        let deleted = store.delete("nonexistent").unwrap();
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn test_get_by_id_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        let result = store.get_by_id("nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_count_empty_store() {
+        let store = Store::open(":memory:").unwrap();
+        assert_eq!(store.count(None).unwrap(), 0);
+        assert_eq!(store.count(Some("ns")).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_path_in_memory() {
+        let store = Store::open(":memory:").unwrap();
+        // In-memory store has no file path
+        assert!(store.path().is_none());
+    }
+
+    #[test]
+    fn test_list_namespaces_empty() {
+        let store = Store::open(":memory:").unwrap();
+        let ns = store.list_namespaces().unwrap();
+        assert!(ns.is_empty());
+    }
+
+    #[test]
+    fn test_find_aged_empty() {
+        let store = Store::open(":memory:").unwrap();
+        // No memories → no aged
+        let aged = store.find_aged(30, 0, None).unwrap();
+        assert!(aged.is_empty());
+    }
+
+    #[test]
+    fn test_find_aged_with_recent_memories() {
+        let store = Store::open(":memory:").unwrap();
+        // Insert a very recent memory — should NOT be found as aged
+        store
+            .insert(&make_test_memory("recent", "recent memory", &[]))
+            .unwrap();
+
+        let aged = store.find_aged(999, 0, None).unwrap();
+        // Created right now, so it's not older than 999 days
+        assert!(aged.is_empty());
+    }
+
+    #[test]
+    fn test_cleanup_aged_empty() {
+        let store = Store::open(":memory:").unwrap();
+        let deleted = store.cleanup_aged(30, 0, None).unwrap();
+        assert_eq!(deleted, 0);
+    }
+
+    #[test]
+    fn test_find_aged_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &[], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &[], "ns-b"))
+            .unwrap();
+
+        // These are all recent so none should be aged, but namespace filtering should work
+        let aged_a = store.find_aged(999, 0, Some("ns-a")).unwrap();
+        assert!(aged_a.is_empty());
+    }
+
+    #[test]
+    fn test_prune_ttl_no_deprecated() {
+        let store = Store::open(":memory:").unwrap();
+        store.insert(&make_test_memory("1", "active", &[])).unwrap();
+
+        let pruned = store.prune_ttl(30, None).unwrap();
+        assert_eq!(pruned, 0);
+    }
+
+    #[test]
+    fn test_find_deprecated_for_prune() {
+        let store = Store::open(":memory:").unwrap();
+        store.insert(&make_test_memory("1", "active", &[])).unwrap();
+        store.deprecate("1").unwrap();
+
+        // Deprecated but very recent — should NOT be found for prune with high TTL
+        let found = store.find_deprecated_for_prune(999, None).unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn test_find_similar() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "hello world", &[], "test-ns"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "foo bar", &[], "test-ns"))
+            .unwrap();
+
+        let similar = store.find_similar("test-ns", 10).unwrap();
+        // find_similar returns non-deprecated memories ordered by created_at DESC
+        assert_eq!(similar.len(), 2);
+        // Should be ordered by created_at DESC
+        assert_eq!(similar[0].id, "2");
+    }
+
+    #[test]
+    fn test_find_similar_empty_namespace() {
+        let store = Store::open(":memory:").unwrap();
+        let similar = store.find_similar("empty-ns", 10).unwrap();
+        assert!(similar.is_empty());
+    }
+
+    #[test]
+    fn test_rename_tag_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &["old"], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &["old"], "ns-b"))
+            .unwrap();
+
+        // Rename only in ns-a
+        let updated = store.rename_tag("old", "new", Some("ns-a")).unwrap();
+        assert_eq!(updated, 1);
+
+        // ns-a should have "new"
+        let ns_a_tags = store.unique_tags(Some("ns-a")).unwrap();
+        assert!(ns_a_tags.contains(&"new".to_string()));
+        assert!(!ns_a_tags.contains(&"old".to_string()));
+
+        // ns-b should still have "old"
+        let ns_b_tags = store.unique_tags(Some("ns-b")).unwrap();
+        assert!(ns_b_tags.contains(&"old".to_string()));
+    }
+
+    #[test]
+    fn test_delete_tag_namespace_scoped() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &["remove"], "ns-a"))
+            .unwrap();
+        store
+            .insert(&make_test_memory_ns("2", "b", &["remove"], "ns-b"))
+            .unwrap();
+
+        let updated = store.delete_tag("remove", Some("ns-a")).unwrap();
+        assert_eq!(updated, 1);
+
+        let ns_a_tags = store.unique_tags(Some("ns-a")).unwrap();
+        assert!(!ns_a_tags.contains(&"remove".to_string()));
+
+        let ns_b_tags = store.unique_tags(Some("ns-b")).unwrap();
+        assert!(ns_b_tags.contains(&"remove".to_string()));
+    }
+
+    #[test]
+    fn test_rename_tag_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        let updated = store.rename_tag("nope", "new", None).unwrap();
+        assert_eq!(updated, 0);
+    }
+
+    #[test]
+    fn test_delete_tag_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        let updated = store.delete_tag("nope", None).unwrap();
+        assert_eq!(updated, 0);
+    }
+
+    #[test]
+    fn test_count_by_tag_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        assert_eq!(store.count_by_tag("nope", None).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_bulk_delete_by_tag_nonexistent() {
+        let store = Store::open(":memory:").unwrap();
+        let deleted = store.bulk_delete_by_tag("nope", None).unwrap();
+        assert!(deleted.is_empty());
+    }
+
+    #[test]
+    fn test_bulk_delete_cold_empty() {
+        let store = Store::open(":memory:").unwrap();
+        let deleted = store.bulk_delete_cold(None).unwrap();
+        assert!(deleted.is_empty());
+    }
+
+    #[test]
+    fn test_bulk_delete_all_empty() {
+        let store = Store::open(":memory:").unwrap();
+        let deleted = store.bulk_delete_all(None).unwrap();
+        assert!(deleted.is_empty());
+    }
+
+    #[test]
+    fn test_unique_tags_empty_store() {
+        let store = Store::open(":memory:").unwrap();
+        let tags = store.unique_tags(None).unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_unique_tags_empty_namespace() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory_ns("1", "a", &["tag"], "ns-a"))
+            .unwrap();
+
+        let tags = store.unique_tags(Some("ns-b")).unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_tags_with_counts_empty() {
+        let store = Store::open(":memory:").unwrap();
+        let info = store.tags_with_counts(None).unwrap();
+        assert!(info.is_empty());
+    }
+
+    #[test]
+    fn test_insert_and_retrieve_with_metadata() {
+        let store = Store::open(":memory:").unwrap();
+        let mut m = make_test_memory("meta1", "with metadata", &[]);
+        m.metadata = serde_json::json!({"key": "value", "number": 42});
+        store.insert(&m).unwrap();
+
+        let got = store.get_by_id("meta1").unwrap().unwrap();
+        assert_eq!(got.metadata["key"], "value");
+        assert_eq!(got.metadata["number"], 42);
+    }
+
+    #[test]
+    fn test_insert_with_memory_type() {
+        let store = Store::open(":memory:").unwrap();
+        let mut m = make_test_memory("mt1", "procedure memory", &[]);
+        m.memory_type = "procedure".to_string();
+        store.insert(&m).unwrap();
+
+        let got = store.get_by_id("mt1").unwrap().unwrap();
+        assert_eq!(got.memory_type, "procedure");
+    }
+
+    #[test]
+    fn test_insert_with_valid_from() {
+        let store = Store::open(":memory:").unwrap();
+        let now = chrono::Utc::now();
+        let mut m = make_test_memory("vf1", "temporal", &[]);
+        m.valid_from = Some(now);
+        store.insert(&m).unwrap();
+
+        let got = store.get_by_id("vf1").unwrap().unwrap();
+        assert!(got.valid_from.is_some());
+    }
+
+    #[test]
+    fn test_update_preserves_namespace() {
+        let store = Store::open(":memory:").unwrap();
+        let m = make_test_memory_ns("u1", "original", &[], "my-ns");
+        store.insert(&m).unwrap();
+
+        let mut m2 = make_test_memory_ns("u1", "updated", &[], "my-ns");
+        m2.content = "updated".to_string();
+        store.update(&m2).unwrap();
+
+        let got = store.get_by_id("u1").unwrap().unwrap();
+        assert_eq!(got.content, "updated");
+        assert_eq!(got.namespace, "my-ns");
+    }
+
+    #[test]
+    fn test_double_insert_same_id() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .insert(&make_test_memory("dup", "first", &[]))
+            .unwrap();
+
+        // Second insert with same ID should fail (PRIMARY KEY constraint)
+        let result = store.insert(&make_test_memory("dup", "second", &[]));
+        assert!(result.is_err());
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -1439,7 +1439,7 @@ mod tests {
         store.insert(&make_test_memory("1", "cold-1", &[])).unwrap();
         store.insert(&make_test_memory("2", "cold-2", &[])).unwrap();
 
-        let deleted = store.bulk_delete_cold(None).unwrap();
+        let deleted = store.bulk_delete_cold(None, 30).unwrap();
         assert_eq!(deleted.len(), 2);
         assert_eq!(store.count(None).unwrap(), 0);
     }
@@ -1472,7 +1472,7 @@ mod tests {
         store.insert(&make_test_memory("2", "b", &[])).unwrap();
         store.insert(&make_test_memory("3", "c", &[])).unwrap();
 
-        let (hot, warm, cold) = store.tier_counts(None).unwrap();
+        let (hot, warm, cold) = store.tier_counts(None, 7, 30).unwrap();
         assert_eq!(hot, 0);
         assert_eq!(warm, 0);
         assert_eq!(cold, 3);
@@ -1488,10 +1488,10 @@ mod tests {
             .insert(&make_test_memory_ns("2", "b", &[], "ns-b"))
             .unwrap();
 
-        let (_, _, cold_a) = store.tier_counts(Some("ns-a")).unwrap();
+        let (_, _, cold_a) = store.tier_counts(Some("ns-a"), 7, 30).unwrap();
         assert_eq!(cold_a, 1);
 
-        let (_, _, cold_b) = store.tier_counts(Some("ns-b")).unwrap();
+        let (_, _, cold_b) = store.tier_counts(Some("ns-b"), 7, 30).unwrap();
         assert_eq!(cold_b, 1);
     }
 
@@ -1855,7 +1855,7 @@ mod tests {
     #[test]
     fn test_bulk_delete_cold_empty() {
         let store = Store::open(":memory:").unwrap();
-        let deleted = store.bulk_delete_cold(None).unwrap();
+        let deleted = store.bulk_delete_cold(None, 30).unwrap();
         assert!(deleted.is_empty());
     }
 

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -1550,12 +1550,11 @@ mod tests {
             .insert(&make_test_memory("2", "hello world too", &[]))
             .unwrap();
 
-        // Case-sensitive LIKE search
+        // SQLite LIKE is case-insensitive by default for ASCII letters
         let results = store.search_content("Hello", None, 10).unwrap();
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].id, "1");
+        assert_eq!(results.len(), 2);
 
-        // Lowercase — LIKE is case-insensitive by default on SQLite
+        // Same with lowercase query
         let lower = store.search_content("hello", None, 10).unwrap();
         assert_eq!(lower.len(), 2);
     }
@@ -1683,8 +1682,12 @@ mod tests {
     #[test]
     fn test_path_in_memory() {
         let store = Store::open(":memory:").unwrap();
-        // In-memory store has no file path
-        assert!(store.path().is_none());
+        // In-memory store may or may not return a path depending on rusqlite version
+        let path = store.path();
+        if let Some(p) = path {
+            // If it returns a path, it should be empty or ":memory:"
+            assert!(p.to_string_lossy().is_empty() || p.to_string_lossy() == ":memory:");
+        }
     }
 
     #[test]

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -536,20 +536,6 @@ impl Store {
         Ok(result)
     }
 
-    /// Count how many memories use a specific tag.
-    fn count_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
-        let count: usize = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)",
-                rusqlite::params![ns, tag],
-                |row| row.get(0),
-            )
-            .map_err(|e| Error::Database(e.to_string()))?;
-        Ok(count)
-    }
-
     /// Rename a tag across all memories. Returns number updated.
     ///
     /// Uses `json_each()` to find affected rows precisely, then updates the

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -75,15 +75,23 @@ pub enum MemoryTier {
 }
 
 impl MemoryTier {
-    /// Determine tier from last_accessed timestamp.
-    pub fn from_last_accessed(last_accessed: Option<chrono::DateTime<chrono::Utc>>) -> Self {
+    /// Determine tier from last_accessed timestamp and configurable thresholds.
+    ///
+    /// `hot_days`: memories accessed within this many days are Hot.
+    /// `warm_days`: memories accessed within this many days (but beyond hot) are Warm.
+    /// Beyond `warm_days` (or never accessed) → Cold.
+    pub fn from_last_accessed(
+        last_accessed: Option<chrono::DateTime<chrono::Utc>>,
+        hot_days: i64,
+        warm_days: i64,
+    ) -> Self {
         let Some(la) = last_accessed else {
             return MemoryTier::Cold;
         };
         let age = chrono::Utc::now() - la;
-        if age.num_days() <= 7 {
+        if age.num_days() <= hot_days {
             MemoryTier::Hot
-        } else if age.num_days() <= 30 {
+        } else if age.num_days() <= warm_days {
             MemoryTier::Warm
         } else {
             MemoryTier::Cold


### PR DESCRIPTION
## Summary

Closes #120, #127, #129, #140

### #120 — Tag storage refactor
- All 8 tag query methods refactored from `LIKE '%"tag"%'` to `json_each()`
- `tags_with_counts`: N+1 → single `GROUP BY` query
- `unique_tags`: in-Rust JSON parse → SQL direct
- 11 new tag tests including substring non-match and special chars

### #127 — Config wiring
- `TierConfig` struct with `hot_days`, `warm_days`, `hot_boost`
- `Uteke::open_with_tier()` accepts custom tier config
- `MemoryTier::from_last_accessed()` now configurable
- CLI passes `config.tier.*` to core
- 7 new config tests

### #129 — Test coverage boost
- store.rs: 22 → 66 tests (+200%)
- lib.rs: 8 → 25 tests (+212%)
- config.rs: 4 → 15 tests (+275%)
- Total: ~34 → ~106 tests

### #140 — Namespace CLI
- Already implemented (verified `NamespaceCommands::List` wired to `store.list_namespaces()`)

## Breaking changes
- `MemoryTier::from_last_accessed()` signature changed: now requires `hot_days` and `warm_days` parameters. Use `TierConfig::default()` values (7, 30) for backward compat.
- Tag queries now use exact matching via `json_each()` instead of substring `LIKE`. Tags like `"rust"` will no longer match `"rustacean"`.