### PR TITLE
docs: fix v0.2.0 consistency issues across README and VitePress docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (108 unit tests)
+cargo test --workspace         # Test (180 unit tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ All critical file I/O uses the `.tmp` + `rename` pattern. On POSIX filesystems, 
 
 ### Schema Versioning
 
-Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v5 (memory_tags junction table). Zero data loss guaranteed.
+Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v7 (knowledge graph tables — `graph_nodes` + `graph_edges`). Schema history: v4 rooms, v5 memory_tags junction, v6 content_type column (text vs json), v7 knowledge graph. Zero data loss guaranteed.
 
 ### Rooms
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.1.0**.
+Complete reference for all uteke commands. Version **0.2.0**.
 
 ## Global Flags
 
@@ -12,9 +12,10 @@ Complete reference for all uteke commands. Version **0.1.0**.
 |------|-------------|---------|
 | `--store <path>` | Override store location | `~/.uteke` |
 | `--namespace <name>` | Namespace for multi-agent isolation | `default` |
-| `--config <path>` | Override config file path | auto-resolved |
 | `--json` | Output as JSON | off |
 | `--verbose` | Enable debug logging | off |
+
+Config file path is auto-resolved (`~/.uteke/uteke.toml` + `.uteke/uteke.toml`); there is no `--config` flag.
 
 ## uteke remember
 
@@ -34,8 +35,8 @@ uteke remember "Deploy staging to AWS us-east-1" \
 # With contradiction detection
 uteke remember "Server runs on port 8080" --tags config --detect-contradiction
 
-# With memory type and temporal bounds
-uteke remember "API rate limit is 1000/min" --type fact --valid-from 2026-01-01 --valid-until 2026-12-31
+# With memory type
+uteke remember "API rate limit is 1000/min" --type fact
 
 # In a specific namespace
 uteke remember "User prefers dark mode" --tags pref --namespace my-agent
@@ -47,11 +48,10 @@ uteke remember "User prefers dark mode" --tags pref --namespace my-agent
 | `--entity <name>` | Associate memory with an entity (e.g. "staging-server") |
 | `--category <cat>` | Categorize the memory (e.g. "infrastructure") |
 | `--meta <pairs>` | Key:value pairs, comma-separated. Auto-detects type (string/number/bool) |
-| `--metadata <json>` | Arbitrary JSON metadata |
-| `--detect-contradiction` | Detect conflicting memories (default threshold: 0.65) |
 | `--type <type>` | Memory type: fact, procedure, preference, decision, context |
-| `--valid-from <datetime>` | Start of validity period (ISO 8601) |
-| `--valid-until <datetime>` | End of validity period (ISO 8601) |
+| `--detect-contradiction` | Detect conflicting memories (default threshold: 0.65) |
+| `--room <room_id>` | Link memory to a room (collaborative context) |
+| `--author <name>` | Author attribution when storing in a room |
 | `--json` | Output stored memory as JSON |
 
 ## uteke recall
@@ -71,6 +71,8 @@ uteke recall "config" --category infrastructure --limit 5
 | `--limit <n>` | Max results (default: 5) |
 | `--entity <name>` | Filter results to a specific entity |
 | `--category <cat>` | Filter results to a specific category |
+| `--content-format <fmt>` | Content display: `auto` (detect), `text`, `json` (pretty-print JSON memories) |
+| `--where <key=value>` | Filter by JSON field on structured memories (e.g. `--where role=CTO`) |
 | `--json` | Output as JSON array |
 
 ## uteke search
@@ -86,7 +88,7 @@ uteke search "api" --namespace backend --json
 | Flag | Description |
 |------|-------------|
 | `--tags <tags>` | Filter by comma-separated tags |
-| `--limit <n>` | Max results (default: 20) |
+| `--limit <n>` | Max results (default: 10) |
 | `--json` | Output as JSON |
 
 ## uteke list
@@ -207,7 +209,7 @@ Semantic search with new flags:
 ```bash
 # Minimum similarity score filter
 uteke recall "database config" --min 0.7
-uteke recall "database config" --strict    # uses 0.7 default
+uteke recall "database config" --strict    # uses min_score_strict (default 0.5)
 
 # Time-travel: query memories at specific point in time
 uteke recall "deployment process" --at 2026-06-01T12:00:00Z
@@ -222,7 +224,7 @@ uteke recall "api design" --context
 | Flag | Description |
 |------|-------------|
 | `--min <score>` | Minimum similarity score (0.0-1.0) |
-| `--strict` | Use strict threshold (0.7) |
+| `--strict` | Use strict threshold (`min_score_strict`, default 0.5) |
 | `--at <timestamp>` | Query memories at point in time (RFC3339) |
 | `--related` | Follow relationship edges |
 | `--depth <n>` | Traversal depth for --related |
@@ -308,11 +310,51 @@ Memory aging management with auto-cleanup.
 uteke aging status
 
 # Preview memories older than 90 days
-uteke aging preview --days 90
+uteke aging preview --older-than-days 90
 
 # Delete memories older than 180 days
-uteke aging cleanup --days 180 --confirm
+uteke aging cleanup --older-than-days 180 --yes
 ```
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `status` | — | Show hot/warm/cold/never-accessed counts |
+| `preview` | `--older-than-days N` (default 180), `--max-access-count N` (default 1) | Dry-run preview of cleanup candidates |
+| `cleanup` | `--older-than-days N` (default 180), `--max-access-count N` (default 1), `--yes` | Delete aged memories (`--yes` skips confirmation) |
+
+## uteke graph
+
+Knowledge graph operations (v0.2.0). Nodes and edges stored in SQLite (`graph_nodes`, `graph_edges` tables, schema v7).
+
+```bash
+# List all nodes (optionally filter by entity type)
+uteke graph nodes
+uteke graph nodes --entity-type person
+
+# List all edges (optionally filter by relation)
+uteke graph edges --relation owns
+
+# Find neighbors of a node via BFS
+uteke graph neighbors alice --depth 2
+
+# Shortest path between two nodes
+uteke graph path alice "project-x" --max-depth 5
+
+# Query edges by relation type
+uteke graph query part_of
+
+# Show graph statistics
+uteke graph stats
+```
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `nodes` | `--entity-type <t>` | List graph nodes |
+| `edges` | `--relation <r>` | List graph edges |
+| `neighbors <label>` | `--depth N` (default 1) | BFS neighbors of a node |
+| `path <source> <target>` | `--max-depth N` (default 5) | BFS shortest path |
+| `query <relation>` | — | Query edges by relation type |
+| `stats` | — | Show graph statistics |
 
 ## Other Commands
 
@@ -327,14 +369,16 @@ uteke aging cleanup --days 180 --confirm
 | `uteke prune` | Remove deprecated/expired memories |
 | `uteke stats` | Show store statistics with tier breakdown |
 | `uteke export` | Export memories to JSONL (no embeddings) |
-| `uteke import <file>` | Import memories from JSONL |
+| `uteke import <file>` | Import memories from JSONL/Markdown/text |
 | `uteke doctor` | Health check (DB, index, model, consistency) |
 | `uteke verify` | Verify DB and index consistency |
+| `uteke verify-checksums --binary <path>` | Verify binary integrity against SHA256 checksums |
 | `uteke repair` | Rebuild index from SQLite |
 | `uteke namespace list` | List all namespaces with memory counts |
 | `uteke namespace stats <name>` | Show stats for a namespace |
 | `uteke namespace switch <name>` | Set default namespace in config |
-| `uteke hook install <shell>` | Install shell hook (bash/zsh/fish) |
+| `uteke hook <shell>` | Print shell hook script (bash/zsh/fish) |
+| `uteke init --agent <type>` | Initialize integration (pi, claude, cursor, copilot, codex) |
 | `uteke completions <shell>` | Generate shell completions |
 
 ## uteke-serve (Server Mode)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Uteke searches for config in this order. Last match wins (highest priority):
 2. **`~/.uteke/uteke.toml`** — Global user-level config
 3. **`.uteke/uteke.toml`** — Project-level (in current working directory)
 
-Override the config file path with the `--config` flag.
+Config file path is auto-resolved (no `--config` flag). Layered merge: each file overlays the previous, with field-level granularity (only keys explicitly present override).
 
 ## Config File Format
 
@@ -28,12 +28,12 @@ path = "~/.uteke"
 # Default namespace (default: "default")
 namespace = "default"
 
-[log]
+[logging]
 # Log level: trace, debug, info, warn, error
 level = "info"
 
-# Log directory (default: ~/.uteke/logs)
-dir = "~/.uteke/logs"
+# Optional log file path. Empty = stderr only.
+# file = ""
 
 [server]
 # Enable CLI auto-routing to server
@@ -97,12 +97,17 @@ Control minimum similarity score for recall results:
 ```toml
 [recall]
 # Minimum similarity score (0.0-1.0). Memories below this score are excluded.
-min_score = 0.0
+# Default: 0.3 (balanced). Use 0.0 to disable filtering.
+min_score = 0.3
+
+# Strict-mode threshold (used with `--strict` flag)
+min_score_strict = 0.5
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `min_score` | 0.0 | Minimum similarity score |
+| `min_score` | 0.3 | Minimum similarity score (0.0-1.0) |
+| `min_score_strict` | 0.5 | Strict-mode threshold (used with `--strict`) |
 
 Use `--strict` flag or `--min 0.7` to override per-query.
 
@@ -154,7 +159,7 @@ log_level = "info"
 path = "~/.uteke"
 namespace = "default"
 
-[log]
+[logging]
 level = "info"
 ```
 
@@ -181,7 +186,7 @@ Place a `.uteke/uteke.toml` in your project root to override defaults for that p
 path = "./.uteke"
 namespace = "my-project"
 
-[log]
+[logging]
 level = "warn"
 
 [server]
@@ -198,9 +203,6 @@ CLI flags always take precedence over config file values:
 ```bash
 # Override store path
 uteke --store /path/to/project/.uteke remember "project note"
-
-# Override config file
-uteke --config ./my-config.toml stats
 
 # Override namespace
 uteke --namespace agent-1 recall "context"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,7 @@ min_score_strict = 0.5
 | `min_score` | 0.3 | Minimum similarity score (0.0-1.0) |
 | `min_score_strict` | 0.5 | Strict-mode threshold (used with `--strict`) |
 
-Use `--strict` flag or `--min 0.7` to override per-query.
+Use `--strict` flag or `--min <score>` to override per-query.
 
 ## Environment Variables
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -97,7 +97,7 @@ The volume contains:
 - `uteke.db` — SQLite database (memories, metadata, FTS5)
 - `uteke_index.usearch` — HNSW vector index
 - `uteke_index.keys` — Index key mapping
-- `models/embeddinggemma-q4/` — ONNX embedding model (~208MB)
+- `models/embeddinggemma-q4/` — ONNX embedding model (~188MB)
 
 ## Multi-Architecture
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,10 +66,10 @@ uteke tags delete unused-tag
 uteke aging status
 
 # Preview memories older than 90 days
-uteke aging preview --days 90
+uteke aging preview --older-than-days 90
 
 # Delete stale memories older than 180 days
-uteke aging cleanup --days 180 --confirm
+uteke aging cleanup --older-than-days 180 --yes
 ```
 
 ## Multi-Agent Isolation


### PR DESCRIPTION
## Summary

Audit of project vs documentation (README + `docs/` VitePress) found 9 issues where docs diverged from code. All fixes align docs to actual `cli.rs`/`config.rs`/`schema.rs` as of v0.2.0.

## Changes

### `README.md`
- Test count `108` → `180` (actual `#[test]` count in `crates/`)

### `docs/cli-reference.md`
- Version `0.1.0` → `0.2.0`
- Added **`uteke graph`** section (`nodes`/`edges`/`neighbors`/`path`/`query`/`stats`) — v0.2.0 knowledge graph
- Added recall `--content-format` and `--where` flags — v0.2.0 structured memory
- Added `uteke get`, `verify-checksums`, `init` to Other Commands
- **Removed nonexistent remember flags:** `--metadata`, `--valid-from`, `--valid-until` (never wired to `cli.rs`)
- Added remember `--room` and `--author` flags
- Removed global `--config` flag (not implemented; config auto-resolves)
- search default limit 20 → 10
- aging: `--days` → `--older-than-days`, `--confirm` → `--yes`
- `hook install <shell>` → `hook <shell>`
- strict threshold label 0.7 → `min_score_strict` (default 0.5)

### `docs/configuration.md`
- All `[log]` → `[logging]` (matches `LoggingConfig` struct)
- Removed nonexistent `dir` field (only `level` and `file` exist)
- Recall `min_score` default 0.0 → 0.3 (matches `RecallConfig::default`)
- Removed `--config` flag mentions
- Config-migration example: flat `path`/`default_namespace` → `store_path`/`namespace`

### `docs/architecture.md`
- Schema version v5 → v7 (v6 `content_type`, v7 `graph_nodes`/`graph_edges`)

### `docs/docker.md`
- Model size 208MB → 188MB (matches README/INSTALL/getting-started)

### `docs/getting-started.md`
- aging flags: `--days` → `--older-than-days`, `--confirm` → `--yes`

## Verification

- `cargo build --workspace` — clean, no warnings
- No code changes; docs-only

## Closes

Closes #365, closes #366, closes #367, closes #369, closes #370, closes #371, closes #372, closes #373