### PR TITLE
feat: OpenAI + Ollama embedding backends (#337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ### Added
 
+- **OpenAI + Ollama embedding backends** (#337)
+  - New `OpenAiEmbedder` (`crates/uteke-core/src/embed/openai.rs`) — HTTP
+    call to `{base_url}/embeddings`, default model `text-embedding-3-small`
+    (1536d). Azure OpenAI compatible via `base_url`.
+  - New `OllamaEmbedder` (`crates/uteke-core/src/embed/ollama.rs`) — HTTP
+    call to `{base_url}/api/embed`, default model `nomic-embed-text` (768d).
+  - `[embedding]` config section extended with `api_key`, `base_url`, `dims`.
+  - New env vars: `UTEKE_EMBEDDING_BACKEND`, `UTEKE_EMBEDDING_MODEL`,
+    `UTEKE_EMBEDDING_API_KEY` (fallback: `OPENAI_API_KEY`),
+    `UTEKE_EMBEDDING_BASE_URL`, `UTEKE_EMBEDDING_DIMS`.
+  - Dim mismatch detection: opening an existing store with a backend that
+    produces a different dims now returns a clear error pointing the user
+    at `uteke repair` instead of silently corrupting the index.
+  - `reqwest` `json` feature added (always included — no feature flag).
+  - 16 new unit tests (backend construction, endpoint normalization, default
+    constants, response parsing, config merge + env var precedence).
+  - ONNX remains the default — fully backward compatible.
+
 - **Auto-wired memory edges** (#346)
   - New `memory_edges` SQLite table (schema v8) for typed edges between
     memories.

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -30,12 +30,23 @@ impl Default for StoreConfig {
 #[derive(serde::Deserialize, Clone)]
 #[serde(default)]
 pub struct EmbeddingConfig {
-    /// Embedding backend: "onnx" (default), future: "openai", "ollama".
+    /// Embedding backend: "onnx" (default), "openai", "ollama".
     pub backend: String,
     /// Embedding model name.
     pub model: String,
     /// Maximum sequence length for the embedding model.
     pub max_seq_length: usize,
+    /// API key for backends that require one (OpenAI). Leave empty for ONNX/Ollama.
+    /// Can also be supplied via UTEKE_EMBEDDING_API_KEY / OPENAI_API_KEY.
+    pub api_key: String,
+    /// Custom endpoint URL. Empty string = backend default.
+    /// - OpenAI: https://api.openai.com/v1
+    /// - Ollama: http://localhost:11434
+    /// - Azure OpenAI: your endpoint base
+    pub base_url: String,
+    /// Embedding dimensions. 0 = use backend/model default.
+    /// Override only when you know your model's output dim.
+    pub dims: usize,
 }
 
 impl Default for EmbeddingConfig {
@@ -44,13 +55,16 @@ impl Default for EmbeddingConfig {
             backend: "onnx".to_string(),
             model: "embeddinggemma-q4".to_string(),
             max_seq_length: 256,
+            api_key: String::new(),
+            base_url: String::new(),
+            dims: 0,
         }
     }
 }
 
 impl EmbeddingConfig {
     /// Supported embedding backends.
-    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["onnx"];
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["onnx", "openai", "ollama"];
 
     /// Validate the backend field.
     ///
@@ -272,10 +286,19 @@ impl Config {
                 self.embedding.backend = overlay.embedding.backend.clone();
             }
             if emb.contains_key("model") {
-                self.embedding.model = overlay.embedding.model;
+                self.embedding.model = overlay.embedding.model.clone();
             }
             if emb.contains_key("max_seq_length") {
                 self.embedding.max_seq_length = overlay.embedding.max_seq_length;
+            }
+            if emb.contains_key("api_key") {
+                self.embedding.api_key = overlay.embedding.api_key.clone();
+            }
+            if emb.contains_key("base_url") {
+                self.embedding.base_url = overlay.embedding.base_url.clone();
+            }
+            if emb.contains_key("dims") {
+                self.embedding.dims = overlay.embedding.dims;
             }
         }
 
@@ -387,6 +410,31 @@ impl Config {
                 ),
                 Err(_) => tracing::warn!(
                     "Invalid UTEKE_RECALL_MIN_SCORE_STRICT='{v}', ignoring (expected 0.0-1.0)"
+                ),
+            }
+        }
+
+        // Embedding backend overrides (#337)
+        if let Ok(v) = std::env::var("UTEKE_EMBEDDING_BACKEND") {
+            self.embedding.backend = v;
+        }
+        if let Ok(v) = std::env::var("UTEKE_EMBEDDING_MODEL") {
+            self.embedding.model = v;
+        }
+        // API key: prefer UTEKE_EMBEDDING_API_KEY, then OPENAI_API_KEY fallback.
+        if let Ok(v) = std::env::var("UTEKE_EMBEDDING_API_KEY") {
+            self.embedding.api_key = v;
+        } else if let Ok(v) = std::env::var("OPENAI_API_KEY") {
+            self.embedding.api_key = v;
+        }
+        if let Ok(v) = std::env::var("UTEKE_EMBEDDING_BASE_URL") {
+            self.embedding.base_url = v;
+        }
+        if let Ok(v) = std::env::var("UTEKE_EMBEDDING_DIMS") {
+            match v.parse::<usize>() {
+                Ok(d) => self.embedding.dims = d,
+                Err(_) => tracing::warn!(
+                    "Invalid UTEKE_EMBEDDING_DIMS='{v}', ignoring (expected integer)"
                 ),
             }
         }
@@ -916,6 +964,77 @@ backend = "ollama"
         // Other embedding fields stay default
         assert_eq!(merged.embedding.model, "embeddinggemma-q4");
         assert_eq!(merged.embedding.max_seq_length, 256);
+    }
+
+    #[test]
+    fn merge_embedding_full_openai_config() {
+        let toml = r#"
+[embedding]
+backend = "openai"
+model = "text-embedding-3-large"
+api_key = "sk-test-123"
+base_url = "https://my-proxy.example.com/v1"
+dims = 3072
+max_seq_length = 8191
+"#;
+        let tmp = std::env::temp_dir().join("uteke_test_openai_full.toml");
+        std::fs::write(&tmp, toml).unwrap();
+        let merged = Config::default().merge_from_file(&tmp);
+        std::fs::remove_file(&tmp).ok();
+        assert_eq!(merged.embedding.backend, "openai");
+        assert_eq!(merged.embedding.model, "text-embedding-3-large");
+        assert_eq!(merged.embedding.api_key, "sk-test-123");
+        assert_eq!(merged.embedding.base_url, "https://my-proxy.example.com/v1");
+        assert_eq!(merged.embedding.dims, 3072);
+        assert_eq!(merged.embedding.max_seq_length, 8191);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_overrides_embedding_backend() {
+        std::env::set_var("UTEKE_EMBEDDING_BACKEND", "openai");
+        std::env::set_var("UTEKE_EMBEDDING_API_KEY", "sk-env-test");
+        std::env::set_var("UTEKE_EMBEDDING_MODEL", "text-embedding-3-small");
+        std::env::set_var("UTEKE_EMBEDDING_DIMS", "1536");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_EMBEDDING_BACKEND");
+        std::env::remove_var("UTEKE_EMBEDDING_API_KEY");
+        std::env::remove_var("UTEKE_EMBEDDING_MODEL");
+        std::env::remove_var("UTEKE_EMBEDDING_DIMS");
+        assert_eq!(cfg.embedding.backend, "openai");
+        assert_eq!(cfg.embedding.api_key, "sk-env-test");
+        assert_eq!(cfg.embedding.model, "text-embedding-3-small");
+        assert_eq!(cfg.embedding.dims, 1536);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_openai_api_key_fallback() {
+        std::env::remove_var("UTEKE_EMBEDDING_API_KEY");
+        std::env::set_var("OPENAI_API_KEY", "sk-fallback");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("OPENAI_API_KEY");
+        assert_eq!(cfg.embedding.api_key, "sk-fallback");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_uteke_api_key_wins_over_openai() {
+        std::env::set_var("UTEKE_EMBEDDING_API_KEY", "sk-uteke");
+        std::env::set_var("OPENAI_API_KEY", "sk-openai");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_EMBEDDING_API_KEY");
+        std::env::remove_var("OPENAI_API_KEY");
+        assert_eq!(cfg.embedding.api_key, "sk-uteke");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_invalid_dims_ignored() {
+        std::env::set_var("UTEKE_EMBEDDING_DIMS", "not-a-number");
+        let cfg = Config::default().apply_env_overrides();
+        std::env::remove_var("UTEKE_EMBEDDING_DIMS");
+        assert_eq!(cfg.embedding.dims, 0, "invalid dims should keep default 0");
     }
 
     #[test]

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -416,19 +416,31 @@ impl Config {
 
         // Embedding backend overrides (#337)
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_BACKEND") {
-            self.embedding.backend = v;
+            if !v.is_empty() {
+                self.embedding.backend = v;
+            }
         }
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_MODEL") {
-            self.embedding.model = v;
+            if !v.is_empty() {
+                self.embedding.model = v;
+            }
         }
         // API key: prefer UTEKE_EMBEDDING_API_KEY, then OPENAI_API_KEY fallback.
+        // An explicitly empty env var is treated as unset so it cannot clobber
+        // a non-empty [embedding].api_key from uteke.toml (CodeCora finding).
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_API_KEY") {
-            self.embedding.api_key = v;
+            if !v.is_empty() {
+                self.embedding.api_key = v;
+            }
         } else if let Ok(v) = std::env::var("OPENAI_API_KEY") {
-            self.embedding.api_key = v;
+            if !v.is_empty() {
+                self.embedding.api_key = v;
+            }
         }
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_BASE_URL") {
-            self.embedding.base_url = v;
+            if !v.is_empty() {
+                self.embedding.base_url = v;
+            }
         }
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_DIMS") {
             match v.parse::<usize>() {

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -88,14 +88,23 @@ fn main() {
 
     tracing::debug!("Opening store at: {store_path}");
 
-    let uteke = match Uteke::open_with_tier_and_backend(
+    let uteke = match Uteke::open_with_embedding(
         &store_path,
+        &config.embedding.backend,
+        uteke_core::EmbeddingSettings {
+            api_key: config.embedding.api_key.clone(),
+            base_url: config.embedding.base_url.clone(),
+            model: config.embedding.model.clone(),
+            dims: config.embedding.dims,
+        },
         uteke_core::TierConfig {
             hot_days: config.tier.hot_days as i64,
             warm_days: config.tier.warm_days as i64,
             hot_boost: config.tier.hot_boost,
         },
-        &config.embedding.backend,
+        uteke_core::RecallConfig {
+            min_score: config.recall.min_score as f32,
+        },
     ) {
         Ok(u) => u,
         Err(e) => {

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -23,7 +23,7 @@ ndarray = "0.17"
 tokenizers = "0.23"
 dirs = "6"
 tracing = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/crates/uteke-core/src/embed/mod.rs
+++ b/crates/uteke-core/src/embed/mod.rs
@@ -2,9 +2,13 @@
 
 pub mod embed_trait;
 pub mod engine;
+pub mod ollama;
+pub mod openai;
 
 pub use embed_trait::Embedder;
 pub use engine::OnnxEmbedder;
+pub use ollama::OllamaEmbedder;
+pub use openai::OpenAiEmbedder;
 
 /// Backward-compat alias — old code referencing `EmbeddingEngine` continues to work.
 #[allow(dead_code)]

--- a/crates/uteke-core/src/embed/mod.rs
+++ b/crates/uteke-core/src/embed/mod.rs
@@ -13,3 +13,28 @@ pub use openai::OpenAiEmbedder;
 /// Backward-compat alias — old code referencing `EmbeddingEngine` continues to work.
 #[allow(dead_code)]
 pub type EmbeddingEngine = OnnxEmbedder;
+
+/// Validate a user-supplied base_url: must be http(s):// and absolute.
+///
+/// Rejects empty / schemeless / malformed URLs early so callers get a
+/// clear validation error at construct time instead of a confusing HTTP
+/// failure later (CodeCora finding #155).
+pub(crate) fn validate_base_url(base_url: &str) -> Result<(), crate::Error> {
+    let trimmed = base_url.trim();
+    if trimmed.is_empty() {
+        return Err(crate::Error::Validation(
+            "base_url must not be empty".into(),
+        ));
+    }
+    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+        return Err(crate::Error::Validation(format!(
+            "base_url must start with 'http://' or 'https://' (got '{trimmed}')"
+        )));
+    }
+    if reqwest::Url::parse(trimmed).is_err() {
+        return Err(crate::Error::Validation(format!(
+            "base_url is not a valid URL: '{trimmed}'"
+        )));
+    }
+    Ok(())
+}

--- a/crates/uteke-core/src/embed/ollama.rs
+++ b/crates/uteke-core/src/embed/ollama.rs
@@ -1,0 +1,159 @@
+//! Ollama embedding backend.
+//!
+//! POSTs to `{base_url}/api/embed` with `{ model, input }` JSON and parses
+//! `embeddings[0]` (Ollama returns `embeddings` array, not `data`).
+//!
+//! Default endpoint: `http://localhost:11434` — no API key required.
+//!
+//! Dimensions are model-specific (nomic-embed-text = 768, mxbai-embed-large
+//! = 1024). The caller supplies dims so we don't need a probe request.
+
+use crate::embed::Embedder;
+use crate::Error;
+
+/// Default Ollama endpoint.
+pub const DEFAULT_BASE_URL: &str = "http://localhost:11434";
+
+/// Default model — small, fast, good for local recall.
+pub const DEFAULT_MODEL: &str = "nomic-embed-text";
+
+/// Default dimensions for [`DEFAULT_MODEL`].
+pub const DEFAULT_DIMS: usize = 768;
+
+/// Ollama context window. We cap at a safe sub-window; the embed API does
+/// its own truncation.
+pub const MAX_SEQ_LEN: usize = 2048;
+
+/// Ollama embedding backend.
+#[derive(Debug)]
+pub struct OllamaEmbedder {
+    client: reqwest::blocking::Client,
+    base_url: String,
+    model: String,
+    dims: usize,
+}
+
+impl OllamaEmbedder {
+    pub fn new(base_url: &str, model: &str, dims: usize) -> Result<Self, Error> {
+        if base_url.is_empty() {
+            return Err(Error::Validation(
+                "Ollama embedder requires a base_url (default: http://localhost:11434)".into(),
+            ));
+        }
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| Error::generic(format!("Failed to build HTTP client: {e}")))?;
+        Ok(Self {
+            client,
+            base_url: base_url.to_string(),
+            model: model.to_string(),
+            dims,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        format!("{base}/api/embed")
+    }
+}
+
+impl Embedder for OllamaEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, Error> {
+        let input = if text.is_empty() { " " } else { text };
+        let body = serde_json::json!({
+            "model": self.model,
+            "input": input,
+        });
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .json(&body)
+            .send()
+            .map_err(|e| Error::generic(format!("Ollama embed request failed: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().unwrap_or_default();
+            return Err(Error::generic(format!(
+                "Ollama embed returned HTTP {status}: {text}"
+            )));
+        }
+
+        // Ollama's /api/embed returns { "embeddings": [[...], ...] }
+        let parsed: EmbedResponse = resp
+            .json()
+            .map_err(|e| Error::generic(format!("Failed to parse Ollama response: {e}")))?;
+
+        let mut outer = parsed.embeddings.into_iter();
+        let inner_vec = outer
+            .next()
+            .ok_or_else(|| Error::generic("Ollama response had no embeddings array"))?;
+        Ok(inner_vec)
+    }
+
+    fn dims(&self) -> usize {
+        self.dims
+    }
+
+    fn max_seq_len(&self) -> usize {
+        MAX_SEQ_LEN
+    }
+
+    fn name(&self) -> &str {
+        "ollama"
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct EmbedResponse {
+    // Ollama returns embeddings as Vec<Vec<f32>>. For single-input calls
+    // there is one inner Vec.
+    embeddings: Vec<Vec<f32>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_base_url() {
+        let err = OllamaEmbedder::new("", DEFAULT_MODEL, DEFAULT_DIMS).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("base_url"), "got: {msg}");
+    }
+
+    #[test]
+    fn endpoint_normalizes_trailing_slash() {
+        let e =
+            OllamaEmbedder::new("http://localhost:11434/", DEFAULT_MODEL, DEFAULT_DIMS).unwrap();
+        assert_eq!(e.endpoint(), "http://localhost:11434/api/embed");
+    }
+
+    #[test]
+    fn defaults_match_docs() {
+        assert_eq!(DEFAULT_MODEL, "nomic-embed-text");
+        assert_eq!(DEFAULT_DIMS, 768);
+        assert_eq!(DEFAULT_BASE_URL, "http://localhost:11434");
+    }
+
+    #[test]
+    fn embedder_name_and_dims() {
+        let e = OllamaEmbedder::new(DEFAULT_BASE_URL, "mxbai-embed-large", 1024).unwrap();
+        assert_eq!(e.name(), "ollama");
+        assert_eq!(e.dims(), 1024);
+        assert_eq!(e.max_seq_len(), MAX_SEQ_LEN);
+    }
+
+    #[test]
+    fn parses_successful_response() {
+        let raw = r#"{
+            "model": "nomic-embed-text",
+            "embeddings": [[0.4, 0.5, 0.6]]
+        }"#;
+        let parsed: EmbedResponse = serde_json::from_str(raw).unwrap();
+        let emb = parsed.embeddings.into_iter().next().unwrap();
+        assert_eq!(emb, vec![0.4, 0.5, 0.6]);
+    }
+}

--- a/crates/uteke-core/src/embed/ollama.rs
+++ b/crates/uteke-core/src/embed/ollama.rs
@@ -40,6 +40,7 @@ impl OllamaEmbedder {
                 "Ollama embedder requires a base_url (default: http://localhost:11434)".into(),
             ));
         }
+        crate::embed::validate_base_url(base_url)?;
         let client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(60))
             .build()

--- a/crates/uteke-core/src/embed/openai.rs
+++ b/crates/uteke-core/src/embed/openai.rs
@@ -1,0 +1,184 @@
+//! OpenAI embedding backend.
+//!
+//! POSTs to `{base_url}/embeddings` with `{ model, input }` JSON and parses
+//! `data[0].embedding`. No batching — single-text per call, same surface as
+//! the ONNX embedder.
+//!
+//! Auth: `Authorization: Bearer <api_key>` (env `UTEKE_EMBEDDING_API_KEY` or
+//! `OPENAI_API_KEY`, or `[embedding] api_key` in uteke.toml).
+//!
+//! Dimensions are model-specific (1536 for text-embedding-3-small,
+//! 3072 for text-embedding-3-large). The caller supplies dims so we don't
+//! burn a probe request at startup.
+
+use crate::embed::Embedder;
+use crate::Error;
+
+/// Default OpenAI API endpoint.
+pub const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// Default model — cheapest, good enough for semantic recall.
+pub const DEFAULT_MODEL: &str = "text-embedding-3-small";
+
+/// Default dimensions for [`DEFAULT_MODEL`].
+pub const DEFAULT_DIMS: usize = 1536;
+
+/// OpenAI max sequence length in tokens (clamped by the API).
+pub const MAX_SEQ_LEN: usize = 8191;
+
+/// OpenAI embedding backend.
+#[derive(Debug)]
+pub struct OpenAiEmbedder {
+    client: reqwest::blocking::Client,
+    api_key: String,
+    base_url: String,
+    model: String,
+    dims: usize,
+}
+
+impl OpenAiEmbedder {
+    /// Construct a new OpenAI embedder.
+    ///
+    /// `api_key` is required; resolution from env/config is the caller's job
+    /// (see `lib.rs::ensure_embedder`).
+    pub fn new(api_key: &str, model: &str, base_url: &str, dims: usize) -> Result<Self, Error> {
+        if api_key.is_empty() {
+            return Err(Error::Validation(
+                "OpenAI embedder requires an API key (set UTEKE_EMBEDDING_API_KEY or OPENAI_API_KEY)".into(),
+            ));
+        }
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| Error::generic(format!("Failed to build HTTP client: {e}")))?;
+        Ok(Self {
+            client,
+            api_key: api_key.to_string(),
+            base_url: base_url.to_string(),
+            model: model.to_string(),
+            dims,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        format!("{base}/embeddings")
+    }
+}
+
+impl Embedder for OpenAiEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, Error> {
+        // OpenAI rejects empty input with 400; send a single space so the
+        // call is always valid (matches ONNX backend's non-empty contract).
+        let input = if text.is_empty() { " " } else { text };
+        let body = serde_json::json!({
+            "model": self.model,
+            "input": input,
+        });
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .map_err(|e| Error::generic(format!("OpenAI embeddings request failed: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().unwrap_or_default();
+            return Err(Error::generic(format!(
+                "OpenAI embeddings returned HTTP {status}: {text}"
+            )));
+        }
+
+        let parsed: EmbeddingsResponse = resp
+            .json()
+            .map_err(|e| Error::generic(format!("Failed to parse OpenAI response: {e}")))?;
+
+        parsed
+            .data
+            .into_iter()
+            .next()
+            .map(|d| d.embedding)
+            .ok_or_else(|| Error::generic("OpenAI response had no embedding data"))
+    }
+
+    fn dims(&self) -> usize {
+        self.dims
+    }
+
+    fn max_seq_len(&self) -> usize {
+        MAX_SEQ_LEN
+    }
+
+    fn name(&self) -> &str {
+        "openai"
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct EmbeddingsResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(serde::Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_api_key() {
+        let err =
+            OpenAiEmbedder::new("", DEFAULT_MODEL, DEFAULT_BASE_URL, DEFAULT_DIMS).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("API key"), "got: {msg}");
+    }
+
+    #[test]
+    fn endpoint_normalizes_trailing_slash() {
+        let e = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            "https://api.openai.com/v1/",
+            DEFAULT_DIMS,
+        )
+        .unwrap();
+        assert_eq!(e.endpoint(), "https://api.openai.com/v1/embeddings");
+    }
+
+    #[test]
+    fn defaults_match_docs() {
+        assert_eq!(DEFAULT_MODEL, "text-embedding-3-small");
+        assert_eq!(DEFAULT_DIMS, 1536);
+        assert_eq!(DEFAULT_BASE_URL, "https://api.openai.com/v1");
+        assert_eq!(MAX_SEQ_LEN, 8191);
+    }
+
+    #[test]
+    fn embedder_name_and_dims() {
+        let e = OpenAiEmbedder::new("k", DEFAULT_MODEL, DEFAULT_BASE_URL, 3072).unwrap();
+        assert_eq!(e.name(), "openai");
+        assert_eq!(e.dims(), 3072);
+        assert_eq!(e.max_seq_len(), MAX_SEQ_LEN);
+    }
+
+    #[test]
+    fn parses_successful_response() {
+        let raw = r#"{
+            "object": "list",
+            "data": [
+                { "object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3] }
+            ],
+            "model": "text-embedding-3-small",
+            "usage": { "prompt_tokens": 1, "total_tokens": 1 }
+        }"#;
+        let parsed: EmbeddingsResponse = serde_json::from_str(raw).unwrap();
+        let emb = parsed.data.into_iter().next().unwrap().embedding;
+        assert_eq!(emb, vec![0.1, 0.2, 0.3]);
+    }
+}

--- a/crates/uteke-core/src/embed/openai.rs
+++ b/crates/uteke-core/src/embed/openai.rs
@@ -47,6 +47,7 @@ impl OpenAiEmbedder {
                 "OpenAI embedder requires an API key (set UTEKE_EMBEDDING_API_KEY or OPENAI_API_KEY)".into(),
             ));
         }
+        crate::embed::validate_base_url(base_url)?;
         let client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
@@ -71,10 +72,23 @@ impl Embedder for OpenAiEmbedder {
         // OpenAI rejects empty input with 400; send a single space so the
         // call is always valid (matches ONNX backend's non-empty contract).
         let input = if text.is_empty() { " " } else { text };
-        let body = serde_json::json!({
-            "model": self.model,
-            "input": input,
-        });
+        // Include `dimensions` when explicitly configured. This keeps the
+        // API response size in sync with the configured index dims
+        // (CodeCora finding #146) for models that support the field.
+        // text-embedding-3-* support it; older models ignore unknown fields
+        // so sending it unconditionally is safe.
+        let body = if self.dims > 0 {
+            serde_json::json!({
+                "model": self.model,
+                "input": input,
+                "dimensions": self.dims,
+            })
+        } else {
+            serde_json::json!({
+                "model": self.model,
+                "input": input,
+            })
+        };
 
         let resp = self
             .client
@@ -180,5 +194,27 @@ mod tests {
         let parsed: EmbeddingsResponse = serde_json::from_str(raw).unwrap();
         let emb = parsed.data.into_iter().next().unwrap().embedding;
         assert_eq!(emb, vec![0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn rejects_invalid_base_url() {
+        // Schemeless URL — CodeCora #155.
+        let err =
+            OpenAiEmbedder::new("k", DEFAULT_MODEL, "api.openai.com/v1", DEFAULT_DIMS).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("http"), "got: {msg}");
+
+        // Empty string.
+        let err = OpenAiEmbedder::new("k", DEFAULT_MODEL, "", DEFAULT_DIMS).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("empty") || msg.contains("http"), "got: {msg}");
+
+        // Unparseable.
+        let err = OpenAiEmbedder::new("k", DEFAULT_MODEL, "https://", DEFAULT_DIMS).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("valid URL") || msg.contains("http"),
+            "got: {msg}"
+        );
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -154,6 +154,42 @@ pub fn uteke_home() -> Result<PathBuf, Error> {
     }
 }
 
+/// Resolved embedder configuration used by lazy backend dispatch.
+///
+/// Mirrors the CLI-side `EmbeddingConfig` but kept inside `uteke-core` so
+/// the core library can construct OpenAI/Ollama backends without depending
+/// on the CLI crate. Field values are sourced from environment variables
+/// first, then fall back to backend defaults.
+struct EmbedderEnv {
+    api_key: String,
+    base_url: String,
+    model: String,
+    dims: usize,
+}
+
+impl EmbedderEnv {
+    /// Read embedder settings from environment variables. Empty fields
+    /// trigger backend defaults at the call site.
+    fn resolve(_backend: &str) -> Self {
+        let api_key = std::env::var("UTEKE_EMBEDDING_API_KEY")
+            .ok()
+            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+            .unwrap_or_default();
+        let base_url = std::env::var("UTEKE_EMBEDDING_BASE_URL").unwrap_or_default();
+        let model = std::env::var("UTEKE_EMBEDDING_MODEL").unwrap_or_default();
+        let dims = std::env::var("UTEKE_EMBEDDING_DIMS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0);
+        Self {
+            api_key,
+            base_url,
+            model,
+            dims,
+        }
+    }
+}
+
 /// Uteke — AI agent memory engine.
 ///
 /// Combines SQLite persistence, HNSW vector search, and ONNX embedding
@@ -284,10 +320,28 @@ impl Uteke {
         let dims = match embedder.as_ref() {
             Some(e) => e.dims(),
             None => match embedder_backend.as_str() {
-                "onnx" | "" | "custom" => OnnxEmbedder::dims(),
+                "onnx" | "" | "custom" => crate::embed::OnnxEmbedder::dims(),
+                "openai" => {
+                    // User-configurable via UTEKE_EMBEDDING_DIMS. Default 1536
+                    // (text-embedding-3-small).
+                    let cfg = EmbedderEnv::resolve("openai");
+                    if cfg.dims == 0 {
+                        crate::embed::openai::DEFAULT_DIMS
+                    } else {
+                        cfg.dims
+                    }
+                }
+                "ollama" => {
+                    let cfg = EmbedderEnv::resolve("ollama");
+                    if cfg.dims == 0 {
+                        crate::embed::ollama::DEFAULT_DIMS
+                    } else {
+                        cfg.dims
+                    }
+                }
                 other => {
                     return Err(Error::Validation(format!(
-                        "Unknown embedding backend: '{other}'. Supported: 'onnx'."
+                        "Unknown embedding backend: '{other}'. Supported: onnx, openai, ollama."
                     )));
                 }
             },
@@ -334,19 +388,77 @@ impl Uteke {
             .map_err(|_| Error::lock("embedder lock during lazy init"))?;
         if guard.is_none() {
             tracing::debug!(backend = %self.embedder_backend, "Lazy-initializing embedding backend");
-            *guard = Some(match self.embedder_backend.as_str() {
-                "onnx" | "" => Box::new(OnnxEmbedder::new()?),
+            let backend = self.embedder_backend.as_str();
+            let embedder: Box<dyn crate::embed::Embedder> = match backend {
+                "onnx" | "" => Box::new(crate::embed::OnnxEmbedder::new()?),
                 "custom" => {
                     return Err(Error::generic(
                         "Custom embedder backend set but no embedder was provided",
                     ));
                 }
+                "openai" => {
+                    let cfg = EmbedderEnv::resolve(backend);
+                    let model = if cfg.model.is_empty() {
+                        crate::embed::openai::DEFAULT_MODEL.to_string()
+                    } else {
+                        cfg.model
+                    };
+                    let base_url = if cfg.base_url.is_empty() {
+                        crate::embed::openai::DEFAULT_BASE_URL.to_string()
+                    } else {
+                        cfg.base_url
+                    };
+                    let dims = if cfg.dims == 0 {
+                        crate::embed::openai::DEFAULT_DIMS
+                    } else {
+                        cfg.dims
+                    };
+                    Box::new(crate::embed::OpenAiEmbedder::new(
+                        &cfg.api_key,
+                        &model,
+                        &base_url,
+                        dims,
+                    )?)
+                }
+                "ollama" => {
+                    let cfg = EmbedderEnv::resolve(backend);
+                    let model = if cfg.model.is_empty() {
+                        crate::embed::ollama::DEFAULT_MODEL.to_string()
+                    } else {
+                        cfg.model
+                    };
+                    let base_url = if cfg.base_url.is_empty() {
+                        crate::embed::ollama::DEFAULT_BASE_URL.to_string()
+                    } else {
+                        cfg.base_url
+                    };
+                    let dims = if cfg.dims == 0 {
+                        crate::embed::ollama::DEFAULT_DIMS
+                    } else {
+                        cfg.dims
+                    };
+                    Box::new(crate::embed::OllamaEmbedder::new(&base_url, &model, dims)?)
+                }
                 other => {
                     return Err(Error::Validation(format!(
-                        "Unknown embedding backend: '{other}'. Supported: 'onnx'."
+                        "Unknown embedding backend: '{other}'. Supported: onnx, openai, ollama."
                     )));
                 }
-            });
+            };
+
+            // Dim mismatch detection (#337): refuse to silently mix vectors
+            // from different backends in one index. Catch it at first use
+            // so the user gets a clear error instead of garbage recall.
+            let backend_dims = embedder.dims();
+            let index_dims = self.index.read().map(|i| i.dims()).unwrap_or(backend_dims);
+            if index_dims != backend_dims {
+                return Err(Error::Validation(format!(
+                    "Embedding dimension mismatch: index has {index_dims}d vectors but backend '{backend}' produces {backend_dims}d. \
+                     Rebuild the index (`uteke repair`) or switch backend."
+                )));
+            }
+
+            *guard = Some(embedder);
         }
         Ok(())
     }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -178,15 +178,20 @@ impl EmbeddingSettings {
     /// (UTEKE_EMBEDDING_*) win over the caller-supplied values; the caller
     /// is responsible for having already merged uteke.toml into the input.
     fn resolve_with_defaults(input: &EmbeddingSettings) -> Self {
-        let api_key = std::env::var("UTEKE_EMBEDDING_API_KEY")
-            .ok()
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+        // Env vars win over caller-supplied values, but an explicitly empty
+        // env var is treated as "unset" so it cannot clobber a non-empty
+        // config-provided value (CodeCora finding: empty
+        // UTEKE_EMBEDDING_API_KEY previously overwrote a populated
+        // [embedding].api_key).
+        let env_or = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+        let api_key = env_or("UTEKE_EMBEDDING_API_KEY")
+            .or_else(|| env_or("OPENAI_API_KEY"))
             .unwrap_or_else(|| input.api_key.clone());
-        let base_url =
-            std::env::var("UTEKE_EMBEDDING_BASE_URL").unwrap_or_else(|_| input.base_url.clone());
-        let model = std::env::var("UTEKE_EMBEDDING_MODEL").unwrap_or_else(|_| input.model.clone());
+        let base_url = env_or("UTEKE_EMBEDDING_BASE_URL").unwrap_or_else(|| input.base_url.clone());
+        let model = env_or("UTEKE_EMBEDDING_MODEL").unwrap_or_else(|| input.model.clone());
         let dims = std::env::var("UTEKE_EMBEDDING_DIMS")
             .ok()
+            .filter(|v| !v.is_empty())
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(input.dims);
         Self {
@@ -865,6 +870,31 @@ mod tests {
         // Non-overridden fields fall through from the caller config.
         assert_eq!(merged.base_url, "https://config.example.com");
         assert_eq!(merged.dims, 1024);
+    }
+
+    #[test]
+    fn embedding_settings_empty_env_does_not_overwrite_config() {
+        // Explicitly empty env var must NOT clobber a non-empty config value
+        // (CodeCora finding: std::env::var returns Ok("") for empty vars).
+        std::env::set_var("UTEKE_EMBEDDING_API_KEY", "");
+        std::env::set_var("UTEKE_EMBEDDING_MODEL", "");
+        let input = EmbeddingSettings {
+            api_key: "sk-from-config".to_string(),
+            base_url: "https://config.example.com".to_string(),
+            model: "config-model".to_string(),
+            dims: 1536,
+        };
+        let merged = EmbeddingSettings::resolve_with_defaults(&input);
+        std::env::remove_var("UTEKE_EMBEDDING_API_KEY");
+        std::env::remove_var("UTEKE_EMBEDDING_MODEL");
+        assert_eq!(
+            merged.api_key, "sk-from-config",
+            "empty env must not clobber config"
+        );
+        assert_eq!(
+            merged.model, "config-model",
+            "empty env must not clobber config"
+        );
     }
 
     #[test]

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -158,29 +158,37 @@ pub fn uteke_home() -> Result<PathBuf, Error> {
 ///
 /// Mirrors the CLI-side `EmbeddingConfig` but kept inside `uteke-core` so
 /// the core library can construct OpenAI/Ollama backends without depending
-/// on the CLI crate. Field values are sourced from environment variables
-/// first, then fall back to backend defaults.
-struct EmbedderEnv {
-    api_key: String,
-    base_url: String,
-    model: String,
-    dims: usize,
+/// on the CLI crate. Field values are sourced from the merged CLI config
+/// (env vars + uteke.toml) by the caller, then further env-var overrides
+/// take precedence at resolve time.
+#[derive(Clone, Default)]
+pub struct EmbeddingSettings {
+    /// API key for OpenAI (or compatible). Empty = ONNX/Ollama.
+    pub api_key: String,
+    /// Custom endpoint. Empty = backend default.
+    pub base_url: String,
+    /// Model name. Empty = backend default.
+    pub model: String,
+    /// Force dims. 0 = backend/model default.
+    pub dims: usize,
 }
 
-impl EmbedderEnv {
-    /// Read embedder settings from environment variables. Empty fields
-    /// trigger backend defaults at the call site.
-    fn resolve(_backend: &str) -> Self {
+impl EmbeddingSettings {
+    /// Merge caller-provided settings with env-var overrides. Env vars
+    /// (UTEKE_EMBEDDING_*) win over the caller-supplied values; the caller
+    /// is responsible for having already merged uteke.toml into the input.
+    fn resolve_with_defaults(input: &EmbeddingSettings) -> Self {
         let api_key = std::env::var("UTEKE_EMBEDDING_API_KEY")
             .ok()
             .or_else(|| std::env::var("OPENAI_API_KEY").ok())
-            .unwrap_or_default();
-        let base_url = std::env::var("UTEKE_EMBEDDING_BASE_URL").unwrap_or_default();
-        let model = std::env::var("UTEKE_EMBEDDING_MODEL").unwrap_or_default();
+            .unwrap_or_else(|| input.api_key.clone());
+        let base_url =
+            std::env::var("UTEKE_EMBEDDING_BASE_URL").unwrap_or_else(|_| input.base_url.clone());
+        let model = std::env::var("UTEKE_EMBEDDING_MODEL").unwrap_or_else(|_| input.model.clone());
         let dims = std::env::var("UTEKE_EMBEDDING_DIMS")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(0);
+            .unwrap_or(input.dims);
         Self {
             api_key,
             base_url,
@@ -190,6 +198,10 @@ impl EmbedderEnv {
     }
 }
 
+// Backward-compat alias removed — use EmbeddingSettings::resolve_with_defaults
+// directly. The old EmbedderEnv struct was only used inside lib.rs and is
+// now replaced by the public EmbeddingSettings API.
+
 /// Uteke — AI agent memory engine.
 ///
 /// Combines SQLite persistence, HNSW vector search, and ONNX embedding
@@ -198,8 +210,11 @@ pub struct Uteke {
     store: Store,
     index: RwLock<VectorIndex>,
     embedder: Mutex<Option<Box<dyn Embedder>>>,
-    /// Embedding backend name ("onnx", "openai", etc.). Used by lazy init.
+    /// Embedding backend name ("onnx", "openai", "ollama", "custom"). Used by lazy init.
     embedder_backend: String,
+    /// Caller-supplied embedding settings (from uteke.toml). Env vars still
+    /// override these at resolve time.
+    embedding_settings: EmbeddingSettings,
     tier_config: TierConfig,
     #[allow(dead_code)] // Stored for future per-store default threshold enforcement
     recall_config: RecallConfig,
@@ -232,6 +247,7 @@ impl Uteke {
             "custom".to_string(),
             TierConfig::default(),
             RecallConfig::default(),
+            EmbeddingSettings::default(),
         )
     }
 
@@ -247,6 +263,7 @@ impl Uteke {
             "onnx".to_string(),
             tier_config,
             RecallConfig::default(),
+            EmbeddingSettings::default(),
         )
     }
 
@@ -263,6 +280,7 @@ impl Uteke {
             backend.to_string(),
             tier_config,
             RecallConfig::default(),
+            EmbeddingSettings::default(),
         )
     }
 
@@ -278,6 +296,7 @@ impl Uteke {
             "onnx".to_string(),
             TierConfig::default(),
             recall_config,
+            EmbeddingSettings::default(),
         )
     }
 
@@ -292,6 +311,30 @@ impl Uteke {
             backend.to_string(),
             TierConfig::default(),
             RecallConfig::default(),
+            EmbeddingSettings::default(),
+        )
+    }
+
+    /// Open with caller-supplied embedding settings (CLI passes merged config).
+    ///
+    /// `backend` selects onnx/openai/ollama/custom. `settings` carries the
+    /// api_key/base_url/model/dims resolved from uteke.toml; env vars still
+    /// take precedence at first-embed resolve time.
+    pub fn open_with_embedding(
+        path: impl AsRef<Path>,
+        backend: &str,
+        settings: EmbeddingSettings,
+        tier_config: TierConfig,
+        recall_config: RecallConfig,
+    ) -> Result<Self, Error> {
+        let (_db_str, store) = Self::open_store(path)?;
+        Self::finish_open(
+            store,
+            None,
+            backend.to_string(),
+            tier_config,
+            recall_config,
+            settings,
         )
     }
 
@@ -308,6 +351,7 @@ impl Uteke {
         embedder_backend: String,
         tier_config: TierConfig,
         recall_config: RecallConfig,
+        embedding_settings: EmbeddingSettings,
     ) -> Result<Self, Error> {
         // Determine index path: same directory as SQLite DB
         let index_path = store.path().map(|p| {
@@ -322,9 +366,9 @@ impl Uteke {
             None => match embedder_backend.as_str() {
                 "onnx" | "" | "custom" => crate::embed::OnnxEmbedder::dims(),
                 "openai" => {
-                    // User-configurable via UTEKE_EMBEDDING_DIMS. Default 1536
-                    // (text-embedding-3-small).
-                    let cfg = EmbedderEnv::resolve("openai");
+                    // User-configurable via uteke.toml or UTEKE_EMBEDDING_DIMS.
+                    // Default 1536 (text-embedding-3-small).
+                    let cfg = EmbeddingSettings::resolve_with_defaults(&embedding_settings);
                     if cfg.dims == 0 {
                         crate::embed::openai::DEFAULT_DIMS
                     } else {
@@ -332,7 +376,7 @@ impl Uteke {
                     }
                 }
                 "ollama" => {
-                    let cfg = EmbedderEnv::resolve("ollama");
+                    let cfg = EmbeddingSettings::resolve_with_defaults(&embedding_settings);
                     if cfg.dims == 0 {
                         crate::embed::ollama::DEFAULT_DIMS
                     } else {
@@ -370,6 +414,7 @@ impl Uteke {
             index: RwLock::new(index),
             embedder: Mutex::new(embedder),
             embedder_backend,
+            embedding_settings,
             tier_config,
             recall_config,
             recall_cache: recall_cache::RecallCache::new(recall_cache::RecallCacheConfig::default()),
@@ -397,7 +442,7 @@ impl Uteke {
                     ));
                 }
                 "openai" => {
-                    let cfg = EmbedderEnv::resolve(backend);
+                    let cfg = EmbeddingSettings::resolve_with_defaults(&self.embedding_settings);
                     let model = if cfg.model.is_empty() {
                         crate::embed::openai::DEFAULT_MODEL.to_string()
                     } else {
@@ -421,7 +466,7 @@ impl Uteke {
                     )?)
                 }
                 "ollama" => {
-                    let cfg = EmbedderEnv::resolve(backend);
+                    let cfg = EmbeddingSettings::resolve_with_defaults(&self.embedding_settings);
                     let model = if cfg.model.is_empty() {
                         crate::embed::ollama::DEFAULT_MODEL.to_string()
                     } else {
@@ -781,5 +826,56 @@ mod tests {
             .recall("rust programming", 5, None, None, 0.0)
             .unwrap();
         assert!(!results.is_empty());
+    }
+
+    #[test]
+    fn embedding_settings_defaults_empty() {
+        let d = EmbeddingSettings::default();
+        assert!(d.api_key.is_empty());
+        assert!(d.base_url.is_empty());
+        assert!(d.model.is_empty());
+        assert_eq!(d.dims, 0);
+    }
+
+    #[test]
+    fn embedding_settings_env_overrides_caller_config() {
+        // Env vars win over caller-supplied settings.
+        std::env::set_var("UTEKE_EMBEDDING_API_KEY", "sk-env-wins");
+        std::env::set_var("UTEKE_EMBEDDING_MODEL", "env-model");
+        let input = EmbeddingSettings {
+            api_key: "sk-config".to_string(),
+            base_url: "https://config.example.com".to_string(),
+            model: "config-model".to_string(),
+            dims: 1024,
+        };
+        let merged = EmbeddingSettings::resolve_with_defaults(&input);
+        std::env::remove_var("UTEKE_EMBEDDING_API_KEY");
+        std::env::remove_var("UTEKE_EMBEDDING_MODEL");
+        // Env overrides
+        assert_eq!(merged.api_key, "sk-env-wins");
+        assert_eq!(merged.model, "env-model");
+        // Non-overridden fields fall through from the caller config.
+        assert_eq!(merged.base_url, "https://config.example.com");
+        assert_eq!(merged.dims, 1024);
+    }
+
+    #[test]
+    fn embedding_settings_config_used_when_env_absent() {
+        std::env::remove_var("UTEKE_EMBEDDING_API_KEY");
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::remove_var("UTEKE_EMBEDDING_BASE_URL");
+        std::env::remove_var("UTEKE_EMBEDDING_MODEL");
+        std::env::remove_var("UTEKE_EMBEDDING_DIMS");
+        let input = EmbeddingSettings {
+            api_key: "sk-config-only".to_string(),
+            base_url: "https://from-toml.example.com".to_string(),
+            model: "from-toml-model".to_string(),
+            dims: 2048,
+        };
+        let merged = EmbeddingSettings::resolve_with_defaults(&input);
+        assert_eq!(merged.api_key, "sk-config-only");
+        assert_eq!(merged.base_url, "https://from-toml.example.com");
+        assert_eq!(merged.model, "from-toml-model");
+        assert_eq!(merged.dims, 2048);
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -494,12 +494,20 @@ impl Uteke {
             // Dim mismatch detection (#337): refuse to silently mix vectors
             // from different backends in one index. Catch it at first use
             // so the user gets a clear error instead of garbage recall.
+            //
+            // Escape hatch: UTEKE_ALLOW_DIM_MISMATCH=1 skips the check so the
+            // user can open the store with a different backend to run
+            // `uteke repair` (which rebuilds vectors with the new backend).
+            // Without this, a user who flips backend on an existing store
+            // can never recover (CodeCora finding #154).
             let backend_dims = embedder.dims();
             let index_dims = self.index.read().map(|i| i.dims()).unwrap_or(backend_dims);
-            if index_dims != backend_dims {
+            if index_dims != backend_dims
+                && std::env::var("UTEKE_ALLOW_DIM_MISMATCH").as_deref() != Ok("1")
+            {
                 return Err(Error::Validation(format!(
                     "Embedding dimension mismatch: index has {index_dims}d vectors but backend '{backend}' produces {backend_dims}d. \
-                     Rebuild the index (`uteke repair`) or switch backend."
+                     Rebuild the index (`UTEKE_ALLOW_DIM_MISMATCH=1 uteke repair`) or switch backend."
                 )));
             }
 

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -233,6 +233,14 @@ impl VectorIndex {
         self.index.size()
     }
 
+    /// Embedding dimensionality of this index.
+    ///
+    /// Used by backend dispatch to detect dim mismatch when the user swaps
+    /// embedding backends on an existing store (#337).
+    pub fn dims(&self) -> usize {
+        self.index.dimensions()
+    }
+
     /// Check if the index is empty.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,11 @@ Embedding dimension mismatch: index has 768d vectors but backend 'openai' produc
 Rebuild the index (`uteke repair`) or switch backend.
 ```
 
-To migrate, run `uteke repair` after switching backends — it rebuilds the vector index from the SQLite source of truth using the new backend's embeddings.
+To migrate, run `uteke repair` after switching backends — it rebuilds the vector index from the SQLite source of truth using the new backend's embeddings. Because the dim-mismatch guard will block any embed-based operation on first contact, set `UTEKE_ALLOW_DIM_MISMATCH=1` once to let `uteke repair` open the store with the new backend:
+
+```bash
+UTEKE_ALLOW_DIM_MISMATCH=1 uteke repair
+```
 
 ## Recall Threshold
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,7 +107,7 @@ When you set `backend = "openai"` or `"ollama"` and leave `model`/`base_url`/`di
 
 ### Azure OpenAI
 
-Set `backend = "openai"`, `base_url = "https://<your-resource>.openai.azure.com/openai/deployments/<deployment>"` and `api_key` to your Azure key. The request path `/embeddings` is appended automatically.
+Set `backend = "openai"`, `base_url = "https://<your-resource>.openai.azure.com/openai/deployments/<deployment>?api-version=2024-10-21"` and `api_key` to your Azure key. The request path `/embeddings` is appended automatically. Azure requires the `api-version` query param — include it in `base_url`.
 
 ### Dim mismatch detection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,7 +107,7 @@ When you set `backend = "openai"` or `"ollama"` and leave `model`/`base_url`/`di
 
 ### Azure OpenAI
 
-Set `backend = "openai"`, `base_url = "https://<your-resource>.openai.azure.com/openai/deployments/<deployment>` and `api_key` to your Azure key. The request path `/embeddings` is appended automatically.
+Set `backend = "openai"`, `base_url = "https://<your-resource>.openai.azure.com/openai/deployments/<deployment>"` and `api_key` to your Azure key. The request path `/embeddings` is appended automatically.
 
 ### Dim mismatch detection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,25 +70,55 @@ If the server is not running, CLI falls back to local store automatically.
 
 ## Embedding Backend
 
-Configure the embedding backend:
+Configure the embedding backend. Three backends are supported:
+
+- **`onnx`** (default) — fully offline, EmbeddingGemma Q4, 768d. Zero API keys, zero network.
+- **`openai`** — OpenAI `text-embedding-3-small` (1536d) or `text-embedding-3-large` (3072d). Requires API key.
+- **`ollama`** — local Ollama server with models like `nomic-embed-text` (768d) or `mxbai-embed-large` (1024d). No API key, runs on `http://localhost:11434`.
 
 ```toml
 [embedding]
-# Backend: "onnx" (default), future: "openai", "ollama"
-backend = "onnx"
-
-# Model name (for ONNX backend)
-model = "embeddinggemma-q4"
-
-# Maximum sequence length in tokens
+backend = "onnx"              # onnx | openai | ollama
+model = "embeddinggemma-q4"   # backend-specific
 max_seq_length = 256
+api_key = ""                  # OpenAI only (or use UTEKE_EMBEDDING_API_KEY)
+base_url = ""                 # custom endpoint (Azure OpenAI, Ollama URL, proxy)
+dims = 0                     # 0 = use model default (override only if you know)
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `backend` | onnx | Embedding backend |
-| `model` | embeddinggemma-q4 | Model identifier |
-| `max_seq_length` | 256 | Max tokens per input |
+| `backend` | `onnx` | `onnx`, `openai`, or `ollama` |
+| `model` | `embeddinggemma-q4` | Backend-specific model name |
+| `max_seq_length` | `256` | Max tokens per input |
+| `api_key` | `""` | OpenAI API key (ONNX/Ollama ignore) |
+| `base_url` | `""` | Custom endpoint. Empty = backend default |
+| `dims` | `0` | Force dims. 0 = backend/model default |
+
+### Backend-specific defaults
+
+When you set `backend = "openai"` or `"ollama"` and leave `model`/`base_url`/`dims` empty, uteke picks:
+
+| Backend | Model | Base URL | Dims |
+|---|---|---|---|
+| `onnx` | `embeddinggemma-q4` | (local) | 768 |
+| `openai` | `text-embedding-3-small` | `https://api.openai.com/v1` | 1536 |
+| `ollama` | `nomic-embed-text` | `http://localhost:11434` | 768 |
+
+### Azure OpenAI
+
+Set `backend = "openai"`, `base_url = "https://<your-resource>.openai.azure.com/openai/deployments/<deployment>` and `api_key` to your Azure key. The request path `/embeddings` is appended automatically.
+
+### Dim mismatch detection
+
+If you open an existing store with a different backend (different dims), the first embedding operation returns a clear error instead of silently corrupting the index:
+
+```
+Embedding dimension mismatch: index has 768d vectors but backend 'openai' produces 1536d.
+Rebuild the index (`uteke repair`) or switch backend.
+```
+
+To migrate, run `uteke repair` after switching backends — it rebuilds the vector index from the SQLite source of truth using the new backend's embeddings.
 
 ## Recall Threshold
 
@@ -131,6 +161,11 @@ Resolution order (highest priority first):
 | `UTEKE_SERVER_PORT` | `[server] port` | `8767` | Server port |
 | `UTEKE_RECALL_MIN_SCORE` | `[recall] min_score` | `0.3` | Default similarity threshold |
 | `UTEKE_RECALL_MIN_SCORE_STRICT` | `[recall] min_score_strict` | `0.5` | Strict threshold |
+| `UTEKE_EMBEDDING_BACKEND` | `[embedding] backend` | `onnx` | Embedding backend: onnx, openai, ollama |
+| `UTEKE_EMBEDDING_MODEL` | `[embedding] model` | backend-specific | Override model name |
+| `UTEKE_EMBEDDING_API_KEY` | `[embedding] api_key` | — | API key (OpenAI). Fallback: `OPENAI_API_KEY` |
+| `UTEKE_EMBEDDING_BASE_URL` | `[embedding] base_url` | backend-specific | Custom endpoint URL |
+| `UTEKE_EMBEDDING_DIMS` | `[embedding] dims` | `0` (auto) | Force embedding dimensionality |
 
 ### Docker Example
 


### PR DESCRIPTION
## Summary

Implements #337 (priority: high). Three embedding backends now supported via `[embedding] backend`:

- **`onnx`** (default, fully offline, EmbeddingGemma Q4 768d) — unchanged.
- **`openai`** — `text-embedding-3-small` (1536d) default. Azure-compatible via `base_url`.
- **`ollama`** — `nomic-embed-text` (768d) default. Local server on `http://localhost:11434`.

## New files

- `crates/uteke-core/src/embed/openai.rs` — `OpenAiEmbedder` + 5 unit tests
- `crates/uteke-core/src/embed/ollama.rs` — `OllamaEmbedder` + 5 unit tests

## Core changes (`uteke-core`)

- `EmbedderEnv` resolver in lib.rs reads backend config from env vars without pulling the CLI config crate into core.
- `ensure_embedder()` dispatch now constructs OpenAI/Ollama backends with backend-specific defaults when `model`/`base_url`/`dims` are empty.
- **Dim mismatch detection**: if backend dims != index dims on first embed call, return a clear `Validation` error pointing at `uteke repair` instead of silently producing garbage vectors:
  ```
  Embedding dimension mismatch: index has 768d vectors but backend 'openai' produces 1536d.
  Rebuild the index (`uteke repair`) or switch backend.
  ```
- `VectorIndex::dims()` exposed (wraps `usearch Index::dimensions()`).
- `reqwest` 0.12 gains `json` feature — **always included, no feature flag**.

## CLI config changes (`uteke-cli`)

- `EmbeddingConfig` extended: `api_key`, `base_url`, `dims`.
- `SUPPORTED_BACKENDS` now `[onnx, openai, ollama]`.
- `merge_from_file` handles the 3 new fields.
- `apply_env_overrides` handles `UTEKE_EMBEDDING_BACKEND/MODEL/API_KEY/BASE_URL/DIMS`. API key falls back to `OPENAI_API_KEY`.
- +6 new config tests (full openai merge, env precedence, fallback, invalid dims).

## Docs

- `configuration.md`: expanded Embedding Backend section with:
  - backend-specific defaults table
  - Azure OpenAI recipe
  - dim mismatch error example
- Env var table extended with the 5 new `UTEKE_EMBEDDING_*` vars.
- CHANGELOG entry.

## Backend defaults

| Backend | Model | Base URL | Dims |
|---|---|---|---|
| `onnx` | `embeddinggemma-q4` | (local) | 768 |
| `openai` | `text-embedding-3-small` | `https://api.openai.com/v1` | 1536 |
| `ollama` | `nomic-embed-text` | `http://localhost:11434` | 768 |

## Acceptance criteria (from issue #337)

- [x] `OpenAiEmbedder` implements `Embedder` trait with HTTP call
- [x] `OllamaEmbedder` implements `Embedder` trait with HTTP call
- [x] Config `[embedding] backend/api_key/base_url/model/dims` supported
- [x] Env vars override config (`UTEKE_EMBEDDING_*`)
- [x] ONNX remains default (backward compatible)
- [x] Dim mismatch detection with clear error message
- [x] `reqwest` always included (no feature flags)
- [x] Documentation updated (`configuration.md`)
- [x] Tests for backend selection logic

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace` — 212 pass (29 CLI + 183 core), 0 fail

## Competitive impact (per issue)

| Feature | Uteke (after) | Mem0 | Zep | Letta |
|---|---|---|---|---|
| ONNX local | ✅ Default | ❌ | ❌ | ❌ |
| OpenAI | ✅ | ✅ | ✅ | ✅ |
| Ollama | ✅ | ❌ | ✅ | ✅ |
| Zero-dep mode | ✅ (ONNX) | ❌ | ❌ | ❌ |

## Notes

- ONNX path unchanged; existing users see no behavior diff.
- OpenAI/Ollama network errors bubble up as `Error::generic` with HTTP status + body for debugging.
- No live network calls in tests — all tests are construction/validation/JSON-parsing only.

Closes #337