### PR TITLE
release: v0.0.12 — TOCTOU race fixes, bulk lock order, server hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] — 2026-06-07
+
+### Fixed
+
+- **TOCTOU race in tag operations** — `rename_tag` and `delete_tag` now start transaction before SELECT, preventing lost updates from concurrent writers (#235)
+- **TOCTOU race in aging/prune** — `aging_cleanup` and `prune` now delete by specific IDs instead of re-querying by criteria, preventing vector index orphans (#235)
+- **bulk_forget_* lock order** — All 3 bulk delete methods now acquire index lock before SQLite delete, matching the pattern from `forget()` (#236)
+- **Server 500 leaks internals** — 500 responses now return generic "Internal server error" to client; full error logged server-side (#237)
+- **Server JSON fallback** — `json_response` fallback now uses `serde_json::json!` instead of `format!`, preventing broken JSON (#237)
+- **Atomic write tmp naming** — Temp files now named `filename.tmp` instead of fragile extension swapping (#238)
+
+### Added
+
+- **`Store::delete_by_ids()`** — New method for atomic batch deletion by specific IDs
+
 ## [0.0.11] — 2026-06-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "chrono",
  "dirs",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "ctrlc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ajianaz/uteke"

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -171,11 +171,11 @@ fn download_hf_file(
         .map_err(|e| Error::embed("read download response", e))?;
 
     // Atomic write: write to .tmp then rename — prevents corrupt files on crash.
-    let tmp_path = local_path.with_extension(format!(
+    let tmp_path = local_path.with_file_name(format!(
         "{}.tmp",
         local_path
-            .extension()
-            .map(|e| e.to_string_lossy().to_string())
+            .file_name()
+            .map(|f| f.to_string_lossy().to_string())
             .unwrap_or_default()
     ));
     std::fs::write(&tmp_path, bytes.as_ref())

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -211,10 +211,8 @@ impl crate::Uteke {
             return Ok(CleanupResult { deleted: 0 });
         }
 
-        // Delete from SQLite
-        let deleted = self
-            .store
-            .cleanup_aged(older_than_days, max_access_count, namespace)?;
+        // Delete by specific IDs to avoid TOCTOU race (not re-query by criteria)
+        let deleted = self.store.delete_by_ids(&ids)?;
 
         // Remove from vector index
         {
@@ -253,8 +251,8 @@ impl crate::Uteke {
             });
         }
 
-        // Delete from SQLite
-        let pruned = self.store.prune_ttl(ttl_days, namespace)?;
+        // Delete by specific IDs to avoid TOCTOU race (not re-query by criteria)
+        let pruned = self.store.delete_by_ids(&ids)?;
 
         // Remove from vector index
         {

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -148,4 +148,31 @@ impl super::Store {
         }
         Ok(memories)
     }
+
+    /// Delete memories by specific IDs. Returns count of deleted rows.
+    /// Use this instead of criteria-based delete to avoid TOCTOU races.
+    pub fn delete_by_ids(&self, ids: &[String]) -> Result<usize, Error> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        // Build parameterized IN clause: "WHERE id IN (?1, ?2, ?3)"
+        let placeholders: String = ids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!("DELETE FROM memories WHERE id IN ({placeholders})");
+        let params: Vec<Box<dyn rusqlite::types::ToSql>> = ids
+            .iter()
+            .map(|id| Box::new(id.clone()) as Box<dyn rusqlite::types::ToSql>)
+            .collect();
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let deleted = self
+            .conn
+            .execute(&sql, rusqlite::params_from_iter(param_refs))
+            .map_err(|e| Error::db("database operation", e))?;
+        Ok(deleted)
+    }
 }

--- a/crates/uteke-core/src/memory/tags.rs
+++ b/crates/uteke-core/src/memory/tags.rs
@@ -96,6 +96,12 @@ impl super::Store {
         new: &str,
         namespace: Option<&str>,
     ) -> Result<usize, Error> {
+        // Start transaction BEFORE read to prevent TOCTOU race.
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("begin transaction", e))?;
+
         let (sql, ns_param): (&str, Option<&str>) = match namespace {
             Some(_) => ("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)", namespace),
             None => ("SELECT id, tags FROM memories WHERE EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?1)", None),
@@ -121,11 +127,6 @@ impl super::Store {
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| Error::db("database operation", e))?,
         };
-
-        let tx = self
-            .conn
-            .unchecked_transaction()
-            .map_err(|e| Error::db("begin transaction", e))?;
         let mut updated = 0;
 
         for (id, tags_str) in &rows {
@@ -167,6 +168,12 @@ impl super::Store {
     /// Uses `json_each()` to find affected rows precisely. Wrapped in a
     /// transaction for atomicity.
     pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
+        // Start transaction BEFORE read to prevent TOCTOU race.
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("begin transaction", e))?;
+
         let (sql, ns_param): (&str, Option<&str>) = match namespace {
             Some(_) => ("SELECT id, tags FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?2)", namespace),
             None => ("SELECT id, tags FROM memories WHERE EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?1)", None),
@@ -192,11 +199,6 @@ impl super::Store {
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| Error::db("database operation", e))?,
         };
-
-        let tx = self
-            .conn
-            .unchecked_transaction()
-            .map_err(|e| Error::db("begin transaction", e))?;
         let mut updated = 0;
 
         for (id, tags_str) in &rows {

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -247,12 +247,12 @@ impl crate::Uteke {
         tag: &str,
         namespace: Option<&str>,
     ) -> Result<BulkDeleteResult, Error> {
-        // SQLite first (source of truth), then vector index.
-        let ids = self.store.bulk_delete_by_tag(tag, namespace)?;
+        // Acquire index lock BEFORE SQLite delete to narrow inconsistency window.
         let mut index = self
             .index
             .lock()
             .map_err(|_| Error::lock("index lock during bulk_forget_by_tag"))?;
+        let ids = self.store.bulk_delete_by_tag(tag, namespace)?;
         for id in &ids {
             if !index.remove(id) {
                 tracing::warn!(
@@ -274,14 +274,14 @@ impl crate::Uteke {
 
     /// Bulk delete all cold memories. Also removes from index.
     pub fn bulk_forget_cold(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
-        // SQLite first (source of truth), then vector index.
-        let ids = self
-            .store
-            .bulk_delete_cold(namespace, self.tier_config.warm_days)?;
+        // Acquire index lock BEFORE SQLite delete to narrow inconsistency window.
         let mut index = self
             .index
             .lock()
             .map_err(|_| Error::lock("index lock during bulk_forget_cold"))?;
+        let ids = self
+            .store
+            .bulk_delete_cold(namespace, self.tier_config.warm_days)?;
         for id in &ids {
             if !index.remove(id) {
                 tracing::warn!("Vector index entry not found during bulk_forget_cold for id={id}");
@@ -301,12 +301,12 @@ impl crate::Uteke {
 
     /// Bulk delete all memories in a namespace. Also removes from index.
     pub fn bulk_forget_all(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
-        // SQLite first (source of truth), then vector index.
-        let ids = self.store.bulk_delete_all(namespace)?;
+        // Acquire index lock BEFORE SQLite delete to narrow inconsistency window.
         let mut index = self
             .index
             .lock()
             .map_err(|_| Error::lock("index lock during bulk_forget_all"))?;
+        let ids = self.store.bulk_delete_all(namespace)?;
         for id in &ids {
             if !index.remove(id) {
                 tracing::warn!("Vector index entry not found during bulk_forget_all for id={id}");

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -100,7 +100,10 @@ fn cors_headers() -> Vec<Header> {
 }
 
 fn json_response<T: Serialize>(status: u16, body: &T) -> Response<Cursor<Vec<u8>>> {
-    let data = serde_json::to_string(body).unwrap_or_else(|e| format!(r#"{{"error":"{e}"}}"#));
+    let data = serde_json::to_string(body).unwrap_or_else(|e| {
+        // Use serde for fallback too — avoids broken JSON from format!
+        serde_json::json!({"error": e.to_string()}).to_string()
+    });
     let mut headers = cors_headers();
     headers.push(json_header());
     Response::new(
@@ -212,7 +215,10 @@ fn route(
 
                 match result {
                     Ok(id) => ok_response(&serde_json::json!({"id": id})),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 }
             }
             Err(e) => error_response(400, e),
@@ -229,7 +235,10 @@ fn route(
                 };
                 match uteke.recall(&req.query, req.limit, tags_filter, ns(&req.namespace)) {
                     Ok(results) => ok_response(&results),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 }
             }
             Err(e) => error_response(400, e),
@@ -246,7 +255,10 @@ fn route(
                 };
                 match uteke.search(&req.query, req.limit, tags_filter, ns(&req.namespace)) {
                     Ok(results) => ok_response(&results),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 }
             }
             Err(e) => error_response(400, e),
@@ -262,7 +274,10 @@ fn route(
                     ns(&req.namespace),
                 ) {
                     Ok(memories) => ok_response(&memories),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 }
             }
             Err(e) => error_response(400, e),
@@ -286,13 +301,19 @@ fn route(
                 }
                 match uteke.forget(id) {
                     Ok(()) => ok_response(&serde_json::json!({"forgotten": id})),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 }
             } else if let Some(tag) = params.get("tag") {
                 let namespace = params.get("namespace").map(|s| s.as_str());
                 match uteke.bulk_forget_by_tag(tag, namespace) {
                     Ok(result) => ok_response(&result),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 }
             } else {
                 error_response(400, "Provide ?id= or ?tag= parameter")
@@ -302,7 +323,10 @@ fn route(
         // ── Stats (GET = all, POST = by namespace) ─────────────────────
         (&Method::Get, "/stats") => match uteke.stats(None) {
             Ok(stats) => ok_response(&stats),
-            Err(e) => error_response(500, format!("Failed: {e}")),
+            Err(e) => {
+                error!("Internal error: {e}");
+                error_response(500, "Internal server error")
+            }
         },
         (&Method::Post, "/stats") => {
             #[derive(Deserialize)]
@@ -312,7 +336,10 @@ fn route(
             match read_body::<StatsReq>(body) {
                 Ok(req) => match uteke.stats(ns(&req.namespace)) {
                     Ok(stats) => ok_response(&stats),
-                    Err(e) => error_response(500, format!("Failed: {e}")),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        error_response(500, "Internal server error")
+                    }
                 },
                 Err(e) => error_response(400, e),
             }
@@ -321,7 +348,10 @@ fn route(
         // ── Namespaces ──────────────────────────────────────────────────
         (&Method::Get, "/namespaces") => match uteke.list_namespaces() {
             Ok(namespaces) => ok_response(&namespaces),
-            Err(e) => error_response(500, format!("Failed: {e}")),
+            Err(e) => {
+                error!("Internal error: {e}");
+                error_response(500, "Internal server error")
+            }
         },
 
         // ── Get memory by ID ──────────────────────────────────────────
@@ -334,7 +364,10 @@ fn route(
             match uteke.get_by_id(id) {
                 Ok(Some(memory)) => ok_response(&memory),
                 Ok(None) => error_response(404, format!("Memory not found: {id}")),
-                Err(e) => error_response(500, format!("Failed: {e}")),
+                Err(e) => {
+                    error!("Internal error: {e}");
+                    error_response(500, "Internal server error")
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

v0.0.12 release — fixes from Cora scan #2. Closes #235, #236, #237, #238.

### Fixes
- **#235**: TOCTOU race in `rename_tag`/`delete_tag` — transaction now wraps both SELECT and UPDATE
- **#235**: TOCTOU race in `aging_cleanup`/`prune` — now delete by specific IDs via `delete_by_ids()`, not re-query by criteria
- **#236**: `bulk_forget_*` methods now acquire index lock before SQLite delete (matching `forget()` pattern)
- **#237**: Server 500 responses return generic "Internal server error" to client; full error logged server-side
- **#237**: `json_response` fallback uses `serde_json::json!` instead of `format!` — prevents broken JSON
- **#238**: Atomic write temp files named `filename.tmp` instead of fragile extension swapping

### Added
- `Store::delete_by_ids()` — atomic batch deletion by specific IDs

### Test Results
- 116 tests pass
- Clippy clean
- Format clean
- Cora review passed
