### PR TITLE
feat(security): harden HTTP server auth, CORS, input validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +368,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "ctrlc"
@@ -522,6 +550,16 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -718,6 +756,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2012,6 +2060,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2704,7 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_json",
+ "sha2",
  "tiny_http",
  "toml",
  "tracing",

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -20,3 +20,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ctrlc = "3"
 uuid = "1"
+sha2 = "0.10"

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -1,7 +1,7 @@
 //! Uteke HTTP Server — persistent warm memory for AI agents.
 //!
 //! Keeps the embedding model loaded in RAM for <50ms recall.
-//! Usage: `uteke-serve [--port 8767] [--host 127.0.0.1]`
+//! Usage: `uteke-serve [--port 8767] [--host 127.0.0.1] [--auth-token <TOKEN>]`
 
 use std::io::{Cursor, Read as IoRead};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use tiny_http::{Header, Method, Response, Server, StatusCode};
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use tracing::{error, info, warn};
 use uteke_core::Uteke;
 
@@ -91,37 +91,223 @@ fn json_header() -> Header {
     Header::from_bytes("Content-Type", "application/json").unwrap()
 }
 
-fn cors_headers() -> Vec<Header> {
-    vec![
-        Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap(),
-        Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS").unwrap(),
-        Header::from_bytes("Access-Control-Allow-Headers", "Content-Type").unwrap(),
-    ]
+/// Check bearer token auth on a request.
+/// Returns Ok(()) if auth passes or is disabled.
+/// Returns Err(response) with 401 if auth fails.
+fn check_auth(
+    req: &Request,
+    ctx: &ReqCtx,
+) -> Result<(), Response<Cursor<Vec<u8>>>> {
+    let token = match &ctx.auth_token {
+        // No token configured — auth disabled
+        None => return Ok(()),
+        Some(t) => t,
+    };
+
+    // Look for Authorization: Bearer <token>
+    let auth_header = req
+        .headers()
+        .iter()
+        .find(|h| h.field.equiv("Authorization"));
+
+    match auth_header {
+        Some(h) => {
+            let val = h.value.as_str();
+            if let Some(provided) = val.strip_prefix("Bearer ") {
+                // Constant-time comparison to prevent timing attacks
+                if constant_time_eq(provided.as_bytes(), token.as_bytes()) {
+                    Ok(())
+                } else {
+                    let mut hdrs = ctx.cors_headers_for(req);
+                    hdrs.push(
+                        Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap(),
+                    );
+                    hdrs.push(json_header());
+                    let body = ErrorResponse {
+                        error: "Invalid or expired token".into(),
+                    };
+                    let data = serde_json::to_string(&body).unwrap();
+                    Err(Response::new(
+                        StatusCode::from(401),
+                        hdrs,
+                        Cursor::new(data.into_bytes()),
+                        None,
+                        None,
+                    ))
+                }
+            } else {
+                let mut hdrs = ctx.cors_headers_for(req);
+                hdrs.push(
+                    Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap(),
+                );
+                hdrs.push(json_header());
+                let body = ErrorResponse {
+                    error: "Invalid auth scheme. Use: Authorization: Bearer <token>".into(),
+                };
+                let data = serde_json::to_string(&body).unwrap();
+                Err(Response::new(
+                    StatusCode::from(401),
+                    hdrs,
+                    Cursor::new(data.into_bytes()),
+                    None,
+                    None,
+                ))
+            }
+        }
+        None => {
+            let mut hdrs = ctx.cors_headers_for(req);
+            hdrs.push(
+                Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap(),
+            );
+            hdrs.push(json_header());
+            let body = ErrorResponse {
+                error: "Authentication required. Provide Authorization: Bearer <token>".into(),
+            };
+            let data = serde_json::to_string(&body).unwrap();
+            Err(Response::new(
+                StatusCode::from(401),
+                hdrs,
+                Cursor::new(data.into_bytes()),
+                None,
+                None,
+            ))
+        }
+    }
 }
 
-fn json_response<T: Serialize>(status: u16, body: &T) -> Response<Cursor<Vec<u8>>> {
-    let data = serde_json::to_string(body).unwrap_or_else(|e| {
-        // Use serde for fallback too — avoids broken JSON from format!
-        serde_json::json!({"error": e.to_string()}).to_string()
-    });
-    let mut headers = cors_headers();
-    headers.push(json_header());
-    Response::new(
-        StatusCode::from(status),
-        headers,
-        Cursor::new(data.into_bytes()),
-        None,
-        None,
-    )
+/// Constant-time byte comparison to resist timing attacks.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut result: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        result |= x ^ y;
+    }
+    result == 0
 }
 
-fn error_response(status: u16, msg: impl Into<String>) -> Response<Cursor<Vec<u8>>> {
-    let body = ErrorResponse { error: msg.into() };
-    json_response(status, &body)
+struct ReqCtx {
+    auth_token: Option<String>,
+    /// Allowed CORS origins from config. Empty = wildcard.
+    cors_origins: Vec<String>,
 }
 
-fn ok_response<T: Serialize>(body: &T) -> Response<Cursor<Vec<u8>>> {
-    json_response(200, body)
+impl ReqCtx {
+    /// Resolve the allowed origin for a specific request by matching
+    /// its `Origin` header against the configured origins list.
+    /// Returns "*" if no origins configured (backward compatible).
+    /// Returns the matching origin if found, or "*" as fallback.
+    fn resolve_origin_for(&self, req: &Request) -> String {
+        if self.cors_origins.is_empty() {
+            return "*".to_string();
+        }
+        // Check if request has an Origin header
+        if let Some(origin_header) = req.headers().iter().find(|h| h.field.equiv("Origin")) {
+            let origin = origin_header.value.as_str();
+            if self.cors_origins.iter().any(|o| o == origin) {
+                return origin.to_string();
+            }
+        }
+        // No matching origin — return empty string so CORS headers are omitted.
+        // Browser will block cross-origin requests from untrusted origins.
+        // Non-browser clients (API users) are unaffected by CORS.
+        String::new()
+    }
+
+    fn cors_headers_for(&self, req: &Request) -> Vec<Header> {
+        let origin = self.resolve_origin_for(req);
+        if origin.is_empty() {
+            // Origin not in allowlist — omit CORS headers entirely.
+            // Browser will block cross-origin reads.
+            return vec![];
+        }
+        // When auth is enabled but CORS is wildcard, omit Authorization
+        // from allowed headers to prevent browser-origin auth abuse.
+        let allowed_headers = if self.auth_token.is_some() && self.cors_origins.is_empty() {
+            "Content-Type"
+        } else {
+            "Content-Type, Authorization"
+        };
+        vec![
+            Header::from_bytes("Access-Control-Allow-Origin", origin).unwrap(),
+            Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS").unwrap(),
+            Header::from_bytes("Access-Control-Allow-Headers", allowed_headers).unwrap(),
+        ]
+    }
+
+    /// Build CORS headers for preflight, validating requested headers
+    /// against an explicit allowlist.
+    fn preflight_headers(&self, req: &Request) -> Vec<Header> {
+        let origin = self.resolve_origin_for(req);
+        if origin.is_empty() {
+            // Origin not in allowlist — return minimal headers so browser blocks.
+            return vec![];
+        }
+        // Fixed allowlist of headers we accept in cross-origin requests
+        // When auth is enabled but CORS is wildcard, restrict to prevent browser abuse
+        let allowed_headers_set: &[&str] = if self.auth_token.is_some() && self.cors_origins.is_empty() {
+            &["Content-Type", "Accept", "X-Requested-With"]
+        } else {
+            &["Content-Type", "Authorization", "Accept", "X-Requested-With"]
+        };
+        let allow_headers = req
+            .headers()
+            .iter()
+            .find(|h| h.field.equiv("Access-Control-Request-Headers"))
+            .map(|h| {
+                // Only echo back headers that are in our allowlist
+                h.value.as_str()
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| allowed_headers_set.iter().any(|a| a.eq_ignore_ascii_case(s)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_else(|| "Content-Type".to_string());
+        // Fallback if no requested headers matched
+        let allow_headers = if allow_headers.is_empty() {
+            allowed_headers_set.join(", ")
+        } else {
+            allow_headers
+        };
+        vec![
+            Header::from_bytes("Access-Control-Allow-Origin", origin).unwrap(),
+            Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS").unwrap(),
+            Header::from_bytes("Access-Control-Allow-Headers", allow_headers).unwrap(),
+        ]
+    }
+
+    /// Build an error response with CORS headers specific to a request.
+    fn error_response_for(&self, req: &Request, status: u16, msg: impl Into<String>) -> Response<Cursor<Vec<u8>>> {
+        let body = ErrorResponse { error: msg.into() };
+        let data = serde_json::to_string(&body).unwrap();
+        let mut headers = self.cors_headers_for(req);
+        headers.push(json_header());
+        Response::new(
+            StatusCode::from(status),
+            headers,
+            Cursor::new(data.into_bytes()),
+            None,
+            None,
+        )
+    }
+
+    /// Build an OK response with CORS headers specific to a request.
+    fn ok_response_for<T: Serialize>(&self, req: &Request, body: &T) -> Response<Cursor<Vec<u8>>> {
+        let data = serde_json::to_string(body).unwrap_or_else(|e| {
+            serde_json::json!({"error": e.to_string()}).to_string()
+        });
+        let mut headers = self.cors_headers_for(req);
+        headers.push(json_header());
+        Response::new(
+            StatusCode::from(200),
+            headers,
+            Cursor::new(data.into_bytes()),
+            None,
+            None,
+        )
+    }
 }
 
 fn read_body<T: serde::de::DeserializeOwned>(reader: &mut dyn IoRead) -> Result<T, String> {
@@ -150,27 +336,39 @@ fn ns(ns: &Option<String>) -> Option<&str> {
 
 fn route(
     uteke: &Uteke,
-    method: &Method,
-    path: &str,
-    body: &mut dyn IoRead,
+    ctx: &ReqCtx,
+    req: &mut Request,
 ) -> Response<Cursor<Vec<u8>>> {
-    // CORS preflight
-    if method == &Method::Options {
+    let method = req.method().clone();
+    let path = req.url().to_string();
+
+    // CORS preflight — no auth required
+    if method == Method::Options {
         return Response::new(
             StatusCode::from(204),
-            cors_headers(),
+            ctx.preflight_headers(req),
             Cursor::new(Vec::new()),
             None,
             None,
         );
     }
 
-    match (method, path) {
+    // Health endpoint — no auth required (useful for load balancers)
+    let is_health = matches!((&method, path.as_str()), (Method::Get, "/health"));
+
+    // Authenticate all non-health requests
+    if !is_health {
+        if let Err(resp) = check_auth(req, ctx) {
+            return resp;
+        }
+    }
+
+    match (method, path.as_str()) {
         // ── Health ──────────────────────────────────────────────────────
-        (&Method::Get, "/health") => {
+        (Method::Get, "/health") => {
             let total = uteke.count(None).unwrap_or(0);
             let namespaces = uteke.list_namespaces().unwrap_or_default().len();
-            ok_response(&HealthResponse {
+            ctx.ok_response_for(req, &HealthResponse {
                 status: "ok",
                 memories: total,
                 namespaces,
@@ -178,19 +376,24 @@ fn route(
         }
 
         // ── Remember ───────────────────────────────────────────────────
-        (&Method::Post, "/remember") => match read_body::<RememberRequest>(body) {
-            Ok(req) => {
-                let tag_refs: Vec<&str> = req.tags.iter().map(|s| s.as_str()).collect();
+        (Method::Post, "/remember") => match read_body::<RememberRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                // Validate input
+                if let Err(e) = uteke_core::validate_input(&req_data.content, &req_data.tags) {
+                    return ctx.error_response_for(req, 400, e.to_string());
+                }
+
+                let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
 
                 // Build metadata from optional fields
                 let mut meta = serde_json::Map::new();
-                if let Some(t) = &req.r#type {
+                if let Some(t) = &req_data.r#type {
                     meta.insert("type".into(), serde_json::Value::String(t.clone()));
                 }
-                if let Some(vf) = &req.valid_from {
+                if let Some(vf) = &req_data.valid_from {
                     meta.insert("valid_from".into(), serde_json::Value::String(vf.clone()));
                 }
-                if let Some(vu) = &req.valid_until {
+                if let Some(vu) = &req_data.valid_until {
                     meta.insert("valid_until".into(), serde_json::Value::String(vu.clone()));
                 }
                 let metadata = if meta.is_empty() {
@@ -199,93 +402,93 @@ fn route(
                     Some(serde_json::Value::Object(meta))
                 };
 
-                let result = if req.detect_contradiction {
+                let result = if req_data.detect_contradiction {
                     uteke
                         .remember_with_contradiction(
-                            &req.content,
+                            &req_data.content,
                             &tag_refs,
-                            ns(&req.namespace),
-                            req.r#type.as_deref(),
+                            ns(&req_data.namespace),
+                            req_data.r#type.as_deref(),
                             true,
                         )
                         .map(|(id, _)| id)
                 } else {
-                    uteke.remember(&req.content, &tag_refs, metadata, ns(&req.namespace))
+                    uteke.remember(&req_data.content, &tag_refs, metadata, ns(&req_data.namespace))
                 };
 
                 match result {
-                    Ok(id) => ok_response(&serde_json::json!({"id": id})),
+                    Ok(id) => ctx.ok_response_for(req, &serde_json::json!({"id": id})),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 }
             }
-            Err(e) => error_response(400, e),
+            Err(e) => ctx.error_response_for(req, 400, e),
         },
 
         // ── Recall (semantic search) ────────────────────────────────────
-        (&Method::Post, "/recall") => match read_body::<RecallRequest>(body) {
-            Ok(req) => {
-                let tag_refs: Vec<&str> = req.tags.iter().map(|s| s.as_str()).collect();
+        (Method::Post, "/recall") => match read_body::<RecallRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
                 let tags_filter = if tag_refs.is_empty() {
                     None
                 } else {
                     Some(tag_refs.as_slice())
                 };
-                match uteke.recall(&req.query, req.limit, tags_filter, ns(&req.namespace)) {
-                    Ok(results) => ok_response(&results),
+                match uteke.recall(&req_data.query, req_data.limit, tags_filter, ns(&req_data.namespace)) {
+                    Ok(results) => ctx.ok_response_for(req, &results),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 }
             }
-            Err(e) => error_response(400, e),
+            Err(e) => ctx.error_response_for(req, 400, e),
         },
 
         // ── Search (keyword) ────────────────────────────────────────────
-        (&Method::Post, "/search") => match read_body::<SearchRequest>(body) {
-            Ok(req) => {
-                let tag_refs: Vec<&str> = req.tags.iter().map(|s| s.as_str()).collect();
+        (Method::Post, "/search") => match read_body::<SearchRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
                 let tags_filter = if tag_refs.is_empty() {
                     None
                 } else {
                     Some(tag_refs.as_slice())
                 };
-                match uteke.search(&req.query, req.limit, tags_filter, ns(&req.namespace)) {
-                    Ok(results) => ok_response(&results),
+                match uteke.search(&req_data.query, req_data.limit, tags_filter, ns(&req_data.namespace)) {
+                    Ok(results) => ctx.ok_response_for(req, &results),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 }
             }
-            Err(e) => error_response(400, e),
+            Err(e) => ctx.error_response_for(req, 400, e),
         },
 
         // ── List ────────────────────────────────────────────────────────
-        (&Method::Post, "/list") => match read_body::<ListParams>(body) {
-            Ok(req) => {
+        (Method::Post, "/list") => match read_body::<ListParams>(req.as_reader()) {
+            Ok(req_data) => {
                 match uteke.list(
-                    req.tag.as_deref(),
-                    req.limit,
-                    req.offset,
-                    ns(&req.namespace),
+                    req_data.tag.as_deref(),
+                    req_data.limit,
+                    req_data.offset,
+                    ns(&req_data.namespace),
                 ) {
-                    Ok(memories) => ok_response(&memories),
+                    Ok(memories) => ctx.ok_response_for(req, &memories),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 }
             }
-            Err(e) => error_response(400, e),
+            Err(e) => ctx.error_response_for(req, 400, e),
         },
 
         // ── Forget by ID or tag (DELETE /forget?id=xxx or ?tag=xxx) ────
-        (&Method::Delete, path) if path == "/forget" || path.starts_with("/forget?") => {
-            let query = path.split('?').nth(1).unwrap_or("");
+        (Method::Delete, p) if p == "/forget" || p.starts_with("/forget?") => {
+            let query = p.split('?').nth(1).unwrap_or("");
             let params: std::collections::HashMap<String, String> = query
                 .split('&')
                 .filter_map(|pair| {
@@ -297,82 +500,82 @@ fn route(
             if let Some(id) = params.get("id") {
                 // Validate UUID format
                 if uuid::Uuid::parse_str(id).is_err() {
-                    return error_response(400, format!("Invalid UUID format: {id}"));
+                    return ctx.error_response_for(req, 400, format!("Invalid UUID format: {id}"));
                 }
                 match uteke.forget(id) {
-                    Ok(()) => ok_response(&serde_json::json!({"forgotten": id})),
+                    Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"forgotten": id})),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 }
             } else if let Some(tag) = params.get("tag") {
                 let namespace = params.get("namespace").map(|s| s.as_str());
                 match uteke.bulk_forget_by_tag(tag, namespace) {
-                    Ok(result) => ok_response(&result),
+                    Ok(result) => ctx.ok_response_for(req, &result),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 }
             } else {
-                error_response(400, "Provide ?id= or ?tag= parameter")
+                ctx.error_response_for(req, 400, "Provide ?id= or ?tag= parameter")
             }
         }
 
         // ── Stats (GET = all, POST = by namespace) ─────────────────────
-        (&Method::Get, "/stats") => match uteke.stats(None) {
-            Ok(stats) => ok_response(&stats),
+        (Method::Get, "/stats") => match uteke.stats(None) {
+            Ok(stats) => ctx.ok_response_for(req, &stats),
             Err(e) => {
                 error!("Internal error: {e}");
-                error_response(500, "Internal server error")
+                ctx.error_response_for(req, 500, "Internal server error")
             }
         },
-        (&Method::Post, "/stats") => {
+        (Method::Post, "/stats") => {
             #[derive(Deserialize)]
             struct StatsReq {
                 namespace: Option<String>,
             }
-            match read_body::<StatsReq>(body) {
-                Ok(req) => match uteke.stats(ns(&req.namespace)) {
-                    Ok(stats) => ok_response(&stats),
+            match read_body::<StatsReq>(req.as_reader()) {
+                Ok(req_data) => match uteke.stats(ns(&req_data.namespace)) {
+                    Ok(stats) => ctx.ok_response_for(req, &stats),
                     Err(e) => {
                         error!("Internal error: {e}");
-                        error_response(500, "Internal server error")
+                        ctx.error_response_for(req, 500, "Internal server error")
                     }
                 },
-                Err(e) => error_response(400, e),
+                Err(e) => ctx.error_response_for(req, 400, e),
             }
         }
 
         // ── Namespaces ──────────────────────────────────────────────────
-        (&Method::Get, "/namespaces") => match uteke.list_namespaces() {
-            Ok(namespaces) => ok_response(&namespaces),
+        (Method::Get, "/namespaces") => match uteke.list_namespaces() {
+            Ok(namespaces) => ctx.ok_response_for(req, &namespaces),
             Err(e) => {
                 error!("Internal error: {e}");
-                error_response(500, "Internal server error")
+                ctx.error_response_for(req, 500, "Internal server error")
             }
         },
 
         // ── Get memory by ID ──────────────────────────────────────────
-        (&Method::Get, path) if path.starts_with("/memory?id=") => {
-            let id = path.trim_start_matches("/memory?id=");
+        (Method::Get, p) if p.starts_with("/memory?id=") => {
+            let id = p.trim_start_matches("/memory?id=");
             // Validate UUID format
             if uuid::Uuid::parse_str(id).is_err() {
-                return error_response(400, format!("Invalid UUID format: {id}"));
+                return ctx.error_response_for(req, 400, format!("Invalid UUID format: {id}"));
             }
             match uteke.get_by_id(id) {
-                Ok(Some(memory)) => ok_response(&memory),
-                Ok(None) => error_response(404, format!("Memory not found: {id}")),
+                Ok(Some(memory)) => ctx.ok_response_for(req, &memory),
+                Ok(None) => ctx.error_response_for(req, 404, format!("Memory not found: {id}")),
                 Err(e) => {
                     error!("Internal error: {e}");
-                    error_response(500, "Internal server error")
+                    ctx.error_response_for(req, 500, "Internal server error")
                 }
             }
         }
 
         // ── 404 ─────────────────────────────────────────────────────────
-        _ => error_response(404, "Not found"),
+        _ => ctx.error_response_for(req, 404, "Not found"),
     }
 }
 
@@ -385,6 +588,8 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let mut cli_host: Option<String> = None;
     let mut cli_port: Option<u16> = None;
+    let mut cli_auth_token: Option<String> = None;
+    let mut cli_cors_origins: Vec<String> = Vec::new();
 
     let mut i = 1;
     while i < args.len() {
@@ -410,21 +615,47 @@ fn main() {
                     std::process::exit(1);
                 }
             }
+            "--auth-token" => {
+                i += 1;
+                if i < args.len() {
+                    cli_auth_token = Some(args[i].clone());
+                } else {
+                    eprintln!("Error: --auth-token requires a value");
+                    std::process::exit(1);
+                }
+            }
+            "--cors-origin" => {
+                i += 1;
+                if i < args.len() {
+                    cli_cors_origins.push(args[i].clone());
+                } else {
+                    eprintln!("Error: --cors-origin requires a value");
+                    std::process::exit(1);
+                }
+            }
             "--help" | "-h" => {
                 println!("uteke-serve — persistent warm memory server");
                 println!();
                 println!("Usage: uteke-serve [OPTIONS]");
                 println!();
                 println!("Options:");
-                println!("  --host <HOST>  Bind address (default: 0.0.0.0)");
-                println!("  --port <PORT>  Port number (default: 8767)");
-                println!("  -h, --help     Show this help");
+                println!("  --host <HOST>        Bind address (default: 127.0.0.1)");
+                println!("  --port <PORT>        Port number (default: 8767)");
+                println!("  --auth-token <TOKEN> Bearer token for API auth");
+                println!("  --cors-origin <URL>  Allowed CORS origin (repeatable)");
+                println!("  -h, --help           Show this help");
                 println!();
                 println!("Config: reads [server] section from uteke.toml");
                 println!("  CLI args override config values.");
                 println!();
                 println!("Environment:");
-                println!("  UTEKE_HOME    Data directory (default: ~/.uteke)");
+                println!("  UTEKE_HOME          Data directory (default: ~/.uteke)");
+                println!("  UTEKE_AUTH_TOKEN     Bearer token (alternative to --auth-token)");
+                println!();
+                println!("Security:");
+                println!("  If --auth-token or UTEKE_AUTH_TOKEN is set, all endpoints");
+                println!("  (except GET /health) require Authorization: Bearer <TOKEN>.");
+                println!("  Configure CORS origins in uteke.toml [server].cors_origins.");
                 println!();
                 println!("API:");
                 println!("  GET  /health              → {{ status, memories }}");
@@ -449,17 +680,35 @@ fn main() {
         i += 1;
     }
 
-    // Load config: defaults → uteke.toml → CLI args
+    // Load config: defaults → uteke.toml → CLI args (env vars fill gaps where CLI is absent)
     let config = load_uteke_toml();
     let config_host = config
         .server
         .as_ref()
         .and_then(|s| s.host.clone())
-        .unwrap_or_else(|| "0.0.0.0".to_string());
+        .unwrap_or_else(|| "127.0.0.1".to_string());
     let config_port = config.server.as_ref().and_then(|s| s.port).unwrap_or(8767);
+    let config_auth_token = config.server.as_ref().and_then(|s| s.auth_token.clone());
+    let config_cors_origins = config
+        .server
+        .as_ref()
+        .and_then(|s| s.cors_origins.clone())
+        .unwrap_or_default();
+
+    // Merge CORS origins: CLI flags override config
+    let cors_origins = if !cli_cors_origins.is_empty() {
+        cli_cors_origins
+    } else {
+        config_cors_origins
+    };
 
     let host = cli_host.unwrap_or(config_host);
     let port = cli_port.unwrap_or(config_port);
+
+    // Auth token precedence: CLI flag > environment variable > config file
+    let auth_token = cli_auth_token
+        .or_else(|| std::env::var("UTEKE_AUTH_TOKEN").ok())
+        .or(config_auth_token);
 
     // Logging
     tracing_subscriber::fmt()
@@ -488,6 +737,19 @@ fn main() {
         }
     };
 
+    // Build request context
+    // Warn if auth is configured but CORS origins are not — this is safe for
+    // non-browser clients (curl, SDKs, agents) but risky if browser access is needed.
+    if auth_token.is_some() && cors_origins.is_empty() {
+        warn!("Security: auth token is set but cors_origins is not configured.");
+        warn!("  For browser access, set cors_origins in uteke.toml or --cors-origin.");
+        warn!("  Non-browser clients (curl, agents) are unaffected by CORS.");
+    }
+    let ctx = ReqCtx {
+        auth_token: auth_token.clone(),
+        cors_origins: cors_origins.clone(),
+    };
+
     // Start server
     let addr = format!("{host}:{port}");
     let server = Server::http(&addr).unwrap_or_else(|e| {
@@ -496,6 +758,18 @@ fn main() {
     });
     info!("Uteke server listening on http://{addr}");
     info!("Embedding model warm. Ready for <50ms recall.");
+
+    // Security info
+    if auth_token.is_some() {
+        info!("Authentication: enabled (Bearer token)");
+    } else {
+        warn!("Authentication: disabled — set --auth-token or UTEKE_AUTH_TOKEN for production");
+    }
+    if cors_origins.is_empty() {
+        warn!("CORS: wildcard (*) — restrict cors_origins in uteke.toml for production");
+    } else {
+        info!("CORS: allowing origins: {:?}", cors_origins);
+    }
 
     // SIGINT handler
     ctrlc::set_handler(|| {
@@ -519,7 +793,7 @@ fn main() {
         let url = req.url().to_string();
         info!("{method} {url}");
 
-        let response = route(&uteke, &method, &url, &mut req.as_reader());
+        let response = route(&uteke, &ctx, &mut req);
         if let Err(e) = req.respond(response) {
             warn!("Response error: {e}");
         }
@@ -546,6 +820,13 @@ struct ServerFileConfig {
 struct ServerFileSection {
     host: Option<String>,
     port: Option<u16>,
+    /// Bearer token for API authentication.
+    /// If set, all endpoints except GET /health require Authorization: Bearer <token>.
+    auth_token: Option<String>,
+    /// Allowed CORS origins. Defaults to empty (wildcard `*`).
+    /// Set to specific origins like ["http://localhost:3000"] for production.
+    /// Each request's `Origin` header is matched against this list.
+    cors_origins: Option<Vec<String>>,
 }
 
 /// Find and parse the nearest uteke.toml, looking at:

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -94,10 +94,7 @@ fn json_header() -> Header {
 /// Check bearer token auth on a request.
 /// Returns Ok(()) if auth passes or is disabled.
 /// Returns Err(response) with 401 if auth fails.
-fn check_auth(
-    req: &Request,
-    ctx: &ReqCtx,
-) -> Result<(), Response<Cursor<Vec<u8>>>> {
+fn check_auth(req: &Request, ctx: &ReqCtx) -> Result<(), Response<Cursor<Vec<u8>>>> {
     let token = match &ctx.auth_token {
         // No token configured — auth disabled
         None => return Ok(()),
@@ -156,9 +153,7 @@ fn check_auth(
         }
         None => {
             let mut hdrs = ctx.cors_headers_for(req);
-            hdrs.push(
-                Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap(),
-            );
+            hdrs.push(Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap());
             hdrs.push(json_header());
             let body = ErrorResponse {
                 error: "Authentication required. Provide Authorization: Bearer <token>".into(),
@@ -231,7 +226,8 @@ impl ReqCtx {
         };
         vec![
             Header::from_bytes("Access-Control-Allow-Origin", origin).unwrap(),
-            Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS").unwrap(),
+            Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+                .unwrap(),
             Header::from_bytes("Access-Control-Allow-Headers", allowed_headers).unwrap(),
         ]
     }
@@ -246,21 +242,32 @@ impl ReqCtx {
         }
         // Fixed allowlist of headers we accept in cross-origin requests
         // When auth is enabled but CORS is wildcard, restrict to prevent browser abuse
-        let allowed_headers_set: &[&str] = if self.auth_token.is_some() && self.cors_origins.is_empty() {
-            &["Content-Type", "Accept", "X-Requested-With"]
-        } else {
-            &["Content-Type", "Authorization", "Accept", "X-Requested-With"]
-        };
+        let allowed_headers_set: &[&str] =
+            if self.auth_token.is_some() && self.cors_origins.is_empty() {
+                &["Content-Type", "Accept", "X-Requested-With"]
+            } else {
+                &[
+                    "Content-Type",
+                    "Authorization",
+                    "Accept",
+                    "X-Requested-With",
+                ]
+            };
         let allow_headers = req
             .headers()
             .iter()
             .find(|h| h.field.equiv("Access-Control-Request-Headers"))
             .map(|h| {
                 // Only echo back headers that are in our allowlist
-                h.value.as_str()
+                h.value
+                    .as_str()
                     .split(',')
                     .map(|s| s.trim())
-                    .filter(|s| allowed_headers_set.iter().any(|a| a.eq_ignore_ascii_case(s)))
+                    .filter(|s| {
+                        allowed_headers_set
+                            .iter()
+                            .any(|a| a.eq_ignore_ascii_case(s))
+                    })
                     .collect::<Vec<_>>()
                     .join(", ")
             })
@@ -273,13 +280,19 @@ impl ReqCtx {
         };
         vec![
             Header::from_bytes("Access-Control-Allow-Origin", origin).unwrap(),
-            Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS").unwrap(),
+            Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+                .unwrap(),
             Header::from_bytes("Access-Control-Allow-Headers", allow_headers).unwrap(),
         ]
     }
 
     /// Build an error response with CORS headers specific to a request.
-    fn error_response_for(&self, req: &Request, status: u16, msg: impl Into<String>) -> Response<Cursor<Vec<u8>>> {
+    fn error_response_for(
+        &self,
+        req: &Request,
+        status: u16,
+        msg: impl Into<String>,
+    ) -> Response<Cursor<Vec<u8>>> {
         let body = ErrorResponse { error: msg.into() };
         let data = serde_json::to_string(&body).unwrap();
         let mut headers = self.cors_headers_for(req);
@@ -295,9 +308,8 @@ impl ReqCtx {
 
     /// Build an OK response with CORS headers specific to a request.
     fn ok_response_for<T: Serialize>(&self, req: &Request, body: &T) -> Response<Cursor<Vec<u8>>> {
-        let data = serde_json::to_string(body).unwrap_or_else(|e| {
-            serde_json::json!({"error": e.to_string()}).to_string()
-        });
+        let data = serde_json::to_string(body)
+            .unwrap_or_else(|e| serde_json::json!({"error": e.to_string()}).to_string());
         let mut headers = self.cors_headers_for(req);
         headers.push(json_header());
         Response::new(
@@ -334,11 +346,7 @@ fn ns(ns: &Option<String>) -> Option<&str> {
 
 // ── Router ──────────────────────────────────────────────────────────────────
 
-fn route(
-    uteke: &Uteke,
-    ctx: &ReqCtx,
-    req: &mut Request,
-) -> Response<Cursor<Vec<u8>>> {
+fn route(uteke: &Uteke, ctx: &ReqCtx, req: &mut Request) -> Response<Cursor<Vec<u8>>> {
     let method = req.method().clone();
     let path = req.url().to_string();
 
@@ -368,11 +376,14 @@ fn route(
         (Method::Get, "/health") => {
             let total = uteke.count(None).unwrap_or(0);
             let namespaces = uteke.list_namespaces().unwrap_or_default().len();
-            ctx.ok_response_for(req, &HealthResponse {
-                status: "ok",
-                memories: total,
-                namespaces,
-            })
+            ctx.ok_response_for(
+                req,
+                &HealthResponse {
+                    status: "ok",
+                    memories: total,
+                    namespaces,
+                },
+            )
         }
 
         // ── Remember ───────────────────────────────────────────────────
@@ -413,7 +424,12 @@ fn route(
                         )
                         .map(|(id, _)| id)
                 } else {
-                    uteke.remember(&req_data.content, &tag_refs, metadata, ns(&req_data.namespace))
+                    uteke.remember(
+                        &req_data.content,
+                        &tag_refs,
+                        metadata,
+                        ns(&req_data.namespace),
+                    )
                 };
 
                 match result {
@@ -436,7 +452,12 @@ fn route(
                 } else {
                     Some(tag_refs.as_slice())
                 };
-                match uteke.recall(&req_data.query, req_data.limit, tags_filter, ns(&req_data.namespace)) {
+                match uteke.recall(
+                    &req_data.query,
+                    req_data.limit,
+                    tags_filter,
+                    ns(&req_data.namespace),
+                ) {
                     Ok(results) => ctx.ok_response_for(req, &results),
                     Err(e) => {
                         error!("Internal error: {e}");
@@ -456,7 +477,12 @@ fn route(
                 } else {
                     Some(tag_refs.as_slice())
                 };
-                match uteke.search(&req_data.query, req_data.limit, tags_filter, ns(&req_data.namespace)) {
+                match uteke.search(
+                    &req_data.query,
+                    req_data.limit,
+                    tags_filter,
+                    ns(&req_data.namespace),
+                ) {
                     Ok(results) => ctx.ok_response_for(req, &results),
                     Err(e) => {
                         error!("Internal error: {e}");

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use tracing::{error, info, warn};
 use uteke_core::Uteke;
@@ -91,14 +92,36 @@ fn json_header() -> Header {
     Header::from_bytes("Content-Type", "application/json").unwrap()
 }
 
+/// Build a 401 Unauthorized response with CORS and WWW-Authenticate headers.
+fn unauthorized_response(
+    ctx: &ReqCtx,
+    req: &Request,
+    error_msg: &str,
+) -> Response<Cursor<Vec<u8>>> {
+    let mut hdrs = ctx.cors_headers_for(req);
+    hdrs.push(Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap());
+    hdrs.push(json_header());
+    let body = ErrorResponse {
+        error: error_msg.to_string(),
+    };
+    let data = serde_json::to_string(&body).unwrap();
+    Response::new(
+        StatusCode::from(401),
+        hdrs,
+        Cursor::new(data.into_bytes()),
+        None,
+        None,
+    )
+}
+
 /// Check bearer token auth on a request.
 /// Returns Ok(()) if auth passes or is disabled.
 /// Returns Err(response) with 401 if auth fails.
 fn check_auth(req: &Request, ctx: &ReqCtx) -> Result<(), Response<Cursor<Vec<u8>>>> {
-    let token = match &ctx.auth_token {
+    let token_hash = match &ctx.auth_token_hash {
         // No token configured — auth disabled
         None => return Ok(()),
-        Some(t) => t,
+        Some(h) => h,
     };
 
     // Look for Authorization: Bearer <token>
@@ -109,72 +132,46 @@ fn check_auth(req: &Request, ctx: &ReqCtx) -> Result<(), Response<Cursor<Vec<u8>
 
     match auth_header {
         Some(h) => {
-            let val = h.value.as_str();
-            if let Some(provided) = val.strip_prefix("Bearer ") {
-                // Constant-time comparison to prevent timing attacks
-                if constant_time_eq(provided.as_bytes(), token.as_bytes()) {
+            let val = h.value.as_str().trim();
+            // RFC 7235: scheme is case-insensitive, exactly 2 parts expected
+            let parts: Vec<&str> = val.split_whitespace().collect();
+            if parts.len() != 2 {
+                return Err(unauthorized_response(
+                    ctx,
+                    req,
+                    "Invalid auth header format. Use: Authorization: Bearer <token>",
+                ));
+            }
+            if parts[0].eq_ignore_ascii_case("Bearer") {
+                // Constant-time comparison of precomputed SHA-256 digests.
+                // Only the incoming token is hashed per-request; the configured
+                // token's hash was precomputed at startup.
+                let provided_hash: [u8; 32] = Sha256::digest(parts[1].as_bytes()).into();
+                if constant_time_eq_digest(&provided_hash, token_hash) {
                     Ok(())
                 } else {
-                    let mut hdrs = ctx.cors_headers_for(req);
-                    hdrs.push(
-                        Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap(),
-                    );
-                    hdrs.push(json_header());
-                    let body = ErrorResponse {
-                        error: "Invalid or expired token".into(),
-                    };
-                    let data = serde_json::to_string(&body).unwrap();
-                    Err(Response::new(
-                        StatusCode::from(401),
-                        hdrs,
-                        Cursor::new(data.into_bytes()),
-                        None,
-                        None,
-                    ))
+                    Err(unauthorized_response(ctx, req, "Invalid or expired token"))
                 }
             } else {
-                let mut hdrs = ctx.cors_headers_for(req);
-                hdrs.push(
-                    Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap(),
-                );
-                hdrs.push(json_header());
-                let body = ErrorResponse {
-                    error: "Invalid auth scheme. Use: Authorization: Bearer <token>".into(),
-                };
-                let data = serde_json::to_string(&body).unwrap();
-                Err(Response::new(
-                    StatusCode::from(401),
-                    hdrs,
-                    Cursor::new(data.into_bytes()),
-                    None,
-                    None,
+                Err(unauthorized_response(
+                    ctx,
+                    req,
+                    "Invalid auth scheme. Use: Authorization: Bearer <token>",
                 ))
             }
         }
-        None => {
-            let mut hdrs = ctx.cors_headers_for(req);
-            hdrs.push(Header::from_bytes("WWW-Authenticate", "Bearer realm=\"uteke\"").unwrap());
-            hdrs.push(json_header());
-            let body = ErrorResponse {
-                error: "Authentication required. Provide Authorization: Bearer <token>".into(),
-            };
-            let data = serde_json::to_string(&body).unwrap();
-            Err(Response::new(
-                StatusCode::from(401),
-                hdrs,
-                Cursor::new(data.into_bytes()),
-                None,
-                None,
-            ))
-        }
+        None => Err(unauthorized_response(
+            ctx,
+            req,
+            "Authentication required. Provide Authorization: Bearer <token>",
+        )),
     }
 }
 
-/// Constant-time byte comparison to resist timing attacks.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
+/// Constant-time comparison of two fixed-length SHA-256 digests.
+/// The configured token's digest is precomputed at startup,
+/// so only the incoming token is hashed per-request.
+fn constant_time_eq_digest(a: &[u8; 32], b: &[u8; 32]) -> bool {
     let mut result: u8 = 0;
     for (x, y) in a.iter().zip(b.iter()) {
         result |= x ^ y;
@@ -183,7 +180,9 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 struct ReqCtx {
-    auth_token: Option<String>,
+    /// Hashed auth token for constant-time comparison.
+    /// If None, auth is disabled.
+    auth_token_hash: Option<[u8; 32]>,
     /// Allowed CORS origins from config. Empty = wildcard.
     cors_origins: Vec<String>,
 }
@@ -219,7 +218,7 @@ impl ReqCtx {
         }
         // When auth is enabled but CORS is wildcard, omit Authorization
         // from allowed headers to prevent browser-origin auth abuse.
-        let allowed_headers = if self.auth_token.is_some() && self.cors_origins.is_empty() {
+        let allowed_headers = if self.auth_token_hash.is_some() && self.cors_origins.is_empty() {
             "Content-Type"
         } else {
             "Content-Type, Authorization"
@@ -243,7 +242,7 @@ impl ReqCtx {
         // Fixed allowlist of headers we accept in cross-origin requests
         // When auth is enabled but CORS is wildcard, restrict to prevent browser abuse
         let allowed_headers_set: &[&str] =
-            if self.auth_token.is_some() && self.cors_origins.is_empty() {
+            if self.auth_token_hash.is_some() && self.cors_origins.is_empty() {
                 &["Content-Type", "Accept", "X-Requested-With"]
             } else {
                 &[
@@ -271,13 +270,9 @@ impl ReqCtx {
                     .collect::<Vec<_>>()
                     .join(", ")
             })
-            .unwrap_or_else(|| "Content-Type".to_string());
-        // Fallback if no requested headers matched
-        let allow_headers = if allow_headers.is_empty() {
-            allowed_headers_set.join(", ")
-        } else {
-            allow_headers
-        };
+            .unwrap_or_else(String::new);
+        // If no requested headers matched the allowlist, browser gets no
+        // Access-Control-Allow-Headers — it will block the request as intended.
         vec![
             Header::from_bytes("Access-Control-Allow-Origin", origin).unwrap(),
             Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
@@ -763,16 +758,20 @@ fn main() {
         }
     };
 
+    // Precompute auth token hash at startup so only incoming tokens
+    // need hashing per-request (avoids double-hash on every auth check).
+    let auth_token_hash = auth_token.as_deref().map(|t| Sha256::digest(t).into());
+
     // Build request context
     // Warn if auth is configured but CORS origins are not — this is safe for
     // non-browser clients (curl, SDKs, agents) but risky if browser access is needed.
-    if auth_token.is_some() && cors_origins.is_empty() {
+    if auth_token_hash.is_some() && cors_origins.is_empty() {
         warn!("Security: auth token is set but cors_origins is not configured.");
         warn!("  For browser access, set cors_origins in uteke.toml or --cors-origin.");
         warn!("  Non-browser clients (curl, agents) are unaffected by CORS.");
     }
     let ctx = ReqCtx {
-        auth_token: auth_token.clone(),
+        auth_token_hash,
         cors_origins: cors_origins.clone(),
     };
 


### PR DESCRIPTION
## Security Hardening — Priority 1

Addresses issues #204, #205, #132, #101.

### Changes

**#205 — Default bind address**
- Changed from `0.0.0.0` → `127.0.0.1`
- Server only accessible from localhost by default

**#101/#204 — Bearer token authentication**
- `Authorization: Bearer <token>` required on all endpoints except `GET /health`
- Config sources:
  - `uteke.toml`: `[server].auth_token = "..."`
  - CLI: `--auth-token <TOKEN>`
  - Env: `UTEKE_AUTH_TOKEN`
  - Precedence: CLI > env > config
- Constant-time comparison prevents timing attacks

**#204 — Configurable CORS origins**
- Replaces wildcard `*` with configurable allowlist
- `uteke.toml`: `cors_origins = ["http://localhost:3000"]`
- CLI: `--cors-origin <URL>` (repeatable)
- Request `Origin` header matched against allowlist
- Preflight: validated header allowlist (no blind reflection)
- When auth + wildcard CORS: `Authorization` excluded from CORS allowed headers
- Non-browser clients (curl, SDKs, agents) unaffected

**#132 — Input validation on /remember**
- Content length, tag count, tag length validated via `validate_input()`
- Returns 400 with clear error messages

### Startup warnings
- Warns when auth is disabled
- Warns when CORS wildcard + auth enabled
- Warns when CORS wildcard for production use

### Validation
- ✅ `cargo clippy --all-targets -- -D warnings` — clean
- ✅ `cargo test` — 116/116 pass
- ✅ Cora code review — 0 critical, 0 major security issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bearer-token authentication for API endpoints (excluding health checks)
  * Added configurable per-request CORS origin handling

* **Chores**
  * New `--auth-token` and repeatable `--cors-origin` CLI flags
  * Support for `UTEKE_AUTH_TOKEN` environment variable
  * Config file schema updated with authentication and CORS options
  * Added startup logging for authentication and CORS configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->