### PR TITLE
chore(deps): bump sha2 0.10 → 0.11 (supersedes #364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Changed
+
+- **Bump sha2 0.10 → 0.11** (supersedes Dependabot PR #364)
+  - sha2 0.11 dropped the `LowerHex` impl on the digest output, breaking
+    `format!("{:x}", hasher.finalize())` in `engine.rs`.
+  - Fix: iterate the digest bytes and format each as `{:02x}`.
+  - Unifies the crate on a single sha2 version (uteke-server was already
+    on 0.11).
+
 ### Added
 
 - **OpenAI + Ollama embedding backends** (#337)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,15 +134,6 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -343,15 +334,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -392,16 +374,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "crypto-common"
@@ -587,23 +559,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -811,16 +773,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2197,24 +2149,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2838,7 +2779,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -2865,7 +2806,7 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tiny_http",
  "toml",
  "tracing",

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -24,7 +24,7 @@ tokenizers = "0.23"
 dirs = "6"
 tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
-sha2 = "0.10"
+sha2 = "0.11"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -267,7 +267,10 @@ fn verify_checksum(path: &std::path::Path, filename: &str) -> Result<(), Error> 
     let data = std::fs::read(path).map_err(|e| Error::embed("read file for checksum", e))?;
     let mut hasher = Sha256::new();
     hasher.update(&data);
-    let actual = format!("{:x}", hasher.finalize());
+    let digest = hasher.finalize();
+    // sha2 0.11 dropped the LowerHex impl on the digest Array type, so format
+    // the 32 bytes as lowercase hex manually.
+    let actual: String = digest.iter().map(|b| format!("{b:02x}")).collect();
 
     if actual != expected {
         // Delete corrupted file so next run re-downloads


### PR DESCRIPTION
## Summary

Supersedes Dependabot PR #364, which bumped `sha2` in `uteke-core` from 0.10 to 0.11 but sat BLOCKED because sha2 0.11 dropped the `LowerHex` impl on the digest output. The failing line was:

```rust
let actual = format!("{:x}", hasher.finalize());  // engine.rs:270
```

Dependabot doesn't patch code, so this PR applies the bump + the compatibility fix.

## Changes

- `crates/uteke-core/Cargo.toml`: `sha2 = "0.10"` → `"0.11"`
- `crates/uteke-core/src/embed/engine.rs`: replace `format!("{:x}", hasher.finalize())` with manual per-byte `{:02x}` formatting. sha2 0.11 returns `Array<u8, _>` which has no `LowerHex` impl.
- `Cargo.lock`: regenerated.
- Side benefit: unifies the workspace on a single sha2 version. `uteke-server` was already on 0.11; now `uteke-core` matches.

## Verification

- `cargo build --workspace` — clean
- `cargo test --workspace` — 217 pass (188 core + 29 CLI), 0 fail
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Closes

Closes #364 (Dependabot PR, superseded).