### PR TITLE
fix: make crates.io publish resilient to re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
 
       - name: Publish uteke-core
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-core --allow-dirty
+        continue-on-error: true
 
       - name: Publish uteke-cli
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-cli --allow-dirty


### PR DESCRIPTION
Add continue-on-error for uteke-core publish step. This handles the case where a previous run partially succeeded (core published, cli failed) and a re-tag/re-run would fail on 'already exists'.