### PR TITLE
fix: add version to workspace deps for crates.io publish

### DIFF
--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core" }
+uteke-core = { path = "../uteke-core", version = "0.0.14" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core" }
+uteke-core = { path = "../uteke-core", version = "0.0.14" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
uteke-cli and uteke-server depended on uteke-core with path only. crates.io requires all dependencies to have a version specifier. Added version to both.

This caused the v0.0.14 release publish-crates job to fail (uteke-core succeeded, uteke-cli failed).