### PR TITLE
feat(#46): external knowledge import — markdown, text, auto-detect

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -192,11 +192,17 @@ pub enum Commands {
         #[arg(default_value = "-")]
         output: String,
     },
-    /// Import memories from JSONL file (re-embeds content)
+    /// Import memories from JSONL, Markdown, or text files (re-embeds content)
     Import {
         /// Input file path (use - for stdin)
         #[arg(default_value = "-")]
         input: String,
+        /// Tags to apply to all imported memories (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+        /// Import format: auto, jsonl, markdown, text (default: auto-detect)
+        #[arg(long, default_value = "auto")]
+        format: String,
     },
     /// Generate shell completions
     Completions {

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -146,31 +146,140 @@ pub(crate) fn run_import(
     uteke: &Uteke,
     ns: Option<&str>,
     input: &str,
+    tags: &[String],
+    format: &str,
 ) -> Result<(), String> {
-    tracing::info!("Importing memories from {input}");
-    let jsonl = if input == "-" {
+    tracing::info!("Importing memories from {input} (format: {format})");
+
+    let content = if input == "-" {
         let mut buf = String::new();
         std::io::stdin()
             .read_to_string(&mut buf)
             .map_err(|e| format!("Failed to read stdin: {e}"))?;
         buf
     } else {
-        std::fs::read_to_string(input).map_err(|e| format!("Failed to read import file: {e}"))?
+        std::fs::read_to_string(input).map_err(|e| format!("Failed to read file: {e}"))?
     };
 
-    let result = uteke
-        .import(&jsonl, ns)
-        .map_err(|e| format!("Failed to import: {e}"))?;
+    let detected_format = if format == "auto" {
+        detect_format(input, &content)
+    } else {
+        format.to_string()
+    };
+
+    let result = match detected_format.as_str() {
+        "jsonl" => uteke
+            .import(&content, ns)
+            .map_err(|e| format!("Failed to import JSONL: {e}"))?,
+        "markdown" | "text" => {
+            let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+            import_text(uteke, &content, &tag_refs, ns)?
+        }
+        other => {
+            return Err(format!(
+                "Unknown import format: '{other}'. Use: jsonl, markdown, text"
+            ))
+        }
+    };
 
     if cli.json {
         output::print_json(&result);
     } else {
         println!(
-            "\u{2713} Imported {} memories ({} skipped)",
+            "\u{2713} Imported {} memories ({} skipped) as {detected_format}",
             result.imported, result.skipped
         );
     }
     Ok(())
+}
+
+/// Detect import format from file extension and content.
+fn detect_format(filename: &str, content: &str) -> String {
+    // Check file extension
+    let ext = filename.rsplit('.').next().unwrap_or("");
+    match ext {
+        "jsonl" => "jsonl".to_string(),
+        "md" | "markdown" => "markdown".to_string(),
+        "txt" => "text".to_string(),
+        "csv" => "text".to_string(), // treat CSV as text for now
+        _ => {
+            // Auto-detect from content
+            let first_line = content.lines().next().unwrap_or("");
+            if first_line.starts_with('{') {
+                "jsonl".to_string()
+            } else {
+                "text".to_string()
+            }
+        }
+    }
+}
+
+/// Import text/markdown content as memories.
+/// Splits by double newline (paragraphs) or markdown headings.
+fn import_text(
+    uteke: &Uteke,
+    content: &str,
+    tags: &[&str],
+    ns: Option<&str>,
+) -> Result<uteke_core::ImportResult, String> {
+    use uteke_core::ImportResult;
+
+    let chunks: Vec<String> = if content.contains("\n# ") || content.contains("\n## ") {
+        // Markdown with headings — split by headings
+        split_markdown(content)
+    } else {
+        // Plain text — split by double newline (paragraphs)
+        content
+            .split("\n\n")
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty() && s.len() > 10) // skip very short chunks
+            .collect()
+    };
+
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+
+    for chunk in &chunks {
+        match uteke.remember(chunk, tags, None, ns) {
+            Ok(_) => imported += 1,
+            Err(e) => {
+                tracing::warn!("Failed to import chunk: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    Ok(ImportResult { imported, skipped })
+}
+
+/// Split markdown by headings. Each heading + body becomes a chunk.
+fn split_markdown(content: &str) -> Vec<String> {
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+
+    for line in content.lines() {
+        let is_heading =
+            line.starts_with("# ") || line.starts_with("## ") || line.starts_with("### ");
+        if is_heading {
+            // New section — save previous
+            if !current.trim().is_empty() {
+                chunks.push(current.trim().to_string());
+            }
+            current = line.to_string();
+            current.push('\n'); // separator after heading
+        } else {
+            if !current.is_empty() {
+                current.push('\n');
+            }
+            current.push_str(line);
+        }
+    }
+    if !current.trim().is_empty() {
+        chunks.push(current.trim().to_string());
+    }
+
+    // Filter very short chunks
+    chunks.into_iter().filter(|c| c.len() > 10).collect()
 }
 
 pub(crate) fn run_verify_checksums(

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -149,7 +149,11 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
 
         Commands::Export { output } => maintenance::run_export(cli, uteke, ns, output),
 
-        Commands::Import { input } => maintenance::run_import(cli, uteke, ns, input),
+        Commands::Import {
+            input,
+            tags,
+            format,
+        } => maintenance::run_import(cli, uteke, ns, input, tags, format),
 
         Commands::Completions { .. } => {
             // Already handled in main()


### PR DESCRIPTION
Closes #46

## Changes

### Extended Import command
```bash
# Auto-detect format
uteke import README.md --tags docs

# Explicit format
uteke import notes.md --format markdown --tags notes
uteke import data.jsonl --format jsonl

# Stdin
echo "Quick note" | uteke import - --tags quick

# Plain text
uteke import notes.txt --format text --tags journal
```

### Format detection
- `.md`/`.markdown` → markdown (split by `#`/`##`/`###` headings)
- `.jsonl` → JSONL (existing behavior)
- `.txt`/`.csv` → text (split by double newline paragraphs)
- Content starting with `{` → JSONL
- Default fallback → text

### Markdown splitting
- Each `#`/`##`/`###` heading starts a new chunk
- Heading + body becomes one memory
- Very short chunks (<10 chars) filtered

## Tests
- `cargo test --workspace` ✅ (162 passed, 5 ignored)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all` ✅