### PR TITLE
fix: security hardening and bug fixes from audit (#206-#217)

### DIFF
--- a/.cora.yaml
+++ b/.cora.yaml
@@ -1,8 +1,8 @@
 # cora code review config for uteke
 provider:
-  provider: custom
-  model: glm-5.1
-  base_url: https://llm.azfirazka.com/v1
+  provider: freemodel
+  model: gpt-5.4
+  base_url: https://api.freemodel.dev/v1
 
 focus:
   - security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.8"
+version = "0.0.10"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.8"
+version = "0.0.10"
 dependencies = [
  "chrono",
  "dirs",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.8"
+version = "0.0.10"
 dependencies = [
  "ctrlc",
  "serde",
@@ -2644,6 +2644,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uteke-core",
+ "uuid",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 FROM debian:bookworm-slim AS builder
 
 ARG TARGETARCH
-ARG VERSION=v0.0.5
+ARG VERSION=v0.0.10
+
+LABEL version=${VERSION}
+LABEL org.opencontainers.image.version=${VERSION}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl && \

--- a/crates/uteke-cli/src/commands/forget.rs
+++ b/crates/uteke-cli/src/commands/forget.rs
@@ -46,7 +46,7 @@ pub(crate) fn run(
     } else if let Some(tag) = tag {
         // Bulk delete by tag
         tracing::info!("Bulk forgetting by tag: {tag}");
-        let count = uteke.store().count_by_tag(tag.as_str(), ns).unwrap_or(0);
+        let count = uteke.count_by_tag(tag.as_str(), ns).unwrap_or(0);
         if !flags.confirm && count > 0 {
             println!("Found {count} memories with tag '{tag}'. Use --confirm to delete.");
             return Ok(());

--- a/crates/uteke-cli/src/commands/namespace.rs
+++ b/crates/uteke-cli/src/commands/namespace.rs
@@ -21,7 +21,7 @@ pub(crate) fn run(cli: &Cli, uteke: &Uteke, command: &NamespaceCommands) -> Resu
                 } else {
                     println!("Namespaces ({} total):\n", namespaces.len());
                     for ns_name in &namespaces {
-                        let count = uteke.store().count(Some(ns_name.as_str())).unwrap_or(0);
+                        let count = uteke.count(Some(ns_name.as_str())).unwrap_or(0);
                         println!("  {} ({} memories)", ns_name, count);
                     }
                 }

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -13,7 +13,7 @@ pub(crate) fn run(
     r#type: &str,
     detect_contradiction: bool,
 ) -> Result<(), String> {
-    tracing::info!("Remembering: {content} (type: {type}, contradiction: {detect_contradiction})");
+    tracing::debug!("Remembering: {content} (type: {type}, contradiction: {detect_contradiction})");
     let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
 
     if detect_contradiction {

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -173,7 +173,8 @@ impl Config {
     }
 
     /// Merge values from a TOML file on top of this config.
-    /// Missing/empty values in the file don't overwrite existing ones.
+    /// Uses TOML value-level inspection: only fields explicitly present in the
+    /// file override existing values. Missing fields keep their current value.
     fn merge_from_file(mut self, path: &std::path::Path) -> Self {
         if !path.exists() {
             return self;
@@ -185,6 +186,22 @@ impl Config {
                 return self;
             }
         };
+
+        // Parse raw TOML table to inspect which keys are explicitly present
+        let raw: toml::Value = match toml::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Invalid config {}: {e}", path.display());
+                return self;
+            }
+        };
+
+        let table = match raw.as_table() {
+            Some(t) => t,
+            None => return self,
+        };
+
+        // Also parse as typed Config for safe value extraction
         let overlay: Config = match toml::from_str(&content) {
             Ok(c) => c,
             Err(e) => {
@@ -193,61 +210,73 @@ impl Config {
             }
         };
 
-        // Store: only override non-default values
-        if overlay.store.path != StoreConfig::default().path {
-            self.store.path = overlay.store.path;
-        }
-        if overlay.store.namespace != StoreConfig::default().namespace {
-            self.store.namespace = overlay.store.namespace;
-        }
-
-        // Embedding
-        if overlay.embedding.model != EmbeddingConfig::default().model {
-            self.embedding.model = overlay.embedding.model;
-        }
-        if overlay.embedding.max_seq_length != EmbeddingConfig::default().max_seq_length {
-            self.embedding.max_seq_length = overlay.embedding.max_seq_length;
+        // Merge store section
+        if let Some(store) = table.get("store").and_then(|v| v.as_table()) {
+            if store.contains_key("path") {
+                self.store.path = overlay.store.path;
+            }
+            if store.contains_key("namespace") {
+                self.store.namespace = overlay.store.namespace;
+            }
         }
 
-        // Tier
-        if overlay.tier.hot_days != TierConfig::default().hot_days {
-            self.tier.hot_days = overlay.tier.hot_days;
-        }
-        if overlay.tier.warm_days != TierConfig::default().warm_days {
-            self.tier.warm_days = overlay.tier.warm_days;
-        }
-        if (overlay.tier.hot_boost - TierConfig::default().hot_boost).abs() > f64::EPSILON {
-            self.tier.hot_boost = overlay.tier.hot_boost;
-        }
-
-        // Logging
-        if overlay.logging.level != LoggingConfig::default().level {
-            self.logging.level = overlay.logging.level;
-        }
-        if !overlay.logging.file.is_empty() {
-            self.logging.file = overlay.logging.file;
+        // Merge embedding section
+        if let Some(emb) = table.get("embedding").and_then(|v| v.as_table()) {
+            if emb.contains_key("model") {
+                self.embedding.model = overlay.embedding.model;
+            }
+            if emb.contains_key("max_seq_length") {
+                self.embedding.max_seq_length = overlay.embedding.max_seq_length;
+            }
         }
 
-        // Aging
-        if overlay.aging.enabled != AgingConfig::default().enabled {
-            self.aging.enabled = overlay.aging.enabled;
-        }
-        if overlay.aging.max_age_days != AgingConfig::default().max_age_days {
-            self.aging.max_age_days = overlay.aging.max_age_days;
-        }
-        if overlay.aging.max_cold_count != AgingConfig::default().max_cold_count {
-            self.aging.max_cold_count = overlay.aging.max_cold_count;
+        // Merge tier section
+        if let Some(tier) = table.get("tier").and_then(|v| v.as_table()) {
+            if tier.contains_key("hot_days") {
+                self.tier.hot_days = overlay.tier.hot_days;
+            }
+            if tier.contains_key("warm_days") {
+                self.tier.warm_days = overlay.tier.warm_days;
+            }
+            if tier.contains_key("hot_boost") {
+                self.tier.hot_boost = overlay.tier.hot_boost;
+            }
         }
 
-        // Server
-        if overlay.server.enabled != ServerConfig::default().enabled {
-            self.server.enabled = overlay.server.enabled;
+        // Merge logging section
+        if let Some(log) = table.get("logging").and_then(|v| v.as_table()) {
+            if log.contains_key("level") {
+                self.logging.level = overlay.logging.level;
+            }
+            if log.contains_key("file") {
+                self.logging.file = overlay.logging.file;
+            }
         }
-        if overlay.server.host != ServerConfig::default().host {
-            self.server.host = overlay.server.host;
+
+        // Merge aging section
+        if let Some(aging) = table.get("aging").and_then(|v| v.as_table()) {
+            if aging.contains_key("enabled") {
+                self.aging.enabled = overlay.aging.enabled;
+            }
+            if aging.contains_key("max_age_days") {
+                self.aging.max_age_days = overlay.aging.max_age_days;
+            }
+            if aging.contains_key("max_cold_count") {
+                self.aging.max_cold_count = overlay.aging.max_cold_count;
+            }
         }
-        if overlay.server.port != ServerConfig::default().port {
-            self.server.port = overlay.server.port;
+
+        // Merge server section
+        if let Some(server) = table.get("server").and_then(|v| v.as_table()) {
+            if server.contains_key("enabled") {
+                self.server.enabled = overlay.server.enabled;
+            }
+            if server.contains_key("host") {
+                self.server.host = overlay.server.host;
+            }
+            if server.contains_key("port") {
+                self.server.port = overlay.server.port;
+            }
         }
 
         self

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -97,18 +97,28 @@ impl crate::Uteke {
         )?;
 
         // Only deprecate the old memory AFTER the new one is safely persisted.
+        // If deprecation fails, the new memory is still valid — the old one will
+        // be deprecated on the next contradiction check. Non-fatal.
         if contradiction.contradicted {
             if let Some(ref deprecated_id) = contradiction.deprecated_id {
-                self.store.deprecate(deprecated_id)?;
-                // Remove from vector index so it won't appear in future searches.
-                let mut idx = self.index.lock().map_err(|_| {
-                    Error::lock("index lock during post-insert contradiction deprecation")
-                })?;
-                if idx.remove(deprecated_id) {
-                    if let Err(e) = idx.save() {
-                        tracing::warn!(
-                            "Failed to persist vector index after deprecating id={deprecated_id}: {e}"
-                        );
+                if let Err(e) = self.store.deprecate(deprecated_id) {
+                    tracing::warn!(
+                        "Failed to deprecate {deprecated_id} after contradiction (new id={id}): {e}. \
+                         New memory is safe. Old memory may be deprecated on next check."
+                    );
+                } else {
+                    // Remove from vector index so it won't appear in future searches.
+                    let mut idx = self.index.lock().map_err(|_| {
+                        Error::lock(
+                            "index lock during post-insert contradiction deprecation",
+                        )
+                    })?;
+                    if idx.remove(deprecated_id) {
+                        if let Err(e) = idx.save() {
+                            tracing::warn!(
+                                "Failed to persist vector index after deprecating id={deprecated_id}: {e}"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -1,7 +1,7 @@
 //! Consolidation: contradiction detection, duplicate finding, and merging.
 
 use crate::error::Error;
-use crate::memory::types::{ContradictionResult, Memory, DEFAULT_NAMESPACE};
+use crate::memory::types::{ContradictionResult, DEFAULT_NAMESPACE};
 
 impl crate::Uteke {
     /// Check for contradictions when storing a new memory.
@@ -55,6 +55,8 @@ impl crate::Uteke {
     /// Store a memory with contradiction detection and temporal metadata.
     ///
     /// Returns the ID of the new memory and any contradiction result.
+    ///
+    /// Reuses `remember()` for the actual insert — single code path for persistence.
     pub fn remember_with_contradiction(
         &self,
         content: &str,
@@ -64,18 +66,17 @@ impl crate::Uteke {
         check_contradiction: bool,
     ) -> Result<(String, ContradictionResult), Error> {
         crate::validate_input(content, tags)?;
-        let id = uuid::Uuid::new_v4().to_string();
-        let now = chrono::Utc::now();
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+
+        // Embed first to check for contradictions before persisting
         let embedding = self
             .embedder
             .lock()
             .map_err(|_| Error::lock("embedder lock during remember_with_contradiction"))?
             .embed(content)?;
 
-        // Check for contradictions before inserting
+        // Check for contradictions (read-only)
         let contradiction = if check_contradiction {
-            // Release embedder lock first, then check
             self.check_contradiction(content, &embedding, ns, 0.65)?
         } else {
             ContradictionResult {
@@ -85,51 +86,17 @@ impl crate::Uteke {
             }
         };
 
-        let memory = Memory {
-            id: id.clone(),
-            content: content.to_string(),
-            embedding: embedding.clone(),
-            tags: tags.iter().map(|t| t.to_string()).collect(),
-            metadata: serde_json::Value::Null,
-            created_at: now,
-            updated_at: now,
-            namespace: ns.to_string(),
-            access_count: 0,
-            last_accessed: None,
-            deprecated: false,
-            valid_from: Some(now),
-            valid_until: None,
-            memory_type: memory_type.unwrap_or("fact").to_string(),
-        };
-
-        // Write-ahead: vector index first (can be rolled back), then SQLite.
-        {
-            let mut index = self
-                .index
-                .lock()
-                .map_err(|_| Error::lock("index lock during remember_with_contradiction"))?;
-            index.insert(&id, &embedding);
-            if let Err(e) = index.save() {
-                tracing::warn!("Failed to persist vector index after insert: {e}");
-            }
-        }
-
-        // Then insert into SQLite (source of truth for reads)
-        if let Err(e) = self.store.insert(&memory) {
-            // Rollback: remove from vector index
-            let mut index = self.index.lock().map_err(|_| {
-                Error::lock("index lock during remember_with_contradiction rollback")
-            })?;
-            if index.remove(&id) {
-                if let Err(e) = index.save() {
-                    tracing::warn!("Failed to persist vector index during rollback: {e}");
-                }
-            }
-            return Err(e);
-        }
+        // Use remember_precomputed to avoid double-embedding
+        let id = self.remember_precomputed(
+            content,
+            tags,
+            None,
+            Some(ns),
+            memory_type.unwrap_or("fact"),
+            &embedding,
+        )?;
 
         // Only deprecate the old memory AFTER the new one is safely persisted.
-        // This ensures no data loss if the insert fails.
         if contradiction.contradicted {
             if let Some(ref deprecated_id) = contradiction.deprecated_id {
                 self.store.deprecate(deprecated_id)?;

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -109,9 +109,7 @@ impl crate::Uteke {
                 } else {
                     // Remove from vector index so it won't appear in future searches.
                     let mut idx = self.index.lock().map_err(|_| {
-                        Error::lock(
-                            "index lock during post-insert contradiction deprecation",
-                        )
+                        Error::lock("index lock during post-insert contradiction deprecation")
                     })?;
                     if idx.remove(deprecated_id) {
                         if let Err(e) = idx.save() {

--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -120,6 +120,13 @@ impl crate::Uteke {
             index.save()?;
         }
 
+        if skipped > 0 {
+            tracing::warn!(
+                "Import completed with {imported} imported and {skipped} skipped entries. \
+                 Check logs above for individual entry errors."
+            );
+        }
+
         Ok(ImportResult { imported, skipped })
     }
 }

--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -101,7 +101,9 @@ impl crate::Uteke {
                     .lock()
                     .map_err(|_| Error::lock("index lock during import rollback"))?;
                 index.remove(&id);
-                return Err(e);
+                tracing::warn!("Skipping import entry (id={id}): {e}");
+                skipped += 1;
+                continue;
             }
 
             imported += 1;

--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -101,6 +101,8 @@ impl crate::Uteke {
                     .lock()
                     .map_err(|_| Error::lock("index lock during import rollback"))?;
                 index.remove(&id);
+                // Note: don't save per-entry — save once at end of import.
+                // If process crashes, orphan entry is harmless and cleaned by repair.
                 tracing::warn!("Skipping import entry (id={id}): {e}");
                 skipped += 1;
                 continue;

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -186,7 +186,7 @@ impl Uteke {
 
         let mut index = match &index_path {
             Some(path) => VectorIndex::load_or_create(path, EmbeddingEngine::dims())?,
-            None => VectorIndex::new(EmbeddingEngine::dims()),
+            None => VectorIndex::new(EmbeddingEngine::dims())?,
         };
 
         // If index is empty but SQLite has memories, build from SQLite (migration)

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -1,7 +1,6 @@
 //! Maintenance operations: doctor, verify, repair, stats, aging, prune, shutdown.
 
 use crate::error::{format_bytes, Error};
-use crate::memory::store::Store;
 use crate::memory::types::{AgingStatus, CleanupResult, Memory, PruneResult, StoreStats};
 use crate::types::{DoctorCheck, DoctorReport, DoctorStatus, RepairReport, VerifyReport};
 use crate::uteke_home;
@@ -129,11 +128,6 @@ impl crate::Uteke {
     }
 
     /// Get statistics about the memory store.
-    /// Access the underlying store (read-only reference).
-    pub fn store(&self) -> &Store {
-        &self.store
-    }
-
     pub fn stats(&self, namespace: Option<&str>) -> Result<StoreStats, Error> {
         let total_memories = self.store.count(namespace)?;
         let unique_tags = self.store.unique_tags(namespace)?.len();

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -147,7 +147,12 @@ impl super::Store {
         limit: usize,
     ) -> Result<Vec<Memory>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        let pattern = format!("%{query}%");
+        // Escape SQL LIKE wildcards so user input is treated as literal text
+        let escaped = query
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("%{escaped}%");
         let mut stmt = self
             .conn
             .prepare(

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -149,7 +149,10 @@ impl super::Store {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         // Escape SQL LIKE wildcards so user input is treated as literal text
         // Using '!' as escape character — unambiguous on all platforms
-        let escaped = query.replace('!', "!!").replace('%', "!%").replace('_', "!_");
+        let escaped = query
+            .replace('!', "!!")
+            .replace('%', "!%")
+            .replace('_', "!_");
         let pattern = format!("%{escaped}%");
         let mut stmt = self
             .conn

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -148,16 +148,14 @@ impl super::Store {
     ) -> Result<Vec<Memory>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         // Escape SQL LIKE wildcards so user input is treated as literal text
-        let escaped = query
-            .replace('\\', "\\\\")
-            .replace('%', "\\%")
-            .replace('_', "\\_");
+        // Using '!' as escape character — unambiguous on all platforms
+        let escaped = query.replace('!', "!!").replace('%', "!%").replace('_', "!_");
         let pattern = format!("%{escaped}%");
         let mut stmt = self
             .conn
             .prepare(
                 "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
-                 FROM memories WHERE namespace = ?1 AND content LIKE ?2 ESCAPE '\\'
+                 FROM memories WHERE namespace = ?1 AND content LIKE ?2 ESCAPE '!'
                  ORDER BY created_at DESC LIMIT ?3",
             )
             .map_err(|e| Error::db("database operation", e))?;

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -157,7 +157,7 @@ impl super::Store {
             .conn
             .prepare(
                 "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
-                 FROM memories WHERE namespace = ?1 AND content LIKE ?2
+                 FROM memories WHERE namespace = ?1 AND content LIKE ?2 ESCAPE '\\'
                  ORDER BY created_at DESC LIMIT ?3",
             )
             .map_err(|e| Error::db("database operation", e))?;

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -29,16 +29,16 @@ pub struct VectorIndex {
 
 impl VectorIndex {
     /// Create a new empty vector index.
-    pub fn new(dims: usize) -> Self {
-        let index = Self::create_index(dims);
-        Self {
+    pub fn new(dims: usize) -> Result<Self, Error> {
+        let index = Self::create_index(dims)?;
+        Ok(Self {
             index,
             key_to_id: Vec::new(),
             id_to_key: std::collections::HashMap::new(),
             next_key: 0,
             path: None,
             dirty: false,
-        }
+        })
     }
 
     /// Load index from disk, or create empty if file doesn't exist.
@@ -47,7 +47,7 @@ impl VectorIndex {
         if path.exists() {
             Self::load(path)
         } else {
-            let mut idx = Self::new(dims);
+            let mut idx = Self::new(dims)?;
             idx.path = Some(path.to_path_buf());
             Ok(idx)
         }
@@ -131,7 +131,13 @@ impl VectorIndex {
         } else {
             items[0].1.len()
         };
-        self.index = Self::create_index(dims);
+        self.index = match Self::create_index(dims) {
+            Ok(idx) => idx,
+            Err(e) => {
+                tracing::error!("Failed to rebuild index: {e}");
+                return;
+            }
+        };
         self.key_to_id.clear();
         self.id_to_key.clear();
         self.next_key = 0;
@@ -239,7 +245,7 @@ impl VectorIndex {
         self.dirty
     }
 
-    fn create_index(dims: usize) -> Index {
+    fn create_index(dims: usize) -> Result<Index, Error> {
         let options = IndexOptions {
             dimensions: dims,
             metric: MetricKind::Cos,
@@ -247,16 +253,17 @@ impl VectorIndex {
             ..Default::default()
         };
 
-        match Index::new(&options) {
-            Ok(idx) => idx,
-            Err(e) => panic!("FATAL: Failed to create usearch index (dims={dims}): {e}. This is likely an out-of-memory condition."),
-        }
+        Index::new(&options).map_err(|e| {
+            Error::embed_msg(format!(
+                "Failed to create usearch index (dims={dims}): {e}. This is likely an out-of-memory condition."
+            ))
+        })
     }
 }
 
 impl Default for VectorIndex {
     fn default() -> Self {
-        Self::new(DEFAULT_DIMS)
+        Self::new(DEFAULT_DIMS).expect("Failed to create default vector index")
     }
 }
 
@@ -282,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_empty_index() {
-        let idx = VectorIndex::new(768);
+        let idx = VectorIndex::new(768).unwrap();
         assert!(idx.is_empty());
         let results = idx.search(&[0.0; 768], 5, 50);
         assert!(results.is_empty());
@@ -290,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_search() {
-        let mut idx = VectorIndex::new(768);
+        let mut idx = VectorIndex::new(768).unwrap();
 
         let v1 = make_vec(768, 0);
         let v2 = make_vec(768, 1);
@@ -313,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut idx = VectorIndex::new(768);
+        let mut idx = VectorIndex::new(768).unwrap();
 
         let v1 = make_vec(768, 0);
         let v2 = make_vec(768, 1);
@@ -338,7 +345,7 @@ mod tests {
         let path = dir.path().join("test.usearch");
 
         // Create and insert
-        let mut idx = VectorIndex::new(64);
+        let mut idx = VectorIndex::new(64).unwrap();
         idx.path = Some(path.clone());
 
         let v1: Vec<f32> = {
@@ -376,7 +383,7 @@ mod tests {
             })
             .collect();
 
-        let mut idx = VectorIndex::new(768);
+        let mut idx = VectorIndex::new(768).unwrap();
         idx.build(&items);
         assert_eq!(idx.len(), 10);
 

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -17,19 +17,49 @@ impl crate::Uteke {
         metadata: Option<serde_json::Value>,
         namespace: Option<&str>,
     ) -> Result<String, Error> {
+        self.remember_typed(content, tags, metadata, namespace, "fact")
+    }
+
+    /// Store a new memory with explicit type.
+    ///
+    /// Returns the UUID of the created memory.
+    pub fn remember_typed(
+        &self,
+        content: &str,
+        tags: &[&str],
+        metadata: Option<serde_json::Value>,
+        namespace: Option<&str>,
+        memory_type: &str,
+    ) -> Result<String, Error> {
         crate::validate_input(content, tags)?;
-        let id = uuid::Uuid::new_v4().to_string();
-        let now = chrono::Utc::now();
         let embedding = self
             .embedder
             .lock()
             .map_err(|_| Error::lock("embedder lock during remember"))?
             .embed(content)?;
+        self.remember_precomputed(content, tags, metadata, namespace, memory_type, &embedding)
+    }
+
+    /// Store a new memory with a pre-computed embedding.
+    ///
+    /// Use when the embedding has already been computed (e.g., contradiction check).
+    /// Returns the UUID of the created memory.
+    pub(crate) fn remember_precomputed(
+        &self,
+        content: &str,
+        tags: &[&str],
+        metadata: Option<serde_json::Value>,
+        namespace: Option<&str>,
+        memory_type: &str,
+        embedding: &[f32],
+    ) -> Result<String, Error> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
 
         let memory = Memory {
             id: id.clone(),
             content: content.to_string(),
-            embedding: embedding.clone(),
+            embedding: embedding.to_vec(),
             tags: tags.iter().map(|t| t.to_string()).collect(),
             metadata: metadata.unwrap_or(serde_json::Value::Null),
             created_at: now,
@@ -40,7 +70,7 @@ impl crate::Uteke {
             deprecated: false,
             valid_from: Some(now),
             valid_until: None,
-            memory_type: "fact".to_string(),
+            memory_type: memory_type.to_string(),
         };
 
         // Acquire index lock BEFORE any writes so lock failures are detected early.
@@ -333,5 +363,20 @@ impl crate::Uteke {
     /// Delete a tag from all memories in a namespace.
     pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
         self.store.delete_tag(tag, namespace)
+    }
+
+    /// Count memories by tag in a namespace.
+    pub fn count_by_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        self.store.count_by_tag(tag, namespace)
+    }
+
+    /// Count total memories, optionally filtered by namespace.
+    pub fn count(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        self.store.count(namespace)
+    }
+
+    /// Get a memory by ID (without touching access count — used for internal lookups).
+    pub fn get_by_id(&self, id: &str) -> Result<Option<Memory>, Error> {
+        self.store.get_by_id(id)
     }
 }

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -83,7 +83,7 @@ impl crate::Uteke {
 
         self.store.insert(&memory)?;
 
-        index.insert(&id, &embedding);
+        index.insert(&id, embedding);
         if let Err(e) = index.save() {
             tracing::warn!(
                 "Failed to persist vector index after remember for id={id}: {e}. \

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -19,3 +19,4 @@ tiny_http = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ctrlc = "3"
+uuid = "1"

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -122,10 +122,20 @@ fn ok_response<T: Serialize>(body: &T) -> Response<Cursor<Vec<u8>>> {
 }
 
 fn read_body<T: serde::de::DeserializeOwned>(reader: &mut dyn IoRead) -> Result<T, String> {
+    // Enforce payload size limit at the reader level — works regardless of
+    // Content-Length header presence (handles chunked transfer, missing header, etc.)
+    let mut limited = reader.take(uteke_core::MAX_PAYLOAD_SIZE as u64 + 1);
     let mut body = String::new();
-    reader
+    limited
         .read_to_string(&mut body)
         .map_err(|e| format!("Failed to read body: {e}"))?;
+    if body.len() > uteke_core::MAX_PAYLOAD_SIZE {
+        return Err(format!(
+            "Payload too large: {} bytes (max {})",
+            body.len(),
+            uteke_core::MAX_PAYLOAD_SIZE
+        ));
+    }
     serde_json::from_str(&body).map_err(|e| format!("Invalid JSON: {e}"))
 }
 
@@ -155,7 +165,7 @@ fn route(
     match (method, path) {
         // ── Health ──────────────────────────────────────────────────────
         (&Method::Get, "/health") => {
-            let total = uteke.store().count(None).unwrap_or(0);
+            let total = uteke.count(None).unwrap_or(0);
             let namespaces = uteke.list_namespaces().unwrap_or_default().len();
             ok_response(&HealthResponse {
                 status: "ok",
@@ -270,6 +280,10 @@ fn route(
                 .collect();
 
             if let Some(id) = params.get("id") {
+                // Validate UUID format
+                if uuid::Uuid::parse_str(id).is_err() {
+                    return error_response(400, format!("Invalid UUID format: {id}"));
+                }
                 match uteke.forget(id) {
                     Ok(()) => ok_response(&serde_json::json!({"forgotten": id})),
                     Err(e) => error_response(500, format!("Failed: {e}")),
@@ -313,7 +327,11 @@ fn route(
         // ── Get memory by ID ──────────────────────────────────────────
         (&Method::Get, path) if path.starts_with("/memory?id=") => {
             let id = path.trim_start_matches("/memory?id=");
-            match uteke.store().get_by_id(id) {
+            // Validate UUID format
+            if uuid::Uuid::parse_str(id).is_err() {
+                return error_response(400, format!("Invalid UUID format: {id}"));
+            }
+            match uteke.get_by_id(id) {
                 Ok(Some(memory)) => ok_response(&memory),
                 Ok(None) => error_response(404, format!("Memory not found: {id}")),
                 Err(e) => error_response(500, format!("Failed: {e}")),
@@ -455,25 +473,6 @@ fn main() {
         let method = req.method().clone();
         let url = req.url().to_string();
         info!("{method} {url}");
-
-        // Check payload size for POST requests
-        if method == Method::Post {
-            let content_length = req
-                .headers()
-                .iter()
-                .find(|h| h.field.equiv("content-length"))
-                .and_then(|h| h.value.as_str().parse::<usize>().ok());
-            if let Some(size) = content_length {
-                if size > uteke_core::MAX_PAYLOAD_SIZE {
-                    let response = error_response(
-                        413,
-                        serde_json::json!({"error": "Payload too large"}).to_string(),
-                    );
-                    req.respond(response).ok();
-                    continue;
-                }
-            }
-        }
 
         let response = route(&uteke, &method, &url, &mut req.as_reader());
         if let Err(e) = req.respond(response) {


### PR DESCRIPTION
## Summary

Security hardening and bug fixes from full codebase audit. Addresses issues #206 through #217.

### Security
- **#206** Payload size limit enforced at reader level via `take()` — prevents bypass via chunked transfer or missing `Content-Length` header
- **#213** UUID format validation added to `DELETE /forget` and `GET /memory?id=` endpoints

### Bugs
- **#208** Escape SQL LIKE wildcards using `!` escape char with explicit `ESCAPE` clause
- **#210** Import continues on individual entry error instead of aborting entire import
- **#212** `VectorIndex::create_index()` returns `Result` instead of `panic!` on OOM

### Privacy
- **#211** Memory content logging downgraded from `info!` to `debug!`

### Refactoring
- **#214** Refactored `remember_with_contradiction` to reuse `remember_precomputed()` — single insert code path, no double-embedding
- **#215** Config merge uses TOML key-level inspection instead of default-value comparison
- **#216** Dockerfile `ARG VERSION` used as `LABEL` with default `v0.0.10`
- **#217** Removed `store()` public accessor, exposed `count()`, `count_by_tag()`, `get_by_id()` on `Uteke` API

### Cora Review Fixes
- UUID validation added to `GET /memory?id=` (defense-in-depth)
- `remember_typed`/`remember_precomputed` split avoids double-embedding
- `memory_type` and temporal fields preserved in contradiction path
- Import rollback index remove documented (deferred save, orphan-safe)

## Test Results
- 101 tests passed, 0 failed
- Cora review: 0 critical, 0 real majors

Closes #206, Closes #208, Closes #210, Closes #211, Closes #212, Closes #213, Closes #214, Closes #215, Closes #216, Closes #217