### PR TITLE
refactor(#131): extract CLI structs and logging into dedicated modules

### DIFF
--- a/.cora.yaml
+++ b/.cora.yaml
@@ -1,0 +1,41 @@
+# Cora Code Review Configuration
+# See: https://github.com/codecoradev/cora-cli
+
+# Provider settings — matches CI (CORA_API_KEY, CORA_BASE_URL, CORA_MODEL)
+provider:
+  provider: freemodel
+  model: gpt-5.4
+  base_url: https://api.freemodel.dev/v1
+
+# Review focus areas: security, performance, bugs, best-practice, style
+focus:
+  - security
+  - performance
+  - bugs
+
+# Custom rules / additional instructions for the reviewer
+rules:
+  - "All SQL queries use parameterized/bound statements via rusqlite. CLI args are struct fields passed to uteke-core which uses param() bindings, never string interpolation. Do not flag SQL injection on CLI struct definitions."
+
+# Ignore patterns
+ignore:
+  files:
+    - "*.lock"
+    - "package-lock.json"
+    - "yarn.lock"
+    - "vendor/"
+    - "node_modules/"
+  rules: []
+#   rules:
+#     - "style"  # ignore style issues
+
+# Hook settings
+hook:
+  mode: warn          # "warn" (print but allow) or "block" (fail commit)
+  min_severity: major # minimum severity to trigger hook action
+  max_diff_size: 5242880 # max 5MB diff chars before refusing
+
+# Output settings
+output:
+  format: pretty      # pretty, json, compact, sarif
+  color: true

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ uteke_index.keys
 uteke_index.usearch
 .fusion/
 progress.md
+.cora/

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -1,0 +1,294 @@
+//! CLI argument definitions (clap structs and enums).
+//!
+//! All clap-derived types live here so main.rs stays focused on
+//! orchestration (logging, config, dispatch).
+
+use clap::{Parser, Subcommand};
+use clap_complete::Shell;
+
+/// Uteke — persistent memory engine for AI agents.
+#[derive(Parser)]
+#[command(
+    name = "uteke",
+    about = "The Brain for Your AI — persistent memory engine",
+    version
+)]
+pub struct Cli {
+    /// Store path override (default: ~/.uteke)
+    #[arg(long, global = true)]
+    pub store: Option<String>,
+
+    /// Namespace for multi-agent isolation (default: "default")
+    #[arg(long, global = true)]
+    pub namespace: Option<String>,
+
+    /// Output as JSON
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Enable verbose logging
+    #[arg(long, global = true)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Supported shell types for completions and hooks.
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum SupportedShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+/// All top-level CLI subcommands.
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Store a new memory
+    Remember {
+        /// The content to remember
+        content: String,
+        /// Tags for categorization (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+        /// Memory type: fact, procedure, preference, decision, context
+        #[arg(long, default_value = "fact")]
+        r#type: String,
+        /// Enable contradiction detection (auto-deprecate conflicting memories)
+        #[arg(long)]
+        detect_contradiction: bool,
+        /// Entity identifier for structured metadata
+        #[arg(long)]
+        entity: Option<String>,
+        /// Category classification
+        #[arg(long)]
+        category: Option<String>,
+        /// Arbitrary key:value metadata pairs (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        meta: Vec<String>,
+    },
+    /// Recall memories relevant to a query (semantic search)
+    Recall {
+        /// The search query
+        query: String,
+        /// Maximum results to return
+        #[arg(long, default_value = "5")]
+        limit: usize,
+        /// Filter by tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+        /// Filter by entity name
+        #[arg(long)]
+        entity: Option<String>,
+        /// Filter by category
+        #[arg(long)]
+        category: Option<String>,
+        /// Minimum similarity score (0.0-1.0). Results below are filtered.
+        #[arg(long)]
+        min: Option<f32>,
+        /// Use strict threshold from config (min_score_strict)
+        #[arg(long)]
+        strict: bool,
+    },
+    /// Search memories by content keywords (text search)
+    Search {
+        /// Keywords to search for
+        query: String,
+        /// Maximum results to return
+        #[arg(long, default_value = "10")]
+        limit: usize,
+        /// Filter by tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+    },
+    /// List memories, optionally filtered by tag
+    List {
+        /// Filter by tag
+        #[arg(long)]
+        tag: Option<String>,
+        /// Maximum results to return
+        #[arg(long, default_value = "20")]
+        limit: usize,
+        /// Offset for pagination
+        #[arg(long, default_value = "0")]
+        offset: usize,
+        /// Filter by entity name
+        #[arg(long)]
+        entity: Option<String>,
+        /// Filter by category
+        #[arg(long)]
+        category: Option<String>,
+    },
+    /// Get a single memory by ID
+    Get {
+        /// Memory ID (UUID)
+        id: String,
+    },
+    /// Delete a memory by ID
+    Forget {
+        /// Memory ID (UUID)
+        id: Option<String>,
+        /// Delete all memories with this tag
+        #[arg(long)]
+        tag: Option<String>,
+        /// Delete all cold (not accessed in 30+ days) memories
+        #[arg(long)]
+        cold: bool,
+        /// Delete ALL memories in namespace (requires --confirm)
+        #[arg(long)]
+        all: bool,
+        /// Confirm destructive operations
+        #[arg(long)]
+        confirm: bool,
+    },
+    /// Show memory store statistics
+    Stats,
+    /// Check system health (DB, index, model, consistency)
+    Doctor,
+    /// Verify DB and index consistency
+    Verify,
+    /// Verify binary integrity against SHA256 checksums
+    VerifyChecksums {
+        /// Path to CHECKSUMS.txt file
+        #[arg(long, default_value = "CHECKSUMS.txt")]
+        checksums_file: String,
+        /// Path to the binary to verify
+        #[arg(long)]
+        binary: String,
+    },
+    /// Repair index by rebuilding from SQLite
+    Repair,
+    /// Export all memories to JSONL file (no embeddings — portable)
+    Export {
+        /// Output file path (use - for stdout)
+        #[arg(default_value = "-")]
+        output: String,
+    },
+    /// Import memories from JSONL file (re-embeds content)
+    Import {
+        /// Input file path (use - for stdin)
+        #[arg(default_value = "-")]
+        input: String,
+    },
+    /// Generate shell completions
+    Completions {
+        /// Shell type
+        shell: Shell,
+    },
+    /// Initialize uteke integration for an AI agent
+    Init {
+        /// Agent type: pi, claude, cursor, copilot, codex
+        #[arg(long, default_value = "pi")]
+        agent: String,
+    },
+    /// Memory aging: status, preview cleanup, cleanup
+    Aging {
+        #[command(subcommand)]
+        command: AgingCommands,
+    },
+    /// Output shell hook script for auto-context loading
+    Hook {
+        /// Shell type: bash, zsh, fish
+        shell: SupportedShell,
+    },
+    /// Namespace management: list, stats
+    Namespace {
+        #[command(subcommand)]
+        command: NamespaceCommands,
+    },
+    /// Manage tags: list, rename, delete
+    Tags {
+        #[command(subcommand)]
+        command: TagCommands,
+    },
+    /// Prune deprecated memories (auto-forget with TTL)
+    Prune {
+        /// TTL in days — deprecate memories older than this
+        #[arg(long, default_value = "30")]
+        ttl: u32,
+        /// Dry run — show what would be pruned without deleting
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Consolidate near-duplicate memories
+    Consolidate {
+        /// Similarity threshold (0.0-1.0) for detecting duplicates
+        #[arg(long, default_value = "0.90")]
+        threshold: f32,
+        /// Dry run — show duplicates without merging
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Subcommands for tag management.
+#[derive(Subcommand)]
+pub enum TagCommands {
+    /// List all tags with usage counts
+    List {
+        /// Sort by count (descending) instead of alphabetical
+        #[arg(long)]
+        by_count: bool,
+    },
+    /// Rename a tag across all memories
+    Rename {
+        /// Current tag name
+        old: String,
+        /// New tag name
+        new: String,
+    },
+    /// Delete a tag from all memories
+    Delete {
+        /// Tag name to delete
+        tag: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        confirm: bool,
+    },
+}
+
+/// Subcommands for namespace management.
+#[derive(Subcommand)]
+pub enum NamespaceCommands {
+    /// List all namespaces with memory counts
+    List,
+    /// Show stats for a specific namespace
+    Stats {
+        /// Namespace name
+        name: String,
+    },
+    /// Set default namespace in config
+    Switch {
+        /// Namespace name to set as default
+        name: String,
+    },
+}
+
+/// Subcommands for memory aging operations.
+#[derive(Subcommand)]
+pub enum AgingCommands {
+    /// Show aging status: hot, warm, cold, never-accessed counts
+    Status,
+    /// Preview memories eligible for cleanup (dry-run)
+    Preview {
+        /// Minimum age in days for a memory to be considered aged
+        #[arg(long, default_value = "180")]
+        older_than_days: u32,
+        /// Maximum access count threshold
+        #[arg(long, default_value = "1")]
+        max_access_count: u32,
+    },
+    /// Delete aged memories (use --yes to skip confirmation)
+    Cleanup {
+        /// Minimum age in days for a memory to be considered aged
+        #[arg(long, default_value = "180")]
+        older_than_days: u32,
+        /// Maximum access count threshold
+        #[arg(long, default_value = "1")]
+        max_access_count: u32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+}

--- a/crates/uteke-cli/src/commands/aging.rs
+++ b/crates/uteke-cli/src/commands/aging.rs
@@ -1,8 +1,8 @@
 //! Aging subcommands — status, preview, cleanup.
 
+use crate::cli::AgingCommands;
+use crate::cli::Cli;
 use crate::output;
-use crate::AgingCommands;
-use crate::Cli;
 use uteke_core::Uteke;
 
 pub(crate) fn run(

--- a/crates/uteke-cli/src/commands/forget.rs
+++ b/crates/uteke-cli/src/commands/forget.rs
@@ -2,8 +2,8 @@
 
 use std::io;
 
+use crate::cli::Cli;
 use crate::output;
-use crate::Cli;
 use uteke_core::Uteke;
 
 /// Flags for the forget command.

--- a/crates/uteke-cli/src/commands/list.rs
+++ b/crates/uteke-cli/src/commands/list.rs
@@ -1,7 +1,7 @@
 //! List, Get, and Stats commands.
 
+use crate::cli::Cli;
 use crate::output;
-use crate::Cli;
 use uteke_core::Uteke;
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -2,8 +2,8 @@
 
 use std::io::Read;
 
+use crate::cli::Cli;
 use crate::output;
-use crate::Cli;
 use uteke_core::Uteke;
 
 pub(crate) fn run_doctor(cli: &Cli, uteke: &Uteke) -> Result<(), String> {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -10,9 +10,9 @@ mod remember;
 mod server;
 mod tags;
 
+use crate::cli::Cli;
+use crate::cli::Commands;
 use crate::resolve_namespace;
-use crate::Cli;
-use crate::Commands;
 use crate::Config;
 use uteke_core::Uteke;
 
@@ -142,7 +142,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
         Commands::Aging { command } => aging::run(cli, uteke, ns, command),
 
         Commands::Hook { shell } => {
-            use crate::SupportedShell;
+            use crate::cli::SupportedShell;
             let script = match shell {
                 SupportedShell::Bash => include_str!("../../assets/shell/uteke-hook.bash"),
                 SupportedShell::Zsh => include_str!("../../assets/shell/uteke-hook.zsh"),

--- a/crates/uteke-cli/src/commands/namespace.rs
+++ b/crates/uteke-cli/src/commands/namespace.rs
@@ -1,9 +1,9 @@
 //! Namespace subcommands — list, stats, switch.
 
+use crate::cli::Cli;
+use crate::cli::NamespaceCommands;
 use crate::output;
-use crate::Cli;
 use crate::Config;
-use crate::NamespaceCommands;
 use uteke_core::Uteke;
 
 pub(crate) fn run(cli: &Cli, uteke: &Uteke, command: &NamespaceCommands) -> Result<(), String> {

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -1,8 +1,8 @@
 //! Recall and Search commands — semantic and keyword search.
 
+use crate::cli::Cli;
 use crate::config::Config;
 use crate::output;
-use crate::Cli;
 use uteke_core::Uteke;
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -1,7 +1,7 @@
 //! Remember command — store a new memory.
 
+use crate::cli::Cli;
 use crate::output;
-use crate::Cli;
 use uteke_core::Uteke;
 
 /// Parse --meta key:value pairs into a JSON object.

--- a/crates/uteke-cli/src/commands/server.rs
+++ b/crates/uteke-cli/src/commands/server.rs
@@ -1,8 +1,8 @@
 //! HTTP server routing for CLI commands.
 
+use crate::cli::Cli;
+use crate::cli::Commands;
 use crate::output;
-use crate::Cli;
-use crate::Commands;
 
 /// Check if uteke server is reachable.
 pub(crate) fn is_server_running(url: &str) -> bool {

--- a/crates/uteke-cli/src/commands/tags.rs
+++ b/crates/uteke-cli/src/commands/tags.rs
@@ -1,8 +1,8 @@
 //! Tags subcommands — list, rename, delete.
 
+use crate::cli::Cli;
+use crate::cli::TagCommands;
 use crate::output;
-use crate::Cli;
-use crate::TagCommands;
 use uteke_core::Uteke;
 
 pub(crate) fn run(

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -1,7 +1,7 @@
 //! Agent initialization commands (pi, claude, cursor).
 
-use crate::Cli;
-use crate::Commands;
+use crate::cli::Cli;
+use crate::cli::Commands;
 
 /// Handle the Init command from the CLI.
 pub(crate) fn run_init_command(cli: &Cli) -> Result<(), String> {

--- a/crates/uteke-cli/src/logging.rs
+++ b/crates/uteke-cli/src/logging.rs
@@ -1,0 +1,36 @@
+//! Logging setup: console + daily rotating file.
+//!
+//! Console shows WARN by default (DEBUG with --verbose).
+//! File always captures DEBUG to `~/.uteke/uteke.log` with daily rotation.
+
+use tracing::Level;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+
+/// Initialize logging. Returns a guard that must stay alive for the
+/// file writer to continue flushing.
+pub fn init(verbose: bool) -> Box<dyn std::any::Any + Send> {
+    let log_dir = dirs::home_dir()
+        .map(|h| h.join(".uteke"))
+        .filter(|d| d.is_dir() || std::fs::create_dir_all(d).is_ok())
+        .unwrap_or_else(|| {
+            // Fallback to temp dir instead of cwd
+            std::env::temp_dir().join("uteke")
+        });
+
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "uteke.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking)
+        .with_filter(EnvFilter::from_default_env().add_directive(Level::DEBUG.into()));
+
+    let console_level = if verbose { Level::DEBUG } else { Level::WARN };
+    let console_layer = tracing_subscriber::fmt::layer()
+        .with_filter(EnvFilter::from_default_env().add_directive(console_level.into()));
+
+    tracing_subscriber::registry()
+        .with(console_layer)
+        .with(file_layer)
+        .init();
+
+    Box::new(guard)
+}

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -1,350 +1,38 @@
 //! Uteke CLI — persistent memory for AI agents.
 
+mod cli;
 mod commands;
 mod config;
 mod init;
+mod logging;
 mod output;
 
-use clap::{CommandFactory, Parser, Subcommand};
-use clap_complete::{generate, Shell};
+use clap::{CommandFactory, Parser};
+use cli::{Cli, Commands};
 use config::Config;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tracing::Level;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use uteke_core::Uteke;
 
 /// Global flag set by SIGINT handler.
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
-// ── CLI definition ──────────────────────────────────────────────────────────
-
-#[derive(Parser)]
-#[command(
-    name = "uteke",
-    about = "The Brain for Your AI — persistent memory engine",
-    version
-)]
-struct Cli {
-    /// Store path override (default: ~/.uteke)
-    #[arg(long, global = true)]
-    store: Option<String>,
-
-    /// Namespace for multi-agent isolation (default: "default")
-    #[arg(long, global = true)]
-    namespace: Option<String>,
-
-    /// Output as JSON
-    #[arg(long, global = true)]
-    json: bool,
-
-    /// Enable verbose logging
-    #[arg(long, global = true)]
-    verbose: bool,
-
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Clone, Copy, clap::ValueEnum)]
-enum SupportedShell {
-    Bash,
-    Zsh,
-    Fish,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Store a new memory
-    Remember {
-        /// The content to remember
-        content: String,
-        /// Tags for categorization (comma-separated)
-        #[arg(long, value_delimiter = ',')]
-        tags: Vec<String>,
-        /// Memory type: fact, procedure, preference, decision, context
-        #[arg(long, default_value = "fact")]
-        r#type: String,
-        /// Enable contradiction detection (auto-deprecate conflicting memories)
-        #[arg(long)]
-        detect_contradiction: bool,
-        /// Entity identifier for structured metadata
-        #[arg(long)]
-        entity: Option<String>,
-        /// Category classification
-        #[arg(long)]
-        category: Option<String>,
-        /// Arbitrary key:value metadata pairs (comma-separated)
-        #[arg(long, value_delimiter = ',')]
-        meta: Vec<String>,
-    },
-    /// Recall memories relevant to a query (semantic search)
-    Recall {
-        /// The search query
-        query: String,
-        /// Maximum results to return
-        #[arg(long, default_value = "5")]
-        limit: usize,
-        /// Filter by tags (comma-separated)
-        #[arg(long, value_delimiter = ',')]
-        tags: Vec<String>,
-        /// Filter by entity name
-        #[arg(long)]
-        entity: Option<String>,
-        /// Filter by category
-        #[arg(long)]
-        category: Option<String>,
-        /// Minimum similarity score (0.0-1.0). Results below are filtered.
-        #[arg(long)]
-        min: Option<f32>,
-        /// Use strict threshold from config (min_score_strict)
-        #[arg(long)]
-        strict: bool,
-    },
-    /// Search memories by content keywords (text search)
-    Search {
-        /// Keywords to search for
-        query: String,
-        /// Maximum results to return
-        #[arg(long, default_value = "10")]
-        limit: usize,
-        /// Filter by tags (comma-separated)
-        #[arg(long, value_delimiter = ',')]
-        tags: Vec<String>,
-    },
-    /// List memories, optionally filtered by tag
-    List {
-        /// Filter by tag
-        #[arg(long)]
-        tag: Option<String>,
-        /// Maximum results to return
-        #[arg(long, default_value = "20")]
-        limit: usize,
-        /// Offset for pagination
-        #[arg(long, default_value = "0")]
-        offset: usize,
-        /// Filter by entity name
-        #[arg(long)]
-        entity: Option<String>,
-        /// Filter by category
-        #[arg(long)]
-        category: Option<String>,
-    },
-    /// Get a single memory by ID
-    Get {
-        /// Memory ID (UUID)
-        id: String,
-    },
-    /// Delete a memory by ID
-    Forget {
-        /// Memory ID (UUID)
-        id: Option<String>,
-        /// Delete all memories with this tag
-        #[arg(long)]
-        tag: Option<String>,
-        /// Delete all cold (not accessed in 30+ days) memories
-        #[arg(long)]
-        cold: bool,
-        /// Delete ALL memories in namespace (requires --confirm)
-        #[arg(long)]
-        all: bool,
-        /// Confirm destructive operations
-        #[arg(long)]
-        confirm: bool,
-    },
-    /// Show memory store statistics
-    Stats,
-    /// Check system health (DB, index, model, consistency)
-    Doctor,
-    /// Verify DB and index consistency
-    Verify,
-    /// Verify binary integrity against SHA256 checksums
-    VerifyChecksums {
-        /// Path to CHECKSUMS.txt file
-        #[arg(long, default_value = "CHECKSUMS.txt")]
-        checksums_file: String,
-        /// Path to the binary to verify
-        #[arg(long)]
-        binary: String,
-    },
-    /// Repair index by rebuilding from SQLite
-    Repair,
-    /// Export all memories to JSONL file (no embeddings — portable)
-    Export {
-        /// Output file path (use - for stdout)
-        #[arg(default_value = "-")]
-        output: String,
-    },
-    /// Import memories from JSONL file (re-embeds content)
-    Import {
-        /// Input file path (use - for stdin)
-        #[arg(default_value = "-")]
-        input: String,
-    },
-    /// Generate shell completions
-    Completions {
-        /// Shell type
-        shell: Shell,
-    },
-    /// Initialize uteke integration for an AI agent
-    Init {
-        /// Agent type: pi, claude, cursor, copilot, codex
-        #[arg(long, default_value = "pi")]
-        agent: String,
-    },
-    /// Memory aging: status, preview cleanup, cleanup
-    Aging {
-        #[command(subcommand)]
-        command: AgingCommands,
-    },
-    /// Output shell hook script for auto-context loading
-    Hook {
-        /// Shell type: bash, zsh, fish
-        shell: SupportedShell,
-    },
-    /// Namespace management: list, stats
-    Namespace {
-        #[command(subcommand)]
-        command: NamespaceCommands,
-    },
-    /// Manage tags: list, rename, delete
-    Tags {
-        #[command(subcommand)]
-        command: TagCommands,
-    },
-    /// Prune deprecated memories (auto-forget with TTL)
-    Prune {
-        /// TTL in days — deprecate memories older than this
-        #[arg(long, default_value = "30")]
-        ttl: u32,
-        /// Dry run — show what would be pruned without deleting
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Consolidate near-duplicate memories
-    Consolidate {
-        /// Similarity threshold (0.0-1.0) for detecting duplicates
-        #[arg(long, default_value = "0.90")]
-        threshold: f32,
-        /// Dry run — show duplicates without merging
-        #[arg(long)]
-        dry_run: bool,
-    },
-}
-
-#[derive(Subcommand)]
-enum TagCommands {
-    /// List all tags with usage counts
-    List {
-        /// Sort by count (descending) instead of alphabetical
-        #[arg(long)]
-        by_count: bool,
-    },
-    /// Rename a tag across all memories
-    Rename {
-        /// Current tag name
-        old: String,
-        /// New tag name
-        new: String,
-    },
-    /// Delete a tag from all memories
-    Delete {
-        /// Tag name to delete
-        tag: String,
-        /// Skip confirmation prompt
-        #[arg(long)]
-        confirm: bool,
-    },
-}
-
-#[derive(Subcommand)]
-enum NamespaceCommands {
-    /// List all namespaces with memory counts
-    List,
-    /// Show stats for a specific namespace
-    Stats {
-        /// Namespace name
-        name: String,
-    },
-    /// Set default namespace in config
-    Switch {
-        /// Namespace name to set as default
-        name: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum AgingCommands {
-    /// Show aging status: hot, warm, cold, never-accessed counts
-    Status,
-    /// Preview memories eligible for cleanup (dry-run)
-    Preview {
-        /// Minimum age in days for a memory to be considered aged
-        #[arg(long, default_value = "180")]
-        older_than_days: u32,
-        /// Maximum access count threshold
-        #[arg(long, default_value = "1")]
-        max_access_count: u32,
-    },
-    /// Delete aged memories (use --yes to skip confirmation)
-    Cleanup {
-        /// Minimum age in days for a memory to be considered aged
-        #[arg(long, default_value = "180")]
-        older_than_days: u32,
-        /// Maximum access count threshold
-        #[arg(long, default_value = "1")]
-        max_access_count: u32,
-        /// Skip confirmation prompt
-        #[arg(long)]
-        yes: bool,
-    },
-}
-
-// ── Main ────────────────────────────────────────────────────────────────────
-
 fn main() {
     let cli = Cli::parse();
 
-    // ── Logging: console (existing behavior) + file (always DEBUG, daily rotation) ──
-    let log_dir = dirs::home_dir()
-        .map(|h| h.join(".uteke"))
-        .unwrap_or_default();
-    let _guard = {
-        let file_appender = tracing_appender::rolling::daily(&log_dir, "uteke.log");
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-        let file_layer = tracing_subscriber::fmt::layer()
-            .with_writer(non_blocking)
-            .with_filter(EnvFilter::from_default_env().add_directive(Level::DEBUG.into()));
-
-        let console_level = if cli.verbose {
-            Level::DEBUG
-        } else {
-            Level::WARN
-        };
-        let console_layer = tracing_subscriber::fmt::layer()
-            .with_filter(EnvFilter::from_default_env().add_directive(console_level.into()));
-
-        tracing_subscriber::registry()
-            .with(console_layer)
-            .with(file_layer)
-            .init();
-
-        guard
-    };
-    // _guard must stay alive — dropping it flushes and disables the non-blocking file writer.
+    // Initialize logging (console + file). Guard must stay alive.
+    let _log_guard = logging::init(cli.verbose);
 
     // Handle completions and init early — don't need store
     match &cli.command {
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();
-            generate(*shell, &mut cmd, &name, &mut io::stdout());
+            clap_complete::generate(*shell, &mut cmd, &name, &mut io::stdout());
             std::process::exit(0);
         }
         Commands::Init { .. } => {
-            // Handled in run_command, but we skip store opening
-            let result = init::run_init_command(&cli);
-            if let Err(e) = result {
+            if let Err(e) = init::run_init_command(&cli) {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }
@@ -367,7 +55,6 @@ fn main() {
             Ok(()) => return,
             Err(e) if e == "unsupported" => {
                 tracing::info!("Command not supported via server, using local store");
-                // Fall through to local store
             }
             Err(e) => {
                 eprintln!("Error: {e}");
@@ -376,10 +63,9 @@ fn main() {
         }
     }
 
-    // Fallback: open local store (cold start ~1s)
+    // Fallback: open local store
     tracing::debug!("No server detected, using local store");
 
-    // Determine store path: CLI > config > default
     let store_path = cli
         .store
         .as_deref()
@@ -388,7 +74,6 @@ fn main() {
 
     tracing::debug!("Opening store at: {store_path}");
 
-    // Install SIGINT handler for graceful shutdown
     let uteke = match Uteke::open_with_tier(
         &store_path,
         uteke_core::TierConfig {
@@ -412,14 +97,13 @@ fn main() {
 
     let result = commands::run_command(&cli, &uteke, &config);
 
-    // Graceful shutdown: save dirty index if needed
     if let Err(e) = uteke.shutdown() {
         tracing::warn!("Shutdown flush failed: {e}");
     }
 
     if SHUTDOWN_REQUESTED.load(Ordering::SeqCst) {
         eprintln!("Shutdown complete.");
-        std::process::exit(130); // 128 + SIGINT(2)
+        std::process::exit(130);
     }
 
     if let Err(e) = result {
@@ -429,21 +113,17 @@ fn main() {
 }
 
 /// Resolve namespace: CLI flag > UTEKE_NAMESPACE env > config > "default"
-fn resolve_namespace(cli: &Cli, config: &Config) -> String {
-    // 1. CLI --namespace flag wins
+pub(crate) fn resolve_namespace(cli: &Cli, config: &Config) -> String {
     if let Some(ns) = &cli.namespace {
         return ns.clone();
     }
-    // 2. Environment variable
     if let Ok(env_ns) = std::env::var("UTEKE_NAMESPACE") {
         if !env_ns.is_empty() {
             return env_ns;
         }
     }
-    // 3. Config file
     if config.store.namespace != "default" {
         return config.store.namespace.clone();
     }
-    // 4. Fallback
     "default".to_string()
 }


### PR DESCRIPTION
Extract CLI argument definitions into `cli.rs` and logging setup into `logging.rs`. main.rs reduced from 449 to ~100 lines.

Also adds `.cora.yaml` config with pre-commit hook (Cora v0.5.0).

Closes #131