### PR TITLE
docs(#336): Docker quickstart + docker-compose.yml + VitePress page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ uteke stats
 
 > 📖 [Install options](INSTALL.md) · [Pre-built binaries](https://github.com/codecoradev/uteke/releases) · [Docker](https://github.com/codecoradev/uteke/pkgs/container/uteke) · [Full docs](https://github.com/codecoradev/uteke/tree/develop/docs)
 
+### Docker
+
+```bash
+# One-liner (model pre-baked in image)
+docker run -d --name uteke -p 8767:8767 -v uteke-data:/data \
+  ghcr.io/codecoradev/uteke:latest
+
+# Or docker compose
+docker compose up -d
+```
+
+📖 [Docker docs](docs/docker.md) · [Compose file](docker-compose.yml)
+
 ---
 
 ## Why Uteke?

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ uteke stats
 
 ### Docker
 
+> Listens on localhost only by default. See [Docker docs](docs/docker.md) for auth setup.
+
 ```bash
 # One-liner (model pre-baked in image)
-docker run -d --name uteke -p 8767:8767 -v uteke-data:/data \
+docker run -d --name uteke -p 127.0.0.1:8767:8767 -v uteke-data:/data \
   ghcr.io/codecoradev/uteke:latest
 
 # Or docker compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  uteke:
+    image: ghcr.io/codecoradev/uteke:latest
+    container_name: uteke
+    ports:
+      - "${UTEKE_PORT:-8767}:8767"
+    volumes:
+      - uteke-data:/data
+    environment:
+      # Auth (optional — set UTEKE_AUTH_TOKEN env var to enable)
+      # - UTEKE_AUTH_TOKEN
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8767/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  uteke-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
+# Uteke Docker Compose — default: localhost only, no auth
+# For network access, uncomment UTEKE_AUTH_TOKEN below.
 services:
   uteke:
     image: ghcr.io/codecoradev/uteke:latest
     container_name: uteke
     ports:
-      - "${UTEKE_PORT:-8767}:8767"
+      - "127.0.0.1:${UTEKE_PORT:-8767}:8767"
     volumes:
       - uteke-data:/data
     environment:
@@ -11,6 +13,7 @@ services:
       # - UTEKE_AUTH_TOKEN
     restart: unless-stopped
     healthcheck:
+      # curl is pre-installed in the uteke Docker image (Dockerfile runtime stage)
       test: ["CMD", "curl", "-f", "http://localhost:8767/health"]
       interval: 30s
       timeout: 5s

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
           { text: 'Installation', link: '/getting-started' },
           { text: 'CLI Reference', link: '/cli-reference' },
           { text: 'Configuration', link: '/configuration' },
+          { text: 'Docker', link: '/docker' },
         ],
       },
       {

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,145 @@
+---
+title: Docker
+---
+
+# Docker
+
+Uteke ships as a multi-arch Docker image with the embedding model pre-baked. No download needed on first run.
+
+## Quick Start
+
+```bash
+# Pull and run
+docker run -d --name uteke \
+  -p 8767:8767 \
+  -v uteke-data:/data \
+  ghcr.io/codecoradev/uteke:latest
+
+# Verify it's running
+curl http://localhost:8767/health
+
+# Store a memory
+curl -X POST http://localhost:8767/remember \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Deployed v2.0 to production"}'
+
+# Recall
+curl -X POST http://localhost:8767/recall \
+  -H "Content-Type: application/json" \
+  -d '{"query": "deployment"}'
+```
+
+## Docker Compose
+
+```bash
+# Clone and use the included docker-compose.yml
+docker compose up -d
+
+# Or create your own:
+cat > docker-compose.yml << 'EOF'
+services:
+  uteke:
+    image: ghcr.io/codecoradev/uteke:latest
+    ports:
+      - "8767:8767"
+    volumes:
+      - uteke-data:/data
+    restart: unless-stopped
+
+volumes:
+  uteke-data:
+EOF
+
+docker compose up -d
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `UTEKE_HOME` | `/data` | Data directory (set in Dockerfile) |
+| `UTEKE_AUTH_TOKEN` | — | Bearer token for API authentication |
+| `UTEKE_NAMESPACE` | `default` | Default namespace |
+
+### With authentication
+
+```bash
+docker run -d --name uteke \
+  -p 8767:8767 \
+  -v uteke-data:/data \
+  -e UTEKE_AUTH_TOKEN=$YOUR_TOKEN \
+  ghcr.io/codecoradev/uteke:latest
+
+# Now all requests need Authorization header
+curl -H "Authorization: Bearer $YOUR_TOKEN" \
+  http://localhost:8767/health
+```
+
+## Persistence
+
+Data is stored in the `/data` volume. Mount it for persistence:
+
+```bash
+# Named volume (managed by Docker)
+docker run -v uteke-data:/data ...
+
+# Bind mount (explicit path)
+docker run -v /path/to/uteke:/data ...
+```
+
+The volume contains:
+- `uteke.db` — SQLite database (memories, metadata, FTS5)
+- `uteke_index.usearch` — HNSW vector index
+- `uteke_index.keys` — Index key mapping
+- `models/embeddinggemma-q4/` — ONNX embedding model (~208MB)
+
+## Multi-Architecture
+
+Images are built for:
+- `linux/amd64` — Intel/AMD servers
+- `linux/arm64` — Apple Silicon, ARM servers (Ampere, Graviton)
+
+Docker automatically pulls the correct architecture.
+
+## Image Tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Latest stable release |
+| `v0.2.0` | Specific version |
+| `0.2` | Minor version (latest patch) |
+
+## CLI in Docker
+
+The container runs `uteke-serve` by default. To run CLI commands:
+
+```bash
+# Run a one-off CLI command
+docker exec uteke uteke recall "deployment" --limit 5
+
+# Or override the entrypoint
+docker run --rm -v uteke-data:/data \
+  --entrypoint uteke \
+  ghcr.io/codecoradev/uteke:latest \
+  stats
+```
+
+## Health Check
+
+```bash
+curl http://localhost:8767/health
+# → {"status":"healthy","memories":42,"index_size":1024}
+```
+
+Docker Compose includes a built-in health check:
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "-f", "http://localhost:8767/health"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+```
+
+## Behind a Reverse Proxy
+
+See [TLS & Reverse Proxy](/tls) for Caddy, Nginx, and Cloudflare Tunnel setup.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -8,10 +8,12 @@ Uteke ships as a multi-arch Docker image with the embedding model pre-baked. No 
 
 ## Quick Start
 
+> ⚠️ **Security**: The default config listens on `127.0.0.1` (localhost only). For network access, set `UTEKE_AUTH_TOKEN` (see [Authentication](#with-authentication)).
+
 ```bash
 # Pull and run
 docker run -d --name uteke \
-  -p 8767:8767 \
+  -p 127.0.0.1:8767:8767 \
   -v uteke-data:/data \
   ghcr.io/codecoradev/uteke:latest
 
@@ -41,7 +43,7 @@ services:
   uteke:
     image: ghcr.io/codecoradev/uteke:latest
     ports:
-      - "8767:8767"
+      - "127.0.0.1:8767:8767"
     volumes:
       - uteke-data:/data
     restart: unless-stopped
@@ -64,14 +66,18 @@ docker compose up -d
 ### With authentication
 
 ```bash
+# Read token securely (not stored in shell history)
+read -s UTEKE_AUTH_TOKEN
+export UTEKE_AUTH_TOKEN
+
 docker run -d --name uteke \
-  -p 8767:8767 \
+  -p 127.0.0.1:8767:8767 \
   -v uteke-data:/data \
-  -e UTEKE_AUTH_TOKEN=$YOUR_TOKEN \
+  -e UTEKE_AUTH_TOKEN \
   ghcr.io/codecoradev/uteke:latest
 
 # Now all requests need Authorization header
-curl -H "Authorization: Bearer $YOUR_TOKEN" \
+curl -H "Authorization: Bearer $UTEKE_AUTH_TOKEN" \
   http://localhost:8767/health
 ```
 
@@ -131,7 +137,7 @@ curl http://localhost:8767/health
 # → {"status":"healthy","memories":42,"index_size":1024}
 ```
 
-Docker Compose includes a built-in health check:
+Docker Compose includes a built-in health check (`curl` is pre-installed in the image):
 ```yaml
 healthcheck:
   test: ["CMD", "curl", "-f", "http://localhost:8767/health"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,8 @@ cargo install --git https://github.com/codecoradev/uteke
 
 Pre-built binaries and Docker image also available from [GitHub Releases](https://github.com/codecoradev/uteke/releases) and [GHCR](https://github.com/codecoradev/uteke/pkgs/container/uteke). First run downloads the embedding model (~188MB) — no API keys needed.
 
+> 💡 **Using Docker?** See the [Docker guide](docker.md) for `docker compose` setup, env vars, and persistence.
+
 ## Your First Memory
 
 ```bash


### PR DESCRIPTION
Closes #336

## Changes
- **docker-compose.yml** — single service, healthcheck, volume persistence
- **docs/docker.md** — full Docker guide: quick start, compose, env vars, persistence, CLI, health check, reverse proxy
- **README.md** — Docker quickstart section after install
- **docs/getting-started.md** — link to Docker guide
- **VitePress sidebar** — Docker entry added

## Security
- No hardcoded secrets in examples (uses `$YOUR_TOKEN` placeholder)
- docker-compose.yml auth line commented out by default

## Tests
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (171 passed, 5 ignored) — 3x repeated
- docker-compose.yml YAML structure validated