### PR TITLE
fix: remove VitePress base — Worker handles routing

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
   title: 'Uteke',
   description: 'Local-first semantic memory engine. Single binary, zero infrastructure, 30ms recall.',
   lang: 'en',
-  base: '/docs/uteke/',
   cleanUrls: true,
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg' }],


### PR DESCRIPTION
VitePress base removed. CF Pages serves at root. Worker injects `<base href>` for correct asset resolution under /docs/{project}/.