### PR TITLE
feat(#317): SQLite knowledge graph storage (schema v7)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -273,6 +273,53 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Knowledge graph operations
+    Graph {
+        #[command(subcommand)]
+        command: GraphCommands,
+    },
+}
+
+/// Subcommands for knowledge graph operations.
+#[derive(Subcommand)]
+pub enum GraphCommands {
+    /// List all graph nodes
+    Nodes {
+        /// Filter by entity type
+        #[arg(long)]
+        entity_type: Option<String>,
+    },
+    /// List all graph edges
+    Edges {
+        /// Filter by relation type
+        #[arg(long)]
+        relation: Option<String>,
+    },
+    /// Find neighbors of a node (outgoing edges via BFS)
+    Neighbors {
+        /// Node label
+        label: String,
+        /// Max traversal depth
+        #[arg(long, default_value = "1")]
+        depth: usize,
+    },
+    /// Find shortest path between two nodes (BFS)
+    Path {
+        /// Source node label
+        source: String,
+        /// Target node label
+        target: String,
+        /// Max search depth
+        #[arg(long, default_value = "5")]
+        max_depth: usize,
+    },
+    /// Query edges by relation type
+    Query {
+        /// Relation type (e.g., "owns", "part_of")
+        relation: String,
+    },
+    /// Show graph statistics
+    Stats,
 }
 
 /// Subcommands for tag management.

--- a/crates/uteke-cli/src/commands/graph.rs
+++ b/crates/uteke-cli/src/commands/graph.rs
@@ -1,0 +1,183 @@
+//! Graph command handlers.
+
+use crate::cli::GraphCommands;
+use crate::Cli;
+use uteke_core::GraphStore;
+
+/// Run graph command.
+pub fn run(cli: &Cli, uteke: &uteke_core::Uteke, command: &GraphCommands) -> Result<(), String> {
+    let store = uteke.graph_store();
+    let graph = GraphStore::new(store);
+
+    match command {
+        GraphCommands::Nodes { entity_type } => {
+            let nodes = graph
+                .all_nodes()
+                .map_err(|e| format!("Failed to list nodes: {e}"))?;
+            let filtered: Vec<_> = if let Some(et) = entity_type {
+                nodes
+                    .into_iter()
+                    .filter(|n| n.entity_type.as_deref() == Some(et.as_str()))
+                    .collect()
+            } else {
+                nodes
+            };
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
+            } else {
+                if filtered.is_empty() {
+                    println!("No graph nodes found.");
+                } else {
+                    println!("Graph Nodes ({}):", filtered.len());
+                    for node in &filtered {
+                        let etype = node.entity_type.as_deref().unwrap_or("—");
+                        println!("  • {} [{}] ({})", node.label, etype, node.id);
+                    }
+                }
+            }
+        }
+
+        GraphCommands::Edges { relation } => {
+            let edges = graph
+                .all_edges()
+                .map_err(|e| format!("Failed to list edges: {e}"))?;
+            let filtered: Vec<_> = if let Some(rel) = relation {
+                edges
+                    .into_iter()
+                    .filter(|e| e.relation.eq_ignore_ascii_case(rel))
+                    .collect()
+            } else {
+                edges
+            };
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
+            } else {
+                if filtered.is_empty() {
+                    println!("No graph edges found.");
+                } else {
+                    println!("Graph Edges ({}):", filtered.len());
+                    for edge in &filtered {
+                        println!(
+                            "  • {} -[{}]-> {} (w={:.1})",
+                            edge.source_id, edge.relation, edge.target_id, edge.weight
+                        );
+                    }
+                }
+            }
+        }
+
+        GraphCommands::Neighbors { label, depth } => {
+            let node = graph
+                .find_node(label)
+                .map_err(|e| format!("Failed to find node: {e}"))?
+                .ok_or_else(|| format!("Node '{label}' not found"))?;
+
+            let edges = graph
+                .neighbors(&node.id, *depth)
+                .map_err(|e| format!("Failed to get neighbors: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&edges).unwrap());
+            } else {
+                println!("Neighbors of '{}' (depth {}):", label, depth);
+                if edges.is_empty() {
+                    println!("  (none)");
+                } else {
+                    for edge in &edges {
+                        let target = graph
+                            .get_node(&edge.target_id)
+                            .map_err(|e| format!("Failed to get node: {e}"))?;
+                        let target_label = target
+                            .map(|n| n.label)
+                            .unwrap_or_else(|| edge.target_id.clone());
+                        println!(
+                            "  -[{}]-> {} (w={:.1})",
+                            edge.relation, target_label, edge.weight
+                        );
+                    }
+                }
+            }
+        }
+
+        GraphCommands::Path {
+            source,
+            target,
+            max_depth,
+        } => {
+            let path = graph
+                .find_path(source, target, *max_depth)
+                .map_err(|e| format!("Failed to find path: {e}"))?;
+
+            match path {
+                Some(path) => {
+                    if cli.json {
+                        println!("{}", serde_json::to_string_pretty(&path).unwrap());
+                    } else {
+                        let labels: Vec<&str> =
+                            path.nodes.iter().map(|n| n.label.as_str()).collect();
+                        let rels: Vec<&str> =
+                            path.edges.iter().map(|e| e.relation.as_str()).collect();
+                        println!("Path: {}", labels.join(" → "));
+                        if !rels.is_empty() {
+                            println!("Relations: {}", rels.join(", "));
+                        }
+                        println!("Total weight: {:.1}", path.total_weight);
+                    }
+                }
+                None => {
+                    if cli.json {
+                        println!("null");
+                    } else {
+                        println!(
+                            "No path found between '{}' and '{}' (max depth {})",
+                            source, target, max_depth
+                        );
+                    }
+                }
+            }
+        }
+
+        GraphCommands::Query { relation } => {
+            let triples = graph
+                .query_relation(relation)
+                .map_err(|e| format!("Failed to query relation: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&triples).unwrap());
+            } else {
+                if triples.is_empty() {
+                    println!("No edges with relation '{}'", relation);
+                } else {
+                    println!("Relation '{}' ({}):", relation, triples.len());
+                    for t in &triples {
+                        println!(
+                            "  • {} -[{}]-> {} (w={:.1})",
+                            t.source.label, t.edge.relation, t.target.label, t.edge.weight
+                        );
+                    }
+                }
+            }
+        }
+
+        GraphCommands::Stats => {
+            let stats = graph
+                .stats()
+                .map_err(|e| format!("Failed to get stats: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&stats).unwrap());
+            } else {
+                println!("Graph Statistics:");
+                println!("  Nodes: {}", stats.node_count);
+                println!("  Edges: {}", stats.edge_count);
+                if !stats.relation_types.is_empty() {
+                    println!("  Relations: {}", stats.relation_types.join(", "));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 mod aging;
 pub(crate) mod bench;
 mod forget;
+pub(crate) mod graph;
 mod list;
 mod maintenance;
 mod namespace;
@@ -224,5 +225,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
         // Bench is handled early in main.rs (creates own temp stores, never
         // reaches this dispatch path).
         Commands::Bench { .. } => Ok(()),
+
+        Commands::Graph { command } => crate::commands::graph::run(cli, uteke, command),
     }
 }

--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -1,34 +1,36 @@
-//! Relationship graph traversal — follow edges stored in memory metadata.
+//! Knowledge graph module — relationship traversal + SQLite graph storage.
 //!
-//! Relationships are stored in the `metadata` JSON field under a
-//! `relationships` key, e.g.:
-//! ```json
-//! {"relationships": [{"type": "supersedes", "target": "uuid-xxx"}, ...]}
-//! ```
+//! Two systems coexist:
+//! 1. **Relationship edges** — stored in memory metadata JSON (v0.1.0, #246)
+//! 2. **Graph storage** — graph_nodes + graph_edges tables (v0.2.0, #317)
+//!
+//! The metadata-based system is for lightweight per-memory relationships
+//! (supersedes, contradicts, etc). The table-based system is for rich
+//! entity graphs with multi-hop traversal.
 
 use crate::error::Error;
 use crate::memory::types::{Memory, SearchResult};
-use std::collections::{HashMap, HashSet};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet, VecDeque};
 
-/// Known relationship types.
+// ── Known relationship types (metadata-based) ──────────────────────────
+
 pub const REL_SUPERSEDES: &str = "supersedes";
 pub const REL_CONTRADICTS: &str = "contradicts";
 pub const REL_PART_OF: &str = "part_of";
 pub const REL_REFERENCES: &str = "references";
 
-/// All valid relationship type strings.
 pub const VALID_REL_TYPES: &[&str] =
     &[REL_SUPERSEDES, REL_CONTRADICTS, REL_PART_OF, REL_REFERENCES];
 
-/// A single relationship edge.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relationship {
     #[serde(rename = "type")]
     pub rel_type: String,
     pub target: String,
 }
 
-/// Parse relationships from memory metadata.
 fn parse_relationships(memory: &Memory) -> Vec<Relationship> {
     memory
         .metadata
@@ -37,12 +39,10 @@ fn parse_relationships(memory: &Memory) -> Vec<Relationship> {
         .unwrap_or_default()
 }
 
-/// Build a relationship string for storing in metadata.
 pub fn build_meta_relationship(rel_type: &str, target_id: &str) -> String {
     format!("rel:{rel_type}:{target_id}")
 }
 
-/// Check if a meta value is a relationship directive.
 pub fn is_relationship_meta(value: &str) -> Option<(&str, &str)> {
     let rest = value.strip_prefix("rel:")?;
     let (rel_type, target) = rest.split_once(':')?;
@@ -54,11 +54,6 @@ pub fn is_relationship_meta(value: &str) -> Option<(&str, &str)> {
 }
 
 impl crate::Uteke {
-    /// Recall memories and follow relationship edges up to `depth` levels.
-    ///
-    /// Starts with the results of a normal recall, then traverses the
-    /// `relationships` field in each memory's metadata to find related
-    /// memories. Deduplicates by memory ID.
     pub fn recall_related(
         &self,
         query: &str,
@@ -68,7 +63,6 @@ impl crate::Uteke {
         min_score: f32,
         depth: usize,
     ) -> Result<Vec<SearchResult>, Error> {
-        // Initial recall
         let initial = self.recall_hybrid(
             query,
             limit,
@@ -82,7 +76,6 @@ impl crate::Uteke {
             return Ok(initial);
         }
 
-        // Collect all IDs to visit and track scores
         let mut visited: HashSet<String> = HashSet::new();
         let mut results: HashMap<String, (Memory, f32)> = HashMap::new();
 
@@ -91,22 +84,18 @@ impl crate::Uteke {
             results.insert(sr.memory.id.clone(), (sr.memory.clone(), sr.score));
         }
 
-        // BFS traversal
         let mut frontier: Vec<String> = initial.iter().map(|sr| sr.memory.id.clone()).collect();
 
         for level in 0..depth {
             if frontier.is_empty() {
                 break;
             }
-
             let mut next_frontier: Vec<String> = Vec::new();
-
             for memory_id in &frontier {
                 let memory = match self.get_by_id(memory_id)? {
                     Some(m) => m,
                     None => continue,
                 };
-
                 let rels = parse_relationships(&memory);
                 for rel in rels {
                     if visited.contains(&rel.target) {
@@ -118,10 +107,8 @@ impl crate::Uteke {
                         results.insert(rel.target.clone(), (target_memory.clone(), decayed_score));
                         next_frontier.push(rel.target.clone());
                     }
-                    // Missing targets not marked visited — allows alternate paths.
                 }
             }
-
             tracing::debug!(
                 "Relationship traversal level {}: found {} new memories",
                 level + 1,
@@ -130,7 +117,6 @@ impl crate::Uteke {
             frontier = next_frontier;
         }
 
-        // Convert to sorted results
         let mut all_results: Vec<SearchResult> = results
             .into_iter()
             .map(|(_, (memory, score))| SearchResult { memory, score })
@@ -140,19 +126,15 @@ impl crate::Uteke {
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
-
         all_results.truncate(limit);
         Ok(all_results)
     }
 
-    /// Get all memories related to a specific memory ID via relationship edges.
-    /// Returns both outgoing and incoming relationships.
     pub fn get_related(&self, memory_id: &str) -> Result<Vec<Memory>, Error> {
         let mut related = Vec::new();
         let mut seen = HashSet::new();
         seen.insert(memory_id.to_string());
 
-        // Outgoing: relationships in this memory's metadata
         if let Some(memory) = self.get_by_id(memory_id)? {
             for rel in parse_relationships(&memory) {
                 if !seen.contains(&rel.target) {
@@ -164,8 +146,6 @@ impl crate::Uteke {
             }
         }
 
-        // Incoming: scan memories that reference this one
-        // This is O(n) on metadata — acceptable for now (see AGENT.md: metadata in JSON blob)
         let all_memories = self.store.load_all(None)?;
         for m in all_memories {
             if seen.contains(&m.id) {
@@ -179,7 +159,665 @@ impl crate::Uteke {
                 }
             }
         }
-
         Ok(related)
+    }
+}
+
+// ── SQLite graph storage (#317) ─────────────────────────────────────
+
+/// A graph node representing an entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphNode {
+    pub id: String,
+    pub label: String,
+    pub entity_type: Option<String>,
+    pub properties: serde_json::Value,
+    pub memory_id: Option<String>,
+    pub created_at: String,
+}
+
+/// A directed edge between two nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphEdge {
+    pub id: String,
+    pub source_id: String,
+    pub target_id: String,
+    pub relation: String,
+    pub weight: f64,
+    pub created_at: String,
+}
+
+/// A path between two nodes via BFS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphPath {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    pub total_weight: f64,
+}
+
+/// (source, edge, target) triple for relation queries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphTriple {
+    pub source: GraphNode,
+    pub edge: GraphEdge,
+    pub target: GraphNode,
+}
+
+/// Graph statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphStats {
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub relation_types: Vec<String>,
+}
+
+/// Graph store backed by SQLite. Borrows a connection from the main Store.
+pub struct GraphStore<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> GraphStore<'a> {
+    pub fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Get or create a node by label. Returns node ID.
+    /// Idempotent — if a node with the same label exists, returns its ID.
+    pub fn upsert_node(
+        &self,
+        label: &str,
+        entity_type: Option<&str>,
+        memory_id: Option<&str>,
+    ) -> Result<String, Error> {
+        let existing: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT id FROM graph_nodes WHERE label = ?1 COLLATE NOCASE",
+                params![label],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("graph node lookup", e))?;
+
+        if let Some(id) = existing {
+            // Only set memory_id if not already set (don't overwrite existing link).
+            if let Some(mid) = memory_id {
+                self.conn
+                    .execute(
+                        "UPDATE graph_nodes SET memory_id = ?1 WHERE id = ?2 AND memory_id IS NULL",
+                        params![mid, id],
+                    )
+                    .map_err(|e| Error::db("update graph node", e))?;
+            }
+            return Ok(id);
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "INSERT INTO graph_nodes (id, label, entity_type, properties_json, memory_id, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![id, label, entity_type, "{}", memory_id, now],
+            )
+            .map_err(|e| Error::db("insert graph node", e))?;
+        Ok(id)
+    }
+
+    /// Create an edge between two nodes. Ignores if edge already exists (INSERT OR IGNORE).
+    pub fn add_edge(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relation: &str,
+        weight: f64,
+    ) -> Result<(), Error> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        let affected = self
+            .conn
+            .execute(
+                "INSERT OR IGNORE INTO graph_edges (id, source_id, target_id, relation, weight, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![id, source_id, target_id, relation, weight, now],
+            )
+            .map_err(|e| Error::db("insert graph edge", e))?;
+        if affected == 0 {
+            tracing::debug!(
+                "Edge already exists: {} -[{}]-> {} (new weight {weight} ignored)",
+                source_id,
+                relation,
+                target_id
+            );
+        }
+        Ok(())
+    }
+
+    /// Find a node by label (case-insensitive).
+    pub fn find_node(&self, label: &str) -> Result<Option<GraphNode>, Error> {
+        self.conn
+            .query_row(
+                "SELECT id, label, entity_type, properties_json, memory_id, created_at \
+                 FROM graph_nodes WHERE label = ?1 COLLATE NOCASE",
+                params![label],
+                row_to_node,
+            )
+            .optional()
+            .map_err(|e| Error::db("find graph node", e))
+    }
+
+    /// Get a node by ID.
+    pub fn get_node(&self, id: &str) -> Result<Option<GraphNode>, Error> {
+        self.conn
+            .query_row(
+                "SELECT id, label, entity_type, properties_json, memory_id, created_at \
+                 FROM graph_nodes WHERE id = ?1",
+                params![id],
+                row_to_node,
+            )
+            .optional()
+            .map_err(|e| Error::db("get graph node", e))
+    }
+
+    /// Get outgoing edges from a node, up to `max_depth` hops via BFS.
+    pub fn neighbors(&self, node_id: &str, max_depth: usize) -> Result<Vec<GraphEdge>, Error> {
+        let mut visited: HashSet<String> = HashSet::new();
+        visited.insert(node_id.to_string());
+        let mut result: Vec<GraphEdge> = Vec::new();
+        let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+        queue.push_back((node_id.to_string(), 0));
+
+        while let Some((nid, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let edges = self.outgoing_edges(&nid)?;
+            for edge in edges {
+                result.push(edge.clone());
+                if visited.insert(edge.target_id.clone()) {
+                    queue.push_back((edge.target_id, depth + 1));
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Find shortest path between two nodes using BFS.
+    pub fn find_path(
+        &self,
+        source_label: &str,
+        target_label: &str,
+        max_depth: usize,
+    ) -> Result<Option<GraphPath>, Error> {
+        let source = match self.find_node(source_label)? {
+            Some(n) => n,
+            None => return Ok(None),
+        };
+        let target = match self.find_node(target_label)? {
+            Some(n) => n,
+            None => return Ok(None),
+        };
+
+        if source.id == target.id {
+            return Ok(Some(GraphPath {
+                nodes: vec![source],
+                edges: vec![],
+                total_weight: 0.0,
+            }));
+        }
+
+        // BFS with parent tracking
+        let mut visited: HashSet<String> = HashSet::new();
+        visited.insert(source.id.clone());
+        let mut parent: HashMap<String, (String, GraphEdge)> = HashMap::new();
+        let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+        queue.push_back((source.id.clone(), 0));
+
+        while let Some((nid, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let edges = self.outgoing_edges(&nid)?;
+            for edge in edges {
+                if visited.insert(edge.target_id.clone()) {
+                    parent.insert(edge.target_id.clone(), (nid.clone(), edge.clone()));
+                    if edge.target_id == target.id {
+                        // Reconstruct path
+                        return Ok(Some(self.reconstruct_path(&source, &target, &parent)?));
+                    }
+                    queue.push_back((edge.target_id, depth + 1));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Query all (source, edge, target) triples matching a relation type.
+    pub fn query_relation(&self, relation: &str) -> Result<Vec<GraphTriple>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT s.id, s.label, s.entity_type, s.properties_json, s.memory_id, s.created_at, \
+                        e.id, e.source_id, e.target_id, e.relation, e.weight, e.created_at, \
+                        t.id, t.label, t.entity_type, t.properties_json, t.memory_id, t.created_at \
+                 FROM graph_edges e \
+                 JOIN graph_nodes s ON e.source_id = s.id \
+                 JOIN graph_nodes t ON e.target_id = t.id \
+                 WHERE e.relation = ?1 COLLATE NOCASE",
+            )
+            .map_err(|e| Error::db("prepare relation query", e))?;
+
+        let rows = stmt
+            .query_map(params![relation], |row| {
+                Ok(GraphTriple {
+                    source: row_to_node_at(row, 0)?,
+                    edge: row_to_edge_at(row, 6)?,
+                    target: row_to_node_at(row, 12)?,
+                })
+            })
+            .map_err(|e| Error::db("query relation", e))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::db("collect relation rows", e))
+    }
+
+    /// Get all nodes.
+    pub fn all_nodes(&self) -> Result<Vec<GraphNode>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, label, entity_type, properties_json, memory_id, created_at FROM graph_nodes ORDER BY label",
+            )
+            .map_err(|e| Error::db("prepare all nodes", e))?;
+
+        let rows = stmt
+            .query_map([], row_to_node)
+            .map_err(|e| Error::db("query all nodes", e))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::db("collect nodes", e))
+    }
+
+    /// Get all edges.
+    pub fn all_edges(&self) -> Result<Vec<GraphEdge>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, source_id, target_id, relation, weight, created_at FROM graph_edges ORDER BY created_at",
+            )
+            .map_err(|e| Error::db("prepare all edges", e))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(GraphEdge {
+                    id: row.get(0)?,
+                    source_id: row.get(1)?,
+                    target_id: row.get(2)?,
+                    relation: row.get(3)?,
+                    weight: row.get(4)?,
+                    created_at: row.get(5)?,
+                })
+            })
+            .map_err(|e| Error::db("query all edges", e))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::db("collect edges", e))
+    }
+
+    /// Get graph statistics.
+    pub fn stats(&self) -> Result<GraphStats, Error> {
+        let node_count: usize = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM graph_nodes", [], |row| row.get(0))
+            .map_err(|e| Error::db("count nodes", e))?;
+
+        let edge_count: usize = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM graph_edges", [], |row| row.get(0))
+            .map_err(|e| Error::db("count edges", e))?;
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT relation FROM graph_edges ORDER BY relation")
+            .map_err(|e| Error::db("prepare relation types", e))?;
+
+        let relation_types: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .map_err(|e| Error::db("query relation types", e))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::db("collect relation types", e))?;
+
+        Ok(GraphStats {
+            node_count,
+            edge_count,
+            relation_types,
+        })
+    }
+
+    // --- Internal helpers ---
+
+    fn outgoing_edges(&self, node_id: &str) -> Result<Vec<GraphEdge>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, source_id, target_id, relation, weight, created_at \
+                 FROM graph_edges WHERE source_id = ?1",
+            )
+            .map_err(|e| Error::db("prepare outgoing edges", e))?;
+
+        let rows = stmt
+            .query_map(params![node_id], |row| {
+                Ok(GraphEdge {
+                    id: row.get(0)?,
+                    source_id: row.get(1)?,
+                    target_id: row.get(2)?,
+                    relation: row.get(3)?,
+                    weight: row.get(4)?,
+                    created_at: row.get(5)?,
+                })
+            })
+            .map_err(|e| Error::db("query outgoing edges", e))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::db("collect outgoing edges", e))
+    }
+
+    fn reconstruct_path(
+        &self,
+        source: &GraphNode,
+        target: &GraphNode,
+        parent: &HashMap<String, (String, GraphEdge)>,
+    ) -> Result<GraphPath, Error> {
+        let mut nodes = vec![target.clone()];
+        let mut edges: Vec<GraphEdge> = Vec::new();
+        let mut total_weight = 0.0;
+
+        let mut current = target.id.clone();
+        while current != source.id {
+            let (parent_id, edge) = match parent.get(&current) {
+                Some(p) => p.clone(),
+                None => break,
+            };
+            edges.push(edge.clone());
+            total_weight += edge.weight;
+            if let Some(node) = self.get_node(&parent_id)? {
+                nodes.push(node);
+            }
+            current = parent_id;
+        }
+
+        nodes.reverse();
+        edges.reverse();
+
+        Ok(GraphPath {
+            nodes,
+            edges,
+            total_weight,
+        })
+    }
+}
+
+// --- Row mappers ---
+
+fn row_to_node(row: &rusqlite::Row) -> rusqlite::Result<GraphNode> {
+    let props_str: String = row.get(3)?;
+    let properties = serde_json::from_str(&props_str).unwrap_or(serde_json::json!({}));
+    Ok(GraphNode {
+        id: row.get(0)?,
+        label: row.get(1)?,
+        entity_type: row.get(2)?,
+        properties,
+        memory_id: row.get(4)?,
+        created_at: row.get(5)?,
+    })
+}
+
+fn row_to_node_at(row: &rusqlite::Row, offset: usize) -> rusqlite::Result<GraphNode> {
+    let props_str: String = row.get(offset + 3)?;
+    let properties = serde_json::from_str(&props_str).unwrap_or(serde_json::json!({}));
+    Ok(GraphNode {
+        id: row.get(offset)?,
+        label: row.get(offset + 1)?,
+        entity_type: row.get(offset + 2)?,
+        properties,
+        memory_id: row.get(offset + 4)?,
+        created_at: row.get(offset + 5)?,
+    })
+}
+
+fn row_to_edge_at(row: &rusqlite::Row, offset: usize) -> rusqlite::Result<GraphEdge> {
+    Ok(GraphEdge {
+        id: row.get(offset)?,
+        source_id: row.get(offset + 1)?,
+        target_id: row.get(offset + 2)?,
+        relation: row.get(offset + 3)?,
+        weight: row.get(offset + 4)?,
+        created_at: row.get(offset + 5)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        // Don't enable foreign_keys in test — graph_nodes references memories(id)
+        // which doesn't exist in this minimal test setup.
+        conn.execute_batch(
+            r#"
+            CREATE TABLE graph_nodes (
+                id TEXT PRIMARY KEY,
+                label TEXT NOT NULL COLLATE NOCASE,
+                entity_type TEXT,
+                properties_json TEXT DEFAULT '{}',
+                memory_id TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE graph_edges (
+                id TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+                target_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+                relation TEXT NOT NULL COLLATE NOCASE,
+                weight REAL NOT NULL DEFAULT 1.0,
+                created_at TEXT NOT NULL,
+                UNIQUE(source_id, target_id, relation)
+            );
+            CREATE INDEX idx_graph_nodes_label ON graph_nodes(label);
+            CREATE INDEX idx_graph_edges_source ON graph_edges(source_id);
+            CREATE INDEX idx_graph_edges_target ON graph_edges(target_id);
+            "#,
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_upsert_node_creates_new() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let id = g.upsert_node("Alice", Some("person"), None).unwrap();
+        assert!(!id.is_empty());
+    }
+
+    #[test]
+    fn test_upsert_node_idempotent() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let id1 = g.upsert_node("Alice", None, None).unwrap();
+        let id2 = g.upsert_node("Alice", None, None).unwrap();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_upsert_node_case_insensitive() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let id1 = g.upsert_node("Alice", None, None).unwrap();
+        let id2 = g.upsert_node("alice", None, None).unwrap();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_add_edge() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        let edges = g.all_edges().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].relation, "knows");
+    }
+
+    #[test]
+    fn test_add_edge_idempotent() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap(); // INSERT OR IGNORE
+        let edges = g.all_edges().unwrap();
+        assert_eq!(edges.len(), 1);
+    }
+
+    #[test]
+    fn test_find_node() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        g.upsert_node("Alice", Some("person"), None).unwrap();
+        let node = g.find_node("alice").unwrap();
+        assert!(node.is_some());
+        assert_eq!(node.unwrap().label, "Alice");
+    }
+
+    #[test]
+    fn test_find_node_not_found() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let node = g.find_node("Nobody").unwrap();
+        assert!(node.is_none());
+    }
+
+    #[test]
+    fn test_neighbors_direct() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        let carol = g.upsert_node("Carol", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        g.add_edge(&alice, &carol, "manages", 1.0).unwrap();
+        let neighbors = g.neighbors(&alice, 1).unwrap();
+        assert_eq!(neighbors.len(), 2);
+    }
+
+    #[test]
+    fn test_neighbors_multi_hop() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        let carol = g.upsert_node("Carol", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        g.add_edge(&bob, &carol, "knows", 1.0).unwrap();
+        let neighbors = g.neighbors(&alice, 2).unwrap();
+        assert_eq!(neighbors.len(), 2); // alice→bob, bob→carol
+    }
+
+    #[test]
+    fn test_find_path_direct() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        let path = g.find_path("Alice", "Bob", 5).unwrap();
+        assert!(path.is_some());
+        let path = path.unwrap();
+        assert_eq!(path.nodes.len(), 2);
+        assert_eq!(path.edges.len(), 1);
+    }
+
+    #[test]
+    fn test_find_path_multi_hop() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        let carol = g.upsert_node("Carol", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        g.add_edge(&bob, &carol, "knows", 1.0).unwrap();
+        let path = g.find_path("Alice", "Carol", 5).unwrap();
+        assert!(path.is_some());
+        let path = path.unwrap();
+        assert_eq!(path.nodes.len(), 3);
+        assert_eq!(path.edges.len(), 2);
+    }
+
+    #[test]
+    fn test_find_path_not_found() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        g.upsert_node("Alice", None, None).unwrap();
+        g.upsert_node("Bob", None, None).unwrap();
+        let path = g.find_path("Alice", "Bob", 5).unwrap();
+        assert!(path.is_none()); // no edge
+    }
+
+    #[test]
+    fn test_find_path_same_node() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        g.upsert_node("Alice", None, None).unwrap();
+        let path = g.find_path("Alice", "Alice", 5).unwrap();
+        assert!(path.is_some());
+        assert_eq!(path.unwrap().nodes.len(), 1);
+    }
+
+    #[test]
+    fn test_query_relation() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        let project = g.upsert_node("ProjectX", Some("project"), None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        g.add_edge(&alice, &project, "owns", 1.0).unwrap();
+        g.add_edge(&bob, &project, "contributes", 1.0).unwrap();
+
+        let triples = g.query_relation("owns").unwrap();
+        assert_eq!(triples.len(), 1);
+        assert_eq!(triples[0].source.label, "Alice");
+        assert_eq!(triples[0].target.label, "ProjectX");
+    }
+
+    #[test]
+    fn test_stats() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        let project = g.upsert_node("ProjectX", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        g.add_edge(&alice, &project, "owns", 1.0).unwrap();
+
+        let stats = g.stats().unwrap();
+        assert_eq!(stats.node_count, 3);
+        assert_eq!(stats.edge_count, 2);
+        assert_eq!(stats.relation_types.len(), 2);
+    }
+
+    #[test]
+    fn test_all_nodes() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        g.upsert_node("Charlie", None, None).unwrap();
+        g.upsert_node("Alice", None, None).unwrap();
+        g.upsert_node("Bob", None, None).unwrap();
+        let nodes = g.all_nodes().unwrap();
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(nodes[0].label, "Alice"); // sorted
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -12,7 +12,7 @@
 mod consolidate;
 mod embed;
 mod error;
-mod graph;
+pub mod graph;
 mod import_export;
 mod maintenance;
 pub mod memory;
@@ -22,6 +22,7 @@ mod rooms;
 mod types;
 
 pub use graph::{build_meta_relationship, is_relationship_meta, Relationship, VALID_REL_TYPES};
+pub use graph::{GraphEdge, GraphNode, GraphPath, GraphStats, GraphStore, GraphTriple};
 pub use memory::types::{
     AgingStatus, BulkDeleteResult, CleanupResult, ConsolidationResult, ContradictionResult,
     ExportEntry, ImportResult, Memory, MemoryTier, MemoryType, PruneResult, RecallStrategy,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -362,6 +362,11 @@ impl Uteke {
     pub fn recompute_importance(&self) -> Result<usize, Error> {
         self.store.recompute_importance()
     }
+
+    /// Get a reference to the raw connection for graph operations.
+    pub fn graph_store(&self) -> &rusqlite::Connection {
+        &self.store.conn
+    }
 }
 
 /// Resolve a path to a database string.

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -533,6 +533,6 @@ mod content_type_tests {
         let store = super::super::store::Store::open(":memory:").unwrap();
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
-        assert_eq!(version, 6);
+        assert_eq!(version, 7); // v7 = graph tables added
     }
 }

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -161,6 +161,8 @@ impl super::Store {
                 5 => self.migrate_v4_to_v5()?,
                 // v6: Content type column (text vs json)
                 6 => self.migrate_v5_to_v6()?,
+                // v7: Knowledge graph tables (graph_nodes, graph_edges)
+                7 => self.migrate_v6_to_v7()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -324,5 +326,37 @@ impl super::Store {
             .prepare("SELECT * FROM memories LIMIT 0")
             .map(|stmt| stmt.column_names().iter().any(|n| n == &column))
             .unwrap_or(false)
+    }
+
+    /// v7: Knowledge graph tables (graph_nodes, graph_edges)
+    fn migrate_v6_to_v7(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v6 to v7: knowledge graph tables");
+        self.conn
+            .execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS graph_nodes (
+                    id TEXT PRIMARY KEY,
+                    label TEXT NOT NULL COLLATE NOCASE,
+                    entity_type TEXT,
+                    properties_json TEXT DEFAULT '{}',
+                    memory_id TEXT REFERENCES memories(id) ON DELETE SET NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS graph_edges (
+                    id TEXT PRIMARY KEY,
+                    source_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+                    target_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+                    relation TEXT NOT NULL COLLATE NOCASE,
+                    weight REAL NOT NULL DEFAULT 1.0,
+                    created_at TEXT NOT NULL,
+                    UNIQUE(source_id, target_id, relation)
+                );
+                CREATE INDEX IF NOT EXISTS idx_graph_nodes_label ON graph_nodes(label);
+                CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_id);
+                CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_id);
+                "#,
+            )
+            .map_err(|e| Error::db("schema migration v6 to v7", e))?;
+        Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -34,10 +34,31 @@ CREATE TABLE IF NOT EXISTS memory_tags (
     PRIMARY KEY (memory_id, tag)
 );
 CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON memory_tags(tag);
+
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    id TEXT PRIMARY KEY,
+    label TEXT NOT NULL COLLATE NOCASE,
+    entity_type TEXT,
+    properties_json TEXT DEFAULT '{}',
+    memory_id TEXT REFERENCES memories(id) ON DELETE SET NULL,
+    created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS graph_edges (
+    id TEXT PRIMARY KEY,
+    source_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+    target_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+    relation TEXT NOT NULL COLLATE NOCASE,
+    weight REAL NOT NULL DEFAULT 1.0,
+    created_at TEXT NOT NULL,
+    UNIQUE(source_id, target_id, relation)
+);
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_label ON graph_nodes(label);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_id);
 "#;
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 6;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 7;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -59,6 +80,8 @@ impl Store {
             .map_err(|e| Error::db("Failed to set WAL mode", e))?;
         conn.execute_batch("PRAGMA busy_timeout=5000;")
             .map_err(|e| Error::db("Failed to set busy timeout", e))?;
+        conn.execute_batch("PRAGMA foreign_keys=ON;")
+            .map_err(|e| Error::db("Failed to enable foreign keys", e))?;
 
         let store = Self { conn };
         store.init_schema()?;

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -62,7 +62,7 @@ pub(super) const CURRENT_SCHEMA_VERSION: i32 = 7;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
-    pub(super) conn: Connection,
+    pub conn: Connection,
 }
 
 impl Store {


### PR DESCRIPTION
Closes #317

## Changes

### Schema v7
- `graph_nodes` (id, label, entity_type, properties_json, memory_id, created_at)
- `graph_edges` (id, source_id, target_id, relation, weight, created_at)
- Indexes on label, source_id, target_id

### GraphStore (crates/uteke-core/src/graph.rs)
- `upsert_node()` — get-or-create by label (case-insensitive)
- `add_edge()` — INSERT OR IGNORE (idempotent, logs duplicates)
- `find_node()` / `get_node()` — lookup by label or ID
- `neighbors()` — outgoing edges via BFS up to depth N
- `find_path()` — shortest path via BFS with parent tracking
- `query_relation()` — (source, edge, target) triples
- `all_nodes()` / `all_edges()` / `stats()`

### CLI: `uteke graph`
```
uteke graph nodes [--entity-type TYPE]
uteke graph edges [--relation REL]
uteke graph neighbors <label> [--depth N]
uteke graph path <source> <target> [--max-depth N]
uteke graph query <relation>
uteke graph stats
```
All support `--json` output.

### Backward compatible
- Relationship metadata system (v0.1.0, #246) preserved
- Graph is optional — only used when explicitly queried
- Foreign keys enabled: `PRAGMA foreign_keys=ON`

## Tests
- `cargo test --workspace` ✅ (162 passed, 5 ignored)
- 16 graph tests (upsert, edge, find, neighbors, path, query, stats)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all` ✅