### PR TITLE
feat(#349): memory type formalization + pattern-based auto-inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ### Added
 
+- **Memory type formalization** (#349)
+  - `MemoryType` enum expanded from 5 to 9 variants: original (Fact,
+    Procedure, Preference, Decision, Context) + new (Note, Insight,
+    Reference, Event).
+  - Pattern-based auto-inference (`MemoryType::infer_from_content`):
+    URL prefix → `Reference`; decided/chose/will use → `Decision`;
+    realized/learned/discovered → `Insight`; how-to/numbered list →
+    `Procedure`; always/never/prefer/hate → `Preference`; ISO date +
+    time word → `Event`; fallback → `Note`. Zero LLM.
+  - When callers pass the default `"fact"`, `remember_typed` now runs
+    inference and overrides with a more specific type when one is
+    detected (falls back to `Fact` for ambiguous content, preserving
+    backward compatibility).
+  - `MemoryType::recall_boost()` — small additive score boost per type
+    (Decision/Preference +0.05, Insight +0.03, Event +0.02, Note -0.02).
+    To be wired into recall scoring by #352.
+  - CLI: `--type` help text documents the new types and auto-inference.
+
 - **Backlink auto-generation** (#350)
   - Bidirectional links: whenever memory A creates a forward edge to B
     (`references`, `tagged_as`, `supersedes`, `replies_to`), an inverse

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -52,7 +52,9 @@ pub enum Commands {
         /// Tags for categorization (comma-separated)
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
-        /// Memory type: fact, procedure, preference, decision, context
+        /// Memory type: fact, procedure, preference, decision, context,
+        /// note, insight, reference, event. Default 'fact' triggers pattern-based
+        /// auto-inference (#349) unless an explicit type is passed.
         #[arg(long, default_value = "fact")]
         r#type: String,
         /// Enable contradiction detection (auto-deprecate conflicting memories)

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -228,6 +228,10 @@ pub struct ContradictionResult {
 }
 
 /// Memory type classification.
+///
+/// The taxonomy is fixed (no user-defined types yet, see #349 non-goals).
+/// Auto-inference is pattern-based and runs on every `remember()` when the
+/// caller does not pass an explicit type — see [`MemoryType::infer_from_content`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MemoryType {
     /// A factual statement (has temporal validity).
@@ -240,29 +244,42 @@ pub enum MemoryType {
     Decision,
     /// Contextual information (session-scoped, may expire).
     Context,
+    /// A general freeform note (no specific type signal detected).
+    ///
+    /// Added in #349. Distinguished from `Fact` (which claims verifiable
+    /// truth) — `Note` is a generic capture bucket.
+    Note,
+    /// A realization or learning (contains "realized", "learned",
+    /// "discovered", "turns out").
+    ///
+    /// Added in #349. High long-term value for memory-engine epics.
+    Insight,
+    /// Factual reference info (links, specs, docs — starts with URL or
+    /// `ref:` / `see:` / `docs:`).
+    ///
+    /// Added in #349.
+    Reference,
+    /// A time-bound event (has an explicit ISO date + time word).
+    ///
+    /// Added in #349. Eligible for recency-boosted recall.
+    Event,
 }
 
 impl MemoryType {
     /// Parse from string (case-insensitive).
     pub fn from_str_opt(s: &str) -> Option<Self> {
-        match s {
-            "fact" | "Fact" | "FACT" => Some(Self::Fact),
-            "procedure" | "Procedure" | "PROCEDURE" => Some(Self::Procedure),
-            "preference" | "Preference" | "PREFERENCE" => Some(Self::Preference),
-            "decision" | "Decision" | "DECISION" => Some(Self::Decision),
-            "context" | "Context" | "CONTEXT" => Some(Self::Context),
-            _ => {
-                // Fallback: lowercase comparison for mixed case
-                let lower = s.to_lowercase();
-                match lower.as_str() {
-                    "fact" => Some(Self::Fact),
-                    "procedure" => Some(Self::Procedure),
-                    "preference" => Some(Self::Preference),
-                    "decision" => Some(Self::Decision),
-                    "context" => Some(Self::Context),
-                    _ => None,
-                }
-            }
+        let lower = s.to_ascii_lowercase();
+        match lower.as_str() {
+            "fact" => Some(Self::Fact),
+            "procedure" => Some(Self::Procedure),
+            "preference" => Some(Self::Preference),
+            "decision" => Some(Self::Decision),
+            "context" => Some(Self::Context),
+            "note" => Some(Self::Note),
+            "insight" => Some(Self::Insight),
+            "reference" => Some(Self::Reference),
+            "event" => Some(Self::Event),
+            _ => None,
         }
     }
 
@@ -274,13 +291,187 @@ impl MemoryType {
             Self::Preference => "preference",
             Self::Decision => "decision",
             Self::Context => "context",
+            Self::Note => "note",
+            Self::Insight => "insight",
+            Self::Reference => "reference",
+            Self::Event => "event",
         }
     }
 
     /// Whether this memory type has temporal validity.
     pub fn has_temporal_validity(&self) -> bool {
-        matches!(self, Self::Fact | Self::Decision | Self::Context)
+        matches!(
+            self,
+            Self::Fact | Self::Decision | Self::Context | Self::Event
+        )
     }
+
+    /// Recall score boost for this type (#349).
+    ///
+    /// Decisions and Preferences are high-signal, long-lived — they get a
+    /// small boost so they drift upward in recall. Events get a tiny boost
+    /// (recency is handled separately in #352). Notes get a slight penalty
+    /// because they're undifferentiated captures.
+    ///
+    /// The boost is additive and small (±0.05) so it never dominates
+    /// embedding similarity, only acts as a tie-breaker.
+    pub fn recall_boost(&self) -> f32 {
+        match self {
+            Self::Decision | Self::Preference => 0.05,
+            Self::Insight => 0.03,
+            Self::Event => 0.02,
+            Self::Note => -0.02,
+            Self::Fact | Self::Procedure | Self::Context | Self::Reference => 0.0,
+        }
+    }
+
+    /// Pattern-based type inference from content (zero LLM, #349).
+    ///
+    /// Order matters: the first pattern to match wins. Patterns are
+    /// deliberately conservative — ambiguous content falls back to `Note`
+    /// rather than guessing a stronger type.
+    ///
+    /// | Signal | Inferred type |
+    /// |---|---|
+    /// | Starts with URL / `ref:` / `see:` / `docs:` | `Reference` |
+    /// | Contains `decided to`, `chose`, `will use`, `going with` | `Decision` |
+    /// | Contains `realized`, `learned`, `discovered`, `turns out` | `Insight` |
+    /// | Contains `step 1`, `how to`, or numbered list | `Procedure` |
+    /// | Contains `always`, `never`, `prefer`, `hate` | `Preference` |
+    /// | Contains ISO date + time word | `Event` |
+    /// | _(none of the above)_ | `Note` |
+    pub fn infer_from_content(content: &str) -> Self {
+        // Look at the first non-empty line — reference markers are
+        // line-start signals, not body signals.
+        let trimmed = content.trim_start();
+        let first_line = trimmed.lines().next().unwrap_or("").trim();
+        let lower = content.to_ascii_lowercase();
+
+        // Reference: starts with URL scheme or a ref marker.
+        if first_line.starts_with("http://")
+            || first_line.starts_with("https://")
+            || lower.starts_with("ref:")
+            || lower.starts_with("see:")
+            || lower.starts_with("docs:")
+        {
+            return Self::Reference;
+        }
+
+        // Decision: explicit commitment language.
+        if contains_any(&lower, &["decided to", "chose ", "will use", "going with"])
+            || contains_any(&lower, &["we decided", "decision:"])
+        {
+            return Self::Decision;
+        }
+
+        // Insight: realization language.
+        if contains_any(&lower, &["realized", "learned", "discovered", "turns out"])
+            || contains_any(&lower, &["insight:", "aha:"])
+        {
+            return Self::Insight;
+        }
+
+        // Procedure: how-to / steps.
+        if contains_any(&lower, &["how to", "step 1", "steps:"]) || is_numbered_list(content) {
+            return Self::Procedure;
+        }
+
+        // Preference: likes/dislikes.
+        if contains_any(
+            &lower,
+            &["always ", "never ", "prefer", "hate", "i like", "i dislike"],
+        ) {
+            return Self::Preference;
+        }
+
+        // Event: ISO date + time word.
+        if has_iso_date(&lower)
+            && contains_any(
+                &lower,
+                &[
+                    "at ",
+                    " on ",
+                    "meeting",
+                    "deadline",
+                    "standup",
+                    "stand-up",
+                    "scheduled",
+                ],
+            )
+        {
+            return Self::Event;
+        }
+
+        // Fallback: undifferentiated note.
+        Self::Note
+    }
+}
+
+/// Case-insensitive substring search against multiple needles.
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|n| haystack.contains(n))
+}
+
+/// Detect a leading numbered list pattern (e.g. "1. ...\n2. ...\n").
+fn is_numbered_list(content: &str) -> bool {
+    let mut consecutive = 0usize;
+    let mut expected = 1u32;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix(|c: char| c.is_ascii_digit()) {
+            // "1. " / "1) " style
+            if rest.starts_with('.') || rest.starts_with(')') {
+                // Best-effort numeric check on the prefix; we don't strictly
+                // enforce ordering to keep the detector cheap.
+                let num_str: String = trimmed.chars().take_while(|c| c.is_ascii_digit()).collect();
+                if let Ok(n) = num_str.parse::<u32>() {
+                    if n == expected {
+                        consecutive += 1;
+                        expected += 1;
+                        if consecutive >= 2 {
+                            return true;
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
+        // Non-numbered line resets the counter.
+        if !trimmed.is_empty() {
+            consecutive = 0;
+            expected = 1;
+        }
+    }
+    false
+}
+
+/// Detect an ISO 8601 date pattern anywhere in the text (e.g. `2026-06-18`).
+fn has_iso_date(text: &str) -> bool {
+    // Cheap scan: 4 digits, dash, 2 digits, dash, 2 digits.
+    let bytes = text.as_bytes();
+    if bytes.len() < 10 {
+        return false;
+    }
+    for i in 0..=(bytes.len().saturating_sub(10)) {
+        if is_iso_date_bytes(&bytes[i..i + 10]) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_iso_date_bytes(b: &[u8]) -> bool {
+    b.len() == 10
+        && b[0].is_ascii_digit()
+        && b[1].is_ascii_digit()
+        && b[2].is_ascii_digit()
+        && b[3].is_ascii_digit()
+        && b[4] == b'-'
+        && b[5].is_ascii_digit()
+        && b[6].is_ascii_digit()
+        && b[7] == b'-'
+        && b[8].is_ascii_digit()
+        && b[9].is_ascii_digit()
 }
 
 /// Result of a consolidation (deduplication) operation.
@@ -346,5 +537,214 @@ impl RecallStrategy {
             Self::Hybrid => "hybrid",
             Self::Graph => "graph",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_type_roundtrip() {
+        for t in [
+            MemoryType::Fact,
+            MemoryType::Procedure,
+            MemoryType::Preference,
+            MemoryType::Decision,
+            MemoryType::Context,
+            MemoryType::Note,
+            MemoryType::Insight,
+            MemoryType::Reference,
+            MemoryType::Event,
+        ] {
+            let s = t.as_str();
+            assert_eq!(MemoryType::from_str_opt(s), Some(t), "roundtrip {s}");
+        }
+    }
+
+    #[test]
+    fn from_str_opt_case_insensitive() {
+        assert_eq!(MemoryType::from_str_opt("FACT"), Some(MemoryType::Fact));
+        assert_eq!(
+            MemoryType::from_str_opt("Decision"),
+            Some(MemoryType::Decision)
+        );
+        assert_eq!(MemoryType::from_str_opt("Note"), Some(MemoryType::Note));
+        assert_eq!(
+            MemoryType::from_str_opt("Insight"),
+            Some(MemoryType::Insight)
+        );
+        assert_eq!(MemoryType::from_str_opt("unknown"), None);
+    }
+
+    #[test]
+    fn infer_reference_url_prefix() {
+        assert_eq!(
+            MemoryType::infer_from_content("https://rust-lang.org/docs"),
+            MemoryType::Reference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("http://example.com/spec"),
+            MemoryType::Reference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("ref: RFC 1234 section 2"),
+            MemoryType::Reference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("see: upstream docs"),
+            MemoryType::Reference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("docs: https://example.com"),
+            MemoryType::Reference
+        );
+    }
+
+    #[test]
+    fn infer_decision_signals() {
+        assert_eq!(
+            MemoryType::infer_from_content("Decided to use SQLite for local storage"),
+            MemoryType::Decision
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("We chose Rust for performance"),
+            MemoryType::Decision
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("will use Redis for caching"),
+            MemoryType::Decision
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("Going with the simpler approach"),
+            MemoryType::Decision
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("decision: adopt feature flags"),
+            MemoryType::Decision
+        );
+    }
+
+    #[test]
+    fn infer_insight_signals() {
+        assert_eq!(
+            MemoryType::infer_from_content("Realized the bug was in serialization"),
+            MemoryType::Insight
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("learned that async drop is hard"),
+            MemoryType::Insight
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("discovered a race condition"),
+            MemoryType::Insight
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("turns out the cache was poisoned"),
+            MemoryType::Insight
+        );
+    }
+
+    #[test]
+    fn infer_procedure_signals() {
+        assert_eq!(
+            MemoryType::infer_from_content("How to bake bread: mix flour and water"),
+            MemoryType::Procedure
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("step 1: install Rust\nstep 2: run cargo"),
+            MemoryType::Procedure
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("1. first do this\n2. then that\n3. finish"),
+            MemoryType::Procedure
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("steps:\n1. foo\n2. bar"),
+            MemoryType::Procedure
+        );
+    }
+
+    #[test]
+    fn infer_preference_signals() {
+        assert_eq!(
+            MemoryType::infer_from_content("always use tabs, never spaces"),
+            MemoryType::Preference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("I prefer dark mode"),
+            MemoryType::Preference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("I hate manual memory management"),
+            MemoryType::Preference
+        );
+    }
+
+    #[test]
+    fn infer_event_signals() {
+        // Debug what's inferred for each case.
+        let cases = [
+            ("Standup at 2026-06-18 09:00", MemoryType::Event),
+            ("Deadline on 2026-07-01", MemoryType::Event),
+            ("Meeting scheduled 2026-06-18", MemoryType::Event),
+        ];
+        for (content, expected) in cases {
+            let got = MemoryType::infer_from_content(content);
+            assert_eq!(got, expected, "content: {content:?}");
+        }
+    }
+
+    #[test]
+    fn infer_fallback_note() {
+        assert_eq!(
+            MemoryType::infer_from_content("just a random capture"),
+            MemoryType::Note
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("lorem ipsum dolor sit amet"),
+            MemoryType::Note
+        );
+    }
+
+    #[test]
+    fn recall_boost_signs() {
+        // High-signal types get positive boost.
+        assert!(MemoryType::Decision.recall_boost() > 0.0);
+        assert!(MemoryType::Preference.recall_boost() > 0.0);
+        assert!(MemoryType::Insight.recall_boost() > 0.0);
+        // Notes get slight penalty.
+        assert!(MemoryType::Note.recall_boost() < 0.0);
+        // Neutral types.
+        assert_eq!(MemoryType::Fact.recall_boost(), 0.0);
+        assert_eq!(MemoryType::Procedure.recall_boost(), 0.0);
+        assert_eq!(MemoryType::Context.recall_boost(), 0.0);
+        assert_eq!(MemoryType::Reference.recall_boost(), 0.0);
+    }
+
+    #[test]
+    fn has_temporal_validity_updated() {
+        // Event (new) has temporal validity.
+        assert!(MemoryType::Event.has_temporal_validity());
+        // Note (new) does not.
+        assert!(!MemoryType::Note.has_temporal_validity());
+        assert!(!MemoryType::Insight.has_temporal_validity());
+        assert!(!MemoryType::Reference.has_temporal_validity());
+    }
+
+    #[test]
+    fn iso_date_detection() {
+        assert!(has_iso_date("meeting on 2026-06-18 at noon"));
+        assert!(has_iso_date("2026-12-31"));
+        assert!(!has_iso_date("18/06/2026")); // not ISO
+        assert!(!has_iso_date("no date here"));
+    }
+
+    #[test]
+    fn numbered_list_detection() {
+        assert!(is_numbered_list("1. first step\n2. second step\n3. third"));
+        assert!(is_numbered_list("1) one\n2) two\n"));
+        assert!(!is_numbered_list("just plain text"));
+        assert!(!is_numbered_list("1. alone")); // only one item
     }
 }

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -488,9 +488,20 @@ fn is_iso_date_bytes(b: &[u8]) -> bool {
         return false;
     }
     // Validate month and day ranges (CodeCora #386 r4).
+    // Per-month max day (non-leap year approximation — good enough for
+    // pattern detection; we're not a date library).
     let month = (b[5] - b'0') * 10 + (b[6] - b'0');
     let day = (b[8] - b'0') * 10 + (b[9] - b'0');
-    (1..=12).contains(&month) && (1..=31).contains(&day)
+    if !(1..=12).contains(&month) {
+        return false;
+    }
+    let max_day = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => 29, // accept leap day; worst case false positive
+        _ => return false,
+    };
+    day >= 1 && day <= max_day
 }
 
 /// Result of a consolidation (deduplication) operation.
@@ -787,9 +798,14 @@ mod tests {
         assert!(!has_iso_date("meeting on 2026-99-99"));
         assert!(!has_iso_date("date: 2026-13-40"));
         assert!(!has_iso_date("abc2026-00-00xyz"));
+        // Per-month validation: Feb 30, Apr 31 are impossible.
+        assert!(!has_iso_date("2026-02-31 deadline"));
+        assert!(!has_iso_date("2026-04-31 event"));
+        assert!(!has_iso_date("2026-02-30 meeting"));
         // But valid ones should.
         assert!(has_iso_date("meeting on 2026-12-31"));
         assert!(has_iso_date("2026-01-01"));
+        assert!(has_iso_date("2026-02-29 leap")); // leap day accepted
     }
 
     #[test]

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -432,18 +432,21 @@ fn is_numbered_list(content: &str) -> bool {
         let rest = &trimmed[num_str.len()..];
         // "1. " / "1) " style
         if rest.starts_with('.') || rest.starts_with(')') {
-            // Best-effort numeric check on the prefix; we don't strictly
-            // enforce ordering to keep the detector cheap.
-            if let Ok(n) = num_str.parse::<u32>() {
-                if n == expected {
+            match num_str.parse::<u32>() {
+                Ok(n) if n == expected => {
                     consecutive += 1;
                     expected += 1;
                     if consecutive >= 2 {
                         return true;
                     }
                 }
-                continue;
+                _ => {
+                    // Parse failure (overflow) or out-of-order → reset.
+                    consecutive = 0;
+                    expected = 1;
+                }
             }
+            continue;
         }
         // Non-numbered line resets the counter.
         if !trimmed.is_empty() {

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -354,8 +354,8 @@ impl MemoryType {
         // non-empty line. Use first_line (not lower) so leading whitespace
         // doesn't matter.
         let first_lower = first_line.to_ascii_lowercase();
-        if first_line.starts_with("http://")
-            || first_line.starts_with("https://")
+        if first_lower.starts_with("http://")
+            || first_lower.starts_with("https://")
             || first_lower.starts_with("ref:")
             || first_lower.starts_with("see:")
             || first_lower.starts_with("docs:")
@@ -424,22 +424,25 @@ fn is_numbered_list(content: &str) -> bool {
     let mut expected = 1u32;
     for line in content.lines() {
         let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix(|c: char| c.is_ascii_digit()) {
-            // "1. " / "1) " style
-            if rest.starts_with('.') || rest.starts_with(')') {
-                // Best-effort numeric check on the prefix; we don't strictly
-                // enforce ordering to keep the detector cheap.
-                let num_str: String = trimmed.chars().take_while(|c| c.is_ascii_digit()).collect();
-                if let Ok(n) = num_str.parse::<u32>() {
-                    if n == expected {
-                        consecutive += 1;
-                        expected += 1;
-                        if consecutive >= 2 {
-                            return true;
-                        }
+        // Strip ALL leading digits (handles multi-digit like "10. ", "123) ").
+        let num_str: String = trimmed.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if num_str.is_empty() {
+            continue;
+        }
+        let rest = &trimmed[num_str.len()..];
+        // "1. " / "1) " style
+        if rest.starts_with('.') || rest.starts_with(')') {
+            // Best-effort numeric check on the prefix; we don't strictly
+            // enforce ordering to keep the detector cheap.
+            if let Ok(n) = num_str.parse::<u32>() {
+                if n == expected {
+                    consecutive += 1;
+                    expected += 1;
+                    if consecutive >= 2 {
+                        return true;
                     }
-                    continue;
                 }
+                continue;
             }
         }
         // Non-numbered line resets the counter.
@@ -610,6 +613,15 @@ mod tests {
             MemoryType::infer_from_content("docs: https://example.com"),
             MemoryType::Reference
         );
+        // Uppercase URL schemes should also match (CodeCora #386 round 2).
+        assert_eq!(
+            MemoryType::infer_from_content("HTTPS://rust-lang.org/docs"),
+            MemoryType::Reference
+        );
+        assert_eq!(
+            MemoryType::infer_from_content("Http://example.com/spec"),
+            MemoryType::Reference
+        );
     }
 
     #[test]
@@ -672,6 +684,18 @@ mod tests {
         );
         assert_eq!(
             MemoryType::infer_from_content("steps:\n1. foo\n2. bar"),
+            MemoryType::Procedure
+        );
+        // Multi-digit numbered lists should also be detected (CodeCora #386 r2).
+        assert_eq!(
+            MemoryType::infer_from_content(
+                "1. first step\n2. second step\n3. third step\n4. fourth step\n5. fifth step\n6. sixth step\n7. seventh step\n8. eighth step\n9. ninth step\n10. tenth step"
+            ),
+            MemoryType::Procedure
+        );
+        // Parenthesis style with multi-digit.
+        assert_eq!(
+            MemoryType::infer_from_content("1) alpha\n2) beta\n3) gamma"),
             MemoryType::Procedure
         );
     }

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -473,17 +473,24 @@ fn has_iso_date(text: &str) -> bool {
 }
 
 fn is_iso_date_bytes(b: &[u8]) -> bool {
-    b.len() == 10
-        && b[0].is_ascii_digit()
-        && b[1].is_ascii_digit()
-        && b[2].is_ascii_digit()
-        && b[3].is_ascii_digit()
-        && b[4] == b'-'
-        && b[5].is_ascii_digit()
-        && b[6].is_ascii_digit()
-        && b[7] == b'-'
-        && b[8].is_ascii_digit()
-        && b[9].is_ascii_digit()
+    if b.len() != 10
+        || !b[0].is_ascii_digit()
+        || !b[1].is_ascii_digit()
+        || !b[2].is_ascii_digit()
+        || !b[3].is_ascii_digit()
+        || b[4] != b'-'
+        || !b[5].is_ascii_digit()
+        || !b[6].is_ascii_digit()
+        || b[7] != b'-'
+        || !b[8].is_ascii_digit()
+        || !b[9].is_ascii_digit()
+    {
+        return false;
+    }
+    // Validate month and day ranges (CodeCora #386 r4).
+    let month = (b[5] - b'0') * 10 + (b[6] - b'0');
+    let day = (b[8] - b'0') * 10 + (b[9] - b'0');
+    month >= 1 && month <= 12 && day >= 1 && day <= 31
 }
 
 /// Result of a consolidation (deduplication) operation.
@@ -776,6 +783,13 @@ mod tests {
         assert!(has_iso_date("2026-12-31"));
         assert!(!has_iso_date("18/06/2026")); // not ISO
         assert!(!has_iso_date("no date here"));
+        // Invalid dates should NOT match (CodeCora #386 r4).
+        assert!(!has_iso_date("meeting on 2026-99-99"));
+        assert!(!has_iso_date("date: 2026-13-40"));
+        assert!(!has_iso_date("abc2026-00-00xyz"));
+        // But valid ones should.
+        assert!(has_iso_date("meeting on 2026-12-31"));
+        assert!(has_iso_date("2026-01-01"));
     }
 
     #[test]

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -342,17 +342,23 @@ impl MemoryType {
     /// | _(none of the above)_ | `Note` |
     pub fn infer_from_content(content: &str) -> Self {
         // Look at the first non-empty line — reference markers are
-        // line-start signals, not body signals.
+        // line-start signals, not body signals. CodeCora #386: previous
+        // code used lower.starts_with on the original content, which made
+        // detection depend on leading whitespace. We now use first_line for
+        // line-start signals.
         let trimmed = content.trim_start();
         let first_line = trimmed.lines().next().unwrap_or("").trim();
         let lower = content.to_ascii_lowercase();
 
-        // Reference: starts with URL scheme or a ref marker.
+        // Reference: starts with URL scheme or a ref marker on the first
+        // non-empty line. Use first_line (not lower) so leading whitespace
+        // doesn't matter.
+        let first_lower = first_line.to_ascii_lowercase();
         if first_line.starts_with("http://")
             || first_line.starts_with("https://")
-            || lower.starts_with("ref:")
-            || lower.starts_with("see:")
-            || lower.starts_with("docs:")
+            || first_lower.starts_with("ref:")
+            || first_lower.starts_with("see:")
+            || first_lower.starts_with("docs:")
         {
             return Self::Reference;
         }
@@ -584,7 +590,12 @@ mod tests {
             MemoryType::Reference
         );
         assert_eq!(
-            MemoryType::infer_from_content("http://example.com/spec"),
+            MemoryType::infer_from_content("https://example.com/spec"),
+            MemoryType::Reference
+        );
+        // Whitespace before ref marker should still match (CodeCora #386).
+        assert_eq!(
+            MemoryType::infer_from_content("  ref: RFC 1234 section 2"),
             MemoryType::Reference
         );
         assert_eq!(

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -490,7 +490,7 @@ fn is_iso_date_bytes(b: &[u8]) -> bool {
     // Validate month and day ranges (CodeCora #386 r4).
     let month = (b[5] - b'0') * 10 + (b[6] - b'0');
     let day = (b[8] - b'0') * 10 + (b[9] - b'0');
-    month >= 1 && month <= 12 && day >= 1 && day <= 31
+    (1..=12).contains(&month) && (1..=31).contains(&day)
 }
 
 /// Result of a consolidation (deduplication) operation.

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -47,12 +47,27 @@ impl crate::Uteke {
         memory_type: &str,
     ) -> Result<String, Error> {
         crate::validate_input(content, tags)?;
-        // Validate memory_type against known variants
-        crate::memory::types::MemoryType::from_str_opt(memory_type).ok_or_else(|| {
-            Error::Validation(format!(
-                "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context"
-            ))
-        })?;
+        // Validate memory_type against known variants.
+        let parsed_type = crate::memory::types::MemoryType::from_str_opt(memory_type)
+            .ok_or_else(|| {
+                Error::Validation(format!(
+                    "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context, note, insight, reference, event"
+                ))
+            })?;
+        let effective_type = if parsed_type == crate::memory::types::MemoryType::Fact {
+            // #349: when the caller uses the default ("fact"), run
+            // auto-inference and override — unless the inference result is
+            // `Note`, in which case we keep `Fact` as the more specific
+            // default (backward-compat with pre-#349 callers).
+            let inferred = crate::memory::types::MemoryType::infer_from_content(content);
+            if inferred == crate::memory::types::MemoryType::Note {
+                crate::memory::types::MemoryType::Fact
+            } else {
+                inferred
+            }
+        } else {
+            parsed_type
+        };
         // Detect JSON content and use flattened text for embedding
         let content_type = crate::memory::crud::detect_content_type(content);
         let embed_text = if content_type == "json" {
@@ -74,7 +89,7 @@ impl crate::Uteke {
             tags,
             metadata,
             namespace,
-            memory_type,
+            effective_type.as_str(),
             content_type,
             &embedding,
         )

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -17,7 +17,10 @@ impl crate::Uteke {
         metadata: Option<serde_json::Value>,
         namespace: Option<&str>,
     ) -> Result<String, Error> {
-        self.remember_typed(content, tags, metadata, namespace, "fact")
+        // Default path uses auto-inference (#349). Passing "fact" explicitly
+        // would bypass inference — use remember_auto_infer(None) so content
+        // signals drive the type.
+        self.remember_auto_infer(content, tags, metadata, namespace, None)
     }
 
     /// Store a JSON-structured memory. Content must be valid JSON.
@@ -37,6 +40,10 @@ impl crate::Uteke {
 
     /// Store a new memory with explicit type.
     ///
+    /// The caller-chosen type is honored as-is — no auto-inference runs
+    /// (CodeCora #386). Use [`Self::remember_auto_infer`] for the
+    /// pattern-based auto-inference path.
+    ///
     /// Returns the UUID of the created memory.
     pub fn remember_typed(
         &self,
@@ -47,27 +54,64 @@ impl crate::Uteke {
         memory_type: &str,
     ) -> Result<String, Error> {
         crate::validate_input(content, tags)?;
-        // Validate memory_type against known variants.
-        let parsed_type = crate::memory::types::MemoryType::from_str_opt(memory_type)
-            .ok_or_else(|| {
-                Error::Validation(format!(
-                    "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context, note, insight, reference, event"
-                ))
-            })?;
-        let effective_type = if parsed_type == crate::memory::types::MemoryType::Fact {
-            // #349: when the caller uses the default ("fact"), run
-            // auto-inference and override — unless the inference result is
-            // `Note`, in which case we keep `Fact` as the more specific
-            // default (backward-compat with pre-#349 callers).
-            let inferred = crate::memory::types::MemoryType::infer_from_content(content);
-            if inferred == crate::memory::types::MemoryType::Note {
-                crate::memory::types::MemoryType::Fact
-            } else {
-                inferred
+        // Validate memory_type against known variants. The type is used
+        // as-is — no inference, no override.
+        crate::memory::types::MemoryType::from_str_opt(memory_type).ok_or_else(|| {
+            Error::Validation(format!(
+                "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context, note, insight, reference, event"
+            ))
+        })?;
+        self.remember_embed(content, tags, metadata, namespace, memory_type)
+    }
+
+    /// Store a new memory with auto-inferred type (#349).
+    ///
+    /// Runs pattern-based inference on the content. If the caller passes
+    /// `Some(explicit_type)`, that type wins and inference is skipped. If
+    /// `None`, the inference result is used (falling back to `Fact` when
+    /// the content is ambiguous, preserving backward compatibility with
+    /// pre-#349 callers).
+    ///
+    /// Returns the UUID of the created memory.
+    pub fn remember_auto_infer(
+        &self,
+        content: &str,
+        tags: &[&str],
+        metadata: Option<serde_json::Value>,
+        namespace: Option<&str>,
+        explicit_type: Option<&str>,
+    ) -> Result<String, Error> {
+        let effective_type = match explicit_type {
+            Some(t) => t.to_string(),
+            None => {
+                let inferred = crate::memory::types::MemoryType::infer_from_content(content);
+                if inferred == crate::memory::types::MemoryType::Note {
+                    // Ambiguous content → keep Fact (backward compat).
+                    "fact".to_string()
+                } else {
+                    inferred.as_str().to_string()
+                }
             }
-        } else {
-            parsed_type
         };
+        self.remember_embed(content, tags, metadata, namespace, &effective_type)
+    }
+
+    /// Embed-then-store shared by [`remember_typed`] and [`remember_auto_infer`].
+    fn remember_embed(
+        &self,
+        content: &str,
+        tags: &[&str],
+        metadata: Option<serde_json::Value>,
+        namespace: Option<&str>,
+        memory_type: &str,
+    ) -> Result<String, Error> {
+        crate::validate_input(content, tags)?;
+        // Validate memory_type against known variants.
+        crate::memory::types::MemoryType::from_str_opt(memory_type).ok_or_else(|| {
+            Error::Validation(format!(
+                "Unknown memory type '{memory_type}'. Valid types: fact, procedure, preference, decision, context, note, insight, reference, event"
+            ))
+        })?;
         // Detect JSON content and use flattened text for embedding
         let content_type = crate::memory::crud::detect_content_type(content);
         let embed_text = if content_type == "json" {
@@ -89,7 +133,7 @@ impl crate::Uteke {
             tags,
             metadata,
             namespace,
-            effective_type.as_str(),
+            memory_type,
             content_type,
             &embedding,
         )

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -82,7 +82,16 @@ impl crate::Uteke {
         explicit_type: Option<&str>,
     ) -> Result<String, Error> {
         let effective_type = match explicit_type {
-            Some(t) => t.to_string(),
+            Some(t) => {
+                // Validate explicit type — same check as remember_typed
+                // (CodeCora #386 r2).
+                crate::memory::types::MemoryType::from_str_opt(t).ok_or_else(|| {
+                    Error::Validation(format!(
+                        "Unknown memory type '{t}'. Valid types: fact, procedure, preference, decision, context, note, insight, reference, event"
+                    ))
+                })?;
+                t.to_string()
+            }
             None => {
                 let inferred = crate::memory::types::MemoryType::infer_from_content(content);
                 if inferred == crate::memory::types::MemoryType::Note {


### PR DESCRIPTION
Closes #349. See CHANGELOG entry for full details.

## Summary
- MemoryType enum expanded 5→9 variants: +Note, +Insight, +Reference, +Event
- Pattern-based auto-inference (`infer_from_content`) on every `remember()`
- recall_boost() per type for #352 integration
- 13 new tests (208→221 core)

## Tests
`cargo test --workspace` (221 passed, 0 failed), clippy clean, fmt clean.