### PR TITLE
fix: inline shell hooks into uteke-cli crate for crates.io

### DIFF
--- a/crates/uteke-cli/assets/shell/uteke-hook.bash
+++ b/crates/uteke-cli/assets/shell/uteke-hook.bash
@@ -1,0 +1,30 @@
+# Uteke shell hook for Bash
+# Add to ~/.bashrc: eval "$(uteke hook bash)"
+_uteke_find_project() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.uteke/uteke.db" ]]; then
+            echo "$dir/.uteke"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+_uteke_prev_dir="$PWD"
+uteke_prompt_hook() {
+    if [[ "$PWD" != "$_uteke_prev_dir" ]]; then
+        _uteke_prev_dir="$PWD"
+        local project_store
+        if project_store="$(_uteke_find_project)"; then
+            export UTEKE_PROJECT_STORE="$project_store"
+        else
+            unset UTEKE_PROJECT_STORE
+        fi
+    fi
+}
+# Guard against duplicate sourcing
+if [[ ":${PROMPT_COMMAND}:" != *":uteke_prompt_hook:"* ]]; then
+    PROMPT_COMMAND="uteke_prompt_hook;${PROMPT_COMMAND}"
+fi

--- a/crates/uteke-cli/assets/shell/uteke-hook.fish
+++ b/crates/uteke-cli/assets/shell/uteke-hook.fish
@@ -1,0 +1,22 @@
+# Uteke shell hook for Fish
+# Add to ~/.config/fish/config.fish: uteke hook fish | source
+function __uteke_find_project
+    set -l dir $PWD
+    while test "$dir" != "/"
+        if test -f "$dir/.uteke/uteke.db"
+            echo "$dir/.uteke"
+            return 0
+        end
+        set dir (dirname "$dir")
+    end
+    return 1
+end
+
+function __uteke_directory_change --on-variable PWD
+    set -l project_store (__uteke_find_project)
+    if test -n "$project_store"
+        set -gx UTEKE_PROJECT_STORE "$project_store"
+    else
+        set -e UTEKE_PROJECT_STORE
+    end
+end

--- a/crates/uteke-cli/assets/shell/uteke-hook.zsh
+++ b/crates/uteke-cli/assets/shell/uteke-hook.zsh
@@ -1,0 +1,26 @@
+# Uteke shell hook for Zsh
+# Add to ~/.zshrc: eval "$(uteke hook zsh)"
+_uteke_find_project() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.uteke/uteke.db" ]]; then
+            echo "$dir/.uteke"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+uteke_chpwd() {
+    local project_store
+    if project_store="$(_uteke_find_project)"; then
+        export UTEKE_PROJECT_STORE="$project_store"
+    else
+        unset UTEKE_PROJECT_STORE
+    fi
+}
+# Guard against duplicate sourcing
+if [[ " ${chpwd_functions[@]} " != *" uteke_chpwd "* ]]; then
+    chpwd_functions+=(uteke_chpwd)
+fi

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -144,9 +144,9 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
         Commands::Hook { shell } => {
             use crate::SupportedShell;
             let script = match shell {
-                SupportedShell::Bash => include_str!("../../../../scripts/shell/uteke-hook.bash"),
-                SupportedShell::Zsh => include_str!("../../../../scripts/shell/uteke-hook.zsh"),
-                SupportedShell::Fish => include_str!("../../../../scripts/shell/uteke-hook.fish"),
+                SupportedShell::Bash => include_str!("../../assets/shell/uteke-hook.bash"),
+                SupportedShell::Zsh => include_str!("../../assets/shell/uteke-hook.zsh"),
+                SupportedShell::Fish => include_str!("../../assets/shell/uteke-hook.fish"),
             };
             print!("{script}");
             Ok(())


### PR DESCRIPTION
Shell hook scripts were referenced via `include_str!` with paths outside the crate root. crates.io only packages files within the crate directory, so publish failed.

Moves shell hooks to `crates/uteke-cli/assets/shell/` and updates include paths.