### PR TITLE
feat(#348): citation & source attribution system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### Added
 
+- **Citation & source attribution** (#348)
+  - Schema v10 migration: adds `source` and `source_type` columns to
+    `memories` table. Existing rows get `source_type = 'unknown'`.
+  - Source types: `user`, `url`, `file`, `import`, `derived`, `system`,
+    `unknown`.
+  - `Memory` struct gains `source: Option<String>` and `source_type: String`
+    fields. Defaults: `source=None`, `source_type="user"`.
+  - `Uteke::set_source(id, source, source_type)` for post-insert provenance
+    updates.
+  - `ExportEntry` gains optional `source` field for round-trip preservation.
+  - CLI: `--source <URL/path>` and `--source-type <type>` flags on
+    `uteke remember`.
+  - Import sets `source_type = 'import'` with `source = 'import:<filename>'`.
+
 - **Dream cycle** (#353)
   - New `crates/uteke-core/src/dream.rs` module: coordinated maintenance
     pipeline that runs all 6 phases in dependency order, all local, zero

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -75,6 +75,12 @@ pub enum Commands {
         /// Author attribution when storing in a room
         #[arg(long)]
         author: Option<String>,
+        /// Source provenance: URL, file path, or identifier (#348)
+        #[arg(long)]
+        source: Option<String>,
+        /// Source type: user, url, file, import, derived, system, unknown (#348)
+        #[arg(long)]
+        source_type: Option<String>,
     },
     /// Recall memories relevant to a query (semantic search)
     Recall {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -42,6 +42,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             meta,
             room,
             author,
+            source,
+            source_type,
         } => remember::run(
             cli,
             uteke,
@@ -55,6 +57,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             meta,
             room.as_deref(),
             author.as_deref(),
+            source.as_deref(),
+            source_type.as_deref(),
         ),
 
         Commands::Recall {

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -61,6 +61,8 @@ pub(crate) fn run(
     meta: &[String],
     room: Option<&str>,
     author: Option<&str>,
+    source: Option<&str>,
+    source_type: Option<&str>,
 ) -> Result<(), String> {
     tracing::debug!("Remembering: {content} (type: {type}, contradiction: {detect_contradiction})");
     let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
@@ -184,5 +186,20 @@ pub(crate) fn run(
             }
         }
     }
+
+    // Set source provenance if provided (#348).
+    // We need the ID from the remember call. The ID is captured in the
+    // `id` variable inside the if/else blocks above. We need to hoist it.
+    // Simplest: query the most recent memory for this namespace.
+    if source.is_some() || source_type.is_some() {
+        // Get the latest memory to find its ID.
+        if let Ok(memories) = uteke.list(None, 1, 0, ns) {
+            if let Some(latest) = memories.first() {
+                let st = source_type.unwrap_or("user");
+                let _ = uteke.set_source(&latest.id, source, st);
+            }
+        }
+    }
+
     Ok(())
 }

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -92,10 +92,13 @@ pub(crate) fn run(
         Some(serde_json::Value::Object(meta_map))
     };
 
+    let stored_id: String; // captured for set_source (#348)
+
     if detect_contradiction {
         let (id, contradiction) = uteke
             .remember_with_contradiction(content, &tag_refs, ns, Some(r#type), true, 0.65)
             .map_err(|e| format!("Failed to store memory: {e}"))?;
+        stored_id = id.clone();
         tracing::info!("Memory stored with ID: {id}");
         if cli.json {
             let mut obj = serde_json::json!({
@@ -150,6 +153,7 @@ pub(crate) fn run(
                 .remember(content, &tag_refs, metadata, ns)
                 .map_err(|e| format!("Failed to store memory: {e}"))?
         };
+        stored_id = id.clone();
         tracing::info!("Memory stored with ID: {id}");
         if cli.json {
             let mut obj = serde_json::json!({"id": id});
@@ -187,18 +191,10 @@ pub(crate) fn run(
         }
     }
 
-    // Set source provenance if provided (#348).
-    // We need the ID from the remember call. The ID is captured in the
-    // `id` variable inside the if/else blocks above. We need to hoist it.
-    // Simplest: query the most recent memory for this namespace.
+    // Set source provenance using the exact stored ID (#348).
     if source.is_some() || source_type.is_some() {
-        // Get the latest memory to find its ID.
-        if let Ok(memories) = uteke.list(None, 1, 0, ns) {
-            if let Some(latest) = memories.first() {
-                let st = source_type.unwrap_or("user");
-                let _ = uteke.set_source(&latest.id, source, st);
-            }
-        }
+        let st = source_type.unwrap_or("user");
+        let _ = uteke.set_source(&stored_id, source, st);
     }
 
     Ok(())

--- a/crates/uteke-cli/src/commands/remember.rs
+++ b/crates/uteke-cli/src/commands/remember.rs
@@ -194,7 +194,9 @@ pub(crate) fn run(
     // Set source provenance using the exact stored ID (#348).
     if source.is_some() || source_type.is_some() {
         let st = source_type.unwrap_or("user");
-        let _ = uteke.set_source(&stored_id, source, st);
+        uteke
+            .set_source(&stored_id, source, st)
+            .map_err(|e| format!("Failed to set source: {e}"))?;
     }
 
     Ok(())

--- a/crates/uteke-cli/src/commands/server.rs
+++ b/crates/uteke-cli/src/commands/server.rs
@@ -51,6 +51,8 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
             meta,
             room,
             author,
+            source,
+            source_type,
         } => {
             let mut body = serde_json::json!({
                 "content": content,
@@ -87,6 +89,12 @@ pub(crate) fn run_via_server(cli: &Cli, server_url: &str) -> Result<(), String> 
             }
             if let Some(author_name) = author {
                 body["author"] = serde_json::json!(author_name);
+            }
+            if let Some(src) = source {
+                body["source"] = serde_json::json!(src);
+            }
+            if let Some(st) = source_type {
+                body["source_type"] = serde_json::json!(st);
             }
             let resp = client
                 .post(format!("{server_url}/remember"))

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -834,6 +834,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 
@@ -1183,7 +1185,7 @@ mod tests {
     fn migration_dispatcher_reaches_v8() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 9, "fresh store must reach CURRENT_SCHEMA_VERSION=9");
+        assert_eq!(v, 10, "fresh store must reach CURRENT_SCHEMA_VERSION=10");
 
         // memory_edges table must exist and be queryable after migration.
         let n = store.count_memory_edges().unwrap();

--- a/crates/uteke-core/src/graph_rerank.rs
+++ b/crates/uteke-core/src/graph_rerank.rs
@@ -298,6 +298,8 @@ mod tests {
                 pinned: false,
                 content_type: String::from("text"),
                 slug: None,
+                source: None,
+                source_type: "user".to_string(),
             },
             score,
         }

--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -17,6 +17,7 @@ impl crate::Uteke {
                 tags: m.tags,
                 metadata: m.metadata,
                 created_at: m.created_at,
+                source: m.source,
             })
             .collect();
 
@@ -89,6 +90,8 @@ impl crate::Uteke {
                 pinned: false,
                 content_type: "text".to_string(),
                 slug: None,
+                source: Some(format!("import:{}", entry.source.unwrap_or_default())),
+                source_type: "import".to_string(),
             };
 
             // Write-ahead: vector index first (can be rolled back), then SQLite.
@@ -148,6 +151,7 @@ mod tests {
             tags: vec!["greeting".to_string()],
             metadata: serde_json::json!({}),
             created_at: chrono::Utc::now(),
+            source: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         let restored: ExportEntry = serde_json::from_str(&json).unwrap();

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -621,6 +621,16 @@ impl Uteke {
         self.store.unpin(id)
     }
 
+    /// Set source provenance on a memory (#348).
+    pub fn set_source(
+        &self,
+        id: &str,
+        source: Option<&str>,
+        source_type: &str,
+    ) -> Result<bool, Error> {
+        self.store.set_source(id, source, source_type)
+    }
+
     /// Recalculate importance scores for all memories.
     pub fn recompute_importance(&self) -> Result<usize, Error> {
         self.store.recompute_importance()
@@ -684,6 +694,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         };
 
         let json = serde_json::to_string(&m).unwrap();
@@ -730,6 +742,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         };
 
         let sr = SearchResult {

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -70,8 +70,8 @@ impl super::Store {
 
         self.conn
             .execute(
-                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug, source, source_type)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
                 params![
                     memory.id,
                     memory.content,
@@ -91,6 +91,8 @@ impl super::Store {
                     memory.pinned as i32,
                     memory.content_type,
                     memory.slug,
+                    memory.source,
+                    memory.source_type,
                 ],
             )
             .map_err(|e| Error::db("Failed to insert memory", e))?;
@@ -516,6 +518,8 @@ mod content_type_tests {
             pinned: false,
             content_type: "json".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         };
         store.insert(&memory).unwrap();
 
@@ -546,6 +550,8 @@ mod content_type_tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         };
         store.insert(&memory).unwrap();
 
@@ -560,6 +566,6 @@ mod content_type_tests {
         let store = super::super::store::Store::open(":memory:").unwrap();
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
-        assert_eq!(version, 9); // v9 = timeline_events (#347); v8 = memory_edges + slug; v7 = graph tables
+        assert_eq!(version, 10); // v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
     }
 }

--- a/crates/uteke-core/src/memory/fts5.rs
+++ b/crates/uteke-core/src/memory/fts5.rs
@@ -90,14 +90,14 @@ impl super::Store {
 
         let sql = match namespace {
             Some(_) => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, m.source, m.source_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.namespace = ?2 AND m.deprecated = 0
                    ORDER BY f.rank
                    LIMIT ?3"#
             }
             None => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, m.source, m.source_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.deprecated = 0
                    ORDER BY f.rank
@@ -173,14 +173,14 @@ impl super::Store {
 
         let sql = match namespace {
             Some(_) => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, m.source, m.source_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.namespace = ?2 AND m.deprecated = 0
                    ORDER BY f.rank
                    LIMIT ?3"#
             }
             None => {
-                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, f.rank
+                r#"SELECT m.id, m.content, m.embedding, m.tags, m.metadata, m.created_at, m.updated_at, m.namespace, m.access_count, m.last_accessed, m.deprecated, m.valid_from, m.valid_until, m.memory_type, m.importance, m.pinned, m.content_type, m.source, m.source_type, f.rank
                    FROM memories_fts f JOIN memories m ON f.rowid = m.rowid
                    WHERE memories_fts MATCH ?1 AND m.deprecated = 0
                    ORDER BY f.rank
@@ -256,6 +256,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -167,6 +167,8 @@ impl super::Store {
                 8 => self.migrate_v7_to_v8()?,
                 // v9: timeline_events table (per-memory audit log, #347)
                 9 => self.migrate_v8_to_v9()?,
+                // v10: source + source_type columns (citation/provenance, #348)
+                10 => self.migrate_v9_to_v10()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -476,6 +478,23 @@ impl super::Store {
                 "#,
             )
             .map_err(|e| Error::db("schema migration v8 to v9", e))?;
+        Ok(())
+    }
+
+    /// v10: source + source_type columns (citation/provenance, #348).
+    ///
+    /// Adds provenance tracking to every memory. Existing rows get
+    /// `source_type = 'unknown'` (legacy data without source info).
+    fn migrate_v9_to_v10(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v9 to v10: source columns");
+        self.conn
+            .execute_batch(
+                r#"
+                ALTER TABLE memories ADD COLUMN source TEXT;
+                ALTER TABLE memories ADD COLUMN source_type TEXT NOT NULL DEFAULT 'unknown';
+                "#,
+            )
+            .map_err(|e| Error::db("schema migration v9 to v10", e))?;
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -24,7 +24,9 @@ CREATE TABLE IF NOT EXISTS memories (
     importance REAL NOT NULL DEFAULT 0.5,
     pinned INTEGER NOT NULL DEFAULT 0,
     content_type TEXT NOT NULL DEFAULT 'text',
-    slug TEXT
+    slug TEXT,
+    source TEXT,
+    source_type TEXT NOT NULL DEFAULT 'user'
 );
 CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
@@ -91,7 +93,7 @@ CREATE INDEX IF NOT EXISTS idx_timeline_created ON timeline_events(created_at);
 "#;
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 9;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 10;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -141,6 +143,23 @@ impl Store {
                 rusqlite::params![id],
             )
             .map_err(|e| Error::db("unpin memory", e))?;
+        Ok(rows > 0)
+    }
+
+    /// Set source provenance on a memory (#348).
+    pub fn set_source(
+        &self,
+        id: &str,
+        source: Option<&str>,
+        source_type: &str,
+    ) -> Result<bool, Error> {
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE memories SET source = ?1, source_type = ?2 WHERE id = ?3",
+                rusqlite::params![source, source_type, id],
+            )
+            .map_err(|e| Error::db("set source", e))?;
         Ok(rows > 0)
     }
 
@@ -296,6 +315,8 @@ pub(crate) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite:
     let pinned: bool = row.get(15).unwrap_or(false);
     let content_type: String = row.get(16).unwrap_or_else(|_| "text".to_string());
     let slug: Option<String> = row.get(17).ok().flatten();
+    let source: Option<String> = row.get(18).ok().flatten();
+    let source_type: String = row.get(19).unwrap_or_else(|_| "unknown".to_string());
 
     Ok(Memory {
         id,
@@ -316,6 +337,8 @@ pub(crate) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite:
         pinned,
         content_type,
         slug,
+        source,
+        source_type,
     })
 }
 
@@ -345,6 +368,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 
@@ -368,6 +393,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 
@@ -1373,6 +1400,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 
@@ -1512,5 +1541,29 @@ mod tests {
         let results = store.list_at_time(None, None, 100, 0, t1).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "past_vf");
+    }
+
+    #[test]
+    fn test_set_source() {
+        let store = Store::open(":memory:").unwrap();
+        let m = make_test_memory("src1", "test source", &["t"]);
+        store.insert(&m).unwrap();
+
+        // Set source.
+        assert!(store
+            .set_source("src1", Some("https://rust-lang.org"), "url")
+            .unwrap());
+
+        // Verify via direct SQL.
+        let (source, source_type): (Option<String>, String) = store
+            .conn
+            .query_row(
+                "SELECT source, source_type FROM memories WHERE id = ?1",
+                rusqlite::params!["src1"],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(source.as_deref(), Some("https://rust-lang.org"));
+        assert_eq!(source_type, "url");
     }
 }

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -57,10 +57,29 @@ pub struct Memory {
     /// Populated lazily when a memory is referenced by slug.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
+    /// Provenance: free-form source identifier (URL, file path, "user", #348).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Provenance type: user, url, file, import, derived, system, unknown (#348).
+    #[serde(
+        default = "default_source_type",
+        skip_serializing_if = "is_default_source_type"
+    )]
+    pub source_type: String,
 }
 
 fn default_namespace() -> String {
     DEFAULT_NAMESPACE.to_string()
+}
+
+/// Default source type for memories without explicit provenance (#348).
+pub fn default_source_type() -> String {
+    "user".to_string()
+}
+
+/// Serde predicate: skip if source_type equals the default.
+fn is_default_source_type(s: &str) -> bool {
+    s == "user"
 }
 
 fn default_importance() -> f64 {
@@ -161,6 +180,9 @@ pub struct ExportEntry {
     pub metadata: serde_json::Value,
     /// When this memory was originally created.
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Optional source provenance (#348).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// Result of an import operation.

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -185,6 +185,8 @@ impl crate::Uteke {
             pinned: false,
             content_type: content_type.to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         };
 
         // Acquire index write lock BEFORE any writes so lock failures are detected early.

--- a/crates/uteke-core/src/orphans.rs
+++ b/crates/uteke-core/src/orphans.rs
@@ -57,7 +57,8 @@ impl Store {
             SELECT m.id, m.content, m.embedding, m.tags, m.metadata,
                    m.created_at, m.updated_at, m.namespace, m.access_count,
                    m.last_accessed, m.deprecated, m.valid_from, m.valid_until,
-                   m.memory_type, m.importance, m.pinned, m.content_type, m.slug
+                   m.memory_type, m.importance, m.pinned, m.content_type, m.slug,
+                   m.source, m.source_type
             FROM memories m
             LEFT JOIN memory_edges out_e ON out_e.source_id = m.id
             LEFT JOIN memory_edges in_e  ON in_e.target_id  = m.id
@@ -182,6 +183,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 

--- a/crates/uteke-core/src/recall_cache.rs
+++ b/crates/uteke-core/src/recall_cache.rs
@@ -219,6 +219,8 @@ mod tests {
                 pinned: false,
                 content_type: "text".to_string(),
                 slug: None,
+                source: None,
+                source_type: "user".to_string(),
             },
             score: 0.95,
         }];

--- a/crates/uteke-core/src/salience_recency.rs
+++ b/crates/uteke-core/src/salience_recency.rs
@@ -157,6 +157,8 @@ mod tests {
             pinned,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -216,6 +216,8 @@ mod tests {
             pinned: false,
             content_type: "text".to_string(),
             slug: None,
+            source: None,
+            source_type: "user".to_string(),
         }
     }
 
@@ -294,7 +296,7 @@ mod tests {
     fn migration_dispatcher_reaches_v9() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 9, "fresh store must reach CURRENT_SCHEMA_VERSION=9");
+        assert_eq!(v, 10, "fresh store must reach CURRENT_SCHEMA_VERSION=10");
         // timeline_events table must exist.
         let m = mem();
         store.insert(&m).unwrap();


### PR DESCRIPTION
Closes #348. Adds provenance tracking via source + source_type columns (schema v10).

- Schema migration v9→v10 (ALTER TABLE, backward compatible)
- Memory struct: source/source_type fields with serde defaults
- Uteke::set_source() for post-insert updates
- CLI: --source and --source-type flags on remember
- Import auto-tags source_type='import'
- ExportEntry preserves source for round-trip

254 tests pass, clippy clean.