### PR TITLE
fix: address all CorA code review findings (v0.0.10)

### DIFF
--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -38,7 +38,7 @@ pub(crate) fn run(
                     println!(
                         "  \u{26a0} Contradiction detected (sim: {:.3}): deprecated {}",
                         contradiction.similarity,
-                        &dep_id[..8]
+                        dep_id.get(..8).unwrap_or(dep_id)
                     );
                 }
             }

--- a/crates/uteke-cli/src/commands/server.rs
+++ b/crates/uteke-cli/src/commands/server.rs
@@ -13,6 +13,28 @@ pub(crate) fn is_server_running(url: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Send a request and check HTTP status before parsing JSON.
+fn parse_response<T: serde::de::DeserializeOwned>(
+    resp: reqwest::blocking::Response,
+) -> Result<T, String> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().unwrap_or_default();
+        return Err(format!("Server returned {status}: {body}"));
+    }
+    resp.json::<T>().map_err(|e| format!("Parse error: {e}"))
+}
+
+/// Send a request and check HTTP status before parsing raw JSON value.
+fn parse_json_value(resp: reqwest::blocking::Response) -> Result<serde_json::Value, String> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().unwrap_or_default();
+        return Err(format!("Server returned {status}: {body}"));
+    }
+    resp.json().map_err(|e| format!("Parse error: {e}"))
+}
+
 /// Route CLI commands through the HTTP server for <50ms latency.
 pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> {
     let client = reqwest::blocking::Client::new();
@@ -41,7 +63,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                 .json(&body)
                 .send()
                 .map_err(|e| format!("Server error: {e}"))?;
-            let data: serde_json::Value = resp.json().map_err(|e| format!("Parse error: {e}"))?;
+            let data = parse_json_value(resp)?;
             if cli.json {
                 println!("{data}");
             } else {
@@ -62,8 +84,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                 .json(&body)
                 .send()
                 .map_err(|e| format!("Server error: {e}"))?;
-            let results: Vec<uteke_core::SearchResult> =
-                resp.json().map_err(|e| format!("Parse error: {e}"))?;
+            let results = parse_response::<Vec<uteke_core::SearchResult>>(resp)?;
             if cli.json {
                 output::print_json(&results);
             } else {
@@ -84,8 +105,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                 .json(&body)
                 .send()
                 .map_err(|e| format!("Server error: {e}"))?;
-            let results: Vec<uteke_core::SearchResult> =
-                resp.json().map_err(|e| format!("Parse error: {e}"))?;
+            let results = parse_response::<Vec<uteke_core::SearchResult>>(resp)?;
             if cli.json {
                 output::print_json(&results);
             } else {
@@ -106,8 +126,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                 .json(&body)
                 .send()
                 .map_err(|e| format!("Server error: {e}"))?;
-            let memories: Vec<uteke_core::Memory> =
-                resp.json().map_err(|e| format!("Parse error: {e}"))?;
+            let memories = parse_response::<Vec<uteke_core::Memory>>(resp)?;
             if cli.json {
                 output::print_json(&memories);
             } else {
@@ -121,8 +140,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                 .json(&body)
                 .send()
                 .map_err(|e| format!("Server error: {e}"))?;
-            let stats: uteke_core::StoreStats =
-                resp.json().map_err(|e| format!("Parse error: {e}"))?;
+            let stats = parse_response::<uteke_core::StoreStats>(resp)?;
             if cli.json {
                 output::print_json(&stats);
             } else {
@@ -144,8 +162,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                     ))
                     .send()
                     .map_err(|e| format!("Server error: {e}"))?;
-                let data: serde_json::Value =
-                    resp.json().map_err(|e| format!("Parse error: {e}"))?;
+                let data = parse_json_value(resp)?;
                 if cli.json {
                     println!("{data}");
                 } else {
@@ -160,8 +177,7 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
                     ))
                     .send()
                     .map_err(|e| format!("Server error: {e}"))?;
-                let data: serde_json::Value =
-                    resp.json().map_err(|e| format!("Parse error: {e}"))?;
+                let data = parse_json_value(resp)?;
                 if cli.json {
                     println!("{data}");
                 } else {

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -63,7 +63,8 @@ impl super::Store {
 
     /// Delete aged memories from SQLite. Returns count of deleted rows.
     ///
-    /// Same criteria as `find_aged`. Does NOT touch the vector index.
+    /// Same criteria as `find_aged` (including `deprecated = 0` filter).
+    /// Does NOT touch the vector index.
     pub fn cleanup_aged(
         &self,
         older_than_days: u32,
@@ -74,6 +75,7 @@ impl super::Store {
         let sql = r#"
             DELETE FROM memories
             WHERE namespace = ?1
+              AND deprecated = 0
               AND created_at < datetime('now', '-' || ?2 || ' days')
               AND access_count <= ?3
               AND (last_accessed IS NULL OR last_accessed < datetime('now', '-' || ?4 || ' days'))

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -8,29 +8,31 @@ use super::store::row_to_memory;
 
 impl super::Store {
     /// Bulk delete memories by tag within a namespace.
+    ///
+    /// Uses a single DELETE query with `RETURNING id` for efficiency.
     pub fn bulk_delete_by_tag(
         &self,
         tag: &str,
         namespace: Option<&str>,
     ) -> Result<Vec<String>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        let ids: Vec<String> = self
+        let mut stmt = self
             .conn
-            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)")
-            .map_err(|e| Error::db("database operation", e))?
-            .query_map(rusqlite::params![ns, tag], |row| row.get(0))
+            .prepare(
+                "DELETE FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2) RETURNING id",
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params![ns, tag], |row| row.get(0))
             .map_err(|e| Error::db("database operation", e))?
             .filter_map(|r| r.ok())
             .collect();
-        for id in &ids {
-            self.conn
-                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
-                .map_err(|e| Error::db("database operation", e))?;
-        }
         Ok(ids)
     }
 
     /// Bulk delete all cold memories (not accessed in warm_days+ days or never accessed).
+    ///
+    /// Uses a single DELETE query with `RETURNING id` for efficiency.
     pub fn bulk_delete_cold(
         &self,
         namespace: Option<&str>,
@@ -38,38 +40,34 @@ impl super::Store {
     ) -> Result<Vec<String>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         let warm_cutoff = (chrono::Utc::now() - chrono::Duration::days(warm_days)).to_rfc3339();
-        let ids: Vec<String> = self
+        let mut stmt = self
             .conn
-            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)")
-            .map_err(|e| Error::db("database operation", e))?
-            .query_map(rusqlite::params![ns, warm_cutoff], |row| row.get(0))
+            .prepare(
+                "DELETE FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL) RETURNING id",
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params![ns, warm_cutoff], |row| row.get(0))
             .map_err(|e| Error::db("database operation", e))?
             .filter_map(|r| r.ok())
             .collect();
-        for id in &ids {
-            self.conn
-                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
-                .map_err(|e| Error::db("database operation", e))?;
-        }
         Ok(ids)
     }
 
     /// Bulk delete all memories in a namespace.
+    ///
+    /// Uses a single DELETE query with `RETURNING id` for efficiency.
     pub fn bulk_delete_all(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        let ids: Vec<String> = self
+        let mut stmt = self
             .conn
-            .prepare("SELECT id FROM memories WHERE namespace = ?1")
-            .map_err(|e| Error::db("database operation", e))?
-            .query_map(rusqlite::params![ns], |row| row.get(0))
+            .prepare("DELETE FROM memories WHERE namespace = ?1 RETURNING id")
+            .map_err(|e| Error::db("database operation", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params![ns], |row| row.get(0))
             .map_err(|e| Error::db("database operation", e))?
             .filter_map(|r| r.ok())
             .collect();
-        for id in &ids {
-            self.conn
-                .execute("DELETE FROM memories WHERE id = ?1", rusqlite::params![id])
-                .map_err(|e| Error::db("database operation", e))?;
-        }
         Ok(ids)
     }
 

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -134,6 +134,8 @@ impl super::Store {
 
     /// Run incremental migrations from `from_version` (exclusive) up to
     /// `CURRENT_SCHEMA_VERSION` (inclusive).
+    ///
+    /// Each migration step + version stamp is wrapped in a transaction for atomicity.
     fn run_migrations(&self, from_version: i32) -> Result<(), Error> {
         let mut version = from_version;
         loop {
@@ -142,6 +144,12 @@ impl super::Store {
                 break;
             }
             tracing::warn!("applying schema migration v{version}");
+
+            let tx = self
+                .conn
+                .unchecked_transaction()
+                .map_err(|e| Error::db("begin migration transaction", e))?;
+
             #[allow(clippy::match_single_binding)]
             match version {
                 // Future migrations go here, e.g.:
@@ -150,28 +158,34 @@ impl super::Store {
                     // No-op for v1 (first versioned schema).
                 }
             }
+
             let now = chrono::Utc::now().to_rfc3339();
-            self.conn
-                .execute(
-                    "INSERT INTO schema_version (version, applied_at) VALUES (?1, ?2)",
-                    params![version, now],
-                )
-                .map_err(|e| Error::db("database operation", e))?;
+            tx.execute(
+                "INSERT INTO schema_version (version, applied_at) VALUES (?1, ?2)",
+                params![version, now],
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+
+            tx.commit()
+                .map_err(|e| Error::db("commit migration transaction", e))?;
         }
         Ok(())
     }
 
     /// Return the current schema version recorded in the database.
+    ///
+    /// Returns an error if no version is recorded (shouldn't happen after init_schema).
     pub fn schema_version(&self) -> Result<i32, Error> {
-        let version: i32 = self
+        let version: Option<i32> = self
             .conn
             .query_row(
                 "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
                 [],
                 |row| row.get(0),
             )
+            .optional()
             .map_err(|e| Error::db("database operation", e))?;
-        Ok(version)
+        version.ok_or_else(|| Error::db_msg("no schema version recorded"))
     }
 
     pub(super) fn column_exists(&self, column: &str) -> bool {

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -43,23 +43,22 @@ impl crate::Uteke {
             memory_type: "fact".to_string(),
         };
 
-        // SQLite first (source of truth), then vector index.
-        // If vector index fails after SQLite commit, the data is safe in SQLite
-        // and the index entry can be rebuilt via `uteke repair`.
+        // Acquire index lock BEFORE any writes so lock failures are detected early.
+        // If SQLite commit fails after index insert, the orphan index entry is harmless
+        // and will be cleaned up by verify/repair.
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|_| Error::lock("index lock during remember"))?;
+
         self.store.insert(&memory)?;
 
-        {
-            let mut index = self
-                .index
-                .lock()
-                .map_err(|_| Error::lock("index lock during remember"))?;
-            index.insert(&id, &embedding);
-            if let Err(e) = index.save() {
-                tracing::warn!(
-                    "Failed to persist vector index after remember for id={id}: {e}. \
-                     Index entry can be rebuilt via `uteke repair`."
-                );
-            }
+        index.insert(&id, &embedding);
+        if let Err(e) = index.save() {
+            tracing::warn!(
+                "Failed to persist vector index after remember for id={id}: {e}. \
+                 Index entry can be rebuilt via `uteke repair`."
+            );
         }
 
         Ok(id)


### PR DESCRIPTION
Closes #188, #189, #190, #191, #192, #193

## Fixes

| Issue | Fix |
|-------|-----|
| #192 | Safe slice `dep_id.get(..8).unwrap_or(dep_id)` prevents panic |
| #191 | Acquire index lock BEFORE SQLite write to prevent false errors on lock failure |
| #193 | Check HTTP response status before JSON parsing via `parse_response` helper |
| #189 | Add `deprecated=0` filter to `cleanup_aged` matching `find_aged` criteria |
| #188 | Wrap each migration step in transaction + safe `schema_version()` with `.optional()` |
| #190 | Replace N individual DELETEs with single `DELETE ... RETURNING id` query |

**6 files changed, 94 insertions, 65 deletions.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory ID truncation in contradiction output
  * Improved error handling and reporting for server communication failures
  * Prevented accidental removal of deprecated memories during cleanup operations

* **Performance Improvements**
  * Optimized bulk deletion operations to use single database statement instead of multiple sequential deletions

* **Stability & Reliability**
  * Enhanced database transaction handling during schema migrations to ensure atomic updates
  * Improved error reporting for schema version detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->