### PR TITLE
docs: fix version mismatches, config paths, and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/ajianaz/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/ajianaz/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.0.8-green.svg" alt="v0.0.8" />
+  <img src="https://img.shields.io/badge/status-v0.0.10-green.svg" alt="v0.0.10" />
 </p>
 
 ---
@@ -388,7 +388,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
 
 Demand-gated — we build what people actually use.
 
-**✅ v0.0.8 (current):** Multi-agent namespaces, server mode, memory aging, Docker, shell hooks, input validation, benchmarks
+**✅ v0.0.10 (current):** Codebase refactor, VitePress docs migration, bug fixes, Hermes branding removed
+**✅ v0.0.8:** Multi-agent namespaces, server mode, memory aging, Docker, shell hooks, input validation, benchmarks
 **🔮 Phase A (100+ stars):** Better embeddings, import/export, Python SDK (PyO3), editor integrations (VS Code)
 **🔮 Phase B (500+ stars):** Cloud sync (opt-in), team collaboration, API gateway integration
 **🔮 Phase C (1000+ stars):** Plugin ecosystem, advanced consolidation, community extensions

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.0.8**.
+Complete reference for all uteke commands. Version **0.0.10**.
 
 ## Global Flags
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,12 +8,11 @@ Uteke supports `uteke.toml` configuration with layered resolution.
 
 ## Resolution Order
 
-Uteke searches for config in this order. First match wins:
+Uteke searches for config in this order. Last match wins (highest priority):
 
-1. **`./uteke.toml`** — Current directory
-2. **`../uteke.toml`** — Parent directories (walks up to root)
-3. **`~/.config/uteke/uteke.toml`** — User-level config
-4. **(built-in defaults)** — Hardcoded defaults
+1. **(built-in defaults)** — Hardcoded defaults
+2. **`~/.uteke/uteke.toml`** — Global user-level config
+3. **`.uteke/uteke.toml`** — Project-level (in current working directory)
 
 Override the config file path with the `--config` flag.
 
@@ -104,10 +103,10 @@ Switch default namespace permanently with `uteke namespace switch <name>` — th
 
 ## Per-Project Config
 
-Place a `uteke.toml` in your project root to override defaults for that project:
+Place a `.uteke/uteke.toml` in your project root to override defaults for that project:
 
 ```toml
-# my-project/uteke.toml
+# my-project/.uteke/uteke.toml
 [store]
 path = "./.uteke"
 namespace = "my-project"

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -4,7 +4,7 @@ title: Pi Extension
 
 # Pi Extension
 
-uteke provides a [pi coding agent](https://github.com/ajianaz/uteke) extension that shows memory stats in the footer and reminds the agent to use uteke actively.
+uteke provides a [pi coding agent](https://pi.dev) extension that shows memory stats in the footer and reminds the agent to use uteke actively.
 
 ## Status Bar
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,7 +55,7 @@ Demand-gated — we build what people actually use. Track progress on [GitHub Is
 - [#129 Test coverage: 34 → 94 tests](https://github.com/ajianaz/uteke/issues/129) `✓ Done`
 - Tag substring false positive fix ("rust" ≠ "rustacean") `✓ Done`
 
-## v0.0.8 — Stability & Architecture `✓ Done` `Current`
+## v0.0.8 — Stability & Architecture `✓ Done`
 
 - [#130 Architecture: module split (1471→352 lib.rs)](https://github.com/ajianaz/uteke/issues/130) `✓ Done`
 - [#132 Input validation (max 10K chars, 20 tags, 1MB payload)](https://github.com/ajianaz/uteke/issues/132) `✓ Done`
@@ -67,6 +67,30 @@ Demand-gated — we build what people actually use. Track progress on [GitHub Is
 - Memory consolidation command `✓ Done`
 - Import/Export (JSONL backup and restore) `✓ Done`
 - [#174 README overhaul + landing page refresh (GTM Phase 1+2)](https://github.com/ajianaz/uteke/issues/174) `✓ Done`
+
+## v0.0.9 — Website Migration `✓ Done`
+
+- [#194 Website migrated to VitePress](https://github.com/ajianaz/uteke/issues/194) `✓ Done`
+  - SvelteKit (3,750 LOC, 10 deps) → VitePress (1,300 LOC markdown, 2 deps)
+  - Built-in full-text search
+  - Build time: ~15s → ~6s
+  - Brand theme (amber/dark) preserved
+
+## v0.0.10 — Codebase Quality `✓ Done` `Current`
+
+- [#187 Split commands.rs into per-command modules](https://github.com/ajianaz/uteke/issues/187) `✓ Done`
+- [#186 Split store.rs into focused modules](https://github.com/ajianaz/uteke/issues/186) `✓ Done`
+- [#178 Remove all Hermes branding](https://github.com/ajianaz/uteke/issues/178) `✓ Done`
+- [#196 Address all Cora code review findings](https://github.com/ajianaz/uteke/issues/196) `✓ Done`
+- Safe slice for deprecated IDs `✓ Done`
+- Index lock before SQLite write `✓ Done`
+- HTTP status checking in server proxy `✓ Done`
+- Aging cleanup filter fix `✓ Done`
+- Schema migration transactions `✓ Done`
+- Batch bulk deletes `✓ Done`
+- SQLite-first dual-write `✓ Done`
+- Embedding docs corrected (768d) `✓ Done`
+- Shell hook idempotency guards `✓ Done`
 
 ## Phase A — Growth (100+ stars) `Planned`
 


### PR DESCRIPTION
## Summary

Fixes audit findings from website/docs validation after v0.0.10 release.

### Changes

| Issue | Fix | Files |
|-------|-----|-------|
| #199 | Bump version references from v0.0.8 → v0.0.10 | README.md, docs/cli-reference.md, docs/roadmap.md |
| #200 | Fix config resolution path to match source code | docs/configuration.md |
| #201 | Fix broken pi agent link (was self-referencing) | docs/extensions.md |

### Details

- **Version bump:** README badge, CLI Reference header, roadmap current marker
- **Roadmap:** Added v0.0.9 (VitePress migration) and v0.0.10 (Codebase quality) sections from CHANGELOG
- **Config paths:** Updated configuration.md resolution order to match actual implementation: `defaults → ~/.uteke/uteke.toml → .uteke/uteke.toml`
- **Extensions:** Changed pi agent link from uteke repo to https://pi.dev

### Also closed

Closed #178 (Hermes branding removed in v0.0.10), #182 (dual-write fixed), #183 (768d docs corrected) — all already in v0.0.10 CHANGELOG.

Closes #199, Closes #200, Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated version references to v0.0.10 across documentation
* Clarified configuration discovery order and per-project configuration placement
* Extended roadmap with completed milestones for versions v0.0.8 through v0.0.10
* Updated extension reference links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->