### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [0.1.0] — 2026-06-13
 
 ### Added
 
@@ -54,9 +54,13 @@
   - Score decay per depth level (0.8x) to rank direct matches higher
   - No new tables — relationships stored in metadata JSON
 
-### Changed
+### Fixed
 
-- **Normalize tags with junction table** (#184)
+- **Recall `--json` output consistency** — empty results now always output `[]`
+  instead of `{"results":[]}` when min_score threshold is active. Ensures
+  machine consumers (cora-cli, scripts, MCP) can parse output reliably.
+
+### Changed
   - New `memory_tags` junction table for O(log n) tag lookups
   - Schema v5: creates table, populates from existing JSON tags
   - Dual-write: insert/update writes to both JSON column and junction table

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.0.15"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.0.15"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.0.15"
+version = "0.1.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.0.15"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.15"
+version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.0.15" }
+uteke-core = { path = "../uteke-core", version = "0.1.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -93,25 +93,14 @@ pub(crate) fn run_recall(
         })
         .collect();
 
-    if filtered.is_empty() && min_score > 0.0 {
-        if cli.json {
-            let response = serde_json::json!({
-                "results": [],
-                "total": 0,
-                "threshold": min_score,
-                "message": "No memories above similarity threshold"
-            });
-            println!("{}", serde_json::to_string(&response).unwrap());
-        } else {
-            println!("No matching memories found.");
-            println!("(min_score threshold: {:.2})", min_score);
-        }
-        return Ok(());
-    }
-
     if filtered.is_empty() {
         if cli.json {
+            // Always output a JSON array for machine consumers (cora-cli,
+            // scripts, MCP). A bare [] is easier to parse than {"results":[]}.
             output::print_json(&filtered);
+        } else if min_score > 0.0 {
+            println!("No matching memories found.");
+            println!("(min_score threshold: {:.2})", min_score);
         } else if context {
             println!("[No relevant memories found for: {query}]");
         } else {

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -13,7 +13,7 @@ name = "uteke-mcp"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.0.15" }
+uteke-core = { path = "../uteke-core", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.0.15" }
+uteke-core = { path = "../uteke-core", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## v0.1.0 Release Prep

### Changes:
1. **Version bump**: `0.0.15` → `0.1.0` (workspace package + all inter-crate deps)
2. **JSON output fix**: `recall --json` now always outputs `[]` on empty results instead of `{"results":[]}`. This ensures cora-cli and other JSON consumers can parse output reliably.
3. **CHANGELOG**: `[Unreleased]` → `[0.1.0] — 2026-06-13`

### Cora-cli Integration Readiness:
- ✅ `uteke recall --json` → `[{"memory":{"content":"..."}, "score":0.x}, ...]`
- ✅ `uteke remember "content" --tags a,b` → positional content + flags
- ✅ Empty results → `[]` (parseable by `serde_json::from_str::<Vec<Value>>`)
- ✅ `--namespace` works as global flag after subcommand
- ✅ Binary name: `uteke` (detected by `which::which("uteke")`)

### Milestone: v0.1.0 — 0 open / 13 closed ✅

After merge: tag `v0.1.0`, create GitHub Release, publish to crates.io.

## Tests
- `cargo test --workspace` ✅ (134 passed, 5 ignored)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all` ✅