### PR TITLE
release: v0.0.14

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.0.13
+- **Version:** 0.0.14
 - **License:** Apache 2.0
 - **Main branches:** `develop` (all PRs go here), `main` (release)
 
@@ -232,7 +232,7 @@ Entity, category, and meta are stored as JSON in the `metadata` column. This mea
 
 ### Unit Tests Are Not Enough — Manual Stress Testing Is Required
 
-Unit tests (107) don't cover:
+Unit tests (108) don't cover:
 - Bulk insert of 100+ memories (performance regression?)
 - Concurrent access via server mode
 - Unicode / special characters in content
@@ -314,7 +314,7 @@ docs: update CLI reference for metadata flags
 # Build
 cargo build --workspace
 
-# Test (107 unit tests)
+# Test (108 unit tests)
 cargo test --workspace
 
 # Format + Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Uteke will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.14] — 2026-06-12
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chrono",
  "dirs",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "ctrlc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.0.13-green.svg" alt="v0.0.13" />
+  <img src="https://img.shields.io/badge/status-v0.0.14-green.svg" alt="v0.0.14" />
 </p>
 
 <p align="center">
@@ -75,7 +75,7 @@ AI agent melupakan semua hal antar sesi. Uteke memberikan mereka memori persiste
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (107 unit tests)
+cargo test --workspace         # Test (108 unit tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.0.13-green.svg" alt="v0.0.13" />
+  <img src="https://img.shields.io/badge/status-v0.0.14-green.svg" alt="v0.0.14" />
 </p>
 
 <p align="center">
@@ -75,7 +75,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (107 unit tests)
+cargo test --workspace         # Test (108 unit tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -48,7 +48,7 @@ uteke remember "User prefers dark mode" --tags pref --namespace my-agent
 | `--category <cat>` | Categorize the memory (e.g. "infrastructure") |
 | `--meta <pairs>` | Key:value pairs, comma-separated. Auto-detects type (string/number/bool) |
 | `--metadata <json>` | Arbitrary JSON metadata |
-| `--detect-contradiction` | Detect conflicting memories (threshold 0.65) |
+| `--detect-contradiction` | Detect conflicting memories (default threshold: 0.65) |
 | `--type <type>` | Memory type: fact, procedure, preference, decision, context |
 | `--valid-from <datetime>` | Start of validity period (ISO 8601) |
 | `--valid-until <datetime>` | End of validity period (ISO 8601) |


### PR DESCRIPTION
Release v0.0.14 preparation.

### Changes
- Version bump 0.0.13 → 0.0.14
- CHANGELOG [Unreleased] → [0.0.14] — 2026-06-12
- Version badge in README.md and README.id.md
- Test count 107 → 108
- Clarify contradiction threshold is configurable

### After merge
- Tag v0.0.14 on develop
- Release workflow: build binaries + publish crates.io + deploy docs