### PR TITLE
feat(#253): make contradiction threshold configurable

### DIFF
--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -69,7 +69,7 @@ pub(crate) fn run(
 
     if detect_contradiction {
         let (id, contradiction) = uteke
-            .remember_with_contradiction(content, &tag_refs, ns, Some(r#type), true)
+            .remember_with_contradiction(content, &tag_refs, ns, Some(r#type), true, 0.65)
             .map_err(|e| format!("Failed to store memory: {e}"))?;
         tracing::info!("Memory stored with ID: {id}");
         if cli.json {

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -64,6 +64,7 @@ impl crate::Uteke {
         namespace: Option<&str>,
         memory_type: Option<&str>,
         check_contradiction: bool,
+        contradiction_threshold: f32,
     ) -> Result<(String, ContradictionResult), Error> {
         crate::validate_input(content, tags)?;
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
@@ -77,7 +78,7 @@ impl crate::Uteke {
 
         // Check for contradictions (read-only)
         let contradiction = if check_contradiction {
-            self.check_contradiction(content, &embedding, ns, 0.65)?
+            self.check_contradiction(content, &embedding, ns, contradiction_threshold)?
         } else {
             ContradictionResult {
                 contradicted: false,

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -430,6 +430,7 @@ fn route(uteke: &Uteke, ctx: &ReqCtx, req: &mut Request) -> Response<Cursor<Vec<
                             ns(&req_data.namespace),
                             req_data.r#type.as_deref(),
                             true,
+                            0.65,
                         )
                         .map(|(id, _)| id)
                 } else {


### PR DESCRIPTION
Remove hardcoded 0.65 contradiction threshold from `remember_with_contradiction()`. The threshold is now a function parameter, allowing callers to tune per-use-case.

Currently defaults to 0.65 in CLI and server callers.
Future PR: expose via uteke.toml [consolidate] config section.

Closes #253