### PR TITLE
fix: /stats namespace query (#382) + init --agent hermes (#384)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -226,7 +226,7 @@ pub enum Commands {
     },
     /// Initialize uteke integration for an AI agent
     Init {
-        /// Agent type: pi, claude, cursor, copilot, codex
+        /// Agent type: pi, claude, cursor, hermes
         #[arg(long, default_value = "pi")]
         agent: String,
     },

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -17,8 +17,9 @@ pub(crate) fn run_init(agent: &str, json: bool) -> Result<(), String> {
         "pi" => init_pi(json),
         "claude" => init_claude(json),
         "cursor" => init_cursor(json),
+        "hermes" => init_hermes(json),
         _ => Err(format!(
-            "Unknown agent: {agent}. Supported: pi, claude, cursor"
+            "Unknown agent: {agent}. Supported: pi, claude, cursor, hermes"
         )),
     }
 }
@@ -185,6 +186,101 @@ fn init_cursor(json: bool) -> Result<(), String> {
         println!("{obj}");
     } else {
         println!("✓ Cursor rules installed: {}", rules_path.display());
+    }
+    Ok(())
+}
+
+/// Initialize uteke integration for Hermes (#384).
+/// Generates a uteke-tool plugin in the Hermes plugins directory.
+fn init_hermes(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let plugin_dir = cwd.join("uteke-tool");
+    std::fs::create_dir_all(&plugin_dir)
+        .map_err(|e| format!("Failed to create plugin dir: {e}"))?;
+
+    // plugin.yaml — Hermes plugin manifest.
+    let plugin_yaml = r#"name: uteke-tool
+description: Semantic memory recall and storage via uteke
+version: 0.1.0
+author: CodeCoraDev
+"#;
+    std::fs::write(plugin_dir.join("plugin.yaml"), plugin_yaml)
+        .map_err(|e| format!("Failed to write plugin.yaml: {e}"))?;
+
+    // tool.py — Hermes plugin entry point.
+    let tool_py = r#"import json
+import requests
+
+UTEKE_URL = "http://127.0.0.1:8767"
+
+def uteke(action="recall", content="", tags="", namespace="hermes", limit=5):
+    """Call uteke server for memory operations."""
+    if action == "remember":
+        resp = requests.post(f"{UTEKE_URL}/remember", json={
+            "content": content,
+            "tags": tags.split(",") if tags else [],
+            "namespace": namespace
+        })
+        return f"Stored: {content[:50]}..."
+
+    elif action == "recall":
+        resp = requests.post(f"{UTEKE_URL}/recall", json={
+            "query": content,
+            "limit": limit,
+            "namespace": namespace
+        })
+        results = resp.json()
+        if isinstance(results, list) and results:
+            memories = [m["memory"]["content"] for m in results]
+            return "\n".join(memories)
+        return "No memories found."
+
+    elif action == "stats":
+        resp = requests.get(f"{UTEKE_URL}/stats?namespace={namespace}")
+        return json.dumps(resp.json(), indent=2)
+
+    return f"Unknown action: {action}"
+"#;
+    std::fs::write(plugin_dir.join("tool.py"), tool_py)
+        .map_err(|e| format!("Failed to write tool.py: {e}"))?;
+
+    // README.md — quick start guide.
+    let readme = r#"# uteke-tool
+
+Semantic memory plugin for Hermes via [uteke](https://github.com/codecoradev/uteke).
+
+## Setup
+
+1. Install uteke: `curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh`
+2. Start daemon: `uteke-serve --port 8767`
+3. Copy this directory to your Hermes plugins folder
+4. Enable in Hermes config: `plugins: enabled: [uteke-tool]`
+
+## Usage
+
+```python
+uteke(action="remember", content="User prefers dark mode", tags="preference,ui")
+uteke(action="recall", content="user preferences")
+uteke(action="stats")
+```
+"#;
+    std::fs::write(plugin_dir.join("README.md"), readme)
+        .map_err(|e| format!("Failed to write README.md: {e}"))?;
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "hermes",
+            "directory": plugin_dir.to_string_lossy(),
+            "files": ["plugin.yaml", "tool.py", "README.md"],
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!("✓ Hermes plugin generated: {}/", plugin_dir.display());
+        println!("  Next steps:");
+        println!("    1. Copy to your Hermes plugins directory");
+        println!("    2. Enable in Hermes config: plugins.enabled: [uteke-tool]");
+        println!("    3. Start uteke daemon: uteke-serve --port 8767");
     }
     Ok(())
 }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -727,14 +727,26 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
             }
         }
 
-        // ── Stats (GET = all, POST = by namespace) ─────────────────────
-        (Method::Get, "/stats") => match uteke.stats(None) {
-            Ok(stats) => ctx.ok_response_for(req, &stats),
-            Err(e) => {
-                error!("Internal error: {e}");
-                ctx.error_response_for(req, 500, "Internal server error")
+        // ── Stats (GET = all or ?namespace=<name>) ───────────────────
+        (Method::Get, "/stats") => {
+            // Parse ?namespace= query parameter for scoped stats (#382).
+            let query = req.url().split('?').nth(1).unwrap_or("");
+            let params: std::collections::HashMap<String, String> = query
+                .split('&')
+                .filter_map(|pair| {
+                    let mut kv = pair.splitn(2, '=');
+                    Some((kv.next()?.to_string(), kv.next()?.to_string()))
+                })
+                .collect();
+            let ns_param = params.get("namespace").map(|s| s.as_str());
+            match uteke.stats(ns_param) {
+                Ok(stats) => ctx.ok_response_for(req, &stats),
+                Err(e) => {
+                    error!("Internal error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
             }
-        },
+        }
         (Method::Post, "/stats") => {
             #[derive(Deserialize)]
             struct StatsReq {


### PR DESCRIPTION
## Fixes

### #382 — `/stats?namespace=` returns 404
GET /stats?namespace=\<name\> returned `{"error":"Not found"}` because the handler hardcoded `uteke.stats(None)`. Fix: parse `?namespace=` query parameter.

### #384 — `uteke init --agent hermes` not recognized
Added `init_hermes()` which generates a complete uteke-tool plugin directory (plugin.yaml, tool.py, README.md) matching the format in docs/integrations/hermes.md.

Also fixed CLI help text: removed nonexistent 'copilot, codex' agents, added 'hermes'.

### #383 — Port 8888 vs 8767
Already fixed in codebase — config template already uses 8767. No code change needed.

## Test plan
- [x] cargo build --workspace
- [x] cargo test (282 pass)
- [x] cargo clippy (clean)
- [x] cargo fmt (clean)