### PR TITLE
refactor(#232): fix 9 of 11 Cora scan code quality items

### DIFF
--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -127,7 +127,9 @@ impl crate::Uteke {
                 .write()
                 .map_err(|_| Error::lock("index write lock during repair (rebuild)"))?;
             index.build(&items)?;
-            index.save().ok();
+            if let Err(e) = index.save() {
+                tracing::warn!("Failed to save index: {e}");
+            }
         }
 
         Ok(RepairReport {
@@ -223,7 +225,9 @@ impl crate::Uteke {
             for id in &ids {
                 index.remove(id);
             }
-            index.save().ok();
+            if let Err(e) = index.save() {
+                tracing::warn!("Failed to save index: {e}");
+            }
         }
 
         Ok(CleanupResult { deleted })
@@ -263,7 +267,9 @@ impl crate::Uteke {
             for id in &ids {
                 index.remove(id);
             }
-            index.save().ok();
+            if let Err(e) = index.save() {
+                tracing::warn!("Failed to save index: {e}");
+            }
         }
 
         Ok(PruneResult {

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -25,7 +25,12 @@ impl super::Store {
         let ids: Vec<String> = stmt
             .query_map(params![ns, tag], |row| row.get(0))
             .map_err(|e| Error::db("database operation", e))?
-            .filter_map(|r| r.ok())
+            .filter_map(|r| {
+                if let Err(e) = &r {
+                    tracing::warn!("DB row error in bulk delete: {e}");
+                }
+                r.ok()
+            })
             .collect();
         Ok(ids)
     }
@@ -49,7 +54,12 @@ impl super::Store {
         let ids: Vec<String> = stmt
             .query_map(params![ns, warm_cutoff], |row| row.get(0))
             .map_err(|e| Error::db("database operation", e))?
-            .filter_map(|r| r.ok())
+            .filter_map(|r| {
+                if let Err(e) = &r {
+                    tracing::warn!("DB row error in bulk delete: {e}");
+                }
+                r.ok()
+            })
             .collect();
         Ok(ids)
     }
@@ -66,7 +76,12 @@ impl super::Store {
         let ids: Vec<String> = stmt
             .query_map(params![ns], |row| row.get(0))
             .map_err(|e| Error::db("database operation", e))?
-            .filter_map(|r| r.ok())
+            .filter_map(|r| {
+                if let Err(e) = &r {
+                    tracing::warn!("DB row error in bulk delete: {e}");
+                }
+                r.ok()
+            })
             .collect();
         Ok(ids)
     }

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -36,7 +36,7 @@ impl super::Store {
                     memory.memory_type,
                 ],
             )
-            .map_err(|e| Error::db("Failed to prepare statement for insert", e))?;
+            .map_err(|e| Error::db("Failed to insert memory", e))?;
 
         Ok(())
     }
@@ -66,6 +66,10 @@ impl super::Store {
     }
 
     /// Update an existing memory.
+    ///
+    /// Note: Only updates content, embedding, tags, metadata, updated_at, and namespace.
+    /// Fields NOT updated: access_count, last_accessed, deprecated, valid_from,
+    /// valid_until, memory_type. Use dedicated methods for those.
     #[allow(dead_code)]
     pub fn update(&self, memory: &Memory) -> Result<(), Error> {
         let embedding_blob = serialize_embedding(&memory.embedding);

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -67,6 +67,12 @@ pub(super) fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
 
 /// Deserialize an embedding vector from a byte blob.
 pub(super) fn deserialize_embedding(blob: &[u8]) -> Vec<f32> {
+    if blob.len() % 4 != 0 {
+        tracing::warn!(
+            "Embedding blob length ({}) is not a multiple of 4, trailing bytes will be skipped",
+            blob.len()
+        );
+    }
     blob.chunks_exact(4)
         .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
         .collect()
@@ -124,7 +130,10 @@ pub(super) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite:
         .as_deref()
         .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.to_utc());
-    let deprecated: bool = row.get(10).unwrap_or(false);
+    let deprecated: bool = row.get(10).unwrap_or_else(|e| {
+        tracing::debug!("Failed to read deprecated field: {e}, defaulting to false");
+        false
+    });
     let valid_from_str: Option<String> = row.get(11).ok().flatten();
     let valid_from = valid_from_str
         .as_deref()

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -218,15 +218,26 @@ pub enum MemoryType {
 }
 
 impl MemoryType {
-    /// Parse from string.
+    /// Parse from string (case-insensitive).
     pub fn from_str_opt(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "fact" => Some(Self::Fact),
-            "procedure" => Some(Self::Procedure),
-            "preference" => Some(Self::Preference),
-            "decision" => Some(Self::Decision),
-            "context" => Some(Self::Context),
-            _ => None,
+        match s {
+            "fact" | "Fact" | "FACT" => Some(Self::Fact),
+            "procedure" | "Procedure" | "PROCEDURE" => Some(Self::Procedure),
+            "preference" | "Preference" | "PREFERENCE" => Some(Self::Preference),
+            "decision" | "Decision" | "DECISION" => Some(Self::Decision),
+            "context" | "Context" | "CONTEXT" => Some(Self::Context),
+            _ => {
+                // Fallback: lowercase comparison for mixed case
+                let lower = s.to_lowercase();
+                match lower.as_str() {
+                    "fact" => Some(Self::Fact),
+                    "procedure" => Some(Self::Procedure),
+                    "preference" => Some(Self::Preference),
+                    "decision" => Some(Self::Decision),
+                    "context" => Some(Self::Context),
+                    _ => None,
+                }
+            }
         }
     }
 

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -202,6 +202,9 @@ impl VectorIndex {
 
     /// Search for the k nearest neighbors of the query vector.
     /// Returns (memory_id, distance_f32) pairs, sorted by distance ascending.
+    /// Search for k nearest neighbors.
+    /// Note: `ef` parameter is accepted for API compatibility but not passed to
+    /// usearch v2.25.3 (Rust bindings don't expose `ef` in `search()`).
     pub fn search(&self, query: &[f32], k: usize, _ef: usize) -> Vec<(String, f32)> {
         if self.index.size() == 0 {
             return Vec::new();
@@ -265,7 +268,7 @@ impl Default for VectorIndex {
 
 /// Convert cosine distance (0..2) to cosine similarity (0..1).
 /// usearch with MetricKind::Cos returns cosine *distance* (1 - similarity).
-pub fn euclidean_to_cosine(distance: f32) -> f32 {
+pub fn cosine_distance_to_similarity(distance: f32) -> f32 {
     // usearch cosine distance = 1 - cosine_similarity
     let sim = 1.0 - distance;
     sim.clamp(0.0, 1.0)

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::memory::types::{
     BulkDeleteResult, Memory, MemoryTier, RecallStrategy, SearchResult, TagInfo, DEFAULT_NAMESPACE,
 };
-use crate::memory::vector::euclidean_to_cosine;
+use crate::memory::vector::cosine_distance_to_similarity;
 
 impl crate::Uteke {
     /// Store a new memory.
@@ -168,7 +168,7 @@ impl crate::Uteke {
                     }
                 }
 
-                let score = euclidean_to_cosine(*distance);
+                let score = cosine_distance_to_similarity(*distance);
 
                 // Boost hot memories (configurable boost)
                 let tier = MemoryTier::from_last_accessed(


### PR DESCRIPTION
Addresses 9 of 11 code quality items found by Cora v0.4.4 scan.

### Fixed (9 items)
1. **Misleading function name** — `euclidean_to_cosine` renamed to `cosine_distance_to_similarity`
2. **Unused ef parameter** — documented as usearch v2.25.3 limitation
3. **String allocation in from_str_opt** — match common cases without allocation
4. **Misleading error message** — `crud.rs` insert now says 'Failed to insert memory'
5. **Silent index save errors** — 3 instances now log warnings
6. **Undocumented update() scope** — doc comment lists which fields are/aren't updated
9. **filter_map swallows DB errors** — bulk.rs now logs errors before filtering
10. **deserialize_embedding trailing bytes** — warns when blob length is not multiple of 4
11. **deprecated bool unwrap_or** — logs error instead of silently defaulting

### Skipped (2 items)
7. **SQL column list constant** — high refactor risk, separate PR recommended
8. **Server 404** — already fixed (generic message, no path leak)

### Verification
- cargo fmt, clippy, 108/108 tests pass

Closes #232