### PR TITLE
fix(#325): release workflow rewrite + roadmap + cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,40 +11,49 @@ env:
 
 jobs:
   sync-main:
-    name: Sync main branch
+    name: Sync main ← tag commit
     runs-on: ubuntu-latest
-    continue-on-error: true
-    # Only runs on v* tag pushes (release trigger). Uses force-push because main
-    # is a release-only mirror of develop — any commits on main not in develop
-    # are stale snapshots that should be overwritten by the current release.
     if: startsWith(github.ref, 'refs/tags/v')
+    # Blocking: main MUST be synced before release artifacts are built.
+    # If main can't be fast-forwarded, the release aborts to prevent
+    # stale install.sh / mismatched main branch (#325).
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: develop
+          fetch-depth: 0
 
-      - name: Push to main
+      - name: Fast-forward main to tag commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # main is a release-only mirror of develop.
-          # Use GitHub API to force-update the ref (bypasses ruleset that blocks
-          # git force-push and branch deletion).
-          git push origin HEAD:refs/heads/main --force 2>/dev/null && {
-            echo "✅ main synced via fast-forward"
-          } || {
-            echo "Force-push blocked by ruleset, using API ref update..."
-            SHA=$(git rev-parse HEAD)
-            gh api repos/${{ github.repository }}/git/refs/heads/main \
-              -X PATCH \
-              --input - <<< '{"sha":"'"$SHA"'","force":true}'
-            echo "✅ main synced to develop at $SHA via API"
-          }
+          # The tag points to a commit on develop. We want main to point
+          # to the exact same commit so install.sh (which fetches from main)
+          # always matches the release binary.
+          #
+          # Strategy: try fast-forward first (works if main is an ancestor
+          # of the tag commit). If that fails (main diverged), force-update
+          # via API — main is a release-only mirror, develop is the source
+          # of truth.
+          TAG_SHA=$(git rev-parse "${{ github.ref }}^{commit}")
+          echo "Tag commit: $TAG_SHA"
+
+          # Check if main is an ancestor of TAG_SHA (safe fast-forward).
+          # If main is NOT an ancestor, abort — force-updating would
+          # rewrite history and potentially lose commits.
+          if git merge-base --is-ancestor origin/main "$TAG_SHA" 2>/dev/null; then
+            git push origin "$TAG_SHA:refs/heads/main"
+            echo "✅ main fast-forwarded to $TAG_SHA"
+          else
+            echo "::error::main is not an ancestor of tag commit. Refusing to force-update."
+            echo "Manual intervention required: merge develop into main first."
+            exit 1
+          fi
 
   build-release:
     name: Build ${{ matrix.target }}
+    needs: sync-main
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -119,7 +128,7 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
-    needs: []
+    needs: [sync-main]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -241,7 +250,6 @@ jobs:
       - name: Extract binaries for Docker context
         run: |
           mkdir -p binaries
-          # Artifacts are uploaded as release/*.tar.gz, so find them recursively
           cd release-artifacts
           AMD64=$(find . -name "uteke-x86_64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
           ARM64=$(find . -name "uteke-aarch64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,7 +420,7 @@
 
 ### Added
 
-- **Website** — https://uteke.ajianaz.dev (SvelteKit 5 + Tailwind)
+- **Website** — https://github.com/codecoradev/uteke (SvelteKit 5 + Tailwind)
   - Landing page, docs, roadmap
   - Auto-deploy via CF Pages + Infisical OIDC
 - **Release matrix** — 4 platforms: Linux x64, Linux ARM64, macOS ARM64, Windows x64

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ title: Architecture
 │          │ RwLock   │   table)  │                    │
 ├──────────┴──────────┴───────────┴────────────────────┤
 │              ~/.uteke/ (local storage)               │
-│ uteke.db │ uteke_index.usearch │ models/embeddinggemma/ │
+│ uteke.db │ uteke_index.usearch │ embeddinggemma-q4/ │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -165,7 +165,8 @@ Benchmarked on Oracle Cloud ARM (Ampere Altra), CPU-only, no GPU.
 ├── uteke.db                    # SQLite (memories + metadata + FTS5)
 ├── uteke_index.usearch         # Persistent HNSW vector index
 ├── uteke_index.keys            # Index key mapping (atomic save)
-├── models/embeddinggemma/      # Local ONNX embedding model (~188MB)
+├── embeddinggemma-q4/           # Local ONNX embedding model (~188MB)
+│   └── onnx/                    # model_q4.onnx + model_q4.onnx_data
 └── logs/
     ├── uteke.log               # Current log
     └── uteke.log.YYYY-MM-DD    # Rotated logs

--- a/docs/launch/hn-post.md
+++ b/docs/launch/hn-post.md
@@ -1,6 +1,6 @@
 # Show HN: Uteke — Offline-first semantic memory for AI agents, single Rust binary
 
-**URL:** https://github.com/ajianaz/uteke
+**URL:** https://github.com/codecoradev/uteke
 
 Hey HN,
 
@@ -9,7 +9,7 @@ I built Uteke because I was tired of AI agents forgetting everything between ses
 Uteke is a local-first memory engine for AI agents. It's a single Rust binary with zero configuration:
 
 ```
-curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 
 uteke remember "Deploy v2.1 to staging on Friday" --tags deploy
 uteke recall "what deployment is coming up?"

--- a/docs/launch/twitter-thread.md
+++ b/docs/launch/twitter-thread.md
@@ -7,7 +7,7 @@ Every new session starts from zero. Decisions lost. Context rebuilt. Again.
 
 I built Uteke to fix this. A local-first semantic memory engine for AI — single Rust binary, fully offline, 30ms recall.
 
-🧠 https://github.com/ajianaz/uteke
+🧠 https://github.com/codecoradev/uteke
 
 #Rust #AI #OpenSource
 
@@ -16,7 +16,7 @@ I built Uteke to fix this. A local-first semantic memory engine for AI — singl
 **Tweet 2/7**
 What does Uteke do?
 
-curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 
 uteke remember "BOND uses Go + SvelteKit monorepo" --tags architecture
 uteke recall "what architecture does BOND use?"
@@ -84,7 +84,7 @@ Apache 2.0 — use it, fork it, ship it.
 **Tweet 7/7**
 If you build AI agents and hate that they forget everything — give Uteke a try.
 
-⭐ Star the repo: https://github.com/ajianaz/uteke
+⭐ Star the repo: https://github.com/codecoradev/uteke
 🐛 Report bugs: Open an issue
 🤝 Contribute: PRs to develop branch
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,81 +32,82 @@ Demand-gated — we build what people actually use. Track progress on [GitHub Is
   - `--related --depth N` BFS traversal
 - [#247 Smart memory decay](https://github.com/codecoradev/uteke/issues/247) `✓ Done`
   - Composite importance scoring, pin/unpin
+- [#49 Benchmark suite](https://github.com/codecoradev/uteke/issues/49) `✓ Done`
+  - `uteke bench` command + LongMemEval retrieval harness
+- [#316 LongMemEval harness](https://github.com/codecoradev/uteke/issues/316) `✓ Done`
+  - Retrieval accuracy evaluation (Recall@k, NDCG@k)
 
-## v0.0.12 — Search & Concurrency `✓ Done`
+## v0.0.15 — CLI Performance `✓ Done`
 
-- [#250 FTS5 hybrid search with RRF](https://github.com/codecoradev/uteke/issues/250) `✓ Done`
+- [#185 Lazy ONNX model loading](https://github.com/codecoradev/uteke/issues/185)
+  - CLI cold start: ~3s → ~20ms for non-embedding commands
+  - Model loaded on first use (`remember`, `recall`, `search`)
+- [#131 Modular CLI refactor](https://github.com/codecoradev/uteke/issues/131)
+  - CLI args extracted to `cli.rs`, logging to `logging.rs`
+- Release workflow decoupled: parallel builds + crates.io publish
+
+## v0.0.14 — Security & Polish `✓ Done`
+
+- [#134 Binary checksums & file permissions](https://github.com/codecoradev/uteke/issues/134)
+  - SHA256 checksum verification for ONNX model files
+  - Owner-only permissions (0700/0600) on database and model dirs
+- [#277 Indonesian README translation](https://github.com/codecoradev/uteke/issues/277)
+- [#100 TLS & Reverse Proxy docs](https://github.com/codecoradev/uteke/issues/100)
+- Crates.io metadata in all Cargo.toml files
+
+## v0.0.13 — Search & Concurrency `✓ Done`
+
+- [#250 FTS5 hybrid search with RRF](https://github.com/codecoradev/uteke/issues/250)
   - FTS5 full-text search as parallel retrieval channel
   - Reciprocal Rank Fusion (k=60) merges vector + FTS5 results
-  - `RecallStrategy` enum: hybrid (default), vector, fts5
   - Schema migration v1→v2 (auto, zero data loss)
-  - Phrase search + token-OR fallback
-  - Deprecated memories excluded from FTS5
-- [#251 Metadata enrichment via CLI flags](https://github.com/codecoradev/uteke/issues/251) `✓ Done`
+- [#251 Metadata enrichment via CLI flags](https://github.com/codecoradev/uteke/issues/251)
   - `--entity`, `--category`, `--meta key:value,...` on remember
-  - Post-filter on `recall` and `list` by entity/category
-  - Auto type detection for meta values (string/number/bool)
-- [#209 Concurrent reads via RwLock](https://github.com/codecoradev/uteke/issues/209) `✓ Done`
+- [#209 Concurrent reads via RwLock](https://github.com/codecoradev/uteke/issues/209)
   - `Mutex<VectorIndex>` → `RwLock<VectorIndex>` for read-heavy workload
-  - Multiple concurrent recalls share read lock
-  - Embedder lock scope minimized
-- [#139 Vector index consistency](https://github.com/codecoradev/uteke/issues/139) `✓ Done`
+- [#139 Vector index consistency](https://github.com/codecoradev/uteke/issues/139)
   - Atomic save for `.keys` sidecar file (temp + rename)
-  - `insert()` and `build()` now return `Result` (error propagation)
 
 ## v0.0.10 — Codebase Quality `✓ Done`
 
-- [#187 Split commands.rs into per-command modules](https://github.com/codecoradev/uteke/issues/187) `✓ Done`
-- [#186 Split store.rs into focused modules](https://github.com/codecoradev/uteke/issues/186) `✓ Done`
-- [#178 Remove all Hermes branding](https://github.com/codecoradev/uteke/issues/178) `✓ Done`
-- [#196 Address all Cora code review findings](https://github.com/codecoradev/uteke/issues/196) `✓ Done`
-- Safe slice, index lock ordering, HTTP status checking, aging filter fix
-- Schema migration transactions, batch bulk deletes, SQLite-first dual-write
-- Embedding docs corrected (768d), shell hook idempotency guards
+- [#187 Split commands.rs into per-command modules](https://github.com/codecoradev/uteke/issues/187)
+- [#186 Split store.rs into focused modules](https://github.com/codecoradev/uteke/issues/186)
+- [#178 Remove all Hermes branding](https://github.com/codecoradev/uteke/issues/178)
+- [#196 Address all Cora code review findings](https://github.com/codecoradev/uteke/issues/196)
 
 ## v0.0.9 — Website Migration `✓ Done`
 
-- [#194 Website migrated to VitePress](https://github.com/codecoradev/uteke/issues/194) `✓ Done`
-  - SvelteKit → VitePress, built-in full-text search
+- [#194 Website migrated to VitePress](https://github.com/codecoradev/uteke/issues/194)
 
 ## v0.0.8 — Stability & Architecture `✓ Done`
 
 - [#130 Architecture: module split](https://github.com/codecoradev/uteke/issues/130), [#132 Input validation](https://github.com/codecoradev/uteke/issues/132), [#134 Binary checksums](https://github.com/codecoradev/uteke/issues/134)
 - [#138 Schema versioning](https://github.com/codecoradev/uteke/issues/138), [#144 Error handling rewrite](https://github.com/codecoradev/uteke/issues/144)
-- [#137 Python wrapper: 21 methods](https://github.com/codecoradev/uteke/issues/137), [#49 Memory benchmark](https://github.com/codecoradev/uteke/issues/49)
 - Memory consolidation, import/export (JSONL)
 
 ## v0.0.7 — Core Stability `✓ Done`
 
 - [#120 Tag queries → json_each()](https://github.com/codecoradev/uteke/issues/120), [#127 Configurable tier thresholds](https://github.com/codecoradev/uteke/issues/127)
-- [#129 Test coverage: 34 → 94](https://github.com/codecoradev/uteke/issues/129)
 
 ## v0.0.5–v0.0.6 — Docker & Hardening `✓ Done`
 
 - [#95 UTEKE_HOME](https://github.com/codecoradev/uteke/issues/95), [#97 Dockerfile](https://github.com/codecoradev/uteke/issues/97), [#99 GHCR](https://github.com/codecoradev/uteke/issues/99)
-- Non-root container, Dependabot, JSON output omits embeddings
 
 ## v0.0.4 — Server Mode & Intelligence `✓ Done`
 
 - [#54 Daemon/server mode](https://github.com/codecoradev/uteke/issues/54), [#51 Temporal facts](https://github.com/codecoradev/uteke/issues/51), [#52 Consolidation](https://github.com/codecoradev/uteke/issues/52)
-- [#43 Bulk operations](https://github.com/codecoradev/uteke/issues/43), [#45 Namespace switching](https://github.com/codecoradev/uteke/issues/45), [#86 Cora CI review](https://github.com/codecoradev/uteke/issues/86)
 
 ## v0.0.2–v0.0.3 — Foundation `✓ Done`
 
 - [#40 usearch persistent index](https://github.com/codecoradev/uteke/issues/40), [#39 Multi-agent namespaces](https://github.com/codecoradev/uteke/issues/39)
-- [#38 Tiered memory](https://github.com/codecoradev/uteke/issues/38), [#37 Health checks](https://github.com/codecoradev/uteke/issues/37)
-- [#42 Tag management](https://github.com/codecoradev/uteke/issues/42), [#44 Memory aging](https://github.com/codecoradev/uteke/issues/44)
-- [#48 Configuration file](https://github.com/codecoradev/uteke/issues/48), [#47 Shell hooks](https://github.com/codecoradev/uteke/issues/47)
-- Graceful shutdown, file logging with rotation
+- [#38 Tiered memory](https://github.com/codecoradev/uteke/issues/38), [#42 Tag management](https://github.com/codecoradev/uteke/issues/42)
 
-## What's Next
+---
 
-Demand-gated — we build what people actually use.
+## v0.2.0 — Knowledge Graph & Scale `Current`
 
-- Better embeddings (larger model option)
+- [#317 SQLite graph storage](https://github.com/codecoradev/uteke/issues/317) — optional knowledge graph mode
+- [#245 Code-aware embedding with AST chunking](https://github.com/codecoradev/uteke/issues/245) — entity extraction from code
+- [#293 Structured memory](https://github.com/codecoradev/uteke/issues/293) — nested JSON content
 - [#46 Import from external knowledge sources](https://github.com/codecoradev/uteke/issues/46)
-- Python SDK (PyO3 bindings)
-- Editor integrations (VS Code, JetBrains)
-- Node.js SDK (NAPI)
-- [#100 TLS support](https://github.com/codecoradev/uteke/issues/100)
-- [#101 API key auth for uteke-serve](https://github.com/codecoradev/uteke/issues/101)
+- [#55 Hermes plugin](https://github.com/codecoradev/uteke/issues/55) — uteke integration


### PR DESCRIPTION
Closes #325

## Changes

### Release workflow (`.github/workflows/release.yml`)
- **sync-main blocking again** — removed `continue-on-error`, build-release and publish-crates now `needs: [sync-main]`
- **Safe fast-forward** — checks `merge-base --is-ancestor` before pushing. If main diverged, aborts with error instead of blind force-push
- **No more separate develop checkout** — sync-main checks out tag commit directly (tag already points to develop HEAD)

### Roadmap (`docs/roadmap.md`)
- Added v0.0.13, v0.0.14, v0.0.15 sections (were missing)
- Replaced speculative "What Next" list with concrete **v0.2.0 — Knowledge Graph & Scale** section
- Added #49 and #316 to v0.1.0 section
- Consolidated older versions

### Docs cleanup
- `docs/launch/`: ajianaz → codecoradev (3 files)
- `docs/architecture.md`: model path `models/embeddinggemma/` → `embeddinggemma-q4/onnx/`
- `CHANGELOG.md`: historical website URL updated

## Root cause of #325
Commit `20cb3e8` made sync-main `continue-on-error: true`, so when it failed (main diverged from develop), builds proceeded anyway. The workflow fix makes sync-main blocking again — if main can't be fast-forwarded, the release aborts.

## Post-merge action
After this PR merges to develop, main needs to be fast-forwarded to develop HEAD. The next `v*` tag push will auto-sync via the new workflow.