### PR TITLE
feat(#286): room-based collaborative memory for multi-agent discussions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.0.14
+- **Version:** 0.0.15
 - **License:** Apache 2.0
 - **Main branches:** `develop` (all PRs go here), `main` (release)
 
@@ -48,11 +48,21 @@ crates/uteke-core/src/
     └── vector.rs       # Vector index management
 
 crates/uteke-cli/src/
-├── main.rs             # Entry point, clap app definition
+├── main.rs             # Entry point (logging, config, dispatch)
+├── cli.rs              # Clap structs + enums (Cli, Commands, etc.)
+├── config.rs           # Config file loading (uteke.toml)
+├── logging.rs          # Console + daily file appender setup
+├── output.rs           # Print helpers (human + JSON formatters)
+├── init.rs             # Agent init (pi, claude, cursor, copilot, codex)
+├── bench.rs            # Benchmark helpers
+├── assets/shell/       # Shell hook scripts (include_str! at compile time)
+│   ├── uteke-hook.bash
+│   ├── uteke-hook.zsh
+│   └── uteke-hook.fish
 └── commands/
-    ├── mod.rs
+    ├── mod.rs           # Command dispatch
     ├── remember.rs      # --entity, --category, --meta flags
-    ├── recall.rs        # --entity, --category filter
+    ├── recall.rs        # --entity, --category filter, hybrid search
     ├── list.rs          # --entity, --category filter
     ├── server.rs        # HTTP proxy to uteke-serve
     └── ...              # Other per-command modules
@@ -187,6 +197,32 @@ If a CI check fails:
 
 Principle: **Red CI = there's a problem. Investigate first, don't assume.**
 
+### 11. Release Tags Require Approval
+
+**Never push a `v*` tag without explicit approval.** The tag triggers the release workflow which:
+- Publishes to crates.io (irreversible)
+- Builds 4 platform binaries
+- Creates GitHub Release
+- Pushes Docker image
+- Deploys docs
+
+Before tagging:
+1. All PRs for the version must be merged
+2. Run `cargo publish --dry-run --allow-dirty -p uteke-core && cargo publish --dry-run --allow-dirty -p uteke-cli && cargo publish --dry-run --allow-dirty -p uteke-server` locally
+3. Verify CHANGELOG is complete and version bumped
+4. Get approval from project owner
+5. Then tag and push
+
+### 12. Always Run Cora Pre-Commit Hook
+
+The `cora hook install` pre-commit hook runs on every `git commit`. Do NOT bypass with `--no-verify` unless the Cora API is down. The hook catches real issues before they reach CI.
+
+```bash
+# Pre-commit hook is auto-installed at .git/hooks/pre-commit
+# Verify it works:
+cora review --staged --format compact
+```
+
 ---
 
 ## Lessons Learned — From Real Experience
@@ -244,6 +280,27 @@ Run manual stress tests after significant changes.
 ### Documentation Gets Outdated Quickly
 
 CONTRIBUTING.md once said "2 crates" when it had been 3 since v0.0.4. Version badge was behind. **Always update docs before commit** — see Critical Rule #8.
+
+### crates.io Publish Requires All Files Inside the Crate Directory
+
+v0.0.14 release failed 3 times because:
+1. **Intra-workspace dependencies need `version` field** — `uteke-cli` depended on `uteke-core` with only `path`, but crates.io requires `version = "x.y.z"`
+2. **`include_str!` paths must be within the crate root** — shell hooks were in `scripts/shell/` (repo root), outside `crates/uteke-cli/`. `cargo publish` only packages files within the crate directory.
+3. **Windows build failure blocked GitHub Release** — release job depended on both `build-release` AND `publish-crates`, so one platform failure blocked everything.
+
+**Fix:** Run `cargo publish --dry-run --allow-dirty` locally before tagging. Decouple publish from release.
+
+### Re-tagging Is Destructive and Confusing
+
+Deleting and re-pushing a tag triggers a new release workflow but leaves stale state on crates.io (partial publish). Always verify locally with `--dry-run` before pushing any tag.
+
+### Pre-commit Hooks Prevent Dumb Mistakes
+
+Cora pre-commit hook (`cora hook install`) catches issues before they reach CI. Found real bugs like log directory not created before appender init, and false-positive SQL injection flags on CLI struct definitions.
+
+### Lazy Initialization for Cold Start
+
+ONNX model load takes ~2.5s. Wrapping `embedder` in `Mutex<Option<EmbeddingEngine>>` and lazy-loading on first `embed()` call makes all non-embedding commands (list, stats, tags, get, forget, namespace, aging, export, doctor, verify) start in ~20ms instead of ~3s. The key insight: **not every command needs every expensive resource**.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Uteke will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Room-based collaborative memory for multi-agent discussions** (#286)
+  - `uteke remember --room <id> --author <name>` — store memory in a shared room
+  - `uteke room list` — list all rooms
+  - `uteke room stats <id>` — room metadata, participants, memory count
+  - `uteke room recall <id>` — cross-namespace recall of all room memories
+  - `uteke room recall <id> --author <name>` — filter by author
+  - `uteke room delete <id>` — delete room links (memories preserved)
+  - Schema v3: `rooms` + `room_memories` tables with auto-migration
+  - Dual-write: memories exist in agent namespace AND linked to room
+
 ## [0.0.15] — 2026-06-12
 
 ### Changed

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -67,6 +67,12 @@ pub enum Commands {
         /// Arbitrary key:value metadata pairs (comma-separated)
         #[arg(long, value_delimiter = ',')]
         meta: Vec<String>,
+        /// Room ID to link this memory to (collaborative context)
+        #[arg(long)]
+        room: Option<String>,
+        /// Author attribution when storing in a room
+        #[arg(long)]
+        author: Option<String>,
     },
     /// Recall memories relevant to a query (semantic search)
     Recall {
@@ -220,6 +226,11 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Room management: list, stats, recall
+    Room {
+        #[command(subcommand)]
+        command: RoomCommands,
+    },
 }
 
 /// Subcommands for tag management.
@@ -262,6 +273,41 @@ pub enum NamespaceCommands {
     Switch {
         /// Namespace name to set as default
         name: String,
+    },
+}
+
+/// Subcommands for room management.
+#[derive(Subcommand)]
+pub enum RoomCommands {
+    /// List all rooms
+    List {
+        /// Filter by namespace
+        #[arg(long)]
+        namespace: Option<String>,
+    },
+    /// Show room statistics and participants
+    Stats {
+        /// Room ID
+        room_id: String,
+    },
+    /// Recall all memories in a room (cross-namespace)
+    Recall {
+        /// Room ID
+        room_id: String,
+        /// Filter by author
+        #[arg(long)]
+        author: Option<String>,
+        /// Maximum results to return
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
+    /// Delete a room (memories are NOT deleted, only room links)
+    Delete {
+        /// Room ID
+        room_id: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        confirm: bool,
     },
 }
 

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod maintenance;
 mod namespace;
 mod recall;
 mod remember;
+mod room;
 mod server;
 mod tags;
 
@@ -33,6 +34,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             entity,
             category,
             meta,
+            room,
+            author,
         } => remember::run(
             cli,
             uteke,
@@ -44,6 +47,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             entity.as_deref(),
             category.as_deref(),
             meta,
+            room.as_deref(),
+            author.as_deref(),
         ),
 
         Commands::Recall {
@@ -156,5 +161,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             checksums_file,
             binary,
         } => maintenance::run_verify_checksums(cli, checksums_file, binary),
+
+        Commands::Room { command } => crate::commands::room::run(cli, uteke, ns, command),
     }
 }

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -38,6 +38,8 @@ pub(crate) fn run(
     entity: Option<&str>,
     category: Option<&str>,
     meta: &[String],
+    room: Option<&str>,
+    author: Option<&str>,
 ) -> Result<(), String> {
     tracing::debug!("Remembering: {content} (type: {type}, contradiction: {detect_contradiction})");
     let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
@@ -106,9 +108,25 @@ pub(crate) fn run(
             }
         }
     } else {
-        let id = uteke
-            .remember(content, &tag_refs, metadata, ns)
-            .map_err(|e| format!("Failed to store memory: {e}"))?;
+        let id = if let Some(room_id) = room {
+            // Room mode: store memory and link to room with author
+            let author_name = author.unwrap_or("anonymous");
+            uteke
+                .remember_in_room(
+                    content,
+                    &tag_refs,
+                    metadata.clone(),
+                    ns,
+                    r#type,
+                    room_id,
+                    author_name,
+                )
+                .map_err(|e| format!("Failed to store memory in room: {e}"))?
+        } else {
+            uteke
+                .remember(content, &tag_refs, metadata, ns)
+                .map_err(|e| format!("Failed to store memory: {e}"))?
+        };
         tracing::info!("Memory stored with ID: {id}");
         if cli.json {
             let mut obj = serde_json::json!({"id": id});

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -1,0 +1,129 @@
+//! Room command handlers — list, stats, recall, delete.
+
+use crate::cli::{Cli, RoomCommands};
+use uteke_core::Uteke;
+
+pub(crate) fn run(
+    cli: &Cli,
+    uteke: &Uteke,
+    ns: Option<&str>,
+    command: &RoomCommands,
+) -> Result<(), String> {
+    match command {
+        RoomCommands::List { namespace } => {
+            let filter_ns = namespace.as_deref().or(ns);
+            let rooms = uteke
+                .list_rooms(filter_ns)
+                .map_err(|e| format!("Failed to list rooms: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&rooms).unwrap());
+            } else if rooms.is_empty() {
+                println!("No rooms found.");
+            } else {
+                println!("Found {} room(s):\n", rooms.len());
+                for room in &rooms {
+                    let title = room.title.as_deref().unwrap_or("(untitled)");
+                    println!("  {}  {}", room.id, title);
+                    println!(
+                        "    namespace: {}  created: {}",
+                        room.namespace,
+                        room.created_at.get(..19).unwrap_or(&room.created_at)
+                    );
+                }
+            }
+            Ok(())
+        }
+
+        RoomCommands::Stats { room_id } => {
+            let stats = uteke
+                .room_stats(room_id)
+                .map_err(|e| format!("Failed to get room stats: {e}"))?
+                .ok_or_else(|| format!("Room not found: {room_id}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&stats).unwrap());
+            } else {
+                println!("Room: {}", stats.room_id);
+                if let Some(title) = &stats.title {
+                    println!("  Title: {title}");
+                }
+                println!("  Memories: {}", stats.memory_count);
+                println!("  Participants: {}", stats.participant_count);
+                if !stats.participants.is_empty() {
+                    println!("    {}", stats.participants.join(", "));
+                }
+                println!(
+                    "  Created: {}",
+                    stats.created_at.get(..19).unwrap_or(&stats.created_at)
+                );
+                if let Some(last) = &stats.last_activity {
+                    println!("  Last activity: {}", last.get(..19).unwrap_or(last));
+                }
+            }
+            Ok(())
+        }
+
+        RoomCommands::Recall {
+            room_id,
+            author,
+            limit,
+        } => {
+            let memories = uteke
+                .recall_room(room_id, author.as_deref(), *limit)
+                .map_err(|e| format!("Failed to recall room: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&memories).unwrap());
+            } else if memories.is_empty() {
+                println!("No memories found in room {room_id}.");
+            } else {
+                println!(
+                    "Found {} memory/memories in room {}:\n",
+                    memories.len(),
+                    room_id
+                );
+                for (i, m) in memories.iter().enumerate() {
+                    let preview = if m.content.len() > 80 {
+                        format!("{}...", &m.content[..77])
+                    } else {
+                        m.content.clone()
+                    };
+                    let tags = if m.tags.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", m.tags.join(", "))
+                    };
+                    println!(
+                        "  {}. {} (ns: {}){}\n     ID: {}",
+                        i + 1,
+                        preview,
+                        m.namespace,
+                        tags,
+                        &m.id[..8],
+                    );
+                }
+            }
+            Ok(())
+        }
+
+        RoomCommands::Delete { room_id, confirm } => {
+            if !confirm {
+                eprintln!("This will delete room {room_id} and all memory links.");
+                eprintln!("Memories themselves are NOT deleted. Use --confirm to proceed.");
+                return Err("Operation not confirmed".to_string());
+            }
+
+            uteke
+                .delete_room(room_id)
+                .map_err(|e| format!("Failed to delete room: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::json!({"deleted": room_id}));
+            } else {
+                println!("Room {room_id} deleted. Memories are preserved in their namespaces.");
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/uteke-cli/src/commands/server.rs
+++ b/crates/uteke-cli/src/commands/server.rs
@@ -49,6 +49,8 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
             entity,
             category,
             meta,
+            room,
+            author,
         } => {
             let mut body = serde_json::json!({
                 "content": content,
@@ -79,6 +81,12 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
             }
             if !meta_map.is_empty() {
                 body["metadata"] = serde_json::Value::Object(meta_map);
+            }
+            if let Some(room_id) = room {
+                body["room"] = serde_json::json!(room_id);
+            }
+            if let Some(author_name) = author {
+                body["author"] = serde_json::json!(author_name);
             }
             let resp = client
                 .post(format!("{server_url}/remember"))

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -16,6 +16,7 @@ mod import_export;
 mod maintenance;
 pub mod memory;
 mod operations;
+mod rooms;
 mod types;
 
 pub use memory::types::{
@@ -23,6 +24,7 @@ pub use memory::types::{
     ExportEntry, ImportResult, Memory, MemoryTier, MemoryType, PruneResult, RecallStrategy,
     SearchResult, SimilarPair, StoreStats, TagInfo, DEFAULT_NAMESPACE,
 };
+pub use memory::{Room, RoomMemory, RoomStats};
 
 pub use error::{format_bytes, Error};
 pub use types::{DoctorCheck, DoctorReport, DoctorStatus, RepairReport, VerifyReport};

--- a/crates/uteke-core/src/memory/mod.rs
+++ b/crates/uteke-core/src/memory/mod.rs
@@ -4,12 +4,14 @@ pub mod aging;
 pub mod bulk;
 pub mod crud;
 pub mod fts5;
+pub mod rooms;
 pub mod schema;
 pub mod store;
 pub mod tags;
 pub mod types;
 pub mod vector;
 
+pub use rooms::{Room, RoomMemory, RoomStats};
 pub use store::Store;
 pub use types::{Memory, RecallStrategy, SearchResult, StoreStats};
 pub use vector::VectorIndex;

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -1,0 +1,278 @@
+//! Room operations — collaborative memory spaces for multi-agent discussions.
+
+use crate::Error;
+use rusqlite::params;
+use rusqlite::OptionalExtension;
+
+/// A shared collaboration context identified by an external ID.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Room {
+    pub id: String,
+    pub title: Option<String>,
+    pub namespace: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Statistics about a room.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RoomStats {
+    pub room_id: String,
+    pub title: Option<String>,
+    pub memory_count: usize,
+    pub participant_count: usize,
+    pub participants: Vec<String>,
+    pub created_at: String,
+    pub last_activity: Option<String>,
+}
+
+/// A memory linked to a room with author attribution.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RoomMemory {
+    pub memory_id: String,
+    pub room_id: String,
+    pub author: String,
+    pub role: String,
+    pub joined_at: String,
+}
+
+impl super::Store {
+    /// Create a new room. Returns error if room already exists.
+    pub fn create_room(
+        &self,
+        room_id: &str,
+        title: Option<&str>,
+        namespace: &str,
+    ) -> Result<(), Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "INSERT INTO rooms (id, title, namespace, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![room_id, title, namespace, now, now],
+            )
+            .map_err(|e| {
+                if e.to_string().contains("UNIQUE constraint") {
+                    Error::db_msg(format!("Room already exists: {room_id}"))
+                } else {
+                    Error::db("create room", e)
+                }
+            })?;
+        Ok(())
+    }
+
+    /// Get a room by ID.
+    pub fn get_room(&self, room_id: &str) -> Result<Option<Room>, Error> {
+        self.conn
+            .query_row(
+                "SELECT id, title, namespace, created_at, updated_at FROM rooms WHERE id = ?1",
+                params![room_id],
+                |row| {
+                    Ok(Room {
+                        id: row.get(0)?,
+                        title: row.get(1)?,
+                        namespace: row.get(2)?,
+                        created_at: row.get(3)?,
+                        updated_at: row.get(4)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| Error::db("get room", e))
+    }
+
+    /// List rooms that a namespace has participated in.
+    pub fn list_rooms(&self, namespace: Option<&str>) -> Result<Vec<Room>, Error> {
+        let sql = match namespace {
+            Some(_) => {
+                "SELECT DISTINCT r.id, r.title, r.namespace, r.created_at, r.updated_at \
+                 FROM rooms r \
+                 INNER JOIN room_memories rm ON r.id = rm.room_id \
+                 WHERE r.namespace = ?1 \
+                 ORDER BY r.updated_at DESC"
+            }
+            None => {
+                "SELECT id, title, namespace, created_at, updated_at FROM rooms \
+                 ORDER BY updated_at DESC"
+            }
+        };
+
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::db("list rooms", e))?;
+
+        let rows = match namespace {
+            Some(ns) => stmt
+                .query_map(params![ns], |row| {
+                    Ok(Room {
+                        id: row.get(0)?,
+                        title: row.get(1)?,
+                        namespace: row.get(2)?,
+                        created_at: row.get(3)?,
+                        updated_at: row.get(4)?,
+                    })
+                })
+                .map_err(|e| Error::db("list rooms", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("list rooms", e))?,
+            None => stmt
+                .query_map([], |row| {
+                    Ok(Room {
+                        id: row.get(0)?,
+                        title: row.get(1)?,
+                        namespace: row.get(2)?,
+                        created_at: row.get(3)?,
+                        updated_at: row.get(4)?,
+                    })
+                })
+                .map_err(|e| Error::db("list rooms", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("list rooms", e))?,
+        };
+
+        Ok(rows)
+    }
+
+    /// Get statistics about a room.
+    pub fn room_stats(&self, room_id: &str) -> Result<Option<RoomStats>, Error> {
+        let room = match self.get_room(room_id)? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        let memory_count: usize = self
+            .conn
+            .query_row(
+                "SELECT COUNT(DISTINCT memory_id) FROM room_memories WHERE room_id = ?1",
+                params![room_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("room memory count", e))?;
+
+        // Get distinct authors as participants
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT author FROM room_memories WHERE room_id = ?1 ORDER BY author")
+            .map_err(|e| Error::db("room participants", e))?;
+        let participants: Vec<String> = stmt
+            .query_map(params![room_id], |row| row.get(0))
+            .map_err(|e| Error::db("room participants", e))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::db("room participants", e))?;
+
+        let last_activity: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT MAX(joined_at) FROM room_memories WHERE room_id = ?1",
+                params![room_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("room last activity", e))?
+            .flatten();
+
+        Ok(Some(RoomStats {
+            room_id: room.id,
+            title: room.title,
+            memory_count,
+            participant_count: participants.len(),
+            participants,
+            created_at: room.created_at,
+            last_activity,
+        }))
+    }
+
+    /// Link a memory to a room with author attribution.
+    pub fn link_memory_to_room(
+        &self,
+        room_id: &str,
+        memory_id: &str,
+        author: &str,
+        role: &str,
+    ) -> Result<(), Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO room_memories (room_id, memory_id, author, role, joined_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![room_id, memory_id, author, role, now],
+            )
+            .map_err(|e| Error::db("link memory to room", e))?;
+
+        // Update room's updated_at timestamp
+        self.conn
+            .execute(
+                "UPDATE rooms SET updated_at = ?1 WHERE id = ?2",
+                params![now, room_id],
+            )
+            .map_err(|e| Error::db("update room timestamp", e))?;
+
+        Ok(())
+    }
+
+    /// Recall all memories linked to a room, sorted by time.
+    /// Cross-namespace: returns memories from ALL namespaces that contributed to the room.
+    pub fn recall_room(
+        &self,
+        room_id: &str,
+        author: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<crate::memory::types::Memory>, Error> {
+        let sql = match author {
+            Some(_) => {
+                "SELECT m.id, m.content, m.embedding, m.tags, m.metadata, \
+                 m.created_at, m.updated_at, m.namespace, m.access_count, \
+                 m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type \
+                 FROM memories m \
+                 INNER JOIN room_memories rm ON m.id = rm.memory_id \
+                 WHERE rm.room_id = ?1 AND rm.author = ?2 \
+                 ORDER BY rm.joined_at ASC \
+                 LIMIT ?3"
+            }
+            None => {
+                "SELECT m.id, m.content, m.embedding, m.tags, m.metadata, \
+                 m.created_at, m.updated_at, m.namespace, m.access_count, \
+                 m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type \
+                 FROM memories m \
+                 INNER JOIN room_memories rm ON m.id = rm.memory_id \
+                 WHERE rm.room_id = ?1 \
+                 ORDER BY rm.joined_at ASC \
+                 LIMIT ?2"
+            }
+        };
+
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::db("recall room", e))?;
+
+        use super::store::row_to_memory;
+
+        let memories = match author {
+            Some(a) => stmt
+                .query_map(params![room_id, a, limit], row_to_memory)
+                .map_err(|e| Error::db("recall room", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("recall room", e))?,
+            None => stmt
+                .query_map(params![room_id, limit], row_to_memory)
+                .map_err(|e| Error::db("recall room", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::db("recall room", e))?,
+        };
+
+        Ok(memories)
+    }
+
+    /// Delete a room and all its memory links (CASCADE).
+    pub fn delete_room(&self, room_id: &str) -> Result<(), Error> {
+        let rows = self
+            .conn
+            .execute("DELETE FROM rooms WHERE id = ?1", params![room_id])
+            .map_err(|e| Error::db("delete room", e))?;
+        if rows == 0 {
+            return Err(Error::db_msg(format!("Room not found: {room_id}")));
+        }
+        Ok(())
+    }
+}

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -154,6 +154,8 @@ impl super::Store {
             match version {
                 // v2: FTS5 full-text search virtual table + sync triggers
                 2 => self.migrate_v1_to_v2()?,
+                // v3: Room-based collaborative memory tables
+                3 => self.migrate_v2_to_v3()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -204,6 +206,34 @@ impl super::Store {
             tracing::info!("FTS5 index rebuilt successfully.");
         }
 
+        Ok(())
+    }
+
+    /// Migration v2 → v3: Add rooms and room_memories tables.
+    fn migrate_v2_to_v3(&self) -> Result<(), Error> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS rooms (\n\
+                    id TEXT PRIMARY KEY,\n\
+                    title TEXT,\n\
+                    namespace TEXT NOT NULL,\n\
+                    created_at TEXT NOT NULL,\n\
+                    updated_at TEXT NOT NULL\n\
+                );\n\
+                CREATE INDEX IF NOT EXISTS idx_rooms_namespace ON rooms(namespace);\n\
+                \n\
+                CREATE TABLE IF NOT EXISTS room_memories (\n\
+                    room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,\n\
+                    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,\n\
+                    author TEXT NOT NULL,\n\
+                    role TEXT NOT NULL DEFAULT 'participant',\n\
+                    joined_at TEXT NOT NULL,\n\
+                    PRIMARY KEY (room_id, memory_id)\n\
+                );\n\
+                CREATE INDEX IF NOT EXISTS idx_room_memories_room ON room_memories(room_id);\n\
+                CREATE INDEX IF NOT EXISTS idx_room_memories_author ON room_memories(author);",
+            )
+            .map_err(|e| Error::db("create rooms tables", e))?;
         Ok(())
     }
 

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -27,7 +27,7 @@ CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
 "#;
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 2;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 3;
 
 /// Persistent SQLite store for memories.
 pub struct Store {

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -1,0 +1,78 @@
+//! Room-based collaborative memory operations.
+
+use crate::error::Error;
+use crate::memory::types::Memory;
+use crate::memory::{Room, RoomStats};
+
+impl crate::Uteke {
+    /// Create a new room for collaborative memory.
+    pub fn create_room(
+        &self,
+        room_id: &str,
+        title: Option<&str>,
+        namespace: &str,
+    ) -> Result<(), Error> {
+        self.store.create_room(room_id, title, namespace)
+    }
+
+    /// Get a room by ID.
+    pub fn get_room(&self, room_id: &str) -> Result<Option<Room>, Error> {
+        self.store.get_room(room_id)
+    }
+
+    /// List rooms for a namespace (or all rooms if namespace is None).
+    pub fn list_rooms(&self, namespace: Option<&str>) -> Result<Vec<Room>, Error> {
+        self.store.list_rooms(namespace)
+    }
+
+    /// Get statistics about a room.
+    pub fn room_stats(&self, room_id: &str) -> Result<Option<RoomStats>, Error> {
+        self.store.room_stats(room_id)
+    }
+
+    /// Store a memory and link it to a room.
+    /// Dual-write: memory is stored in the agent's namespace AND linked to the room.
+    #[allow(clippy::too_many_arguments)]
+    pub fn remember_in_room(
+        &self,
+        content: &str,
+        tags: &[&str],
+        metadata: Option<serde_json::Value>,
+        namespace: Option<&str>,
+        memory_type: &str,
+        room_id: &str,
+        author: &str,
+    ) -> Result<String, Error> {
+        // Store the memory normally (lazy-loads embedder if needed)
+        let memory_id = self.remember_typed(content, tags, metadata, namespace, memory_type)?;
+
+        // Ensure room exists (auto-create if needed)
+        if self.store.get_room(room_id)?.is_none() {
+            let ns = namespace.unwrap_or(crate::memory::types::DEFAULT_NAMESPACE);
+            self.store.create_room(room_id, None, ns)?;
+        }
+
+        // Link memory to room
+        self.store
+            .link_memory_to_room(room_id, &memory_id, author, "participant")?;
+
+        Ok(memory_id)
+    }
+
+    /// Recall all memories in a room (cross-namespace).
+    /// Optionally filter by author.
+    pub fn recall_room(
+        &self,
+        room_id: &str,
+        author: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<Memory>, Error> {
+        self.store.recall_room(room_id, author, limit)
+    }
+
+    /// Delete a room and all its memory links.
+    /// Note: memories themselves are NOT deleted — they remain in their namespaces.
+    pub fn delete_room(&self, room_id: &str) -> Result<(), Error> {
+        self.store.delete_room(room_id)
+    }
+}


### PR DESCRIPTION
## What

Adds collaborative memory rooms where multiple AI agents can share context in a discussion.

## New CLI Commands

```bash
# Store memory in a room with author attribution
uteke remember "SurrealDB graph relevant" --room discord:1514528701109506199 --author cto

# List all rooms
uteke room list

# Room stats (participants, memory count)
uteke room stats discord:1514528701109506199

# Cross-namespace recall
uteke room recall discord:1514528701109506199

# Filter by author
uteke room recall discord:1514528701109506199 --author zeko
```

## Schema v3 Migration

- `rooms` table: id, title, namespace, timestamps
- `room_memories` junction table: room_id, memory_id, author, role
- Auto-migration from v2 (safe, zero data loss)
- Cross-namespace recall within room context

## Key Design Decisions

- **Dual-write**: Memories stored in agent namespace AND linked to room
- **Auto-create room**: Room created on first `remember --room` if not exists
- **Author attribution**: Every room memory has an author and role
- **Memories survive room deletion**: `room delete` only removes links

## Closes

Closes #286