### PR TITLE
docs: fix config resolution order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,11 +332,11 @@ uteke completions fish  > ~/.config/fish/completions/uteke.fish
 
 ## Configuration
 
-Uteke supports `uteke.toml` configuration with layered resolution:
+Uteke supports `uteke.toml` configuration with layered resolution (last match wins):
 
-1. `.uteke/uteke.toml` (project-level, in cwd)
+1. Built-in defaults
 2. `~/.uteke/uteke.toml` (global user-level)
-3. Built-in defaults
+3. `.uteke/uteke.toml` (project-level, in cwd)
 
 ```toml
 [store]


### PR DESCRIPTION
## Summary

Fix CodeRabbit finding from PR #202 — README config precedence list was reversed.

### Change

Reorder configuration resolution in README.md to match source code and docs/configuration.md:

```
Before: .uteke/uteke.toml → ~/.uteke/uteke.toml → defaults
After:  defaults → ~/.uteke/uteke.toml → .uteke/uteke.toml (last match wins)
```

Related to #200