### PR TITLE
docs: update for v0.1.0 — rooms, time-travel, pluggable embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ### Added
 
+- **Time-travel queries** (#292)
+  - `uteke recall --at 2026-06-01T12:00:00Z` — recall memories as they existed at a specific point in time
+  - `uteke list --at 2026-06-01T12:00:00Z` — list memories that existed at timestamp
+  - Filters by created_at, valid_from/valid_until, deprecated status
+  - Server: `/recall` and `/list` accept `"at"` field
+- **Pluggable embedding models** (#249)
+  - New `Embedder` trait — enables different embedding backends (ONNX, OpenAI, Ollama)
+  - `EmbeddingEngine` renamed to `OnnxEmbedder`, implements `Embedder`
+  - Config: `[embedding] backend = "onnx"` (default)
+  - Lazy backend selection via `embedder_backend` field
+- **Room document view** (#306)
+  - `uteke room document <room>` — generate structured document from room memories
+  - Sections grouped by memory_type: 📋 Decisions, 🔍 Facts, ⚙️ Procedures, 🎨 Preferences, 💬 Context
+  - Pinned memories get 📌 section first
+  - Server: `POST /room/document`
+- **Semantic room recall** (#304)
+  - `uteke room recall <room> --query "topic"` — semantic recall within a room
+  - `/room/recall` endpoint
+- **Room summary** (#305)
+  - `uteke room summary <room>` — LLM-free room summary via tag clustering
+  - `/room/summary` endpoint
+- **Configurable recall threshold** (#252)
+  - `uteke recall --min 0.7` — set minimum similarity score
+  - `uteke recall --strict` — use 0.7 default threshold
+  - `[recall] min_score = 0.7` in config
+- **Room-based memory** (#286)
+  - `uteke room create/list/add/recall/remove/delete` — full room management
+  - Memories can belong to rooms with author attribution
+  - `/room/*` endpoints
 - **Agent recall optimization** (#181)
   - Recall cache: LRU with TTL (5min, 256 entries) — avoids redundant embedding (~50ms) for repeated queries
   - `uteke recall --context` — formatted output for AI prompt injection
@@ -17,6 +46,12 @@
 
 ### Changed
 
+- **Normalize tags with junction table** (#184)
+  - New `memory_tags` junction table for O(log n) tag lookups
+  - Schema v5: creates table, populates from existing JSON tags
+  - Dual-write: insert/update writes to both JSON column and junction table
+  - All tag queries use junction table instead of json_each()
+  - Backward compat: JSON `tags` column preserved
 - **Smart memory decay and importance scoring** (#247)
   - Composite importance score: 0.3*access + 0.3*recency + 0.2*connectivity + 0.2*pinning
   - `uteke pin <id>` / `uteke unpin <id>` — pin memories so they never decay

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.0.14-green.svg" alt="v0.0.14" />
+  <img src="https://img.shields.io/badge/status-v0.1.0-green.svg" alt="v0.1.0" />
 </p>
 
 <p align="center">
@@ -59,7 +59,13 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 ## Key Features
 
 - 🧠 **Hybrid Search** — Vector similarity + FTS5 full-text search, merged by Reciprocal Rank Fusion (RRF)
+- 🏠 **Rooms** — Group memories by context (meetings, projects) with author attribution
+- ⏳ **Time-travel queries** — Recall memories as they existed at any point in time
+- 🔌 **Pluggable embeddings** — Swap ONNX/OpenAI/Ollama backends via config
 - 🏷️ **Metadata Enrichment** — Tag, entity, category, and key:value metadata on every memory
+- 🔗 **Relationship graph** — Link memories with typed edges (supersedes, contradicts, references)
+- 📉 **Smart decay** — Composite importance scoring, pin critical memories
+- ⚡ **Recall cache** — LRU cache eliminates redundant embedding for repeated queries
 - 👥 **Multi-Agent Namespaces** — Fully isolated memory per agent, zero overhead
 - 🖥️ **Server Mode** — Persistent daemon with ~42ms warm recall (75x faster than CLI)
 - 🔥 **Tiered Memory** — Hot/Warm/Cold tracking with auto-cleanup of stale memories

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,9 @@ SQLite-first dual-write: metadata persisted before index. If index write fails, 
 ### Read Path (recall)
 
 ```
-Query → ONNX embed (Mutex) → 768d vector
+Query → Recall Cache check (TTL 5min, LRU 256)
+         ↓ miss
+       ONNX embed (Mutex) → 768d vector
                                 ↓
               ┌─────────────────┴──────────────────┐
               ↓                                     ↓
@@ -122,7 +124,11 @@ All critical file I/O uses the `.tmp` + `rename` pattern. On POSIX filesystems, 
 
 ### Schema Versioning
 
-Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v2 (FTS5 virtual table). Zero data loss guaranteed.
+Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v5 (memory_tags junction table). Zero data loss guaranteed.
+
+### Rooms
+
+Rooms group related memories with author attribution. Stored in `rooms` and `room_memories` tables (schema v4). Semantic room recall over-fetches via `recall_hybrid()`, then post-filters to room memory IDs. Room summaries use tag co-occurrence clustering — no LLM call required. Room documents group memories by `memory_type` into sections (Decisions, Facts, Procedures, etc).
 
 ## Performance
 
@@ -171,6 +177,5 @@ Benchmarked on Oracle Cloud ARM (Ampere Altra), CPU-only, no GPU.
 |-----------|--------|--------|
 | usearch `ef` not configurable | External | usearch v2.25.3 Rust bindings don't expose `ef` in `search()` |
 | Embedder requires Mutex | Architectural | ONNX tokenizer internally uses `&mut self` |
-| Metadata is post-filter | Design | Entity/category in JSON blob, filtered in Rust not SQL |
 | Consolidate is O(n²) | Algorithm | Pairwise cosine — slow above 1K memories |
 | FTS5-only score is placeholder | Design | BM25 can't normalize to 0..1; actual ranking via RRF |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.0.13**.
+Complete reference for all uteke commands. Version **0.1.0**.
 
 ## Global Flags
 
@@ -198,6 +198,88 @@ uteke tags rename old-tag new-tag
 
 # Delete a tag from all memories
 uteke tags delete unused-tag
+```
+
+## uteke recall (enhanced)
+
+Semantic search with new flags:
+
+```bash
+# Minimum similarity score filter
+uteke recall "database config" --min 0.7
+uteke recall "database config" --strict    # uses 0.7 default
+
+# Time-travel: query memories at specific point in time
+uteke recall "deployment process" --at 2026-06-01T12:00:00Z
+
+# Relationship graph traversal
+uteke recall "auth" --related --depth 2
+
+# AI-context formatted output
+uteke recall "api design" --context
+```
+
+| Flag | Description |
+|------|-------------|
+| `--min <score>` | Minimum similarity score (0.0-1.0) |
+| `--strict` | Use strict threshold (0.7) |
+| `--at <timestamp>` | Query memories at point in time (RFC3339) |
+| `--related` | Follow relationship edges |
+| `--depth <n>` | Traversal depth for --related |
+| `--context` | AI-prompt formatted output |
+
+## uteke list (enhanced)
+
+```bash
+# Time-travel list
+uteke list --at 2026-06-01T12:00:00Z
+```
+
+## uteke room
+
+Room-based memory management:
+
+```bash
+# Create a room
+uteke room create "project-kickoff" --title "Project Kickoff"
+
+# List rooms
+uteke room list
+
+# Add memory to room
+uteke room add "project-kickoff" <memory-id> --author cto
+
+# Recall within a room (semantic)
+uteke room recall "project-kickoff" --query "database decision"
+
+# Generate structured document from room
+uteke room document "project-kickoff"
+
+# Room summary (LLM-free, tag clustering)
+uteke room summary "project-kickoff"
+
+# Remove memory from room
+uteke room remove "project-kickoff" <memory-id>
+
+# Delete room
+uteke room delete "project-kickoff"
+```
+
+## uteke pin / unpin
+
+Pin memories so they never decay:
+
+```bash
+uteke pin <id>
+uteke unpin <id>
+```
+
+## uteke importance
+
+Recalculate importance scores:
+
+```bash
+uteke importance
 ```
 
 ## uteke aging

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,44 @@ If the server is not running, CLI falls back to local store automatically.
 | `host` | 127.0.0.1 | Server bind address |
 | `port` | 8767 | Server port |
 
+## Embedding Backend
+
+Configure the embedding backend:
+
+```toml
+[embedding]
+# Backend: "onnx" (default), future: "openai", "ollama"
+backend = "onnx"
+
+# Model name (for ONNX backend)
+model = "embeddinggemma-q4"
+
+# Maximum sequence length in tokens
+max_seq_length = 256
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `backend` | onnx | Embedding backend |
+| `model` | embeddinggemma-q4 | Model identifier |
+| `max_seq_length` | 256 | Max tokens per input |
+
+## Recall Threshold
+
+Control minimum similarity score for recall results:
+
+```toml
+[recall]
+# Minimum similarity score (0.0-1.0). Memories below this score are excluded.
+min_score = 0.0
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `min_score` | 0.0 | Minimum similarity score |
+
+Use `--strict` flag or `--min 0.7` to override per-query.
+
 ## Config Migration
 
 If you have an older flat-format config (pre-v0.0.4), uteke auto-migrates it on first run:

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -73,6 +73,7 @@ The `--namespace` flag works on every command:
 | `recall` | Search within namespace |
 | `search` | Text search within namespace |
 | `list` | List memories in namespace |
+| `room` | Room operations in namespace |
 | `tags list` | Tags for namespace |
 | `tags rename` | Rename tag in namespace |
 | `tags delete` | Delete tag in namespace |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,34 @@ title: Roadmap
 
 Demand-gated — we build what people actually use. Track progress on [GitHub Issues](https://github.com/codecoradev/uteke/issues).
 
-## v0.0.12 — Search & Concurrency `✓ Done` `Current`
+## v0.1.0 — Rooms, Intelligence & Pluggability `✓ Done`
+
+- [#292 Time-travel queries](https://github.com/codecoradev/uteke/issues/292) `✓ Done`
+  - Recall/list at specific point in time (`--at` flag)
+  - Temporal validity filter: created_at, valid_from/valid_until, deprecated
+- [#249 Pluggable embedding models](https://github.com/codecoradev/uteke/issues/249) `✓ Done`
+  - `Embedder` trait abstraction for multiple backends
+  - ONNX backend (default), future: OpenAI, Ollama
+- [#306 Room document view](https://github.com/codecoradev/uteke/issues/306) `✓ Done`
+  - Structured document output grouped by memory_type
+- [#305 Room summary](https://github.com/codecoradev/uteke/issues/305) `✓ Done`
+  - LLM-free room summary via tag clustering
+- [#304 Semantic room recall](https://github.com/codecoradev/uteke/issues/304) `✓ Done`
+  - `recall_room_semantic()` with `--query` flag
+- [#184 Normalize tags junction table](https://github.com/codecoradev/uteke/issues/184) `✓ Done`
+  - Schema v5, memory_tags table, O(log n) lookups
+- [#252 Configurable recall threshold](https://github.com/codecoradev/uteke/issues/252) `✓ Done`
+  - `--min`, `--strict`, `[recall] min_score` config
+- [#286 Room-based memory](https://github.com/codecoradev/uteke/issues/286) `✓ Done`
+  - Full room management with author attribution
+- [#181 Recall cache optimization](https://github.com/codecoradev/uteke/issues/181) `✓ Done`
+  - LRU cache with TTL, `--context` output format
+- [#246 Relationship graph](https://github.com/codecoradev/uteke/issues/246) `✓ Done`
+  - `--related --depth N` BFS traversal
+- [#247 Smart memory decay](https://github.com/codecoradev/uteke/issues/247) `✓ Done`
+  - Composite importance scoring, pin/unpin
+
+## v0.0.12 — Search & Concurrency `✓ Done`
 
 - [#250 FTS5 hybrid search with RRF](https://github.com/codecoradev/uteke/issues/250) `✓ Done`
   - FTS5 full-text search as parallel retrieval channel


### PR DESCRIPTION
## Summary

Update all documentation to reflect v0.1.0 features.

### Files updated (7):
- **CHANGELOG.md** — v0.1.0 `[Unreleased]` section: #292, #249, #306, #305, #304, #252, #286, #184
- **docs/roadmap.md** — New `v0.1.0` section with all 11 issues, v0.0.12 marked Done
- **docs/cli-reference.md** — Version 0.0.13→0.1.0, new sections: `recall (enhanced)`, `list (enhanced)`, `room`, `pin/unpin`, `importance`
- **docs/configuration.md** — New `[embedding]` backend config + `[recall] min_score` threshold
- **docs/architecture.md** — Schema v2→v5, recall cache in read path, Rooms design section
- **docs/multi-agent.md** — Added `room` to scoped commands table
- **README.md** — Version badge 0.0.14→0.1.0, expanded Key Features

### Coverage:
- ✅ Rooms (create, list, add, recall, document, summary)
- ✅ Time-travel queries (`--at` flag)
- ✅ Pluggable embedding (Embedder trait, ONNX default)
- ✅ Relationship graph (`--related`, `--depth`)
- ✅ Smart decay (pin/unpin, importance)
- ✅ Recall cache (`--context`, LRU TTL)
- ✅ Tag junction table (schema v5)
- ✅ Recall threshold (`--min`, `--strict`)