### PR TITLE
release: v0.0.13

### DIFF
--- a/.agents/skills/uteke-memory/SKILL.md
+++ b/.agents/skills/uteke-memory/SKILL.md
@@ -1,7 +1,11 @@
+---
+description: "Persistent memory engine for AI agents via the uteke CLI — remember, recall, search, forget with semantic + FTS5 hybrid search, metadata enrichment, and multi-agent namespaces."
+---
+
 # Uteke Memory Skill
 
 Persistent memory engine for AI agents via the `uteke` CLI.
-Version: **0.0.2** — persistent vector index, multi-agent namespaces, tiered memory.
+Version: **0.0.13** — FTS5 hybrid search with RRF, metadata enrichment, concurrent reads.
 
 ## Global Flags (all commands)
 
@@ -18,12 +22,37 @@ Version: **0.0.2** — persistent vector index, multi-agent namespaces, tiered m
 
 | Command | Description | Key Options |
 |---------|-------------|-------------|
-| `uteke remember <TEXT>` | Store a new memory | `--tags <tags>` (comma-separated) |
-| `uteke recall <QUERY>` | Semantic search (vector similarity) | `--limit <n>` (default 5), `--tags <tags>` |
-| `uteke search <QUERY>` | Keyword text search | `--limit <n>` (default 10) |
-| `uteke list` | List memories (paginated) | `--tag <tag>`, `--limit <n>`, `--offset <n>` |
+| `uteke remember <TEXT>` | Store a new memory with metadata | `--tags <tags>`, `--entity <name>`, `--category <cat>`, `--meta <k:v,...>` |
+| `uteke recall <QUERY>` | Hybrid search (vector + FTS5, ranked by RRF) | `--limit <n>` (default 5), `--entity <name>`, `--category <cat>` |
+| `uteke search <QUERY>` | Keyword text search | `--limit <n>` (default 10), `--tags <tags>` |
+| `uteke list` | List memories with filters | `--tag <tag>`, `--entity <name>`, `--category <cat>`, `--limit <n>`, `--offset <n>` |
 | `uteke get <ID>` | Get single memory by UUID | |
-| `uteke forget <ID>` | Delete memory by UUID | |
+| `uteke forget <ID>` | Delete memory by ID, tag, tier, or all | `--tag <tag>`, `--cold`, `--all`, `--confirm` |
+
+### Memory Intelligence
+
+| Command | Description |
+|---------|-------------|
+| `uteke consolidate` | Find and merge duplicate memories (`--threshold 0.60 --dry-run`) |
+| `uteke prune` | Remove deprecated/expired temporal memories (`--ttl 30 --dry-run`) |
+
+### Tags & Namespaces
+
+| Command | Description |
+|---------|-------------|
+| `uteke tags list` | List all tags with counts (`--by-count`) |
+| `uteke tags rename <old> <new>` | Rename a tag across all memories |
+| `uteke tags delete <tag>` | Delete a tag from all memories |
+| `uteke namespace list` | List all namespaces with counts |
+| `uteke namespace switch <name>` | Set default namespace in config |
+
+### Memory Aging
+
+| Command | Description |
+|---------|-------------|
+| `uteke aging status` | Show hot/warm/cold/never-accessed breakdown |
+| `uteke aging preview --days N` | Preview memories older than N days |
+| `uteke aging cleanup --days N --confirm` | Delete stale memories |
 
 ### Health & Maintenance
 
@@ -45,16 +74,20 @@ Version: **0.0.2** — persistent vector index, multi-agent namespaces, tiered m
 
 | Command | Description |
 |---------|-------------|
-| `uteke init` | Initialize uteke integration for an AI agent. `--agent <pi\|claude\|cursor\|copilot\|codex>` |
-| `uteke completions <SHELL>` | Generate shell completions (bash, zsh, fish, elvish, powershell) |
+| `uteke hook install <shell>` | Install shell hook for auto-context loading (bash/zsh/fish) |
+| `uteke completions <SHELL>` | Generate shell completions |
 
-## Architecture (v0.0.2)
+## Architecture
 
-- **Storage:** SQLite (WAL mode, bundled) with `namespace` column + index
-- **Vector index:** usearch persistent HNSW (768d, cosine similarity)
+- **Storage:** SQLite (WAL mode, bundled) with `namespace` column + FTS5 virtual table
+- **Vector index:** usearch persistent HNSW (768d, cosine similarity) with `RwLock` for concurrent reads
+- **Full-text search:** SQLite FTS5 with phrase + token-OR fallback
+- **Hybrid search:** Reciprocal Rank Fusion (RRF, k=60) merges vector + FTS5 results
 - **Embedding:** ONNX EmbeddingGemma Q4 (768d), auto-downloaded
 - **Tiered memory:** Hot (<7d, +0.1 boost), Warm (<30d), Cold (>30d)
-- **Index files:** `uteke_index.usearch` + `uteke_index.keys`
+- **Metadata:** Entity, category, and key:value pairs stored as JSON blob
+- **Schema versioning:** Integer counter, auto-migration on upgrade (currently v2)
+- **Index files:** `uteke_index.usearch` + `uteke_index.keys` (atomic save)
 - **Zero unsafe code** (`unsafe_code = "forbid"`)
 
 ## Usage Patterns
@@ -64,14 +97,34 @@ Version: **0.0.2** — persistent vector index, multi-agent namespaces, tiered m
 # Before work — load context
 uteke recall "project architecture decisions" --namespace pi-agent
 
-# After decisions — persist
-uteke remember "Use WAL mode for concurrent reads" --tags architecture,db --namespace pi-agent
+# After decisions — persist with metadata
+uteke remember "Use WAL mode for concurrent reads" \
+  --tags architecture,db \
+  --entity db-layer \
+  --category decision \
+  --namespace pi-agent
 
 # End of session — summarize
-uteke remember "Refactored auth middleware, token expiry fix" --tags session,auth --namespace pi-agent
+uteke remember "Refactored auth middleware, token expiry fix" \
+  --tags session,auth --namespace pi-agent
 
 # Session handoff
 uteke recall "last session state" --namespace pi-agent
+```
+
+### Metadata-enriched storage
+```bash
+uteke remember "Deploy staging to AWS us-east-1" \
+  --tags deploy,aws \
+  --entity staging-server \
+  --category infrastructure \
+  --meta "source:meeting-note,confidence:0.9"
+```
+
+### Filter by entity or category
+```bash
+uteke recall "server" --entity staging-server
+uteke list --category infrastructure --limit 10
 ```
 
 ### Project-scoped memory
@@ -105,6 +158,7 @@ uteke import backup.jsonl           # Import (re-embeds automatically)
 uteke recall "auth flow" --json --limit 3
 uteke stats --json
 uteke list --tag architecture --json --limit 50
+uteke remember "test" --json        # {"id":"a1b2c3d4-..."}
 ```
 
 ## When to Use
@@ -112,8 +166,17 @@ uteke list --tag architecture --json --limit 50
 | Trigger | Action |
 |---------|--------|
 | Before starting work | `uteke recall "<project context>"` |
-| After making decisions | `uteke remember "<decision>" --tags <tags>` |
+| After making decisions | `uteke remember "<decision>" --tags <tags> --entity <name>` |
 | Before closing session | `uteke remember "<session summary>" --tags session` |
 | Important findings | `uteke remember "<finding>" --tags finding,<topic>` |
 | Multi-agent context | Use `--namespace <agent-name>` |
 | Index feels slow/corrupt | `uteke doctor` → `uteke repair` if needed |
+
+## Server Mode
+
+For real-time agent use, start a persistent daemon:
+
+```bash
+uteke-serve --port 8767
+# Now CLI auto-routes to server: ~42ms recall vs ~3s cold start
+```

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,7 +2,8 @@ name: Deploy Website to Cloudflare Pages
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
+    tags: ['v*']
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-website.yml'
@@ -13,8 +14,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  id-token: write
   contents: read
+  deployments: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -46,19 +47,10 @@ jobs:
             exit 1
           fi
 
-      - name: Fetch secrets from Infisical
-        uses: Infisical/secrets-action@v1.0.16
-        with:
-          method: "oidc"
-          identity-id: "6bd2b8d8-a9a3-4331-8b37-bf2764fc320b"
-          project-slug: "github-actions"
-          env-slug: "prod"
-          domain: "https://infisical.ajianaz.dev"
-
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:
-          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: npx wrangler pages project create uteke --production-branch=develop || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=uteke --commit-dirty=true --branch=develop
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          preCommands: npx wrangler pages project create uteke --production-branch=main || true
+          command: pages deploy docs/.vitepress/dist/ --project-name=uteke --commit-dirty=true --branch=main

--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** adalah local-first semantic memory engine untuk AI agents. Single Rust binary, fully offline, ~30ms recall. Tidak butuh API key, Docker, atau cloud service.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local di `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Versi:** 0.0.12
+- **Versi:** 0.0.13
 - **Lisensi:** Apache 2.0
 - **Branch utama:** `develop` ( semua PR ke sini), `main` (release)
 
@@ -148,6 +148,28 @@ fs::rename(&tmp_path, &path)?;
 - `forget()`: Acquire index lock **dulu**, baru SQLite delete
 - Pattern ini mencegah inconsistency antara DB dan index
 
+### 8. Selalu Update CHANGELOG dan Docs Sebelum Commit
+
+Setiap commit yang menambah/mengubah fitur atau fix **wajib** diikuti update:
+
+1. **CHANGELOG.md** — Tambah entry di bawah `[Unreleased]` (Added/Fixed/Changed)
+2. **docs/cli-reference.md** — Kalau ada CLI flag baru atau behavior berubah
+3. **docs/roadmap.md** — Kalau ada issue yang selesai
+4. **README.md** — Kalau ada perubahan signifikan di features atau quick start
+5. **AGENT.md** — Kalau ada perubahan arsitektur, limitation baru, atau lesson learned
+6. **Version badge** — Kalau akan rilis, update badge di README
+
+Dokumentasi yang outdated lebih berbahaya dari tidak ada dokumentasi.
+
+### 9. VitePress Docs Deploy Otomatis Saat Rilis
+
+Workflow `deploy-website.yml` otomatis deploy ke Cloudflare Pages saat:
+- Push ke `main` (setelah release workflow sync dari develop)
+- Push tag `v*` (rilis baru)
+- Manual trigger via GitHub UI
+
+Pastikan docs sudah up-to-date **sebelum** push tag rilis. Docs deploy dari branch `main`, bukan `develop`.
+
 ---
 
 ## Lessons Learned — Dari Pengalaman Nyata
@@ -204,7 +226,7 @@ Jalankan stress test manual setelah perubahan signifikan.
 
 ### Dokumentasi Cepat Outdated
 
-CONTRIBUTING.md pernah bilang "2 crates" padahal sudah 3 sejak v0.0.4. Badge version tertinggal. Setelah merge ke develop, **selalu cek** apakah docs perlu update.
+CONTRIBUTING.md pernah bilang "2 crates" padahal sudah 3 sejak v0.0.4. Badge version tertinggal. **Selalu update docs sebelum commit** — lihat Critical Rule #8.
 
 ---
 
@@ -213,21 +235,22 @@ CONTRIBUTING.md pernah bilang "2 crates" padahal sudah 3 sejak v0.0.4. Badge ver
 ### Per-Issue Workflow
 
 ```
-1. git checkout develop && git pull
-2. git checkout -b <type>/<short-description>
-3. Implementasi (baca modul terkait dulu)
-4. cargo fmt && cargo clippy && cargo test
-5. cora review --base origin/develop --format text  (local review)
-6. Fix semua findings dari Cora
-7. git add -A && git commit -m "type: description"
-8. git push origin <branch>
-9. gh pr create --base develop
-10. Monitor CI (gh pr checks <number>)
-11. Review PR comments (Cora, CodeRabbit)
-12. Fix kalau ada findings baru
-13. gh pr merge <number> --squash --delete-branch
-14. Update docs kalau perlu
-15. Pick next issue
+ 1. git checkout develop && git pull
+ 2. git checkout -b <type>/<short-description>
+ 3. Implementasi (baca modul terkait dulu)
+ 4. cargo fmt && cargo clippy && cargo test
+ 5. cora review --base origin/develop --format text  (local review)
+ 6. Fix semua findings dari Cora
+ 7. Update CHANGELOG.md (tambah di [Unreleased])
+ 8. Update docs/ kalau ada fitur/flag baru (lihat Critical Rule #8)
+ 9. git add -A && git commit -m "type: description"
+10. git push origin <branch>
+11. gh pr create --base develop
+12. Monitor CI (gh pr checks <number>)
+13. Review PR comments (Cora, CodeRabbit)
+14. Fix kalau ada findings baru
+15. gh pr merge <number> --squash --delete-branch
+16. Pick next issue
 ```
 
 ### Branch Naming Convention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13] — 2026-06-10
+
 ### Added
 
 - **FTS5 hybrid search with RRF** — Full-text search (FTS5) as parallel retrieval channel merged with vector search via Reciprocal Rank Fusion (RRF, k=60). New `RecallStrategy` enum: `hybrid` (default), `vector`, `fts5`. FTS5 virtual table auto-created; existing DBs get schema migration v1→v2. Phrase search + token-OR fallback. Deprecated memories excluded from FTS5. 6 new tests (#250, PR #261)
@@ -21,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`memories.remove().unwrap()`** — Replaced with `.expect()` for meaningful panic message (PR #264)
 - **Server-mode metadata support** — `remember` via HTTP API now includes entity, category, and meta in request body (PR #264)
 - **Clippy `collapsible_else_if`** — 2 pre-existing warnings fixed (PR #260)
+
+### Changed
+
+- **Repository transferred** — `ajianaz/uteke` → `codecoradev/uteke`. All references updated across 16 files
+- **Cora Review CI** — switched from local Infisical OIDC action to `codecoradev/cora-review-action@v1` with GitHub Secrets. Removed `.cora.yaml` project config
+- **README simplified** — 400 → 97 lines. Detailed content moved to VitePress docs (`docs/architecture.md`, `docs/cli-reference.md`, etc.)
+- **Roadmap cleaned** — consolidated old versions, removed speculative Phase B/C phases
+- **CONTRIBUTING.md** — added Cora CLI integration docs, CI checks table, architecture updated to 3 crates, Key Design Decisions section
+- **AGENT.md** — new file with persistent AI agent context: critical rules, architecture, lessons learned, proven workflow
+- **docs/architecture.md** — new VitePress page with system overview, data flow diagrams, performance benchmarks, design decisions
+- **docs/roadmap.md** — v0.0.12 section added, old versions consolidated, "What's Next" list
+- **Star History chart** added to README (cora-cli + uteke)
 
 ## [0.0.12] — 2026-06-07
 
@@ -380,6 +394,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Binary name:** `uteke`
 - **Minimum Rust version:** 1.75+
 
+[0.0.13]: https://github.com/codecoradev/uteke/releases/tag/v0.0.13
+[0.0.12]: https://github.com/codecoradev/uteke/releases/tag/v0.0.12
 [0.0.10]: https://github.com/codecoradev/uteke/releases/tag/v0.0.10
 [0.0.9]: https://github.com/codecoradev/uteke/releases/tag/v0.0.9
 [0.0.8]: https://github.com/codecoradev/uteke/releases/tag/v0.0.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "chrono",
  "dirs",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "ctrlc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.0.12-green.svg" alt="v0.0.12" />
+  <img src="https://img.shields.io/badge/status-v0.0.13-green.svg" alt="v0.0.13" />
 </p>
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.0.12**.
+Complete reference for all uteke commands. Version **0.0.13**.
 
 ## Global Flags
 


### PR DESCRIPTION
## Summary

Version bump to 0.0.13 with release preparation fixes.

### Changes

**Version bump (0.0.12 → 0.0.13)**
- `Cargo.toml`, `Cargo.lock`
- README version badge
- `docs/cli-reference.md` version header
- `CHANGELOG.md`: `[Unreleased]` → `[0.0.13] — 2026-06-10` with full release notes

**Fix uteke-memory skill**
- Added required `description` frontmatter field (was causing "description is required" error)
- Updated to v0.0.13: added FTS5 hybrid search, metadata enrichment, server mode, entity/category/meta flags

**Deploy website workflow**
- Removed Infisical OIDC → GitHub Secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`)
- Trigger on `main` branch + `v*` tags (production deploys from `main`, not `develop`)

**AGENT.md — 2 new critical rules**
- Rule 8: Always update CHANGELOG + docs before commit (6-item checklist)
- Rule 9: VitePress docs deploy automatically on release (main branch)
- Updated per-issue workflow to include CHANGELOG + docs update steps

### Required Secrets (set in repo Settings)
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`

### After merge
Tag `v0.0.13` → release workflow builds binaries + merges to main → website deploys.