### PR TITLE
Release v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Uteke will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.15] — 2026-06-12
 
 ### Changed
 
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `doctor`, and `verify` start instantly without waiting for model load.
   Commands that need embedding (`remember`, `recall`, `search`) still take
   ~3s on first use per process invocation.
+- **Refactor CLI into modular structure** (#131)
+  CLI argument definitions extracted to `cli.rs`, logging setup to `logging.rs`.
+  main.rs reduced from 449 to ~100 lines for easier maintenance.
+- Release workflow now decoupled: crates.io publish runs in parallel with
+  builds, GitHub Release only waits for builds. Single platform failure
+  no longer blocks release.
+- Shell hook scripts inlined into uteke-cli crate for crates.io compatibility.
+- Added `.cora.yaml` config and pre-commit hook (Cora v0.5.0).
 
 ## [0.0.14] — 2026-06-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "chrono",
  "dirs",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "ctrlc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.14"
+version = "0.0.15"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.0.14" }
+uteke-core = { path = "../uteke-core", version = "0.0.15" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.0.14" }
+uteke-core = { path = "../uteke-core", version = "0.0.15" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
Version bump to 0.0.15 + CHANGELOG.

## Changes since v0.0.14
- **Lazy ONNX init** — non-embedding commands ~3s → ~20ms (#185)
- **CLI modular refactor** — main.rs 449 → ~100 lines (#131)
- **Release workflow decoupled** — builds and crates.io publish run in parallel
- **Cora pre-commit hook** — v0.5.0 with .cora.yaml config

After merge: tag v0.0.15 to trigger release workflow.