### PR TITLE
feat(#293): structured memory — JSON content support (schema v6)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -108,6 +108,12 @@ pub enum Commands {
         /// Query memories as they existed at this timestamp (RFC3339, e.g. 2026-06-01T12:00:00Z)
         #[arg(long)]
         at: Option<String>,
+        /// Content display format: 'auto' (detect), 'text' (force text), 'json' (pretty-print JSON)
+        #[arg(long, default_value = "auto")]
+        content_format: String,
+        /// Filter results by JSON field (format: key=value, e.g. --where role=CTO)
+        #[arg(long)]
+        r#where: Option<String>,
     },
     /// Search memories by content keywords (text search)
     Search {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -64,6 +64,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             depth,
             context,
             at,
+            content_format,
+            r#where,
         } => recall::run_recall(
             cli,
             uteke,
@@ -80,6 +82,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
             *depth,
             *context,
             at.as_deref(),
+            content_format.as_str(),
+            r#where.as_deref(),
         ),
 
         Commands::Search { query, limit, tags } => {

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -22,6 +22,8 @@ pub(crate) fn run_recall(
     depth: usize,
     context: bool,
     at: Option<&str>,
+    content_format: &str,
+    where_filter: Option<&str>,
 ) -> Result<(), String> {
     // Resolve threshold: --min > --strict (→ config min_score_strict) > config min_score > 0.0
     let min_score = match min {
@@ -93,6 +95,39 @@ pub(crate) fn run_recall(
         })
         .collect();
 
+    // JSON field-level filtering: --where key=value
+    let filtered: Vec<_> = if let Some(where_clause) = where_filter {
+        let (key, value) = parse_where(where_clause)?;
+        filtered
+            .into_iter()
+            .filter(|sr| {
+                if sr.memory.content_type != "json" {
+                    return false;
+                }
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&sr.memory.content) {
+                    if let Some(obj) = v.as_object() {
+                        let field = match obj.get(&key) {
+                            Some(f) => f,
+                            None => return false,
+                        };
+                        // Match string, number, or bool values
+                        let actual = match field {
+                            serde_json::Value::String(s) => s.clone(),
+                            serde_json::Value::Number(n) => n.to_string(),
+                            serde_json::Value::Bool(b) => b.to_string(),
+                            serde_json::Value::Null => "null".to_string(),
+                            _ => return false, // arrays/objects not supported in key=value filter
+                        };
+                        return actual == value;
+                    }
+                }
+                false
+            })
+            .collect()
+    } else {
+        filtered
+    };
+
     if filtered.is_empty() {
         if cli.json {
             // Always output a JSON array for machine consumers (cora-cli,
@@ -140,7 +175,21 @@ pub(crate) fn run_recall(
             );
         }
     } else if cli.json {
-        output::print_json(&filtered);
+        // Apply content_format: pretty-print JSON content when requested
+        if content_format == "json" {
+            let mut formatted: Vec<_> = filtered.into_iter().collect();
+            for sr in &mut formatted {
+                if sr.memory.content_type == "json" {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&sr.memory.content) {
+                        sr.memory.content = serde_json::to_string_pretty(&v)
+                            .unwrap_or_else(|_| sr.memory.content.clone());
+                    }
+                }
+            }
+            output::print_json(&formatted);
+        } else {
+            output::print_json(&filtered);
+        }
     } else {
         output::print_recall_human(&filtered);
     }
@@ -171,4 +220,15 @@ pub(crate) fn run_search(
         output::print_search_human(&results);
     }
     Ok(())
+}
+
+/// Parse a `--where` expression in `key=value` format.
+fn parse_where(s: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = s.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid --where expression: '{s}'. Use key=value format."
+        ));
+    }
+    Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
 }

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -90,6 +90,9 @@ impl crate::Uteke {
             }
         };
 
+        // Detect content type for consolidated memory
+        let content_type = crate::memory::crud::detect_content_type(content);
+
         // Use remember_precomputed to avoid double-embedding
         let id = self.remember_precomputed(
             content,
@@ -97,6 +100,7 @@ impl crate::Uteke {
             None,
             Some(ns),
             memory_type.unwrap_or("fact"),
+            content_type,
             &embedding,
         )?;
 

--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -87,6 +87,7 @@ impl crate::Uteke {
                 memory_type: "fact".to_string(),
                 importance: 0.5,
                 pinned: false,
+                content_type: "text".to_string(),
             };
 
             // Write-ahead: vector index first (can be rolled back), then SQLite.

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -413,6 +413,7 @@ mod tests {
             memory_type: "fact".to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: "text".to_string(),
         };
 
         let json = serde_json::to_string(&m).unwrap();
@@ -457,6 +458,7 @@ mod tests {
             memory_type: "fact".to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: "text".to_string(),
         };
 
         let sr = SearchResult {

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -36,8 +36,8 @@ impl super::Store {
         let cutoff =
             (chrono::Utc::now() - chrono::Duration::days(older_than_days as i64)).to_rfc3339();
         let sql = r#"
-            SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
-            FROM memories
+            SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type
+                 FROM memories
             WHERE namespace = ?1
               AND deprecated = 0
               AND created_at < ?2

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -104,7 +104,7 @@ impl super::Store {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type
                  FROM memories WHERE namespace = ?1 AND deprecated = 0 ORDER BY created_at DESC LIMIT ?2",
             )
             .map_err(|e| Error::db("database operation", e))?;
@@ -147,7 +147,7 @@ impl super::Store {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type
                  FROM memories WHERE namespace = ?1
                  AND deprecated = 1
                  AND updated_at < ?2

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -6,6 +6,59 @@ use rusqlite::{params, OptionalExtension};
 
 use super::store::{row_to_memory, serialize_embedding};
 
+/// Detect whether content is valid JSON (object or array).
+/// Returns "json" if it parses as JSON and starts with `{` or `[`, otherwise "text".
+pub fn detect_content_type(content: &str) -> &'static str {
+    let trimmed = content.trim();
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && serde_json::from_str::<serde_json::Value>(content).is_ok()
+    {
+        "json"
+    } else {
+        "text"
+    }
+}
+
+/// Flatten JSON content to a text representation for embedding.
+/// Example: `{"name": "Alice", "role": "CTO"}` → "name: Alice, role: CTO"
+pub(crate) fn flatten_json_for_embedding(content: &str) -> String {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(content) {
+        if let Some(obj) = v.as_object() {
+            let pairs: Vec<String> = obj
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, flatten_value(v)))
+                .collect();
+            return pairs.join(", ");
+        }
+        // For arrays, flatten each element
+        if let Some(arr) = v.as_array() {
+            let items: Vec<String> = arr.iter().map(flatten_value).collect();
+            return items.join(", ");
+        }
+    }
+    content.to_string()
+}
+
+fn flatten_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Object(map) => {
+            let pairs: Vec<String> = map
+                .iter()
+                .map(|(k, val)| format!("{}: {}", k, flatten_value(val)))
+                .collect();
+            format!("{{{}}}", pairs.join(", "))
+        }
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(flatten_value).collect();
+            format!("[{}]", items.join(", "))
+        }
+    }
+}
+
 impl super::Store {
     /// Insert a new memory. Returns the inserted memory's ID.
     pub fn insert(&self, memory: &Memory) -> Result<(), Error> {
@@ -17,8 +70,8 @@ impl super::Store {
 
         self.conn
             .execute(
-                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                 params![
                     memory.id,
                     memory.content,
@@ -36,6 +89,7 @@ impl super::Store {
                     memory.memory_type,
                     memory.importance,
                     memory.pinned as i32,
+                    memory.content_type,
                 ],
             )
             .map_err(|e| Error::db("Failed to insert memory", e))?;
@@ -57,7 +111,7 @@ impl super::Store {
     pub fn get_by_id(&self, id: &str) -> Result<Option<Memory>, Error> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned FROM memories WHERE id = ?1")
+            .prepare("SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type FROM memories WHERE id = ?1")
             .map_err(|e| Error::db("Failed to prepare statement for get_by_id", e))?;
 
         let result = stmt
@@ -136,8 +190,8 @@ impl super::Store {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
 
         let sql = match tag {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM memory_tags WHERE memory_id = memories.id AND tag = ?2) ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type FROM memories WHERE namespace = ?1 AND EXISTS (SELECT 1 FROM memory_tags WHERE memory_id = memories.id AND tag = ?2) ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type FROM memories WHERE namespace = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
         };
 
         let mut memories = Vec::new();
@@ -211,8 +265,8 @@ impl super::Store {
     /// Load all memories for index rebuilding, optionally filtered by namespace.
     pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
         let sql = match namespace {
-            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned FROM memories WHERE namespace = ?1 ORDER BY created_at",
-            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned FROM memories ORDER BY created_at",
+            Some(_) => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type FROM memories WHERE namespace = ?1 ORDER BY created_at",
+            None => "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type FROM memories ORDER BY created_at",
         };
 
         let mut memories = Vec::new();
@@ -350,5 +404,135 @@ impl super::Store {
     /// Get the underlying database path, if file-based.
     pub fn path(&self) -> Option<std::path::PathBuf> {
         self.conn.path().map(std::path::PathBuf::from)
+    }
+}
+
+#[cfg(test)]
+mod content_type_tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_json_object() {
+        assert_eq!(
+            detect_content_type(r#"{"name": "Alice", "role": "CTO"}"#),
+            "json"
+        );
+    }
+
+    #[test]
+    fn test_detect_json_array() {
+        assert_eq!(detect_content_type(r#"[1, 2, 3]"#), "json");
+    }
+
+    #[test]
+    fn test_detect_text_not_json() {
+        assert_eq!(detect_content_type("hello world"), "text");
+    }
+
+    #[test]
+    fn test_detect_text_looks_like_json_but_invalid() {
+        assert_eq!(detect_content_type("{not valid json}"), "text");
+    }
+
+    #[test]
+    fn test_flatten_simple_object() {
+        let result = flatten_json_for_embedding(r#"{"name": "Alice", "role": "CTO"}"#);
+        assert!(result.contains("name: Alice"));
+        assert!(result.contains("role: CTO"));
+    }
+
+    #[test]
+    fn test_flatten_with_numbers() {
+        let result = flatten_json_for_embedding(r#"{"count": 42, "active": true}"#);
+        assert!(result.contains("count: 42"));
+        assert!(result.contains("active: true"));
+    }
+
+    #[test]
+    fn test_flatten_array() {
+        let result = flatten_json_for_embedding(r#"["rust", "python", "go"]"#);
+        assert_eq!(result, "rust, python, go");
+    }
+
+    #[test]
+    fn test_flatten_nested_object() {
+        let result =
+            flatten_json_for_embedding(r#"{"name": "Alice", "addr": {"city": "Jakarta"}}"#);
+        assert!(result.contains("name: Alice"));
+        assert!(result.contains("addr: {city: Jakarta}"));
+    }
+
+    #[test]
+    fn test_flatten_invalid_json_returns_raw() {
+        let result = flatten_json_for_embedding("not json at all");
+        assert_eq!(result, "not json at all");
+    }
+
+    #[test]
+    fn test_json_content_stored_with_correct_type() {
+        let store = super::super::store::Store::open(":memory:").unwrap();
+        let json_content = r#"{"name": "Alice", "role": "CTO", "timezone": "UTC+7"}"#;
+        let memory = crate::memory::types::Memory {
+            id: "json-test-1".to_string(),
+            content: json_content.to_string(),
+            embedding: vec![0.1; 768],
+            tags: vec!["person".to_string()],
+            metadata: serde_json::Value::Null,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            namespace: "default".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "json".to_string(),
+        };
+        store.insert(&memory).unwrap();
+
+        let retrieved = store.get_by_id("json-test-1").unwrap().unwrap();
+        assert_eq!(retrieved.content_type, "json");
+        assert_eq!(retrieved.content, json_content);
+    }
+
+    #[test]
+    fn test_text_content_still_works() {
+        let store = super::super::store::Store::open(":memory:").unwrap();
+        let memory = crate::memory::types::Memory {
+            id: "text-test-1".to_string(),
+            content: "plain text memory".to_string(),
+            embedding: vec![0.1; 768],
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            namespace: "default".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+        };
+        store.insert(&memory).unwrap();
+
+        let retrieved = store.get_by_id("text-test-1").unwrap().unwrap();
+        assert_eq!(retrieved.content_type, "text");
+        assert_eq!(retrieved.content, "plain text memory");
+    }
+
+    #[test]
+    fn test_schema_migration_v5_to_v6_adds_content_type() {
+        // Fresh DB should have content_type column
+        let store = super::super::store::Store::open(":memory:").unwrap();
+        assert!(store.column_exists("content_type"));
+        let version = store.schema_version().unwrap();
+        assert_eq!(version, 6);
     }
 }

--- a/crates/uteke-core/src/memory/fts5.rs
+++ b/crates/uteke-core/src/memory/fts5.rs
@@ -90,14 +90,14 @@ impl super::Store {
 
         let sql = match namespace {
             Some(_) => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.namespace = ?2 AND m.deprecated = 0
                    ORDER BY f.rank
                    LIMIT ?3"#
             }
             None => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.deprecated = 0
                    ORDER BY f.rank
@@ -173,14 +173,14 @@ impl super::Store {
 
         let sql = match namespace {
             Some(_) => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.namespace = ?2 AND m.deprecated = 0
                    ORDER BY f.rank
                    LIMIT ?3"#
             }
             None => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.deprecated = 0
                    ORDER BY f.rank
@@ -254,6 +254,7 @@ mod tests {
             memory_type: "fact".to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: "text".to_string(),
         }
     }
 

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -280,7 +280,7 @@ impl super::Store {
             Some(_) => {
                 "SELECT m.id, m.content, m.embedding, m.tags, m.metadata, \
                  m.created_at, m.updated_at, m.namespace, m.access_count, \
-                 m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned \
+                 m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
                  WHERE rm.room_id = ?1 AND rm.author = ?2 \
@@ -290,7 +290,7 @@ impl super::Store {
             None => {
                 "SELECT m.id, m.content, m.embedding, m.tags, m.metadata, \
                  m.created_at, m.updated_at, m.namespace, m.access_count, \
-                 m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned \
+                 m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
                  WHERE rm.room_id = ?1 \

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -159,6 +159,8 @@ impl super::Store {
                 4 => self.migrate_v3_to_v4()?,
                 // v5: Tag junction table for O(log n) lookups
                 5 => self.migrate_v4_to_v5()?,
+                // v6: Content type column (text vs json)
+                6 => self.migrate_v5_to_v6()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -299,6 +301,21 @@ impl super::Store {
         }
 
         tracing::info!("Tag junction table populated for {} memories", rows.len());
+        Ok(())
+    }
+
+    /// Migration v5 → v6: Add content_type column for structured memory support.
+    ///
+    /// Stores whether memory content is "text" (default) or "json".
+    /// Existing memories default to "text".
+    fn migrate_v5_to_v6(&self) -> Result<(), Error> {
+        if !self.column_exists("content_type") {
+            self.conn
+                .execute_batch(
+                    "ALTER TABLE memories ADD COLUMN content_type TEXT NOT NULL DEFAULT 'text';",
+                )
+                .map_err(|e| Error::db("add content_type column", e))?;
+        }
         Ok(())
     }
 

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS memories (
     valid_until TEXT,
     memory_type TEXT NOT NULL DEFAULT 'fact',
     importance REAL NOT NULL DEFAULT 0.5,
-    pinned INTEGER NOT NULL DEFAULT 0
+    pinned INTEGER NOT NULL DEFAULT 0,
+    content_type TEXT NOT NULL DEFAULT 'text'
 );
 CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
@@ -36,7 +37,7 @@ CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON memory_tags(tag);
 "#;
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 5;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 6;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -237,6 +238,7 @@ pub(super) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite:
     let memory_type: String = row.get(13).unwrap_or_else(|_| "fact".to_string());
     let importance: f64 = row.get(14).unwrap_or(0.5);
     let pinned: bool = row.get(15).unwrap_or(false);
+    let content_type: String = row.get(16).unwrap_or_else(|_| "text".to_string());
 
     Ok(Memory {
         id,
@@ -255,6 +257,7 @@ pub(super) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite:
         memory_type,
         importance,
         pinned,
+        content_type,
     })
 }
 
@@ -282,6 +285,7 @@ mod tests {
             memory_type: "fact".to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: "text".to_string(),
         }
     }
 
@@ -303,6 +307,7 @@ mod tests {
             memory_type: "fact".to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: "text".to_string(),
         }
     }
 
@@ -1306,6 +1311,7 @@ mod tests {
             memory_type: "fact".to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: "text".to_string(),
         }
     }
 

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -50,6 +50,9 @@ pub struct Memory {
     /// Whether this memory is pinned (never decays).
     #[serde(default)]
     pub pinned: bool,
+    /// Content type: "text" (default) or "json".
+    #[serde(default = "default_content_type")]
+    pub content_type: String,
 }
 
 fn default_namespace() -> String {
@@ -62,6 +65,10 @@ fn default_importance() -> f64 {
 
 fn default_memory_type() -> String {
     "fact".to_string()
+}
+
+fn default_content_type() -> String {
+    "text".to_string()
 }
 
 /// A search result with relevance score.

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -20,6 +20,21 @@ impl crate::Uteke {
         self.remember_typed(content, tags, metadata, namespace, "fact")
     }
 
+    /// Store a JSON-structured memory. Content must be valid JSON.
+    ///
+    /// This is a convenience wrapper that validates JSON before storing.
+    /// The `remember()` method also auto-detects JSON content.
+    pub fn remember_json(
+        &self,
+        json_content: &str,
+        tags: &[&str],
+        namespace: Option<&str>,
+    ) -> Result<String, Error> {
+        serde_json::from_str::<serde_json::Value>(json_content)
+            .map_err(|e| Error::Validation(format!("Invalid JSON content: {e}")))?;
+        self.remember(json_content, tags, None, namespace)
+    }
+
     /// Store a new memory with explicit type.
     ///
     /// Returns the UUID of the created memory.
@@ -38,6 +53,13 @@ impl crate::Uteke {
                 "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context"
             ))
         })?;
+        // Detect JSON content and use flattened text for embedding
+        let content_type = crate::memory::crud::detect_content_type(content);
+        let embed_text = if content_type == "json" {
+            crate::memory::crud::flatten_json_for_embedding(content)
+        } else {
+            content.to_string()
+        };
         // Lazy-load embedder on first use
         self.ensure_embedder()?;
         let embedding = self
@@ -46,14 +68,23 @@ impl crate::Uteke {
             .map_err(|_| Error::lock("embedder lock during remember"))?
             .as_ref()
             .expect("embedder ensured above")
-            .embed(content)?;
-        self.remember_precomputed(content, tags, metadata, namespace, memory_type, &embedding)
+            .embed(&embed_text)?;
+        self.remember_precomputed(
+            content,
+            tags,
+            metadata,
+            namespace,
+            memory_type,
+            content_type,
+            &embedding,
+        )
     }
 
     /// Store a new memory with a pre-computed embedding.
     ///
     /// Use when the embedding has already been computed (e.g., contradiction check).
     /// Returns the UUID of the created memory.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn remember_precomputed(
         &self,
         content: &str,
@@ -61,6 +92,7 @@ impl crate::Uteke {
         metadata: Option<serde_json::Value>,
         namespace: Option<&str>,
         memory_type: &str,
+        content_type: &str,
         embedding: &[f32],
     ) -> Result<String, Error> {
         let id = uuid::Uuid::new_v4().to_string();
@@ -83,6 +115,7 @@ impl crate::Uteke {
             memory_type: memory_type.to_string(),
             importance: 0.5,
             pinned: false,
+            content_type: content_type.to_string(),
         };
 
         // Acquire index write lock BEFORE any writes so lock failures are detected early.

--- a/crates/uteke-core/src/recall_cache.rs
+++ b/crates/uteke-core/src/recall_cache.rs
@@ -217,6 +217,7 @@ mod tests {
                 memory_type: "fact".to_string(),
                 importance: 0.5,
                 pinned: false,
+                content_type: "text".to_string(),
             },
             score: 0.95,
         }];


### PR DESCRIPTION
Closes #293

## Changes

### Schema v6
- New column: `content_type TEXT NOT NULL DEFAULT 'text'`
- Migration v5→v6: ALTER TABLE ADD COLUMN

### JSON content support
- **Auto-detect**: `remember()` detects JSON input (starts with `{` or `[`), sets `content_type='json'`
- **Flatten for embedding**: `{"name":"Alice","role":"CTO"}` → `"name: Alice, role: CTO"` for semantic search
- **remember_json()**: validated wrapper that ensures valid JSON before storing

### CLI flags
- `--where key=value`: filter JSON memories by field (supports string, number, bool, null)
- `--content-format json`: pretty-print JSON content in output

### Backward compatible
- All existing text memories get `content_type='text'`
- No breaking changes to existing API

## Tests
- `cargo test --workspace` ✅ (146 passed, 5 ignored for ONNX)
- 12 new tests (JSON detection, flattening, storage, migration)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all` ✅