### PR TITLE
fix(ci): make sync-main non-blocking for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
   sync-main:
     name: Sync main branch
     runs-on: ubuntu-latest
+    continue-on-error: true
     # Only runs on v* tag pushes (release trigger). Uses force-push because main
     # is a release-only mirror of develop — any commits on main not in develop
     # are stale snapshots that should be overwritten by the current release.
@@ -43,7 +44,6 @@ jobs:
           }
 
   build-release:
-    needs: sync-main
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
sync-main fails when main is already synced (non-fast-forward). Make it non-blocking so binary builds, Docker, and GitHub Release proceed.

Fixes release workflow for future releases.