### PR TITLE
fix(#139): vector index consistency — atomic save, error propagation

### DIFF
--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -90,7 +90,7 @@ impl crate::Uteke {
                     .index
                     .write()
                     .map_err(|_| Error::lock("index write lock during import"))?;
-                index.insert(&id, &embedding);
+                index.insert(&id, &embedding)?;
                 // Don't save per-item — we'll persist once after the full import.
             }
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -199,7 +199,7 @@ impl Uteke {
                     .into_iter()
                     .map(|m| (m.id, m.embedding))
                     .collect();
-                index.build(&items);
+                index.build(&items)?;
                 index.save().ok(); // Persist after migration build
             }
         }

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -126,7 +126,7 @@ impl crate::Uteke {
                 .index
                 .write()
                 .map_err(|_| Error::lock("index write lock during repair (rebuild)"))?;
-            index.build(&items);
+            index.build(&items)?;
             index.save().ok();
         }
 

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -158,7 +158,9 @@ impl VectorIndex {
             let old_key = *old_key;
             self.key_to_id.remove(&old_key);
             self.index.remove(old_key).map_err(|e| {
-                Error::embed_msg(format!("Failed to remove old entry for duplicate ID {id}: {e}"))
+                Error::embed_msg(format!(
+                    "Failed to remove old entry for duplicate ID {id}: {e}"
+                ))
             })?;
         }
 
@@ -176,9 +178,9 @@ impl VectorIndex {
             })?;
         }
 
-        self.index.add(key, embedding).map_err(|e| {
-            Error::embed_msg(format!("Failed to insert into usearch index: {e}"))
-        })?;
+        self.index
+            .add(key, embedding)
+            .map_err(|e| Error::embed_msg(format!("Failed to insert into usearch index: {e}")))?;
 
         self.dirty = true;
         Ok(())
@@ -275,7 +277,8 @@ pub fn euclidean_to_cosine(distance: f32) -> f32 {
 fn atomic_write(path: &std::path::Path, data: &[u8]) -> Result<(), Error> {
     let tmp_path = path.with_extension("keys.tmp");
     std::fs::write(&tmp_path, data).map_err(|e| Error::embed("write temp key mapping", e))?;
-    std::fs::rename(&tmp_path, path).map_err(|e| Error::embed("rename temp to final key mapping", e))?;
+    std::fs::rename(&tmp_path, path)
+        .map_err(|e| Error::embed("rename temp to final key mapping", e))?;
     Ok(())
 }
 

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -96,6 +96,7 @@ impl VectorIndex {
     }
 
     /// Save index and key mappings to disk.
+    /// Uses atomic write (temp file + rename) to prevent corruption on crash.
     pub fn save(&mut self) -> Result<(), Error> {
         if let Some(ref path) = self.path {
             let path_str = path.to_string_lossy().to_string();
@@ -103,14 +104,13 @@ impl VectorIndex {
                 .save(&path_str)
                 .map_err(|e| Error::embed("save vector index", e))?;
 
-            // Save key→id mapping as sidecar file
+            // Save key→id mapping as sidecar file using atomic write
             let mapping_path = path.with_extension("keys");
             let mut lines = Vec::new();
             for (&key, id) in &self.key_to_id {
                 lines.push(format!("{key}\t{id}"));
             }
-            std::fs::write(&mapping_path, lines.join("\n"))
-                .map_err(|e| Error::embed("save key mapping", e))?;
+            atomic_write(&mapping_path, lines.join("\n").as_bytes())?;
 
             self.dirty = false;
         }
@@ -119,7 +119,7 @@ impl VectorIndex {
 
     /// Build the index from a list of (id, embedding) pairs.
     /// Used for migration from old HNSW or full rebuild.
-    pub fn build(&mut self, items: &[(String, Vec<f32>)]) {
+    pub fn build(&mut self, items: &[(String, Vec<f32>)]) -> Result<(), Error> {
         // Reset
         let dims = if items.is_empty() {
             DEFAULT_DIMS
@@ -129,8 +129,7 @@ impl VectorIndex {
         self.index = match Self::create_index(dims) {
             Ok(idx) => idx,
             Err(e) => {
-                tracing::error!("Failed to rebuild index: {e}");
-                return;
+                return Err(e);
             }
         };
         self.key_to_id.clear();
@@ -145,20 +144,22 @@ impl VectorIndex {
         }
 
         for (id, embedding) in items {
-            self.insert(id, embedding);
+            self.insert(id, embedding)?;
         }
+        Ok(())
     }
 
     /// Insert a single item into the index.
     /// If the ID already exists, removes the old entry first to prevent duplicates.
-    pub fn insert(&mut self, id: &str, embedding: &[f32]) {
+    /// Returns error if the underlying usearch operation fails.
+    pub fn insert(&mut self, id: &str, embedding: &[f32]) -> Result<(), Error> {
         // Guard: remove old entry if ID already exists (prevents duplicate + stale slot)
         if let Some(old_key) = self.id_to_key.get(id) {
             let old_key = *old_key;
             self.key_to_id.remove(&old_key);
-            if let Err(e) = self.index.remove(old_key) {
-                tracing::warn!("Failed to remove old entry for duplicate ID {id}: {e}");
-            }
+            self.index.remove(old_key).map_err(|e| {
+                Error::embed_msg(format!("Failed to remove old entry for duplicate ID {id}: {e}"))
+            })?;
         }
 
         let key = self.next_key;
@@ -170,16 +171,17 @@ impl VectorIndex {
         // Auto-reserve if at capacity
         if self.index.size() >= self.index.capacity() {
             let new_cap = (self.index.capacity() + 1024).max(1024);
-            if let Err(e) = self.index.reserve(new_cap) {
-                tracing::error!("Failed to reserve usearch capacity: {e}");
-            }
+            self.index.reserve(new_cap).map_err(|e| {
+                Error::embed_msg(format!("Failed to reserve usearch capacity: {e}"))
+            })?;
         }
 
-        if let Err(e) = self.index.add(key, embedding) {
-            tracing::error!("Failed to insert into usearch index: {e}");
-        }
+        self.index.add(key, embedding).map_err(|e| {
+            Error::embed_msg(format!("Failed to insert into usearch index: {e}"))
+        })?;
 
         self.dirty = true;
+        Ok(())
     }
 
     /// Remove an item by memory ID. Incremental — no rebuild.
@@ -267,6 +269,16 @@ pub fn euclidean_to_cosine(distance: f32) -> f32 {
     sim.clamp(0.0, 1.0)
 }
 
+/// Atomic file write: write to temp file then rename.
+/// Prevents corruption if process crashes mid-write.
+/// POSIX guarantees rename() is atomic on the same filesystem.
+fn atomic_write(path: &std::path::Path, data: &[u8]) -> Result<(), Error> {
+    let tmp_path = path.with_extension("keys.tmp");
+    std::fs::write(&tmp_path, data).map_err(|e| Error::embed("write temp key mapping", e))?;
+    std::fs::rename(&tmp_path, path).map_err(|e| Error::embed("rename temp to final key mapping", e))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -299,9 +311,9 @@ mod tests {
         let norm = v3.iter().map(|x| x * x).sum::<f32>().sqrt();
         v3.iter_mut().for_each(|x| *x /= norm);
 
-        idx.insert("m1", &v1);
-        idx.insert("m2", &v2);
-        idx.insert("m3", &v3);
+        idx.insert("m1", &v1).unwrap();
+        idx.insert("m2", &v2).unwrap();
+        idx.insert("m3", &v3).unwrap();
 
         assert_eq!(idx.len(), 3);
 
@@ -317,8 +329,8 @@ mod tests {
         let v1 = make_vec(768, 0);
         let v2 = make_vec(768, 1);
 
-        idx.insert("m1", &v1);
-        idx.insert("m2", &v2);
+        idx.insert("m1", &v1).unwrap();
+        idx.insert("m2", &v2).unwrap();
 
         assert_eq!(idx.len(), 2);
 
@@ -351,8 +363,8 @@ mod tests {
             v
         };
 
-        idx.insert("mem-1", &v1);
-        idx.insert("mem-2", &v2);
+        idx.insert("mem-1", &v1).unwrap();
+        idx.insert("mem-2", &v2).unwrap();
         idx.save().unwrap();
 
         // Load from disk
@@ -376,7 +388,7 @@ mod tests {
             .collect();
 
         let mut idx = VectorIndex::new(768).unwrap();
-        idx.build(&items);
+        idx.build(&items).unwrap();
         assert_eq!(idx.len(), 10);
 
         let query = make_vec(768, 0);

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -89,7 +89,7 @@ impl crate::Uteke {
 
         self.store.insert(&memory)?;
 
-        index.insert(&id, embedding);
+        index.insert(&id, embedding)?;
         if let Err(e) = index.save() {
             tracing::warn!(
                 "Failed to persist vector index after remember for id={id}: {e}. \


### PR DESCRIPTION
## Problem (#139)

Multiple issues in vector index:

1. **Sidecar file consistency risk** — `.keys` file written non-atomically, corruption risk on crash
2. **Silent error swallowing** — `insert()` and `build()` returned `()`, errors logged but not propagated
3. **ef parameter ignored** — `_ef` accepted but not wired to usearch
4. **embed(&mut self)** — forces Mutex on all callers

## Fixes

1. ✅ **Atomic save** — `.keys` file written via temp + rename (POSIX atomic)
2. ✅ **Error propagation** — `insert()` returns `Result<(), Error>`, `build()` returns `Result<(), Error>`
3. ⚠️ **ef parameter** — usearch v2.25.3 Rust bindings dont expose ef in `search()`. Cannot wire without forking usearch. Left as `_ef` with TODO.
4. ⚠️ **embed(&mut self)** — ONNX tokenizer requires `&mut self` internally. Architectural limitation. Kept as-is.

## What was already fixed (by previous PRs)

- ✅ HashMap instead of Vec for sparse mapping (done before this PR)

## Verification

- ✅ `cargo clippy --all-targets -- -D warnings` — clean
- ✅ `cargo test` — 107/107 pass

Fixes: #139