### PR TITLE
feat(#338): env var coverage — UTEKE_LOG_LEVEL, SERVER_*, RECALL_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1618,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2168,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2734,6 +2817,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "toml",
  "tracing",
  "tracing-appender",

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -28,3 +28,6 @@ tracing-appender = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 urlencoding = "2.1.3"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+
+[dev-dependencies]
+serial_test = "3"

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -212,6 +212,9 @@ impl Config {
             config = config.merge_from_file(&project_path);
         }
 
+        // Layer 3: environment variables (override config file)
+        config = config.apply_env_overrides();
+
         config
     }
 
@@ -332,6 +335,59 @@ impl Config {
             }
             if server.contains_key("port") {
                 self.server.port = overlay.server.port;
+            }
+        }
+
+        self
+    }
+
+    /// Apply environment variable overrides on top of config file values.
+    ///
+    /// Resolution order (highest priority first):
+    /// 1. CLI flags
+    /// 2. Environment variables (UTEKE_*)
+    /// 3. Config file (uteke.toml)
+    /// 4. Built-in defaults
+    fn apply_env_overrides(mut self) -> Self {
+        // Logging
+        if let Ok(v) = std::env::var("UTEKE_LOG_LEVEL") {
+            self.logging.level = v;
+        }
+
+        // Server
+        if let Ok(v) = std::env::var("UTEKE_SERVER_HOST") {
+            self.server.host = v;
+        }
+        if let Ok(v) = std::env::var("UTEKE_SERVER_PORT") {
+            match v.parse::<u16>() {
+                Ok(port) => self.server.port = port,
+                Err(_) => {
+                    tracing::warn!("Invalid UTEKE_SERVER_PORT='{v}', ignoring (expected 0-65535)")
+                }
+            }
+        }
+
+        // Recall thresholds (must be 0.0-1.0)
+        if let Ok(v) = std::env::var("UTEKE_RECALL_MIN_SCORE") {
+            match v.parse::<f64>() {
+                Ok(score) if (0.0..=1.0).contains(&score) => self.recall.min_score = score,
+                Ok(_) => tracing::warn!(
+                    "UTEKE_RECALL_MIN_SCORE='{v}' out of range, ignoring (expected 0.0-1.0)"
+                ),
+                Err(_) => tracing::warn!(
+                    "Invalid UTEKE_RECALL_MIN_SCORE='{v}', ignoring (expected 0.0-1.0)"
+                ),
+            }
+        }
+        if let Ok(v) = std::env::var("UTEKE_RECALL_MIN_SCORE_STRICT") {
+            match v.parse::<f64>() {
+                Ok(score) if (0.0..=1.0).contains(&score) => self.recall.min_score_strict = score,
+                Ok(_) => tracing::warn!(
+                    "UTEKE_RECALL_MIN_SCORE_STRICT='{v}' out of range, ignoring (expected 0.0-1.0)"
+                ),
+                Err(_) => tracing::warn!(
+                    "Invalid UTEKE_RECALL_MIN_SCORE_STRICT='{v}', ignoring (expected 0.0-1.0)"
+                ),
             }
         }
 
@@ -879,5 +935,63 @@ max_seq_length = 128
     fn expand_tilde_no_home() {
         // Just verify it doesn't panic
         let _ = Config::expand_tilde("/absolute/path");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_log_level() {
+        std::env::set_var("UTEKE_LOG_LEVEL", "debug");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_LOG_LEVEL");
+        assert_eq!(cfg.logging.level, "debug");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_server() {
+        std::env::set_var("UTEKE_SERVER_HOST", "0.0.0.0");
+        std::env::set_var("UTEKE_SERVER_PORT", "9999");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_SERVER_HOST");
+        std::env::remove_var("UTEKE_SERVER_PORT");
+        assert_eq!(cfg.server.host, "0.0.0.0");
+        assert_eq!(cfg.server.port, 9999);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_recall() {
+        std::env::set_var("UTEKE_RECALL_MIN_SCORE", "0.7");
+        std::env::set_var("UTEKE_RECALL_MIN_SCORE_STRICT", "0.85");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_RECALL_MIN_SCORE");
+        std::env::remove_var("UTEKE_RECALL_MIN_SCORE_STRICT");
+        assert!((cfg.recall.min_score - 0.7).abs() < f64::EPSILON);
+        assert!((cfg.recall.min_score_strict - 0.85).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_invalid_port_ignored() {
+        std::env::set_var("UTEKE_SERVER_PORT", "not-a-number");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_SERVER_PORT");
+        // Invalid value should be ignored — keeps default
+        assert_eq!(cfg.server.port, 8767);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_no_vars_uses_defaults() {
+        // Ensure no env vars are set
+        std::env::remove_var("UTEKE_LOG_LEVEL");
+        std::env::remove_var("UTEKE_SERVER_HOST");
+        std::env::remove_var("UTEKE_SERVER_PORT");
+        std::env::remove_var("UTEKE_RECALL_MIN_SCORE");
+        let cfg = Config::default().apply_env_overrides();
+        assert_eq!(cfg.logging.level, "warn");
+        assert_eq!(cfg.server.host, "127.0.0.1");
+        assert_eq!(cfg.server.port, 8767);
+        assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,38 @@ min_score = 0.0
 
 Use `--strict` flag or `--min 0.7` to override per-query.
 
+## Environment Variables
+
+Environment variables override config file values. Applied in `Config::load()` after config file merge. CLI flags override env vars.
+
+Resolution order (highest priority first):
+1. CLI flag (`--min`, `--host`, `--port`)
+2. Environment variable (`UTEKE_*`)
+3. Config file (`uteke.toml`)
+4. Built-in default
+
+| Env Var | Config Equivalent | Default | Description |
+|---------|-------------------|---------|-------------|
+| `UTEKE_HOME` | — | `~/.uteke` | Data directory |
+| `UTEKE_NAMESPACE` | `[store] namespace` | `default` | Default namespace (applied in CLI) |
+| `UTEKE_AUTH_TOKEN` | — | — | Server auth token (applied in server) |
+| `UTEKE_LOG_LEVEL` | `[logging] level` | `warn` | Log level (trace/debug/info/warn/error) |
+| `UTEKE_SERVER_HOST` | `[server] host` | `127.0.0.1` | Server bind address |
+| `UTEKE_SERVER_PORT` | `[server] port` | `8767` | Server port |
+| `UTEKE_RECALL_MIN_SCORE` | `[recall] min_score` | `0.3` | Default similarity threshold |
+| `UTEKE_RECALL_MIN_SCORE_STRICT` | `[recall] min_score_strict` | `0.5` | Strict threshold |
+
+### Docker Example
+
+```bash
+docker run -d --name uteke \
+  -p 127.0.0.1:8767:8767 \
+  -v uteke-data:/data \
+  -e UTEKE_LOG_LEVEL=info \
+  -e UTEKE_RECALL_MIN_SCORE=0.5 \
+  ghcr.io/codecoradev/uteke:latest
+```
+
 ## Config Migration
 
 If you have an older flat-format config (pre-v0.0.4), uteke auto-migrates it on first run:


### PR DESCRIPTION
Closes #338

## Changes

### Env var support in Config
- `apply_env_overrides()` called after config file merge in `Config::load()`
- Invalid values logged as warning (not silently ignored)

### New env vars

| Env Var | Config Equivalent | Default |
|---------|-------------------|---------|
| `UTEKE_LOG_LEVEL` | `[logging] level` | warn |
| `UTEKE_SERVER_HOST` | `[server] host` | 127.0.0.1 |
| `UTEKE_SERVER_PORT` | `[server] port` | 8767 |
| `UTEKE_RECALL_MIN_SCORE` | `[recall] min_score` | 0.3 |
| `UTEKE_RECALL_MIN_SCORE_STRICT` | `[recall] min_score_strict` | 0.5 |

### Resolution order
1. CLI flag (highest)
2. Environment variable (UTEKE_*)
3. Config file (uteke.toml)
4. Built-in default

### Tests
- 5 new tests using `serial_test` crate (env var isolation)
- `cargo test --workspace` ✅ (176 passed, 5 ignored) — 3x repeat
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all` ✅

### Defer to v0.2.1
- `UTEKE_EMBEDDING_*` vars — need #337 (OpenAI/Ollama backend) first