### PR TITLE
fix(ci): deploy to CF Pages production (remove --branch flag)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -53,4 +53,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           preCommands: npx wrangler pages project create uteke --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=uteke --commit-dirty=true --branch=main
+          command: pages deploy docs/.vitepress/dist/ --project-name=uteke --commit-dirty=true


### PR DESCRIPTION
Same fix as cora-cli#291 — --branch=main creates preview, not production.