### PR TITLE
feat(#134): file permissions and ONNX model checksum verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Set owner-only file permissions (0700/0600) on database and model directories (#134)
+- Add SHA256 checksum verification for downloaded ONNX model files (#134)
+- Pin expected model checksums to detect corrupted/tampered downloads
+
 ## [0.0.13] — 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -334,6 +343,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -374,6 +392,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -559,13 +587,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -762,6 +800,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2066,13 +2114,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2694,6 +2753,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -2709,7 +2769,7 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tiny_http",
  "toml",
  "tracing",

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -24,6 +24,7 @@ tokenizers = "0.23"
 dirs = "6"
 tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -1,7 +1,11 @@
 //! ONNX-based embedding engine using EmbeddingGemma Q4 (768d).
 
 use crate::Error;
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 const MODEL_DIR_NAME: &str = "embeddinggemma-q4";
 const MODEL_FILE: &str = "model_q4.onnx";
@@ -11,6 +15,23 @@ const MODEL_DIMS: usize = 768;
 const MAX_SEQ_LEN: usize = 256;
 
 const HF_REPO: &str = "onnx-community/embeddinggemma-300m-ONNX";
+
+/// Expected SHA256 checksums for model files.
+/// Pin these to prevent corrupted/tampered downloads from causing cryptic ONNX failures.
+const MODEL_CHECKSUMS: &[(&str, &str)] = &[
+    (
+        "model_q4.onnx",
+        "ad1dfee81a70f7944b9b9d1cc6e48075b832881cf33fab2f2b248be78f3f0043",
+    ),
+    (
+        "model_q4.onnx_data",
+        "599962c3143b040de2dd05e5975be3e9091dd067cacc6a8f7186e3203bab9e02",
+    ),
+    (
+        "tokenizer.json",
+        "4dda02faaf32bc91031dc8c88457ac272b00c1016cc679757d1c441b248b9c47",
+    ),
+];
 
 /// ONNX-based embedding engine using EmbeddingGemma Q4 (768d).
 pub struct EmbeddingEngine {
@@ -28,6 +49,13 @@ impl EmbeddingEngine {
         let onnx_dir = model_dir.join("onnx");
         std::fs::create_dir_all(&onnx_dir).map_err(|e| Error::embed("create onnx directory", e))?;
 
+        // Set model directory permissions to owner-only (0700) on Unix
+        #[cfg(unix)]
+        {
+            std::fs::set_permissions(&model_dir, std::fs::Permissions::from_mode(0o700)).ok();
+            std::fs::set_permissions(&onnx_dir, std::fs::Permissions::from_mode(0o700)).ok();
+        }
+
         let model_path = onnx_dir.join(MODEL_FILE);
         let model_data_path = onnx_dir.join(MODEL_DATA_FILE);
         let tokenizer_path = model_dir.join(TOKENIZER_FILE);
@@ -39,12 +67,15 @@ impl EmbeddingEngine {
         // Download model files if not present
         if !model_path.exists() {
             download_hf_file(HF_REPO, "onnx/model_q4.onnx", &model_path)?;
+            verify_checksum(&model_path, "model_q4.onnx")?;
         }
         if !model_data_path.exists() {
             download_hf_file(HF_REPO, "onnx/model_q4.onnx_data", &model_data_path)?;
+            verify_checksum(&model_data_path, "model_q4.onnx_data")?;
         }
         if !tokenizer_path.exists() {
             download_hf_file(HF_REPO, "tokenizer.json", &tokenizer_path)?;
+            verify_checksum(&tokenizer_path, "tokenizer.json")?;
         }
 
         // Load ONNX session
@@ -183,5 +214,45 @@ fn download_hf_file(
     std::fs::rename(&tmp_path, local_path)
         .map_err(|e| Error::embed("rename temp to final path", e))?;
 
+    // Set file permissions to owner-only (0600) on Unix
+    set_owner_only_permissions(local_path);
+
     Ok(())
+}
+
+/// Verify SHA256 checksum of a downloaded model file.
+fn verify_checksum(path: &std::path::Path, filename: &str) -> Result<(), Error> {
+    let expected = MODEL_CHECKSUMS
+        .iter()
+        .find(|(name, _)| name == &filename)
+        .map(|(_, hash)| *hash)
+        .ok_or_else(|| Error::embed_msg(format!("No checksum pinned for {filename}")))?;
+
+    let data = std::fs::read(path).map_err(|e| Error::embed("read file for checksum", e))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let actual = format!("{:x}", hasher.finalize());
+
+    if actual != expected {
+        // Delete corrupted file so next run re-downloads
+        std::fs::remove_file(path).ok();
+        return Err(Error::embed_msg(format!(
+            "SHA256 checksum mismatch for {filename}.\n\
+             Expected: {expected}\n\
+             Actual:   {actual}\n\
+             File deleted. Re-run to re-download."
+        )));
+    }
+    tracing::debug!("Checksum verified: {filename}");
+    Ok(())
+}
+
+/// Set file permissions to owner-only (0600) on Unix systems.
+fn set_owner_only_permissions(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+            tracing::warn!("Failed to set permissions on {}: {e}", path.display());
+        }
+    }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -78,6 +78,9 @@ use memory::VectorIndex;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, RwLock};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 /// Configuration for memory tier thresholds.
 ///
 /// Controls how memories are classified into hot/warm/cold tiers
@@ -258,10 +261,19 @@ fn resolve_db_path(db_path: &Path) -> Result<String, Error> {
 
     if db_path.is_dir() || db_path.extension().is_none() {
         std::fs::create_dir_all(db_path).map_err(Error::Io)?;
+        // Set directory permissions to owner-only (0700) on Unix
+        #[cfg(unix)]
+        {
+            let p: &std::path::Path = db_path;
+            std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700)).ok();
+        }
         Ok(db_path.join("uteke.db").to_string_lossy().to_string())
     } else {
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent).map_err(Error::Io)?;
+            // Set directory permissions to owner-only (0700) on Unix
+            #[cfg(unix)]
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).ok();
         }
         Ok(db_path.to_string_lossy().to_string())
     }


### PR DESCRIPTION
## Summary

Security improvements for file permissions and model integrity verification.

### Changes
1. **Owner-only directory permissions (0700)** on `~/.uteke/` database directories and model cache directories
2. **Owner-only file permissions (0600)** on downloaded model files
3. **SHA256 checksum verification** after each model file download from HuggingFace
4. **Pinned checksums** for `model_q4.onnx`, `model_q4.onnx_data`, and `tokenizer.json`
5. **Auto-delete corrupted files** with actionable error message on checksum mismatch
6. Added `sha2` dependency for checksum computation

### Verification
- `cargo fmt` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test --workspace` — 108/108 pass ✅

Closes #134