### PR TITLE
feat(#246): relationship graph layer via metadata edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- **Relationship graph layer between memories** (#246)
+  - `uteke recall --related --depth N` — follow relationship edges via BFS traversal
+  - `uteke remember --meta "rel:supersedes:ID"` — link memories with typed relationships
+  - Relationship types: supersedes, contradicts, part_of, references
+  - Score decay per depth level (0.8x) to rank direct matches higher
+  - No new tables — relationships stored in metadata JSON
+
 
 ### Added
 

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -96,6 +96,12 @@ pub enum Commands {
         /// Use strict threshold from config (min_score_strict)
         #[arg(long)]
         strict: bool,
+        /// Follow relationship edges in memory metadata
+        #[arg(long)]
+        related: bool,
+        /// Depth of relationship traversal (default: 1, use with --related)
+        #[arg(long, default_value = "1")]
+        depth: usize,
     },
     /// Search memories by content keywords (text search)
     Search {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -59,6 +59,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             category,
             min,
             strict,
+            related,
+            depth,
         } => recall::run_recall(
             cli,
             uteke,
@@ -71,6 +73,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             *min,
             *strict,
             config,
+            *related,
+            *depth,
         ),
 
         Commands::Search { query, limit, tags } => {

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -18,6 +18,8 @@ pub(crate) fn run_recall(
     min: Option<f32>,
     strict: bool,
     config: &Config,
+    related: bool,
+    depth: usize,
 ) -> Result<(), String> {
     // Resolve threshold: --min > --strict (→ config min_score_strict) > config min_score > 0.0
     let min_score = match min {
@@ -33,9 +35,15 @@ pub(crate) fn run_recall(
     } else {
         Some(tag_refs.as_slice())
     };
-    let results = uteke
-        .recall(query, limit, tags_filter, ns, min_score)
-        .map_err(|e| format!("Failed to recall: {e}"))?;
+    let results = if related {
+        uteke
+            .recall_related(query, limit, tags_filter, ns, min_score, depth)
+            .map_err(|e| format!("Failed to recall: {e}"))?
+    } else {
+        uteke
+            .recall(query, limit, tags_filter, ns, min_score)
+            .map_err(|e| format!("Failed to recall: {e}"))?
+    };
 
     // Post-filter by entity/category metadata
     let filtered: Vec<_> = results

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -5,9 +5,22 @@ use crate::output;
 use uteke_core::Uteke;
 
 /// Parse --meta key:value pairs into a JSON object.
+/// Special handling for `rel:type:target` directives which are
+/// accumulated into a `relationships` array.
 fn parse_meta_pairs(pairs: &[String]) -> serde_json::Map<String, serde_json::Value> {
     let mut map = serde_json::Map::new();
+    let mut relationships: Vec<serde_json::Value> = Vec::new();
+
     for pair in pairs {
+        // Check for relationship directive: rel:type:target
+        if let Some((rel_type, target)) = uteke_core::is_relationship_meta(pair) {
+            relationships.push(serde_json::json!({
+                "type": rel_type,
+                "target": target
+            }));
+            continue;
+        }
+
         if let Some((key, value)) = pair.split_once(':') {
             let val = if let Ok(n) = value.parse::<f64>() {
                 serde_json::Value::from(n)
@@ -23,6 +36,14 @@ fn parse_meta_pairs(pairs: &[String]) -> serde_json::Map<String, serde_json::Val
             map.insert(pair.clone(), serde_json::Value::Bool(true));
         }
     }
+
+    if !relationships.is_empty() {
+        map.insert(
+            "relationships".to_string(),
+            serde_json::Value::Array(relationships),
+        );
+    }
+
     map
 }
 

--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -112,14 +112,13 @@ impl crate::Uteke {
                     if visited.contains(&rel.target) {
                         continue;
                     }
-                    visited.insert(rel.target.clone());
-
                     if let Some(target_memory) = self.get_by_id(&rel.target)? {
-                        // Score decays with depth: each level gets a lower score
+                        visited.insert(rel.target.clone());
                         let decayed_score = (results[memory_id].1 * 0.8).max(0.1);
                         results.insert(rel.target.clone(), (target_memory.clone(), decayed_score));
                         next_frontier.push(rel.target.clone());
                     }
+                    // Missing targets not marked visited — allows alternate paths.
                 }
             }
 
@@ -142,6 +141,7 @@ impl crate::Uteke {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
+        all_results.truncate(limit);
         Ok(all_results)
     }
 

--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -1,0 +1,185 @@
+//! Relationship graph traversal — follow edges stored in memory metadata.
+//!
+//! Relationships are stored in the `metadata` JSON field under a
+//! `relationships` key, e.g.:
+//! ```json
+//! {"relationships": [{"type": "supersedes", "target": "uuid-xxx"}, ...]}
+//! ```
+
+use crate::error::Error;
+use crate::memory::types::{Memory, SearchResult};
+use std::collections::{HashMap, HashSet};
+
+/// Known relationship types.
+pub const REL_SUPERSEDES: &str = "supersedes";
+pub const REL_CONTRADICTS: &str = "contradicts";
+pub const REL_PART_OF: &str = "part_of";
+pub const REL_REFERENCES: &str = "references";
+
+/// All valid relationship type strings.
+pub const VALID_REL_TYPES: &[&str] =
+    &[REL_SUPERSEDES, REL_CONTRADICTS, REL_PART_OF, REL_REFERENCES];
+
+/// A single relationship edge.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Relationship {
+    #[serde(rename = "type")]
+    pub rel_type: String,
+    pub target: String,
+}
+
+/// Parse relationships from memory metadata.
+fn parse_relationships(memory: &Memory) -> Vec<Relationship> {
+    memory
+        .metadata
+        .get("relationships")
+        .and_then(|v| serde_json::from_value::<Vec<Relationship>>(v.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// Build a relationship string for storing in metadata.
+pub fn build_meta_relationship(rel_type: &str, target_id: &str) -> String {
+    format!("rel:{rel_type}:{target_id}")
+}
+
+/// Check if a meta value is a relationship directive.
+pub fn is_relationship_meta(value: &str) -> Option<(&str, &str)> {
+    let rest = value.strip_prefix("rel:")?;
+    let (rel_type, target) = rest.split_once(':')?;
+    if VALID_REL_TYPES.contains(&rel_type) {
+        Some((rel_type, target))
+    } else {
+        None
+    }
+}
+
+impl crate::Uteke {
+    /// Recall memories and follow relationship edges up to `depth` levels.
+    ///
+    /// Starts with the results of a normal recall, then traverses the
+    /// `relationships` field in each memory's metadata to find related
+    /// memories. Deduplicates by memory ID.
+    pub fn recall_related(
+        &self,
+        query: &str,
+        limit: usize,
+        tags_filter: Option<&[&str]>,
+        namespace: Option<&str>,
+        min_score: f32,
+        depth: usize,
+    ) -> Result<Vec<SearchResult>, Error> {
+        // Initial recall
+        let initial = self.recall_hybrid(
+            query,
+            limit,
+            tags_filter,
+            namespace,
+            crate::memory::types::RecallStrategy::Hybrid,
+            min_score,
+        )?;
+
+        if depth == 0 || initial.is_empty() {
+            return Ok(initial);
+        }
+
+        // Collect all IDs to visit and track scores
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut results: HashMap<String, (Memory, f32)> = HashMap::new();
+
+        for sr in &initial {
+            visited.insert(sr.memory.id.clone());
+            results.insert(sr.memory.id.clone(), (sr.memory.clone(), sr.score));
+        }
+
+        // BFS traversal
+        let mut frontier: Vec<String> = initial.iter().map(|sr| sr.memory.id.clone()).collect();
+
+        for level in 0..depth {
+            if frontier.is_empty() {
+                break;
+            }
+
+            let mut next_frontier: Vec<String> = Vec::new();
+
+            for memory_id in &frontier {
+                let memory = match self.get_by_id(memory_id)? {
+                    Some(m) => m,
+                    None => continue,
+                };
+
+                let rels = parse_relationships(&memory);
+                for rel in rels {
+                    if visited.contains(&rel.target) {
+                        continue;
+                    }
+                    visited.insert(rel.target.clone());
+
+                    if let Some(target_memory) = self.get_by_id(&rel.target)? {
+                        // Score decays with depth: each level gets a lower score
+                        let decayed_score = (results[memory_id].1 * 0.8).max(0.1);
+                        results.insert(rel.target.clone(), (target_memory.clone(), decayed_score));
+                        next_frontier.push(rel.target.clone());
+                    }
+                }
+            }
+
+            tracing::debug!(
+                "Relationship traversal level {}: found {} new memories",
+                level + 1,
+                next_frontier.len()
+            );
+            frontier = next_frontier;
+        }
+
+        // Convert to sorted results
+        let mut all_results: Vec<SearchResult> = results
+            .into_iter()
+            .map(|(_, (memory, score))| SearchResult { memory, score })
+            .collect();
+        all_results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        Ok(all_results)
+    }
+
+    /// Get all memories related to a specific memory ID via relationship edges.
+    /// Returns both outgoing and incoming relationships.
+    pub fn get_related(&self, memory_id: &str) -> Result<Vec<Memory>, Error> {
+        let mut related = Vec::new();
+        let mut seen = HashSet::new();
+        seen.insert(memory_id.to_string());
+
+        // Outgoing: relationships in this memory's metadata
+        if let Some(memory) = self.get_by_id(memory_id)? {
+            for rel in parse_relationships(&memory) {
+                if !seen.contains(&rel.target) {
+                    if let Some(target) = self.get_by_id(&rel.target)? {
+                        seen.insert(rel.target.clone());
+                        related.push(target);
+                    }
+                }
+            }
+        }
+
+        // Incoming: scan memories that reference this one
+        // This is O(n) on metadata — acceptable for now (see AGENT.md: metadata in JSON blob)
+        let all_memories = self.store.load_all(None)?;
+        for m in all_memories {
+            if seen.contains(&m.id) {
+                continue;
+            }
+            for rel in parse_relationships(&m) {
+                if rel.target == memory_id {
+                    seen.insert(m.id.clone());
+                    related.push(m);
+                    break;
+                }
+            }
+        }
+
+        Ok(related)
+    }
+}

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -12,6 +12,7 @@
 mod consolidate;
 mod embed;
 mod error;
+mod graph;
 mod import_export;
 mod maintenance;
 pub mod memory;
@@ -19,6 +20,7 @@ mod operations;
 mod rooms;
 mod types;
 
+pub use graph::{build_meta_relationship, is_relationship_meta, Relationship, VALID_REL_TYPES};
 pub use memory::types::{
     AgingStatus, BulkDeleteResult, CleanupResult, ConsolidationResult, ContradictionResult,
     ExportEntry, ImportResult, Memory, MemoryTier, MemoryType, PruneResult, RecallStrategy,


### PR DESCRIPTION
Typed relationship edges between memories stored in metadata JSON.

```bash
uteke remember "Fix login" --meta 'rel:supersedes:bug-uuid'
uteke recall "login" --related --depth 1
```

Types: supersedes, contradicts, part_of, references. BFS traversal with 0.8x score decay. No new tables.

Closes #246