### PR TITLE
feat(#136): add crates.io publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,26 @@ jobs:
           name: ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}
           path: release/${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}
 
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish uteke-core
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-core --allow-dirty
+
+      - name: Publish uteke-cli
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-cli --allow-dirty
+
+      - name: Publish uteke-server
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-server --allow-dirty
+
   release:
     name: Create GitHub Release
-    needs: build-release
+    needs: [build-release, publish-crates]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Adds `publish-crates` job to `release.yml` that publishes all 3 crates to crates.io on tag push.

### Workflow
1. `uteke-core` (library, must be first)
2. `uteke-cli` (binary)
3. `uteke-server` (binary)

Uses `CARGO_REGISTRY_TOKEN` secret. Follows cora-cli@0.5.0 pattern.

### Prerequisites
- [ ] Set `CARGO_REGISTRY_TOKEN` secret in GitHub repo settings (Settings > Secrets > Actions)
- [ ] Token can be created at https://crates.io/settings/tokens

### Also
- Moved #185 (cold start) and #131 (split main.rs) to v0.1.0
- v0.0.14 is now complete except for this secret setup

Closes #136