### PR TITLE
docs: update GTM plan status, CHANGELOG, and launch content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GTM Phase 1+2** — README overhaul + landing page refresh for public launch readiness (#174)
+  - README: benefit-first hero tagline, install.sh quick start, updated comparison table (Mem0/Letta/Zep), "Who is this for?" section, performance highlights
+  - Website: version badge v0.0.8, install.sh CTA, social proof section, updated comparison data, OG meta tags, refreshed hero headline
+  - GTM plan documented in `docs/plans/2026-06-04-readme-landing-page-gtm.md`
+
 ## [0.0.8] — 2026-06-04
 
 ### Added
@@ -295,6 +302,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Binary name:** `uteke`
 - **Minimum Rust version:** 1.75+
 
+[0.0.8]: https://github.com/ajianaz/uteke/releases/tag/v0.0.8
 [0.0.7]: https://github.com/ajianaz/uteke/releases/tag/v0.0.7
 [0.0.6]: https://github.com/ajianaz/uteke/releases/tag/v0.0.6
 [0.0.5]: https://github.com/ajianaz/uteke/releases/tag/v0.0.5

--- a/docs/launch/hn-post.md
+++ b/docs/launch/hn-post.md
@@ -1,4 +1,4 @@
-# Show HN: Uteke — Local-first memory for AI agents, written in Rust
+# Show HN: Uteke — Offline-first semantic memory for AI agents, single Rust binary
 
 **URL:** https://github.com/ajianaz/uteke
 
@@ -9,33 +9,45 @@ I built Uteke because I was tired of AI agents forgetting everything between ses
 Uteke is a local-first memory engine for AI agents. It's a single Rust binary with zero configuration:
 
 ```
+curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
+
 uteke remember "Deploy v2.1 to staging on Friday" --tags deploy
 uteke recall "what deployment is coming up?"
 ```
 
 **What makes it different:**
 
-- **Single binary** — `cargo install` and you're done. No Python, no server, no Docker.
-- **Zero config** — First run downloads the embedding model (~90MB ONNX). That's it.
+- **Single binary** — `curl | sh` and you're done. No Python, no server, no Docker.
+- **Zero config** — First run downloads the embedding model (~188MB ONNX). That's it.
 - **Fully offline** — No API keys. No cloud. Data lives in `~/.uteke/`. SQLite + HNSW.
-- **Semantic search** — Uses EmbeddingGemma Q4 (768d) for vector similarity. ONNX runtime runs locally.
+- **Semantic search** — Uses EmbeddingGemma Q4 (256d) for vector similarity. ONNX runtime runs locally.
+- **~30ms recall** via library, ~42ms via HTTP server. CLI cold start ~3s (model load).
 - **JSON everywhere** — Every command supports `--json` output. Perfect for scripting and agent integration.
 
 **How it works:**
-1. Text goes in → embedded into 768d vector via ONNX → stored in SQLite + indexed in HNSW
-2. Query goes in → embedded → HNSW finds nearest neighbors → returns ranked results
-3. Everything is local. SQLite for metadata. HNSW for fast vector search. ONNX for embeddings.
+1. Text goes in → embedded into 256d vector via ONNX → stored in SQLite + indexed in HNSW (usearch)
+2. Query goes in → embedded → usearch finds nearest neighbors → returns ranked results
+3. Everything is local. SQLite for metadata. usearch for persistent vector search. ONNX for embeddings.
 
-**Why Rust?** I wanted something I could `cargo install` on any machine and it just works. No dependency hell. No virtualenv. Small binary. Fast startup.
+**Features:**
+- Multi-agent namespaces — isolate memories per agent
+- Memory aging — hot/warm/cold tiers with auto-cleanup
+- Temporal facts — time-bounded memories with auto-expiry
+- Contradiction detection — finds conflicting memories on insert
+- Consolidation — merge near-duplicate memories
+- Import/export — JSONL backup and restore
+- Shell hooks — auto-load project context in bash/zsh/fish
+- HTTP server mode — persistent daemon for ~75x faster recall
+
+**Why Rust?** I wanted something that works everywhere with a single binary. No dependency hell. No virtualenv. Small binary. Fast startup. Memory safe (no unsafe code).
 
 **Who is this for?**
-- AI agent developers who need persistent memory
-- People who want a local, searchable second brain
-- Developers tired of context window limits
-- Anyone who values their data staying on their machine
+- AI agent developers who need persistent memory across sessions
+- CLI power users who want a searchable, offline second brain
+- Privacy-conscious developers who want their data on their machine
 
 **Python integration** included — a zero-dependency wrapper that shells out to the binary. Works with any Python 3.8+.
 
-The project is Apache 2.0 licensed. I'm using it daily with my own AI agents (Hermes fleet). PRs welcome.
+The project is Apache 2.0 licensed. I'm using it daily with my own AI agent fleet. PRs welcome.
 
 Happy to answer questions about the architecture, embedding choices, or Rust/ML integration.

--- a/docs/launch/twitter-thread.md
+++ b/docs/launch/twitter-thread.md
@@ -5,7 +5,7 @@ AI agents have amnesia.
 
 Every new session starts from zero. Decisions lost. Context rebuilt. Again.
 
-I built Uteke to fix this. A local-first memory engine for AI agents — written in Rust.
+I built Uteke to fix this. A local-first semantic memory engine for AI — single Rust binary, fully offline, 30ms recall.
 
 🧠 https://github.com/ajianaz/uteke
 
@@ -15,6 +15,8 @@ I built Uteke to fix this. A local-first memory engine for AI agents — written
 
 **Tweet 2/7**
 What does Uteke do?
+
+curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
 
 uteke remember "BOND uses Go + SvelteKit monorepo" --tags architecture
 uteke recall "what architecture does BOND use?"
@@ -26,15 +28,15 @@ Semantic search powered by ONNX embeddings. All local.
 ---
 
 **Tweet 3/7**
-Why not just use ChromaDB or MemGPT?
+Why not just use Mem0, Letta, or Zep?
 
-- No Python dependency hell
-- No server to run
+- No API keys needed
 - No Docker container
-- No API keys
-- No cloud
+- No cloud dependencies
+- No Python requirement
+- No server to run (optional)
 
-One binary. Zero config. `cargo install uteke` and done.
+One binary. Zero config. `curl | sh` and done.
 
 ---
 
@@ -42,32 +44,40 @@ One binary. Zero config. `cargo install uteke` and done.
 Under the hood:
 
 🔹 SQLite — metadata & structured storage
-🔹 HNSW — fast vector search (approximate nearest neighbor)
-🔹 ONNX — EmbeddingGemma Q4 embeddings (768d)
-🔹 Rust — no unsafe code, memory safe
+🔹 usearch — persistent HNSW vector search
+🔹 ONNX — EmbeddingGemma Q4 embeddings (256d)
+🔹 Rust — memory safe, no unsafe code
 
 Everything lives in ~/.uteke/
 
 ---
 
 **Tweet 5/7**
-JSON output on every command:
+Performance:
 
-uteke recall "deploy steps" --json
-→ [{"memory": {...}, "score": 0.95}]
+Library recall: ~30ms
+Server recall: ~42ms
+CLI cold start: ~3s (model load)
 
-Makes it trivial to integrate with any AI agent, script, or tool. Python wrapper included (stdlib only).
+For real-time agent use, run uteke-serve — model stays in memory, 75x faster than CLI.
+
+JSON output on every command. Python wrapper included.
 
 ---
 
 **Tweet 6/7**
-Built for my own AI agent fleet (Hermes). Dogfooding daily.
+Features:
 
-Uteke is Apache 2.0 licensed, fully open source. Contributions welcome.
+✅ Multi-agent namespaces
+✅ Memory aging (hot/warm/cold)
+✅ Temporal facts with auto-expiry
+✅ Contradiction detection
+✅ Consolidation (merge duplicates)
+✅ Import/export (JSONL)
+✅ Shell hooks (bash/zsh/fish)
+✅ HTTP server mode
 
-→ Architecture docs in repo
-→ Contributing guide included
-→ CI passing on all PRs
+Apache 2.0 — use it, fork it, ship it.
 
 ---
 
@@ -78,6 +88,6 @@ If you build AI agents and hate that they forget everything — give Uteke a try
 🐛 Report bugs: Open an issue
 🤝 Contribute: PRs to develop branch
 
-Local-first. Zero config. Your memory, your machine.
+Offline. Zero config. Your memory, your machine.
 
 🧠⚡

--- a/docs/plans/2026-06-04-readme-landing-page-gtm.md
+++ b/docs/plans/2026-06-04-readme-landing-page-gtm.md
@@ -1,6 +1,8 @@
 # Uteke Go-to-Market: README Overhaul + Landing Page Refresh
 
-> **For Hermes:** Execute tasks sequentially, one PR per task group.
+> **Status:** Phase 1 ✅ Completed · Phase 2 ✅ Completed · Phase 3 🔜 Ready to execute
+>
+> **Merged:** PR #174 (2026-06-04) — squash merged to `develop`
 
 **Goal:** Transform Uteke from "developer tool" positioning to "must-have AI memory" — starting with README overhaul and landing page refresh to prepare for public launch (Hacker News, Reddit, X/Threads).
 
@@ -8,18 +10,20 @@
 
 **Tech Stack:** Markdown (README), SvelteKit 5 + Tailwind 4 (website, already built)
 
-**Current State:**
-- README v0.0.8: functional but not "selling" — comparison table is outdated (MemGPT bukan Mem0), hero tagline lemah
-- Website: sudah ada dengan hero, features, comparison, architecture, terminal demo — tapi version badge stale (v0.0.3), install CTA pakai `cargo install --git` bukan `install.sh`, beberapa content outdated
+**Current State (post-PR #174):**
+- README: ✅ Overhauled — benefit-first hero, updated comparison (Mem0/Letta/Zep), install.sh quick start, audience fit table, performance highlights
+- Website: ✅ Refreshed — version badge v0.0.8, install.sh CTA, social proof section, updated comparison table, OG meta tags
 - Install script: sudah ada (`install.sh`)
 
 ---
 
-## Phase 1: README Overhaul (P0 — 3 jam)
+## Phase 1: README Overhaul ✅ COMPLETED
+
+> **Merged in PR #174.** All 6 tasks executed in a single squash commit.
 
 README adalah halaman depan. Developer lihat README dulu sebelum star/download. Harus membuat orang langsung "I need this".
 
-### Task 1.1: Refresh README Hero + Tagline
+### Task 1.1: Refresh README Hero + Tagline ✅
 
 **Objective:** Hook pembaca dalam 5 detik pertama
 
@@ -59,7 +63,7 @@ With:
 
 ---
 
-### Task 1.2: Fix Quick Start — Use install.sh
+### Task 1.2: Fix Quick Start — Use install.sh ✅
 
 **Objective:** First install experience harus one-liner, bukan `git clone + cargo install`
 
@@ -98,7 +102,7 @@ uteke stats
 
 ---
 
-### Task 1.3: Update Comparison Table
+### Task 1.3: Update Comparison Table ✅
 
 **Objective:** Comparison table harus akurat vs kompetitor 2026 yang sebenarnya
 
@@ -136,7 +140,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 
 ---
 
-### Task 1.4: Add "Who is this for" Section
+### Task 1.4: Add "Who is this for" Section ✅
 
 **Objective:** Orang harus langsung tahu apakah Uteke buat mereka
 
@@ -161,7 +165,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 
 ---
 
-### Task 1.5: Refresh Performance Section
+### Task 1.5: Refresh Performance Section ✅
 
 **Objective:** Performance section harus punya "wow" factor dan konteks
 
@@ -192,7 +196,7 @@ For real-time agent use, run `uteke-serve` — model stays in memory, 75x faster
 
 ---
 
-### Task 1.6: Refresh Roadmap + Footer
+### Task 1.6: Refresh Roadmap + Footer ✅
 
 **Objective:** Roadmap harus menunjukkan momentum dan credibility
 
@@ -226,11 +230,13 @@ Demand-gated — we build what people actually use.
 
 ---
 
-## Phase 2: Landing Page Refresh (P0 — 1 hari)
+## Phase 2: Landing Page Refresh ✅ COMPLETED
+
+> **Merged in PR #174.** All 5 tasks executed alongside Phase 1 in the same commit.
 
 Website sudah ada dan bagus, tapi ada beberapa hal yang harus di-fix sebelum go-public.
 
-### Task 2.1: Fix Version Badge + Install CTA
+### Task 2.1: Fix Version Badge + Install CTA ✅
 
 **Objective:** Version badge dan install command harus current
 
@@ -246,7 +252,7 @@ Website sudah ada dan bagus, tapi ada beberapa hal yang harus di-fix sebelum go-
 
 ---
 
-### Task 2.2: Add "Trusted By" / Social Proof Section
+### Task 2.2: Add "Trusted By" / Social Proof Section ✅
 
 **Objective:** Tambah credibility signal untuk visitor baru
 
@@ -289,7 +295,7 @@ Website sudah ada dan bagus, tapi ada beberapa hal yang harus di-fix sebelum go-
 
 ---
 
-### Task 2.3: Update Comparison Table Data
+### Task 2.3: Update Comparison Table Data ✅
 
 **Objective:** Sync landing page comparison with README comparison (Task 1.3)
 
@@ -319,7 +325,7 @@ Added rows: "API Keys", "Privacy", "Recall Speed" — these are Uteke's stronges
 
 ---
 
-### Task 2.4: Add OG Image + Meta Tags
+### Task 2.4: Add OG Image + Meta Tags ✅
 
 **Objective:** Saat di-share ke Twitter/LinkedIn/Discord, preview card harus menarik
 
@@ -348,7 +354,7 @@ Added rows: "API Keys", "Privacy", "Recall Speed" — these are Uteke's stronges
 
 ---
 
-### Task 2.5: Fix Hero Headline for Clarity
+### Task 2.5: Fix Hero Headline for Clarity ✅
 
 **Objective:** Current headline "Your AI forgets everything. Fix that." bagus tapi kurang jelas WHAT Uteke is
 
@@ -377,9 +383,11 @@ Added rows: "API Keys", "Privacy", "Recall Speed" — these are Uteke's stronges
 
 ---
 
-## Phase 3: Distribution Prep (P1 — Setelah README + LP ready)
+## Phase 3: Distribution Prep 🔜 READY
 
-### Task 3.1: Prepare Hacker News "Show HN" Post
+> **Prerequisites met.** Phase 1 + 2 merged. Launch docs ready for review/update.
+
+### Task 3.1: Prepare Hacker News "Show HN" Post 🔜
 
 **File to create:** `/opt/data/repos/uteke/docs/plans/show-hn-draft.md`
 
@@ -402,7 +410,7 @@ Tech: Rust, ONNX Runtime, SQLite (rusqlite), usearch HNSW, EmbeddingGemma Q4
 https://github.com/ajianaz/uteke
 ```
 
-### Task 3.2: Prepare Reddit Posts
+### Task 3.2: Prepare Reddit Posts 🔜
 
 **Subreddits:** r/rust, r/CLI, r/selfhosted, r/LocalLLaMA, r/MachineLearning
 
@@ -412,7 +420,7 @@ https://github.com/ajianaz/uteke
 - r/selfhosted: "Self-hosted AI memory that works 100% offline — no Docker needed"
 - r/LocalLLaMA: "Local-first semantic memory for AI agents — no cloud, built-in embeddings"
 
-### Task 3.3: Record Terminal Demo (asciinema/vhs)
+### Task 3.3: Record Terminal Demo (asciinema/vhs) 🔜
 
 **Objective:** Record demo yang bisa di-embed di README dan landing page
 
@@ -430,16 +438,12 @@ https://github.com/ajianaz/uteke
 
 ## Summary
 
-| Phase | Tasks | Est. Effort | Dependency |
-|-------|-------|-------------|------------|
-| **Phase 1: README** | 1.1–1.6 | 3 jam | None |
-| **Phase 2: Landing Page** | 2.1–2.5 | 1 hari | None (parallel with Phase 1) |
-| **Phase 3: Distribution** | 3.1–3.3 | 3 jam | Phase 1 + 2 done |
+| Phase | Tasks | Status | Result |
+|-------|-------|--------|--------|
+| **Phase 1: README** | 1.1–1.6 | ✅ Completed | PR #174 merged |
+| **Phase 2: Landing Page** | 2.1–2.5 | ✅ Completed | PR #174 merged |
+| **Phase 3: Distribution** | 3.1–3.3 | 🔜 Ready | Awaits execution |
 
-**Execution order:**
-1. Phase 1 + 2 bisa paralel
-2. Phase 3 setelah keduanya selesai dan deploy
-
-**One PR per phase** — bukan per task. Phase 1 = 1 commit/PR, Phase 2 = 1 commit/PR.
-
-**Total est. effort:** 2 hari kerja
+**Next steps:**
+1. Review & update `docs/launch/hn-post.md` and `docs/launch/twitter-thread.md` to match current README/landing page content
+2. Execute distribution when ready


### PR DESCRIPTION
## Summary

Post PR #174 cleanup — bring docs up to date with actual state.

### Changes

**GTM Plan** (`docs/plans/2026-06-04-readme-landing-page-gtm.md`)
- Mark Phase 1 (README) and Phase 2 (Landing Page) as ✅ Completed
- Mark Phase 3 (Distribution) as 🔜 Ready
- Update status header with PR #174 merge info
- Update Summary table

**CHANGELOG.md**
- Add missing `[0.0.8]` link (was absent from bottom links)
- Add `[Unreleased]` entry for GTM Phase 1+2 work

**Launch docs**
- `docs/launch/hn-post.md`: update install command to `curl | sh`, fix model size (188MB), update features list (namespaces, aging, consolidation, shell hooks, server mode)
- `docs/launch/twitter-thread.md`: update competitors (Mem0/Letta/Zep instead of ChromaDB/MemGPT), add performance tweet, update install command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated marketing and launch materials (Show HN and social media messaging) to reflect refreshed product positioning as "offline-first semantic memory engine."
  * Added new product highlights including simplified installation method, 30ms recall performance, and expanded feature list (shell hooks, HTTP server mode, memory aging, etc.).
  * Updated GTM plan documentation with completed phases and distribution strategy for Phase 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->