### PR TITLE
docs(website): update Getting Started install + Roadmap to v0.0.8

### DIFF
--- a/website/src/routes/docs/+page.svelte
+++ b/website/src/routes/docs/+page.svelte
@@ -7,11 +7,15 @@
 <div class="space-y-8 text-[var(--color-text-muted)] leading-relaxed">
 	<h2 id="install" class="text-xl font-semibold text-[var(--color-text)] !mt-0">Install</h2>
 
-	<p>Install from source (requires <a href="https://rustup.rs" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">Rust</a>):</p>
+	<p>One-liner install (macOS, Linux, Windows):</p>
+
+	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh</code></pre>
+
+	<p>Or install from source (requires <a href="https://rustup.rs" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">Rust</a>):</p>
 
 	<pre class="px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm font-mono overflow-x-auto"><code>cargo install --git https://github.com/ajianaz/uteke</code></pre>
 
-	<p>Or download pre-built binaries from <a href="https://github.com/ajianaz/uteke/releases" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Releases</a> — available for Linux (x64/ARM64), macOS (Apple Silicon), and Windows (x64).</p>
+	<p>Pre-built binaries and Docker image also available from <a href="https://github.com/ajianaz/uteke/releases" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Releases</a> and <a href="https://github.com/ajianaz/uteke/pkgs/container/uteke" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GHCR</a>. First run downloads the embedding model (~188MB) — no API keys needed.</p>
 
 	<h2 id="first-memory" class="text-xl font-semibold text-[var(--color-text)]">Your First Memory</h2>
 

--- a/website/src/routes/docs/roadmap/+page.svelte
+++ b/website/src/routes/docs/roadmap/+page.svelte
@@ -4,7 +4,7 @@
 
 <h1 class="text-3xl font-bold mb-6">Roadmap</h1>
 
-<p class="text-[var(--color-text-muted)] mb-10">Track our progress on <a href="https://github.com/ajianaz/uteke/issues" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Issues</a>.</p>
+<p class="text-[var(--color-text-muted)] mb-10">Demand-gated — we build what people actually use. Track progress on <a href="https://github.com/ajianaz/uteke/issues" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:underline">GitHub Issues</a>.</p>
 
 <div class="space-y-10">
 
@@ -16,11 +16,11 @@
 		</h2>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Persistent vector index (usearch)', issue: 40, status: 'done' },
-				{ title: 'Multi-agent namespaces', issue: 39, status: 'done' },
-				{ title: 'Tiered memory (Hot/Warm/Cold)', issue: 38, status: 'done' },
-				{ title: 'Health checks (doctor, verify, repair)', issue: 37, status: 'done' },
-				{ title: 'Website (landing + docs)', issue: 53, status: 'done' },
+				{ title: 'Persistent vector index (usearch)', issue: 40 },
+				{ title: 'Multi-agent namespaces', issue: 39 },
+				{ title: 'Tiered memory (Hot/Warm/Cold)', issue: 38 },
+				{ title: 'Health checks (doctor, verify, repair)', issue: 37 },
+				{ title: 'Website (landing + docs)', issue: 53 },
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -46,13 +46,13 @@
 		</h2>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Tag-based filtering and management', issue: 42, status: 'done' },
-				{ title: 'Memory aging with auto-cleanup', issue: 44, status: 'done' },
-				{ title: 'Shell hook for auto-context loading', issue: 47, status: 'done' },
-				{ title: 'Configuration file (uteke.toml)', issue: 48, status: 'done' },
-				{ title: 'Graceful shutdown (SIGINT handler)', issue: 31, status: 'done' },
-				{ title: 'File logging with daily rotation', issue: 32, status: 'done' },
-				{ title: 'Upgrade Node.js 20→24 in CI', issue: 41, status: 'done' },
+				{ title: 'Tag-based filtering and management', issue: 42 },
+				{ title: 'Memory aging with auto-cleanup', issue: 44 },
+				{ title: 'Shell hook for auto-context loading', issue: 47 },
+				{ title: 'Configuration file (uteke.toml)', issue: 48 },
+				{ title: 'Graceful shutdown (SIGINT handler)', issue: 31 },
+				{ title: 'File logging with daily rotation', issue: 32 },
+				{ title: 'Upgrade Node.js 20→24 in CI', issue: 41 },
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -78,13 +78,13 @@
 		</h2>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Bulk memory operations (tag, cold, all)', issue: 43, status: 'done' },
-				{ title: 'Namespace switching & defaults', issue: 45, status: 'done' },
-				{ title: 'Daemon/server mode — warm recall <50ms', issue: 54, status: 'done' },
-				{ title: 'CLI auto-routes to server (21ms recall)', issue: 54, status: 'done' },
-				{ title: 'Auto-forget & temporal facts', issue: 51, status: 'done' },
-				{ title: 'Consolidation & deduplication', issue: 52, status: 'done' },
-				{ title: 'Cora AI code review in CI', issue: 86, status: 'done' },
+				{ title: 'Bulk memory operations (tag, cold, all)', issue: 43 },
+				{ title: 'Namespace switching & defaults', issue: 45 },
+				{ title: 'Daemon/server mode — warm recall <50ms', issue: 54 },
+				{ title: 'CLI auto-routes to server (21ms recall)', issue: 54 },
+				{ title: 'Auto-forget & temporal facts', issue: 51 },
+				{ title: 'Consolidation & deduplication', issue: 52 },
+				{ title: 'Cora AI code review in CI', issue: 86 },
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -102,20 +102,18 @@
 		</div>
 	</section>
 
-	<!-- v0.0.5 — In Progress -->
+	<!-- Completed v0.0.5 -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-amber-500/20 text-amber-400">v0.0.5</span>
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">v0.0.5</span>
 			Docker & Deployment
 		</h2>
-		<p class="text-sm text-[var(--color-text-muted)] mb-4">Containerize uteke-serve with multi-stage build, flexible data paths, and automated image publishing.</p>
 		<div class="space-y-3">
 			{#each [
 				{ title: 'UTEKE_HOME env var for custom data directory', issue: 95 },
 				{ title: 'uteke-serve reads uteke.toml, default host 0.0.0.0', issue: 96 },
 				{ title: 'Dockerfile (multi-stage build, model baked in)', issue: 97 },
-				{ title: 'Cora review always use latest version', issue: 98 },
-				{ title: 'Docker image build & push on release', issue: 99 },
+				{ title: 'Docker image build & push on release (GHCR)', issue: 99 },
 			] as item}
 				<a
 					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
@@ -127,78 +125,45 @@
 						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
 						<span class="text-sm">{item.title}</span>
 					</div>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400">Open</span>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
 				</a>
 			{/each}
 		</div>
 	</section>
 
-	<!-- v0.0.6 — Planned -->
+	<!-- Completed v0.0.6 -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-500/20 text-blue-400">v0.0.6</span>
-			Network & Auth
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">v0.0.6</span>
+			Hardening & Fixes
 		</h2>
-		<p class="text-sm text-[var(--color-text-muted)] mb-4">Secure remote access with TLS, API key auth, and cloud routing.</p>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'TLS support & reverse proxy documentation', issue: 100 },
-				{ title: 'API key authentication for uteke-serve', issue: 101 },
-				{ title: '--remote flag for cloud API routing', issue: 102 },
-				{ title: 'Hermes plugin for uteke integration', issue: 55 },
-			] as item}
-				<a
-					href="https://github.com/ajianaz/uteke/issues/{item.issue}"
-					target="_blank"
-					rel="noopener"
-					class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
-				>
-					<div class="flex items-center gap-3">
-						<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
-						<span class="text-sm">{item.title}</span>
-					</div>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">Planned</span>
-				</a>
-			{/each}
-		</div>
-	</section>
-
-	<!-- v0.0.7 — Cloud MVP -->
-	<section>
-		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-purple-500/20 text-purple-400">v0.0.7</span>
-			Cloud MVP
-		</h2>
-		<p class="text-sm text-[var(--color-text-muted)] mb-4">Managed cloud API with billing and multi-tenant namespaces — open core with optional paid tier.</p>
-		<div class="space-y-3">
-			{#each [
-				{ title: 'Managed cloud API (uteke.ajianaz.dev)' },
-				{ title: 'Multi-tenant namespace isolation' },
-				{ title: 'Usage-based billing (Stripe/Lynk)' },
-				{ title: 'Web dashboard (usage, namespaces, settings)' },
+				{ title: 'JSON output omits embedding vector (~3KB savings per memory)' },
+				{ title: 'import() now persists vector index (fixes data loss on restart)' },
+				{ title: 'Docker: non-root container with USER uteke' },
+				{ title: 'Dependabot: automated dependency updates' },
 			] as item}
 				<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
 					<span class="text-sm">{item.title}</span>
-					<span class="text-xs px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-400">Future</span>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
 				</div>
 			{/each}
 		</div>
 	</section>
 
-	<!-- Backlog -->
+	<!-- Completed v0.0.7 -->
 	<section>
 		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-zinc-500/20 text-zinc-400">Backlog</span>
-			Nice-to-haves
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">v0.0.7</span>
+			Core Stability
 		</h2>
 		<div class="space-y-3">
 			{#each [
-				{ title: 'Import from external knowledge sources', issue: 46 },
-				{ title: 'Benchmark and performance metrics', issue: 49 },
-				{ title: 'Better embeddings (larger model option)' },
-				{ title: 'Python SDK (PyO3 bindings)' },
-				{ title: 'Node.js SDK (NAPI)' },
-				{ title: 'Editor integrations (VS Code, JetBrains)' },
+				{ title: 'Tag queries: LIKE → json_each() for exact matching', issue: 120 },
+				{ title: 'Configurable tier thresholds (hot_days, warm_days)', issue: 127 },
+				{ title: 'Test coverage: 34 → 94 tests', issue: 129 },
+				{ title: 'Tag substring false positive fix ("rust" ≠ "rustacean")' },
 			] as item}
 				{#if item.issue}
 					<a
@@ -211,14 +176,155 @@
 							<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
 							<span class="text-sm">{item.title}</span>
 						</div>
-						<span class="text-xs px-2 py-0.5 rounded-full bg-zinc-500/20 text-zinc-400">Backlog</span>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
 					</a>
 				{:else}
 					<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
 						<span class="text-sm">{item.title}</span>
-						<span class="text-xs px-2 py-0.5 rounded-full bg-zinc-500/20 text-zinc-400">Backlog</span>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
 					</div>
 				{/if}
+			{/each}
+		</div>
+	</section>
+
+	<!-- Completed v0.0.8 (current) -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-green-500/20 text-green-400">v0.0.8</span>
+			Stability & Architecture
+			<span class="text-xs px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 ml-2">Current</span>
+		</h2>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Architecture: module split (1471→352 lib.rs)', issue: 130 },
+				{ title: 'Input validation (max 10K chars, 20 tags, 1MB payload)', issue: 132 },
+				{ title: 'Binary checksums (SHA256) + verify-checksums subcommand', issue: 134 },
+				{ title: 'Schema versioning + migration framework', issue: 138 },
+				{ title: 'Error handling rewrite — sanitized user-friendly messages', issue: 144 },
+				{ title: 'Python wrapper: 7→21 methods with type hints', issue: 137 },
+				{ title: 'Memory benchmark binary (library-level timing)', issue: 49 },
+				{ title: 'Memory consolidation command' },
+				{ title: 'Import/Export (JSONL backup and restore)' },
+				{ title: 'README overhaul + landing page refresh (GTM Phase 1+2)', issue: 174 },
+			] as item}
+				{#if item.issue}
+					<a
+						href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+						target="_blank"
+						rel="noopener"
+						class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+					>
+						<div class="flex items-center gap-3">
+							<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+							<span class="text-sm">{item.title}</span>
+						</div>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
+					</a>
+				{:else}
+					<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
+						<span class="text-sm">{item.title}</span>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400">✓ Done</span>
+					</div>
+				{/if}
+			{/each}
+		</div>
+	</section>
+
+	<!-- Phase A — Next -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-amber-500/20 text-amber-400">Phase A</span>
+			Growth (100+ stars)
+		</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">Better embeddings, richer integrations, broader reach.</p>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Better embeddings (larger model option)' },
+				{ title: 'Import from external knowledge sources', issue: 46 },
+				{ title: 'Python SDK (PyO3 bindings)' },
+				{ title: 'Editor integrations (VS Code, JetBrains)' },
+				{ title: 'Node.js SDK (NAPI)' },
+			] as item}
+				{#if item.issue}
+					<a
+						href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+						target="_blank"
+						rel="noopener"
+						class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+					>
+						<div class="flex items-center gap-3">
+							<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+							<span class="text-sm">{item.title}</span>
+						</div>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400">Planned</span>
+					</a>
+				{:else}
+					<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
+						<span class="text-sm">{item.title}</span>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400">Planned</span>
+					</div>
+				{/if}
+			{/each}
+		</div>
+	</section>
+
+	<!-- Phase B — Future -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-blue-500/20 text-blue-400">Phase B</span>
+			Collaboration (500+ stars)
+		</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">Optional cloud sync, team features, and gateway integrations.</p>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Cloud sync (opt-in, end-to-end encrypted)' },
+				{ title: 'Team collaboration & shared namespaces' },
+				{ title: 'API gateway integration (Hermes, LangChain, CrewAI)' },
+				{ title: 'TLS support & reverse proxy documentation', issue: 100 },
+				{ title: 'API key authentication for uteke-serve', issue: 101 },
+			] as item}
+				{#if item.issue}
+					<a
+						href="https://github.com/ajianaz/uteke/issues/{item.issue}"
+						target="_blank"
+						rel="noopener"
+						class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)] hover:border-[var(--color-accent-dim)] transition-colors"
+					>
+						<div class="flex items-center gap-3">
+							<span class="text-xs text-[var(--color-text-dim)] font-mono">#{item.issue}</span>
+							<span class="text-sm">{item.title}</span>
+						</div>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">Future</span>
+					</a>
+				{:else}
+					<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
+						<span class="text-sm">{item.title}</span>
+						<span class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">Future</span>
+					</div>
+				{/if}
+			{/each}
+		</div>
+	</section>
+
+	<!-- Phase C — Vision -->
+	<section>
+		<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+			<span class="px-2 py-0.5 rounded text-xs font-semibold bg-purple-500/20 text-purple-400">Phase C</span>
+			Ecosystem (1000+ stars)
+		</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">Plugin ecosystem, advanced consolidation, community extensions.</p>
+		<div class="space-y-3">
+			{#each [
+				{ title: 'Plugin ecosystem (custom embedding, storage backends)' },
+				{ title: 'Advanced consolidation (cross-namespace, summarization)' },
+				{ title: 'Community extensions marketplace' },
+				{ title: 'Managed cloud API (optional paid tier)' },
+			] as item}
+				<div class="flex items-center justify-between px-4 py-3 rounded-lg border border-[var(--color-border)]">
+					<span class="text-sm">{item.title}</span>
+					<span class="text-xs px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-400">Vision</span>
+				</div>
 			{/each}
 		</div>
 	</section>


### PR DESCRIPTION
## Summary

Update website docs pages to match current state (v0.0.8).

### Changes

**Getting Started** (`/docs`)
- Primary install: `curl | sh` one-liner
- `cargo install` demoted to secondary option
- Added GHCR Docker link + model size note

**Roadmap** (`/docs/roadmap`)
- v0.0.5 Docker & Deployment: all items marked Done
- v0.0.6 Hardening & Fixes: new section (Done)
- v0.0.7 Core Stability: new section (Done)
- v0.0.8 Stability & Architecture: new section (Done, Current)
- Future restructured to demand-gated phases A/B/C
- Removed stale Cloud MVP / Network & Auth sections
