### PR TITLE
feat: release branch setup — main as release-only mirror

### DIFF
--- a/.github/workflows/cora-review.yml
+++ b/.github/workflows/cora-review.yml
@@ -2,7 +2,7 @@ name: Cora AI Code Review
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,27 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  sync-main:
+    name: Sync main branch
+    runs-on: ubuntu-latest
+    # Only runs on v* tag pushes (release trigger). Uses force-push because main
+    # is a release-only mirror of develop — any commits on main not in develop
+    # are stale snapshots that should be overwritten by the current release.
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Push to main
+        run: |
+          git push origin HEAD:main --force
+          echo "✅ main synced to develop at ${{ github.sha }}"
+
   build-release:
+    needs: sync-main
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -103,6 +123,12 @@ jobs:
       - name: List artifacts
         run: ls -la release-artifacts/
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd release-artifacts
+          sha256sum * > checksums-sha256.txt
+          cat checksums-sha256.txt
+
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
@@ -132,7 +158,7 @@ jobs:
           printf '| Linux (ARM64) | `uteke-%s-aarch64-unknown-linux-gnu.tar.gz` |\n' "${VER}" >> release-notes.md
           printf '| macOS (Apple Silicon) | `uteke-%s-aarch64-apple-darwin.tar.gz` |\n' "${VER}" >> release-notes.md
           printf '| Windows (x86_64) | `uteke-%s-x86_64-pc-windows-msvc.zip` |\n\n' "${VER}" >> release-notes.md
-          printf '### 🚀 Quick Start\n\n```bash\n# Install\ncurl -fsSL https://uteke.ajianaz.dev/install.sh | sh\n\n# Store a memory\nuteke remember "Important context" --tags project\n\n# Recall by meaning\nuteke recall "what was that context?"\n\n# Start server for fast AI agent access\nuteke-serve --port 8767\n```\n\n' >> release-notes.md
+          printf '### 🚀 Quick Start\n\n```bash\n# Quick install (Linux / macOS)\ncurl -fsSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh\n\n# Pin a specific version\nUTEKE_VERSION=v%s curl -fsSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh\n\n# Store a memory\nuteke remember "Important context" --tags project\n\n# Recall by meaning\nuteke recall "what was that context?"\n\n# Start server for fast AI agent access\nuteke-serve --port 8767\n```\n\n' >> release-notes.md
           printf '**Full changelog:** https://github.com/ajianaz/uteke/blob/main/CHANGELOG.md\n' >> release-notes.md
 
       - name: Create GitHub Release

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,13 +44,19 @@ Download from [GitHub Releases](https://github.com/ajianaz/uteke/releases):
 ### Quick Install (Linux/macOS)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ajianaz/uteke/develop/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
 ```
 
-> Installs to `~/.local/bin`. Add to PATH if needed:
+> Installs `uteke` and `uteke-serve` to `~/.local/bin`. Add to PATH if needed:
 > ```bash
 > echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
 > ```
+
+Pin a specific version with `UTEKE_VERSION`:
+
+```bash
+UTEKE_VERSION=v0.0.7 curl -fsSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
+```
 
 ### Windows Setup
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env sh
+# uteke installer — https://github.com/ajianaz/uteke
+# Usage: curl -fsSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
+
+set -e
+
+REPO="ajianaz/uteke"
+BINARY_NAME="uteke"
+SERVER_BINARY_NAME="uteke-serve"
+INSTALL_DIR="${UTEKE_INSTALL_DIR:-$HOME/.local/bin}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    printf "${GREEN}[INFO]${NC} %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}[WARN]${NC} %s\n" "$1"
+}
+
+error() {
+    printf "${RED}[ERROR]${NC} %s\n" "$1"
+    exit 1
+}
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)  OS="linux";;
+        Darwin*) OS="darwin";;
+        *)       error "Unsupported operating system: $(uname -s)";;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH="x86_64";;
+        arm64|aarch64) ARCH="aarch64";;
+        *)             error "Unsupported architecture: $(uname -m)";;
+    esac
+}
+
+# Get latest release version
+# Primary: parse the 302 redirect on /releases/latest (no API call, no rate limit).
+# Fallback: the GitHub REST API (subject to 60 req/hour anonymous limit).
+get_latest_version() {
+    VERSION=$(curl -sI "https://github.com/${REPO}/releases/latest" \
+        | grep -i '^location:' \
+        | sed -E 's|.*/tag/([^[:space:]]+).*|\1|' \
+        | tr -d '\r')
+
+    if [ -z "$VERSION" ]; then
+        warn "Redirect lookup failed, falling back to GitHub API..."
+        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep '"tag_name":' \
+            | sed -E 's/.*"([^"]+)".*/\1/')
+    fi
+
+    if [ -z "$VERSION" ]; then
+        error "Failed to get latest version. Set UTEKE_VERSION=vX.Y.Z to pin a version."
+    fi
+}
+
+# Build target triple and archive name
+get_target() {
+    case "$OS" in
+        linux)
+            case "$ARCH" in
+                x86_64)  TARGET="x86_64-unknown-linux-gnu";;
+                aarch64) TARGET="aarch64-unknown-linux-gnu";;
+            esac
+            ;;
+        darwin)
+            # Only aarch64 (Apple Silicon) is currently published
+            if [ "$ARCH" != "aarch64" ]; then
+                warn "No pre-built binary for x86_64 macOS. Install via cargo:"
+                warn "  cargo install --path crates/uteke-cli"
+                exit 0
+            fi
+            TARGET="aarch64-apple-darwin"
+            ;;
+    esac
+}
+
+# Download and install
+install() {
+    info "Detected: $OS $ARCH"
+    info "Target: $TARGET"
+    info "Version: $VERSION"
+
+    ARCHIVE_NAME="${BINARY_NAME}-${TARGET}-${VERSION}.tar.gz"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE_NAME}"
+    TEMP_DIR=$(mktemp -d)
+    ARCHIVE="${TEMP_DIR}/${ARCHIVE_NAME}"
+
+    CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums-sha256.txt"
+    CHECKSUM_FILE="${TEMP_DIR}/checksums-sha256.txt"
+
+    info "Downloading from: $DOWNLOAD_URL"
+    if ! curl -fsSL "$DOWNLOAD_URL" -o "$ARCHIVE"; then
+        error "Failed to download ${ARCHIVE_NAME}"
+    fi
+
+    # Verify SHA256 checksum (prevents MITM / corrupted download).
+    info "Downloading checksums..."
+    if curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUM_FILE"; then
+        info "Verifying SHA256 checksum..."
+        EXPECTED=$(grep -F "$ARCHIVE_NAME" "$CHECKSUM_FILE" | awk '{print $1}')
+        if [ -n "$EXPECTED" ]; then
+            ACTUAL=$(sha256sum "$ARCHIVE" | awk '{print $1}')
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+                error "Checksum mismatch! Expected: ${EXPECTED}, got: ${ACTUAL}"
+            fi
+            info "Checksum verified: $EXPECTED"
+        else
+            warn "Checksum for ${ARCHIVE_NAME} not found in checksums file — skipping verification"
+        fi
+    else
+        warn "Failed to download checksums — skipping verification"
+    fi
+
+    # Verify archive contents before extraction (CWE-22 path traversal).
+    # Reject any entry with an absolute path or a ".." component.
+    info "Verifying archive integrity..."
+    if tar -tzf "$ARCHIVE" | grep -qE '^/|(^|/)\.\.(/|$)'; then
+        error "Archive contains unsafe paths (absolute or directory traversal) — refusing to extract"
+    fi
+
+    info "Extracting..."
+    tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
+
+    mkdir -p "$INSTALL_DIR"
+    mv "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/"
+    if [ -f "${TEMP_DIR}/${SERVER_BINARY_NAME}" ]; then
+        mv "${TEMP_DIR}/${SERVER_BINARY_NAME}" "${INSTALL_DIR}/"
+    fi
+
+    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
+        chmod +x "${INSTALL_DIR}/${SERVER_BINARY_NAME}"
+    fi
+
+    # Cleanup
+    rm -rf "$TEMP_DIR"
+
+    info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
+    if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
+        info "Successfully installed ${SERVER_BINARY_NAME} to ${INSTALL_DIR}/${SERVER_BINARY_NAME}"
+    fi
+}
+
+# Verify installation
+verify() {
+    if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        INSTALLED_VERSION=$("$BINARY_NAME" --version 2>/dev/null || echo "unknown")
+        info "Verification: $INSTALLED_VERSION"
+    else
+        warn "Binary installed but not in PATH. Add to your shell profile:"
+        case "${SHELL:-}" in
+            */zsh)
+                warn '  echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> ~/.zshrc'
+                warn '  source ~/.zshrc'
+                ;;
+            */bash)
+                warn '  echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> ~/.bashrc'
+                warn '  source ~/.bashrc'
+                ;;
+            */fish)
+                warn '  fish_add_path ~/.local/bin'
+                ;;
+            *)
+                warn '  export PATH="$HOME/.local/bin:$PATH"'
+                ;;
+        esac
+    fi
+}
+
+main() {
+    info "Installing ${BINARY_NAME}..."
+
+    detect_os
+    detect_arch
+    get_target
+    if [ -n "$UTEKE_VERSION" ]; then
+        VERSION="$UTEKE_VERSION"
+        info "Using pinned version from UTEKE_VERSION: $VERSION"
+    else
+        get_latest_version
+    fi
+    install
+    verify
+
+    echo ""
+    info "Installation complete! Run '${BINARY_NAME} --help' to get started."
+}
+
+main


### PR DESCRIPTION
## Summary

Clones the cora-cli release branch pattern (#154/#155/#156) to uteke.

### Changes

**`install.sh` (new, root level)**
- OS/arch detection + latest version lookup (redirect-first, API fallback)
- Downloads both `uteke` and `uteke-serve` from release tarballs
- SHA256 checksum verification using `checksums-sha256.txt`
- CWE-22 path traversal protection on archive extraction
- `UTEKE_VERSION` env var for pinning specific versions
- PATH hint for all major shells (bash, zsh, fish)

**`.github/workflows/release.yml`**
- Added `sync-main` job: on every `v*` tag push, force-syncs `develop` → `main`
- `build-release` now `needs: sync-main` (sequential, not parallel)
- Added SHA256 checksums generation (`checksums-sha256.txt`) in release job
- Updated release notes template: install.sh URL → `main`, added version pinning example

**`.github/workflows/cora-review.yml`**
- Added `main` to `pull_request.branches` (required for PRs to main)

**`INSTALL.md`**
- Updated quick install URL from `develop/scripts/install.sh` → `main/install.sh`
- Added `UTEKE_VERSION` pinning example

### Flow
```
develop (active development, PR target)
  ↓ on v* tag push
release.yml → sync-main (push develop → main)
  ↓
curl .../main/install.sh | sh ← always works ✅
```

### Post-merge Steps
1. Merge this PR to develop
2. Open PR develop → main to sync main
3. Next release tag auto-syncs going forward