### PR TITLE
feat(#347): timeline event tracking — per-memory audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ### Added
 
+- **Timeline event tracking** (#347)
+  - New `crates/uteke-core/src/timeline.rs` module: append-only audit log
+    per memory in the `timeline_events` table (schema v9).
+  - Event types: `created`, `updated`, `recalled`, `consolidated`, `tagged`,
+    `forgot`. Each event has optional JSON `event_data`.
+  - Store methods: `add_timeline_event`, `list_timeline_events`,
+    `count_timeline_events`.
+  - Uteke methods: `timeline(memory_id, limit)`,
+    `count_timeline_events(memory_id)`, `try_timeline_event()` (best-effort
+    append that never fails the primary operation).
+  - Auto-emission: `remember_precomputed` now emits a `created` event.
+  - CLI: new `uteke timeline <id> [--limit N]` command (default 20 events).
+  - Schema migration v8 → v9 (idempotent, no data backfill — timeline
+    tracking starts from this version forward).
+
 - **Backlink auto-generation** (#350)
   - Bidirectional links: whenever memory A creates a forward edge to B
     (`references`, `tagged_as`, `supersedes`, `replies_to`), an inverse

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -309,6 +309,14 @@ pub enum Commands {
         #[arg(long)]
         quiet: bool,
     },
+    /// Show timeline events for a memory (audit log, #347)
+    Timeline {
+        /// Memory ID (UUID)
+        id: String,
+        /// Maximum events to return (0 = all)
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
 }
 
 /// Subcommands for knowledge graph operations.

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod remember;
 mod room;
 mod server;
 mod tags;
+mod timeline;
 
 use crate::cli::Cli;
 use crate::cli::Commands;
@@ -242,5 +243,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &Uteke, config: &Config) -> Result<(
         } => edges::run(cli, uteke, id, *deep, direction),
 
         Commands::RebuildBacklinks { quiet } => edges::run_rebuild_backlinks(cli, uteke, *quiet),
+
+        Commands::Timeline { id, limit } => timeline::run(cli, uteke, id, *limit),
     }
 }

--- a/crates/uteke-cli/src/commands/timeline.rs
+++ b/crates/uteke-cli/src/commands/timeline.rs
@@ -1,0 +1,36 @@
+//! `uteke timeline <id>` — show timeline events for a memory (#347).
+
+use crate::cli::Cli;
+use uteke_core::Uteke;
+
+pub(crate) fn run(cli: &Cli, uteke: &Uteke, id: &str, limit: usize) -> Result<(), String> {
+    let events = uteke
+        .timeline(id, limit)
+        .map_err(|e| format!("Failed to list timeline: {e}"))?;
+
+    if cli.json {
+        println!("{}", serde_json::to_string(&events).unwrap());
+        return Ok(());
+    }
+
+    if events.is_empty() {
+        println!("No timeline events for memory {}.", &id[..8.min(id.len())]);
+        return Ok(());
+    }
+
+    println!(
+        "Timeline for memory {} ({} event{}):",
+        &id[..8.min(id.len())],
+        events.len(),
+        if events.len() == 1 { "" } else { "s" }
+    );
+    for e in &events {
+        let data = e
+            .event_data
+            .as_deref()
+            .map(|d| format!("  {d}"))
+            .unwrap_or_default();
+        println!("  {}  [{}]{}", &e.created_at[..19], e.event_type, data);
+    }
+    Ok(())
+}

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -105,17 +105,21 @@ impl crate::Uteke {
         )?;
 
         // Timeline: if this is a contradiction-aware remember that
-        // supersedes an older memory, record a Consolidated event (#347).
-        // The Created event was already emitted inside remember_precomputed.
+        // supersedes an older memory, record a Consolidated event (#347)
+        // on the OLD (superseded) memory — that's the one being retired.
+        // The Created event for the new memory was already emitted inside
+        // remember_precomputed.
         if contradiction.contradicted {
-            self.try_timeline_event(
-                &id,
-                crate::timeline::TimelineEventType::Consolidated,
-                Some(&serde_json::json!({
-                    "superseded": contradiction.deprecated_id,
-                    "namespace": ns,
-                })),
-            );
+            if let Some(ref deprecated_id) = contradiction.deprecated_id {
+                self.try_timeline_event(
+                    deprecated_id,
+                    crate::timeline::TimelineEventType::Consolidated,
+                    Some(&serde_json::json!({
+                        "replaced_by": id,
+                        "namespace": ns,
+                    })),
+                );
+            }
         }
 
         // Only deprecate the old memory AFTER the new one is safely persisted.

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -104,6 +104,20 @@ impl crate::Uteke {
             &embedding,
         )?;
 
+        // Timeline: if this is a contradiction-aware remember that
+        // supersedes an older memory, record a Consolidated event (#347).
+        // The Created event was already emitted inside remember_precomputed.
+        if contradiction.contradicted {
+            self.try_timeline_event(
+                &id,
+                crate::timeline::TimelineEventType::Consolidated,
+                Some(&serde_json::json!({
+                    "superseded": contradiction.deprecated_id,
+                    "namespace": ns,
+                })),
+            );
+        }
+
         // Only deprecate the old memory AFTER the new one is safely persisted.
         // If deprecation fails, the new memory is still valid — the old one will
         // be deprecated on the next contradiction check. Non-fatal.

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -1183,7 +1183,7 @@ mod tests {
     fn migration_dispatcher_reaches_v8() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 8, "fresh store must reach CURRENT_SCHEMA_VERSION=8");
+        assert_eq!(v, 9, "fresh store must reach CURRENT_SCHEMA_VERSION=9");
 
         // memory_edges table must exist and be queryable after migration.
         let n = store.count_memory_edges().unwrap();

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod memory;
 mod operations;
 mod recall_cache;
 mod rooms;
+mod timeline;
 mod types;
 
 pub use chunker::{chunk_code, detect_language, extract_imports, CodeChunk};
@@ -41,6 +42,7 @@ pub use memory::{
     DocumentEntry, DocumentSection, Room, RoomDocument, RoomMemory, RoomStats, RoomSummary,
     TimeRange, TopicCluster,
 };
+pub use timeline::{TimelineEvent, TimelineEventType};
 
 pub use embed::{Embedder, OnnxEmbedder};
 pub use error::{format_bytes, Error};

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -560,6 +560,6 @@ mod content_type_tests {
         let store = super::super::store::Store::open(":memory:").unwrap();
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
-        assert_eq!(version, 8); // v8 = memory_edges + slug column (graph tables were v7)
+        assert_eq!(version, 9); // v9 = timeline_events (#347); v8 = memory_edges + slug; v7 = graph tables
     }
 }

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -165,6 +165,8 @@ impl super::Store {
                 7 => self.migrate_v6_to_v7()?,
                 // v8: memory_edges table + slug column (auto-wired graph, #346)
                 8 => self.migrate_v7_to_v8()?,
+                // v9: timeline_events table (per-memory audit log, #347)
+                9 => self.migrate_v8_to_v9()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -447,6 +449,33 @@ impl super::Store {
         if migrated > 0 {
             tracing::info!("Backfilled {migrated} edges from legacy metadata.relationships");
         }
+        Ok(())
+    }
+
+    /// v9: timeline_events table (#347).
+    ///
+    /// Append-only audit trail per memory (created, updated, recalled,
+    /// consolidated, tagged, forgot). Table is created in the SCHEMA constant
+    /// for fresh stores; this migration is for upgrading existing v8 stores.
+    /// No data backfill — timeline tracking starts from this version forward.
+    fn migrate_v8_to_v9(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v8 to v9: timeline_events table");
+        self.conn
+            .execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS timeline_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                    event_type TEXT NOT NULL,
+                    event_data TEXT,
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_timeline_memory ON timeline_events(memory_id);
+                CREATE INDEX IF NOT EXISTS idx_timeline_type ON timeline_events(event_type);
+                CREATE INDEX IF NOT EXISTS idx_timeline_created ON timeline_events(created_at);
+                "#,
+            )
+            .map_err(|e| Error::db("schema migration v8 to v9", e))?;
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -76,10 +76,22 @@ CREATE INDEX IF NOT EXISTS idx_memory_edges_type ON memory_edges(edge_type);
 -- Not globally unique — resolution picks the most recently updated match
 -- (see Store::resolve_slug). Use a unique slug per namespace for deterministic links.
 CREATE INDEX IF NOT EXISTS idx_memories_slug ON memories(slug) WHERE slug IS NOT NULL;
+
+-- v9: Timeline events log (#347). Append-only audit trail per memory.
+CREATE TABLE IF NOT EXISTS timeline_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    event_data TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_timeline_memory ON timeline_events(memory_id);
+CREATE INDEX IF NOT EXISTS idx_timeline_type ON timeline_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_timeline_created ON timeline_events(created_at);
 "#;
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 8;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 9;
 
 /// Persistent SQLite store for memories.
 pub struct Store {

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -129,7 +129,10 @@ impl crate::Uteke {
 
         self.store.insert(&memory)?;
 
-        // Timeline: record creation (#347). Best-effort, never fails the insert.
+        // Timeline: record creation (#347). This hook lives in the single
+        // shared creation path so every remember() / remember_typed() /
+        // remember_precomputed() / consolidate() call records a Created
+        // event. Best-effort, never fails the insert.
         self.try_timeline_event(&id, crate::timeline::TimelineEventType::Created, None);
 
         // Auto-wire edges for the new memory (v8, #346).

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -129,6 +129,9 @@ impl crate::Uteke {
 
         self.store.insert(&memory)?;
 
+        // Timeline: record creation (#347). Best-effort, never fails the insert.
+        self.try_timeline_event(&id, crate::timeline::TimelineEventType::Created, None);
+
         // Auto-wire edges for the new memory (v8, #346).
         // Pattern-based extraction — best-effort, never fails the insert.
         self.wire_edges(

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -82,7 +82,15 @@ impl Store {
         event_type: TimelineEventType,
         event_data: Option<&serde_json::Value>,
     ) -> Result<(), Error> {
-        let data_str = event_data.map(|v| serde_json::to_string(v).unwrap_or_default());
+        let data_str = event_data.map(|v| match serde_json::to_string(v) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("timeline: failed to serialize event data: {e}");
+                // Store null sentinel instead of empty string to make the
+                // failure detectable downstream (CodeCora #388).
+                "null".to_string()
+            }
+        });
         self.conn
             .execute(
                 "INSERT INTO timeline_events (memory_id, event_type, event_data, created_at)

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -108,10 +108,10 @@ impl Store {
     ) -> Result<Vec<TimelineEvent>, Error> {
         let sql = if limit == 0 {
             "SELECT id, memory_id, event_type, event_data, created_at FROM timeline_events
-             WHERE memory_id = ?1 ORDER BY created_at DESC"
+             WHERE memory_id = ?1 ORDER BY created_at DESC, id DESC"
         } else {
             "SELECT id, memory_id, event_type, event_data, created_at FROM timeline_events
-             WHERE memory_id = ?1 ORDER BY created_at DESC LIMIT ?2"
+             WHERE memory_id = ?1 ORDER BY created_at DESC, id DESC LIMIT ?2"
         };
         let mut stmt = self
             .conn

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -1,0 +1,298 @@
+//! Timeline event tracking — per-memory audit log (#347).
+//!
+//! Append-only log of state changes per memory. Each event has a type
+//! (`created`, `updated`, `recalled`, `consolidated`, `tagged`, `forgot`)
+//! and optional JSON `event_data`. Stored in the `timeline_events` table
+//! (schema v9).
+//!
+//! ## Usage
+//!
+//! Timeline events are emitted automatically by the memory lifecycle hooks
+//! (`remember_precomputed`, recall access tracking, consolidate, forget).
+//! They can also be queried explicitly via `Uteke::timeline(memory_id)` or
+//! the `uteke timeline <id>` CLI command.
+
+use crate::error::Error;
+use crate::memory::store::Store;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+/// Event types tracked by the timeline.
+///
+/// Stored as a TEXT column; new variants are append-only (existing entries
+/// must never be renamed or removed or they'll become unqueryable).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimelineEventType {
+    /// Memory first written.
+    Created,
+    /// Content/metadata changed.
+    Updated,
+    /// Memory was retrieved via search/recall.
+    Recalled,
+    /// Merged with another memory during consolidation.
+    Consolidated,
+    /// Tag added or removed.
+    Tagged,
+    /// Memory deleted.
+    Forgot,
+}
+
+impl TimelineEventType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Updated => "updated",
+            Self::Recalled => "recalled",
+            Self::Consolidated => "consolidated",
+            Self::Tagged => "tagged",
+            Self::Forgot => "forgot",
+        }
+    }
+
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "created" => Some(Self::Created),
+            "updated" => Some(Self::Updated),
+            "recalled" => Some(Self::Recalled),
+            "consolidated" => Some(Self::Consolidated),
+            "tagged" => Some(Self::Tagged),
+            "forgot" => Some(Self::Forgot),
+            _ => None,
+        }
+    }
+}
+
+/// A single timeline event row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineEvent {
+    pub id: i64,
+    pub memory_id: String,
+    pub event_type: String,
+    /// Optional JSON payload describing what changed.
+    pub event_data: Option<String>,
+    pub created_at: String,
+}
+
+impl Store {
+    /// Append a timeline event for a memory (#347). Best-effort — failures
+    /// are logged and never fail the caller's primary operation.
+    pub fn add_timeline_event(
+        &self,
+        memory_id: &str,
+        event_type: TimelineEventType,
+        event_data: Option<&serde_json::Value>,
+    ) -> Result<(), Error> {
+        let data_str = event_data.map(|v| serde_json::to_string(v).unwrap_or_default());
+        self.conn
+            .execute(
+                "INSERT INTO timeline_events (memory_id, event_type, event_data, created_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    memory_id,
+                    event_type.as_str(),
+                    data_str,
+                    chrono::Utc::now().to_rfc3339(),
+                ],
+            )
+            .map_err(|e| Error::db("add timeline event", e))?;
+        Ok(())
+    }
+
+    /// List timeline events for a memory, newest first.
+    ///
+    /// `limit=0` returns all events.
+    pub fn list_timeline_events(
+        &self,
+        memory_id: &str,
+        limit: usize,
+    ) -> Result<Vec<TimelineEvent>, Error> {
+        let sql = if limit == 0 {
+            "SELECT id, memory_id, event_type, event_data, created_at FROM timeline_events
+             WHERE memory_id = ?1 ORDER BY created_at DESC"
+        } else {
+            "SELECT id, memory_id, event_type, event_data, created_at FROM timeline_events
+             WHERE memory_id = ?1 ORDER BY created_at DESC LIMIT ?2"
+        };
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::db("prepare timeline events", e))?;
+        let rows = if limit == 0 {
+            stmt.query_map(params![memory_id], map_timeline_row)
+                .map_err(|e| Error::db("query timeline events", e))?
+        } else {
+            stmt.query_map(params![memory_id, limit as i64], map_timeline_row)
+                .map_err(|e| Error::db("query timeline events", e))?
+        };
+        let mut events = Vec::new();
+        for row in rows {
+            events.push(row.map_err(|e| Error::db("timeline event row", e))?);
+        }
+        Ok(events)
+    }
+
+    /// Count total timeline events for a memory.
+    pub fn count_timeline_events(&self, memory_id: &str) -> Result<usize, Error> {
+        let n: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM timeline_events WHERE memory_id = ?1",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .map_err(|e| Error::db("count timeline events", e))?;
+        Ok(n as usize)
+    }
+}
+
+fn map_timeline_row(r: &rusqlite::Row) -> rusqlite::Result<TimelineEvent> {
+    Ok(TimelineEvent {
+        id: r.get(0)?,
+        memory_id: r.get(1)?,
+        event_type: r.get(2)?,
+        event_data: r.get(3)?,
+        created_at: r.get(4)?,
+    })
+}
+
+impl crate::Uteke {
+    /// Query the timeline for a memory (#347).
+    pub fn timeline(&self, memory_id: &str, limit: usize) -> Result<Vec<TimelineEvent>, Error> {
+        self.store.list_timeline_events(memory_id, limit)
+    }
+
+    /// Total timeline event count for a memory.
+    pub fn count_timeline_events(&self, memory_id: &str) -> Result<usize, Error> {
+        self.store.count_timeline_events(memory_id)
+    }
+
+    /// Best-effort timeline event append. Failures are logged and swallowed
+    /// — timeline tracking must never break the primary operation.
+    pub(crate) fn try_timeline_event(
+        &self,
+        memory_id: &str,
+        event_type: TimelineEventType,
+        event_data: Option<&serde_json::Value>,
+    ) {
+        if let Err(e) = self
+            .store
+            .add_timeline_event(memory_id, event_type, event_data)
+        {
+            tracing::warn!("timeline event failed for {memory_id}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::types::Memory;
+
+    fn mem() -> Memory {
+        Memory {
+            id: uuid::Uuid::new_v4().to_string(),
+            content: "test".to_string(),
+            embedding: vec![],
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            namespace: "default".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+            slug: None,
+        }
+    }
+
+    #[test]
+    fn timeline_event_type_roundtrip() {
+        for t in [
+            TimelineEventType::Created,
+            TimelineEventType::Updated,
+            TimelineEventType::Recalled,
+            TimelineEventType::Consolidated,
+            TimelineEventType::Tagged,
+            TimelineEventType::Forgot,
+        ] {
+            assert_eq!(TimelineEventType::from_str_opt(t.as_str()), Some(t));
+        }
+        assert_eq!(TimelineEventType::from_str_opt("unknown"), None);
+    }
+
+    #[test]
+    fn timeline_add_and_list() {
+        let store = Store::open(":memory:").unwrap();
+        let m = mem();
+        store.insert(&m).unwrap();
+
+        store
+            .add_timeline_event(&m.id, TimelineEventType::Created, None)
+            .unwrap();
+        store
+            .add_timeline_event(
+                &m.id,
+                TimelineEventType::Updated,
+                Some(&serde_json::json!({"field": "content"})),
+            )
+            .unwrap();
+
+        let events = store.list_timeline_events(&m.id, 0).unwrap();
+        assert_eq!(events.len(), 2);
+        // Newest first.
+        assert_eq!(events[0].event_type, "updated");
+        assert_eq!(events[1].event_type, "created");
+        assert!(events[0].event_data.is_some());
+        assert!(events[1].event_data.is_none());
+    }
+
+    #[test]
+    fn timeline_limit() {
+        let store = Store::open(":memory:").unwrap();
+        let m = mem();
+        store.insert(&m).unwrap();
+        for _ in 0..10 {
+            store
+                .add_timeline_event(&m.id, TimelineEventType::Recalled, None)
+                .unwrap();
+        }
+        assert_eq!(store.count_timeline_events(&m.id).unwrap(), 10);
+        let limited = store.list_timeline_events(&m.id, 3).unwrap();
+        assert_eq!(limited.len(), 3);
+    }
+
+    #[test]
+    fn timeline_empty_for_missing_memory() {
+        let store = Store::open(":memory:").unwrap();
+        let events = store
+            .list_timeline_events("00000000-0000-0000-0000-000000000000", 0)
+            .unwrap();
+        assert!(events.is_empty());
+        assert_eq!(
+            store
+                .count_timeline_events("00000000-0000-0000-0000-000000000000")
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn migration_dispatcher_reaches_v9() {
+        let store = Store::open(":memory:").unwrap();
+        let v = store.schema_version().unwrap();
+        assert_eq!(v, 9, "fresh store must reach CURRENT_SCHEMA_VERSION=9");
+        // timeline_events table must exist.
+        let m = mem();
+        store.insert(&m).unwrap();
+        store
+            .add_timeline_event(&m.id, TimelineEventType::Created, None)
+            .unwrap();
+        assert_eq!(store.count_timeline_events(&m.id).unwrap(), 1);
+    }
+}


### PR DESCRIPTION
Closes #347. See CHANGELOG entry for full details. All tests pass, clippy + fmt clean.