### PR TITLE
release: v0.0.11 — audit fixes from Cora scan (#221-#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11] — 2026-06-07
+
+### Fixed
+
+- **[CRITICAL] Timestamp format mismatch** — Aging/pruning queries never matched because SQLite `datetime('now')` format differs from stored RFC3339 timestamps. Now computes cutoffs in Rust using `chrono` (#221)
+- **Namespace=None inconsistency** — Tag operations (`tags_with_counts`, `rename_tag`, `delete_tag`, `count_by_tag`) treated `None` as "default" namespace instead of "all namespaces". Now consistent with `unique_tags` behavior (#222)
+- **Non-atomic model file write** — Model downloads now use atomic write (`.tmp` + rename) to prevent corrupt files on crash. Cleans up leftover `.tmp` files on startup (#225)
+- **`uteke_home()` panic** — Replaced `.expect()` with `Result` return type to prevent crashes in minimal Docker/CI environments (#226)
+- **Server path matching** — `DELETE /forget` now uses exact path match, preventing false matches on `/forgetful` etc. (#228)
+- **Query param parsing** — Use `splitn(2, '=')` to preserve values containing `=` (#228)
+- **Missing CLI arg value** — `--host`/`--port` without value now prints error instead of silently ignoring (#228)
+- **404 path reflection** — Generic "Not found" message instead of echoing request path (#228)
+- **SQLite/index inconsistency** — `forget()` now acquires index lock before SQLite delete to narrow the inconsistency window (#231)
+- **Memory type validation** — `remember_typed()` now validates `memory_type` against known variants (#229)
+
+### Added
+
+- **Security scanning workflow** — New `security.yml` CI workflow with `cargo audit` + Trivy filesystem scan. Runs on push, PRs, and daily schedule (#177, #220)
+- **quinn-proto update** — Updated to v0.11.14 fixing CVE-2026-31812 (DoS via crafted QUIC packet)
+- **`Error::Generic` variant** — New error type for general-purpose errors
+
+### Changed
+
+- **`uteke_home()` returns `Result`** — All callers updated to handle potential failure
+
 ## [0.0.10] — 2026-06-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "chrono",
  "dirs",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "ctrlc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ajianaz/uteke"

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -32,6 +32,10 @@ impl EmbeddingEngine {
         let model_data_path = onnx_dir.join(MODEL_DATA_FILE);
         let tokenizer_path = model_dir.join(TOKENIZER_FILE);
 
+        // Clean up leftover .tmp files from interrupted downloads
+        clean_tmp_files(&onnx_dir);
+        clean_tmp_files(&model_dir);
+
         // Download model files if not present
         if !model_path.exists() {
             download_hf_file(HF_REPO, "onnx/model_q4.onnx", &model_path)?;
@@ -123,11 +127,25 @@ impl EmbeddingEngine {
     }
 
     fn model_dir() -> Result<PathBuf, Error> {
-        Ok(crate::uteke_home().join("models").join(MODEL_DIR_NAME))
+        crate::uteke_home().map(|p| p.join("models").join(MODEL_DIR_NAME))
+    }
+}
+
+/// Delete leftover .tmp files from interrupted atomic downloads.
+fn clean_tmp_files(dir: &std::path::Path) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "tmp") {
+                tracing::debug!("Cleaning up temp file: {}", path.display());
+                std::fs::remove_file(&path).ok();
+            }
+        }
     }
 }
 
 /// Download a file from HuggingFace repo to local path.
+/// Uses atomic write (.tmp + rename) to prevent corrupt files on crash.
 fn download_hf_file(
     repo: &str,
     path_in_repo: &str,
@@ -152,8 +170,18 @@ fn download_hf_file(
         .bytes()
         .map_err(|e| Error::embed("read download response", e))?;
 
-    std::fs::write(local_path, bytes.as_ref())
-        .map_err(|e| Error::embed("write downloaded file", e))?;
+    // Atomic write: write to .tmp then rename — prevents corrupt files on crash.
+    let tmp_path = local_path.with_extension(format!(
+        "{}.tmp",
+        local_path
+            .extension()
+            .map(|e| e.to_string_lossy().to_string())
+            .unwrap_or_default()
+    ));
+    std::fs::write(&tmp_path, bytes.as_ref())
+        .map_err(|e| Error::embed("write temporary file", e))?;
+    std::fs::rename(&tmp_path, local_path)
+        .map_err(|e| Error::embed("rename temp to final path", e))?;
 
     Ok(())
 }

--- a/crates/uteke-core/src/error.rs
+++ b/crates/uteke-core/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
 
     #[error("Lock error: {context}")]
     Lock { context: String },
+
+    #[error("{0}")]
+    Generic(String),
 }
 
 impl Error {
@@ -59,6 +62,11 @@ impl Error {
         let context = context.into();
         tracing::warn!(%context, "lock error");
         Error::Lock { context }
+    }
+
+    /// Generic error with a message.
+    pub fn generic(msg: impl Into<String>) -> Self {
+        Error::Generic(msg.into())
     }
 
     // ── Sanitizers ─────────────────────────────────────────────────────

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -114,13 +114,15 @@ impl Default for TierConfig {
 /// UTEKE_HOME=/data   → /data
 /// (not set)           → ~/.uteke
 /// ```
-pub fn uteke_home() -> PathBuf {
+pub fn uteke_home() -> Result<PathBuf, Error> {
     if let Ok(home) = std::env::var("UTEKE_HOME") {
-        PathBuf::from(home)
+        Ok(PathBuf::from(home))
     } else {
         dirs::home_dir()
-            .expect("Cannot determine home directory. Set UTEKE_HOME or HOME.")
-            .join(".uteke")
+            .ok_or_else(|| {
+                Error::generic("Cannot determine home directory. Set UTEKE_HOME or HOME.")
+            })
+            .map(|p| p.join(".uteke"))
     }
 }
 
@@ -328,7 +330,7 @@ mod tests {
     #[test]
     fn test_uteke_home_with_env() {
         std::env::set_var("UTEKE_HOME", "/tmp/custom_home");
-        let home = uteke_home();
+        let home = uteke_home().unwrap_or_else(|_| PathBuf::from("/tmp/.uteke"));
         assert_eq!(home.to_string_lossy(), "/tmp/custom_home");
         std::env::remove_var("UTEKE_HOME");
     }

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -55,7 +55,17 @@ impl crate::Uteke {
         }
 
         // 4. Embedding model
-        let model_dir = uteke_home().join("models").join("embeddinggemma-q4");
+        let model_dir = match uteke_home() {
+            Ok(p) => p.join("models").join("embeddinggemma-q4"),
+            Err(_) => {
+                checks.push(DoctorCheck {
+                    name: "Home directory".to_string(),
+                    status: DoctorStatus::Error,
+                    detail: "Cannot determine home directory. Set UTEKE_HOME.".to_string(),
+                });
+                return Ok(DoctorReport { checks });
+            }
+        };
         let model_file = model_dir.join("onnx").join("model_q4.onnx");
         let tokenizer_file = model_dir.join("tokenizer.json");
         let model_exists = model_file.exists() && tokenizer_file.exists();

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -30,14 +30,19 @@ impl super::Store {
         namespace: Option<&str>,
     ) -> Result<Vec<Memory>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        // Compute cutoffs in Rust using chrono (RFC3339) to match stored timestamp format.
+        // SQLite datetime('now') returns a different format than our RFC3339 strings,
+        // causing lexicographic comparison to fail.
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(older_than_days as i64)).to_rfc3339();
         let sql = r#"
             SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
             FROM memories
             WHERE namespace = ?1
               AND deprecated = 0
-              AND created_at < datetime('now', '-' || ?2 || ' days')
+              AND created_at < ?2
               AND access_count <= ?3
-              AND (last_accessed IS NULL OR last_accessed < datetime('now', '-' || ?4 || ' days'))
+              AND (last_accessed IS NULL OR last_accessed < ?4)
             ORDER BY created_at ASC
         "#;
 
@@ -47,10 +52,7 @@ impl super::Store {
             .map_err(|e| Error::db("database operation", e))?;
 
         let rows = stmt
-            .query_map(
-                params![ns, older_than_days, max_access_count, older_than_days],
-                row_to_memory,
-            )
+            .query_map(params![ns, cutoff, max_access_count, cutoff], row_to_memory)
             .map_err(|e| Error::db("database operation", e))?;
 
         let mut memories = Vec::new();
@@ -72,21 +74,20 @@ impl super::Store {
         namespace: Option<&str>,
     ) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(older_than_days as i64)).to_rfc3339();
         let sql = r#"
             DELETE FROM memories
             WHERE namespace = ?1
               AND deprecated = 0
-              AND created_at < datetime('now', '-' || ?2 || ' days')
+              AND created_at < ?2
               AND access_count <= ?3
-              AND (last_accessed IS NULL OR last_accessed < datetime('now', '-' || ?4 || ' days'))
+              AND (last_accessed IS NULL OR last_accessed < ?4)
         "#;
 
         let deleted = self
             .conn
-            .execute(
-                sql,
-                params![ns, older_than_days, max_access_count, older_than_days],
-            )
+            .execute(sql, params![ns, cutoff, max_access_count, cutoff])
             .map_err(|e| Error::db("database operation", e))?;
         Ok(deleted)
     }

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -107,13 +107,15 @@ impl super::Store {
     /// Returns count of pruned memories.
     pub fn prune_ttl(&self, ttl_days: u32, namespace: Option<&str>) -> Result<usize, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        // Compute cutoff in Rust (RFC3339) to match stored timestamp format.
+        let cutoff = (chrono::Utc::now() - chrono::Duration::days(ttl_days as i64)).to_rfc3339();
         let deleted = self
             .conn
             .execute(
                 "DELETE FROM memories WHERE namespace = ?1
                  AND deprecated = 1
-                 AND datetime(updated_at) < datetime('now', '-' || ?2 || ' days')",
-                params![ns, ttl_days],
+                 AND updated_at < ?2",
+                params![ns, cutoff],
             )
             .map_err(|e| Error::db("database operation", e))?;
         Ok(deleted)
@@ -126,18 +128,19 @@ impl super::Store {
         namespace: Option<&str>,
     ) -> Result<Vec<Memory>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let cutoff = (chrono::Utc::now() - chrono::Duration::days(ttl_days as i64)).to_rfc3339();
         let mut stmt = self
             .conn
             .prepare(
                 "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
                  FROM memories WHERE namespace = ?1
                  AND deprecated = 1
-                 AND datetime(updated_at) < datetime('now', '-' || ?2 || ' days')
+                 AND updated_at < ?2
                  ORDER BY updated_at ASC",
             )
             .map_err(|e| Error::db("database operation", e))?;
         let rows = stmt
-            .query_map(params![ns, ttl_days], row_to_memory)
+            .query_map(params![ns, cutoff], row_to_memory)
             .map_err(|e| Error::db("database operation", e))?;
         let mut memories = Vec::new();
         for row in rows {

--- a/crates/uteke-core/src/memory/tags.rs
+++ b/crates/uteke-core/src/memory/tags.rs
@@ -1,6 +1,6 @@
 //! Tag operations — unique tags, counts, rename, delete, namespaces.
 
-use crate::memory::types::{TagInfo, DEFAULT_NAMESPACE};
+use crate::memory::types::TagInfo;
 use crate::Error;
 use rusqlite::params;
 
@@ -43,23 +43,44 @@ impl super::Store {
     /// Single-query approach using `json_each()` — replaces the old N+1 pattern
     /// that fetched each tag then ran a separate COUNT query per tag.
     pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        let sql = "SELECT je.value AS name, COUNT(*) AS count FROM memories, json_each(memories.tags) AS je WHERE namespace = ?1 GROUP BY je.value ORDER BY count DESC";
-        let mut stmt = self
-            .conn
-            .prepare(sql)
-            .map_err(|e| Error::db("database operation", e))?;
-        let rows = stmt
-            .query_map(params![ns], |row| {
-                Ok(TagInfo {
-                    name: row.get(0)?,
-                    count: row.get(1)?,
-                })
-            })
-            .map_err(|e| Error::db("database operation", e))?;
         let mut result = Vec::new();
-        for row in rows {
-            result.push(row.map_err(|e| Error::db("database operation", e))?);
+        match namespace {
+            Some(ns) => {
+                let sql = "SELECT je.value AS name, COUNT(*) AS count FROM memories, json_each(memories.tags) AS je WHERE namespace = ?1 GROUP BY je.value ORDER BY count DESC";
+                let mut stmt = self
+                    .conn
+                    .prepare(sql)
+                    .map_err(|e| Error::db("database operation", e))?;
+                let rows = stmt
+                    .query_map(params![ns], |row| {
+                        Ok(TagInfo {
+                            name: row.get(0)?,
+                            count: row.get(1)?,
+                        })
+                    })
+                    .map_err(|e| Error::db("database operation", e))?;
+                for row in rows {
+                    result.push(row.map_err(|e| Error::db("database operation", e))?);
+                }
+            }
+            None => {
+                let sql = "SELECT je.value AS name, COUNT(*) AS count FROM memories, json_each(memories.tags) AS je GROUP BY je.value ORDER BY count DESC";
+                let mut stmt = self
+                    .conn
+                    .prepare(sql)
+                    .map_err(|e| Error::db("database operation", e))?;
+                let rows = stmt
+                    .query_map([], |row| {
+                        Ok(TagInfo {
+                            name: row.get(0)?,
+                            count: row.get(1)?,
+                        })
+                    })
+                    .map_err(|e| Error::db("database operation", e))?;
+                for row in rows {
+                    result.push(row.map_err(|e| Error::db("database operation", e))?);
+                }
+            }
         }
         Ok(result)
     }
@@ -75,19 +96,31 @@ impl super::Store {
         new: &str,
         namespace: Option<&str>,
     ) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let (sql, ns_param): (&str, Option<&str>) = match namespace {
+            Some(_) => ("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)", namespace),
+            None => ("SELECT id, tags FROM memories WHERE EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?1)", None),
+        };
         let mut stmt = self
             .conn
-            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)")
+            .prepare(sql)
             .map_err(|e| Error::db("database operation", e))?;
 
-        let rows: Vec<(String, String)> = stmt
-            .query_map(params![ns, old], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(|e| Error::db("database operation", e))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::db("database operation", e))?;
+        let rows: Vec<(String, String)> = match ns_param {
+            Some(ns) => stmt
+                .query_map(params![ns, old], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| Error::db("database operation", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("database operation", e))?,
+            None => stmt
+                .query_map(params![old], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| Error::db("database operation", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("database operation", e))?,
+        };
 
         let tx = self
             .conn
@@ -134,19 +167,31 @@ impl super::Store {
     /// Uses `json_each()` to find affected rows precisely. Wrapped in a
     /// transaction for atomicity.
     pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let (sql, ns_param): (&str, Option<&str>) = match namespace {
+            Some(_) => ("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)", namespace),
+            None => ("SELECT id, tags FROM memories WHERE EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?1)", None),
+        };
         let mut stmt = self
             .conn
-            .prepare("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)")
+            .prepare(sql)
             .map_err(|e| Error::db("database operation", e))?;
 
-        let rows: Vec<(String, String)> = stmt
-            .query_map(params![ns, tag], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(|e| Error::db("database operation", e))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::db("database operation", e))?;
+        let rows: Vec<(String, String)> = match ns_param {
+            Some(ns) => stmt
+                .query_map(params![ns, tag], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| Error::db("database operation", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("database operation", e))?,
+            None => stmt
+                .query_map(params![tag], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| Error::db("database operation", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("database operation", e))?,
+        };
 
         let tx = self
             .conn
@@ -185,14 +230,24 @@ impl super::Store {
 
     /// Count memories by tag in a namespace.
     pub fn count_by_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        self.conn
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)",
-                params![ns, tag],
-                |row| row.get(0),
-            )
-            .map_err(|e| Error::db("database operation", e))
+        match namespace {
+            Some(ns) => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)",
+                    params![ns, tag],
+                    |row| row.get(0),
+                )
+                .map_err(|e| Error::db("database operation", e)),
+            None => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?1)",
+                    params![tag],
+                    |row| row.get(0),
+                )
+                .map_err(|e| Error::db("database operation", e)),
+        }
     }
 
     /// List all distinct namespaces.

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -32,6 +32,12 @@ impl crate::Uteke {
         memory_type: &str,
     ) -> Result<String, Error> {
         crate::validate_input(content, tags)?;
+        // Validate memory_type against known variants
+        crate::memory::types::MemoryType::from_str_opt(memory_type).ok_or_else(|| {
+            Error::Validation(format!(
+                "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context"
+            ))
+        })?;
         let embedding = self
             .embedder
             .lock()
@@ -214,15 +220,14 @@ impl crate::Uteke {
 
     /// Delete a memory by ID. Incremental — no index rebuild.
     pub fn forget(&self, id: &str) -> Result<(), Error> {
-        // SQLite first (source of truth), then vector index.
-        // If vector index remove fails, the orphan is harmless —
-        // verify/repair can clean it up later.
-        self.store.delete(id)?;
-
+        // Acquire index lock BEFORE SQLite delete to narrow inconsistency window.
         let mut index = self
             .index
             .lock()
             .map_err(|_| Error::lock("index lock during forget"))?;
+        // SQLite delete (source of truth)
+        self.store.delete(id)?;
+        // Vector index remove — orphan is harmless if fails (verify/repair cleans up)
         if !index.remove(id) {
             tracing::warn!("Vector index entry not found during forget for id={id}");
         }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -269,12 +269,12 @@ fn route(
         },
 
         // ── Forget by ID or tag (DELETE /forget?id=xxx or ?tag=xxx) ────
-        (&Method::Delete, path) if path.starts_with("/forget") => {
+        (&Method::Delete, path) if path == "/forget" || path.starts_with("/forget?") => {
             let query = path.split('?').nth(1).unwrap_or("");
             let params: std::collections::HashMap<String, String> = query
                 .split('&')
                 .filter_map(|pair| {
-                    let mut kv = pair.split('=');
+                    let mut kv = pair.splitn(2, '=');
                     Some((kv.next()?.to_string(), kv.next()?.to_string()))
                 })
                 .collect();
@@ -339,7 +339,7 @@ fn route(
         }
 
         // ── 404 ─────────────────────────────────────────────────────────
-        _ => error_response(404, format!("Not found: {path}")),
+        _ => error_response(404, "Not found"),
     }
 }
 
@@ -360,6 +360,9 @@ fn main() {
                 i += 1;
                 if i < args.len() {
                     cli_host = Some(args[i].clone());
+                } else {
+                    eprintln!("Error: --host requires a value");
+                    std::process::exit(1);
                 }
             }
             "--port" => {
@@ -369,6 +372,9 @@ fn main() {
                         eprintln!("Invalid port: {e}");
                         std::process::exit(1);
                     }));
+                } else {
+                    eprintln!("Error: --port requires a value");
+                    std::process::exit(1);
                 }
             }
             "--help" | "-h" => {
@@ -431,7 +437,13 @@ fn main() {
         .init();
 
     // Open store
-    let home = uteke_core::uteke_home();
+    let home = match uteke_core::uteke_home() {
+        Ok(h) => h,
+        Err(e) => {
+            error!("Failed to determine home directory: {e}");
+            std::process::exit(1);
+        }
+    };
     let db_path = home.join("uteke.db").to_string_lossy().to_string();
 
     info!("Opening store at: {db_path}");
@@ -509,7 +521,10 @@ struct ServerFileSection {
 fn load_uteke_toml() -> ServerFileConfig {
     let mut config = ServerFileConfig::default();
 
-    let mut paths: Vec<PathBuf> = vec![uteke_core::uteke_home().join("uteke.toml")];
+    let mut paths: Vec<PathBuf> = vec![match uteke_core::uteke_home() {
+        Ok(h) => h.join("uteke.toml"),
+        Err(_) => PathBuf::new(),
+    }];
     if let Ok(cwd) = std::env::current_dir() {
         paths.push(cwd.join(".uteke").join("uteke.toml"));
     }


### PR DESCRIPTION
## Summary

v0.0.11 release — comprehensive fixes from Cora full-project security scan. Closes #221, #222, #225, #226, #228, #229, #231.

### Critical Fixes
- **#221**: Timestamp format mismatch — aging/pruning **never worked** because SQLite `datetime('now')` format doesn't match stored RFC3339 strings. Now computes cutoffs in Rust using `chrono`.

### High Priority Fixes
- **#222**: `namespace=None` inconsistency — tag operations now treat `None` as "all namespaces" consistently with `unique_tags()`
- **#225**: Atomic model file writes — uses `.tmp` + rename pattern, cleans up leftover temp files on startup
- **#226**: `uteke_home()` returns `Result` instead of panicking when home directory can't be determined

### Medium Priority Fixes
- **#228**: Server routing fixes — exact `/forget` path match, `splitn(2,'=')` for query params, error on missing CLI values, generic 404 message
- **#231**: `forget()` acquires index lock before SQLite delete to narrow inconsistency window

### Low Priority Fixes
- **#229**: `memory_type` validated against known variants in `remember_typed()`

### Other Changes
- Security scanning workflow from PR #220 (cargo audit + Trivy)
- quinn-proto 0.11.12 → 0.11.14 (CVE-2026-31812)
- `Error::Generic` variant
- Version bump to 0.0.11

### Test Results
- 101 tests pass
- Clippy clean
- Format clean
- Cora review: No issues found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security scanning CI workflow with vulnerability detection
  * Improved error handling with explicit messages for missing CLI arguments

* **Bug Fixes**
  * Fixed timestamp calculation inconsistencies for memory aging queries
  * Improved tag operation namespace handling consistency
  * Implemented atomic model file writes to prevent corruption
  * Enhanced path validation for safer `/forget` operations
  * Improved query parameter parsing robustness
  * Added validation for memory type inputs
  * Strengthened home directory resolution with better error handling

* **Changed**
  * Updated security dependency (quinn-proto) for CVE fix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->