### PR TITLE
feat(#381): MCP Streamable HTTP transport + protocol version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ### Added
 
+- **MCP Streamable HTTP transport** (#381)
+  - `uteke-mcp` protocol version bumped from `2024-11-05` to `2025-06-18`
+    (current MCP spec).
+  - New `POST /mcp` endpoint on `uteke-server` exposing the full MCP
+    JSON-RPC API over HTTP. Returns `Content-Type: application/json` with
+    `MCP-Protocol-Version: 2025-06-18` header.
+  - Shared handler extracted into `uteke_mcp` library crate — used by both
+    the stdio binary (`uteke-mcp`) and the HTTP endpoint (`uteke-serve`).
+  - Enables remote MCP clients (Claude Desktop, web agents) to connect
+    without spawning a subprocess.
+
 - **Citation & source attribution** (#348)
   - Schema v10 migration: adds `source` and `source_type` columns to
     `memories` table. Existing rows get `source_type = 'unknown'`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uteke-core",
+ "uteke-mcp",
  "uuid",
 ]
 

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["command-line-utilities", "development-tools"]
 name = "uteke-mcp"
 path = "src/main.rs"
 
+[lib]
+name = "uteke_mcp"
+path = "src/lib.rs"
+
 [dependencies]
 uteke-core = { path = "../uteke-core", version = "0.2.0" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -1,0 +1,343 @@
+//! uteke-mcp library — shared MCP protocol handler.
+//!
+//! Used by both the stdio binary (`uteke-mcp`) and the HTTP endpoint
+//! on `uteke-server` (`POST /mcp`).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uteke_core::Uteke;
+
+// ── JSON-RPC types ──────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: &'static str,
+    pub id: Value,
+    pub result: Option<Value>,
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Deserialize)]
+pub struct JsonRpcRequest {
+    #[allow(dead_code)]
+    pub jsonrpc: String,
+    pub id: Option<Value>,
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+// ── MCP Protocol types ──────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+#[serde(tag = "role")]
+enum McpContent {
+    #[serde(rename = "text")]
+    Text { r#type: String, text: String },
+}
+
+#[derive(Serialize)]
+struct ToolResult {
+    content: Vec<McpContent>,
+    #[serde(rename = "isError")]
+    is_error: bool,
+}
+
+/// Handle a single MCP JSON-RPC request (#381).
+///
+/// This is the shared handler used by both the stdio binary and the
+/// HTTP endpoint. Returns a `JsonRpcResponse` ready for serialization.
+pub fn handle_jsonrpc(uteke: &Uteke, raw: &str) -> String {
+    let req: JsonRpcRequest = match serde_json::from_str(raw) {
+        Ok(r) => r,
+        Err(e) => {
+            let resp = JsonRpcResponse {
+                jsonrpc: "2.0",
+                id: Value::Null,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32700,
+                    message: format!("Parse error: {e}"),
+                }),
+            };
+            return serde_json::to_string(&resp).unwrap_or_default();
+        }
+    };
+
+    let id = req.id.clone().unwrap_or(Value::Null);
+
+    match handle_request(uteke, &req.method, req.params) {
+        Ok(result) => serde_json::to_string(&JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        })
+        .unwrap_or_default(),
+        Err(msg) => serde_json::to_string(&JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code: -32603,
+                message: msg,
+            }),
+        })
+        .unwrap_or_default(),
+    }
+}
+
+// ── Handler ─────────────────────────────────────────────────────────────────
+
+fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<Value, String> {
+    match method {
+        "initialize" => Ok(serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": "uteke",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        })),
+
+        "notifications/initialized" => Ok(Value::Null),
+
+        "tools/list" => Ok(serde_json::json!({
+            "tools": [
+                tool_remember(),
+                tool_recall(),
+                tool_list(),
+                tool_forget(),
+                tool_stats(),
+            ]
+        })),
+
+        "tools/call" => {
+            let params = params.ok_or("Missing params for tools/call")?;
+            let tool_name = params["name"].as_str().ok_or("Missing tool name")?;
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or(Value::Object(Default::default()));
+
+            let result = match tool_name {
+                "uteke_remember" => exec_remember(uteke, &arguments)?,
+                "uteke_recall" => exec_recall(uteke, &arguments)?,
+                "uteke_list" => exec_list(uteke, &arguments)?,
+                "uteke_forget" => exec_forget(uteke, &arguments)?,
+                "uteke_stats" => exec_stats(uteke, &arguments)?,
+                _ => return Err(format!("Unknown tool: {tool_name}")),
+            };
+
+            Ok(serde_json::to_value(result).map_err(|e| e.to_string())?)
+        }
+
+        "ping" => Ok(serde_json::json!({})),
+
+        _ => Err(format!("Unknown method: {method}")),
+    }
+}
+
+// ── Tool Definitions ────────────────────────────────────────────────────────
+
+fn tool_remember() -> Value {
+    serde_json::json!({
+        "name": "uteke_remember",
+        "description": "Store a new memory in uteke. The content will be embedded and indexed for semantic search. Optionally specify tags for categorization and a room for collaborative memory.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "content": { "type": "string", "description": "The text content to remember" },
+                "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags for categorization (optional)" },
+                "namespace": { "type": "string", "description": "Namespace for isolation (default: 'default')" }
+            },
+            "required": ["content"]
+        }
+    })
+}
+
+fn tool_recall() -> Value {
+    serde_json::json!({
+        "name": "uteke_recall",
+        "description": "Semantic search over stored memories. Returns the most relevant memories ranked by embedding similarity.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "The search query" },
+                "limit": { "type": "integer", "description": "Max results (default 5)", "default": 5 },
+                "namespace": { "type": "string", "description": "Namespace to search (default: 'default')" }
+            },
+            "required": ["query"]
+        }
+    })
+}
+
+fn tool_list() -> Value {
+    serde_json::json!({
+        "name": "uteke_list",
+        "description": "List memories, optionally filtered by tag.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tag": { "type": "string", "description": "Filter by tag (optional)" },
+                "limit": { "type": "integer", "description": "Max results (default 20)", "default": 20 },
+                "namespace": { "type": "string", "description": "Namespace (optional)" }
+            }
+        }
+    })
+}
+
+fn tool_forget() -> Value {
+    serde_json::json!({
+        "name": "uteke_forget",
+        "description": "Delete a memory by its ID.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "The memory ID (UUID)" }
+            },
+            "required": ["id"]
+        }
+    })
+}
+
+fn tool_stats() -> Value {
+    serde_json::json!({
+        "name": "uteke_stats",
+        "description": "Get memory statistics (total count, tags, tiers).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "namespace": { "type": "string", "description": "Namespace (optional)" }
+            }
+        }
+    })
+}
+
+// ── Tool Executors ──────────────────────────────────────────────────────────
+
+fn exec_remember(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let content = args["content"].as_str().ok_or("Missing 'content'")?;
+    let tags: Vec<&str> = args["tags"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    let namespace = args["namespace"].as_str();
+
+    let id = uteke
+        .remember(content, &tags, None, namespace)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("✓ Stored memory with ID: {id}"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let query = args["query"].as_str().ok_or("Missing 'query'")?;
+    let limit = args["limit"].as_u64().unwrap_or(5) as usize;
+    let namespace = args["namespace"].as_str();
+
+    let results = uteke
+        .recall(query, limit, None, namespace, 0.0)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if results.is_empty() {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "No memories found.".to_string(),
+            }],
+            is_error: false,
+        });
+    }
+
+    let mut lines = Vec::new();
+    for (i, sr) in results.iter().enumerate() {
+        lines.push(format!("[{:.2}] {}", sr.score, sr.memory.content));
+        let _ = i;
+    }
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: lines.join("\n"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_list(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let tag = args["tag"].as_str();
+    let limit = args["limit"].as_u64().unwrap_or(20) as usize;
+    let namespace = args["namespace"].as_str();
+
+    let memories = uteke
+        .list(tag, limit, 0, namespace)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if memories.is_empty() {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "No memories found.".to_string(),
+            }],
+            is_error: false,
+        });
+    }
+
+    let lines: Vec<String> = memories
+        .iter()
+        .map(|m| format!("[{}] {} ({})", &m.id[..8], m.content, m.tags.join(", ")))
+        .collect();
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: lines.join("\n"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_forget(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let id = args["id"].as_str().ok_or("Missing 'id'")?;
+
+    uteke.forget(id).map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("✓ Forgotten: {id}"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_stats(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let namespace = args["namespace"].as_str();
+
+    let stats = uteke.stats(namespace).map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!(
+                "Total: {} | Tags: {} | DB: {} bytes",
+                stats.total_memories, stats.unique_tags, stats.db_size_bytes
+            ),
+        }],
+        is_error: false,
+    })
+}

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -157,7 +157,9 @@ fn tool_remember() -> Value {
                 "content": { "type": "string", "description": "The text content to remember" },
                 "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags for categorization (optional)" },
                 "namespace": { "type": "string", "description": "Namespace for isolation (default: 'default')" },
-                "type": { "type": "string", "description": "Memory type: fact, procedure, preference, decision, context, note, insight, reference, event (default: fact)" }
+                "type": { "type": "string", "description": "Memory type: fact, procedure, preference, decision, context, note, insight, reference, event (default: fact)" },
+                "room": { "type": "string", "description": "Room ID for collaborative memory (optional)" },
+                "author": { "type": "string", "description": "Author attribution when storing in a room (default: anonymous)" }
             },
             "required": ["content"]
         }
@@ -235,10 +237,26 @@ fn exec_remember(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         .unwrap_or_default();
     let namespace = args["namespace"].as_str();
     let memory_type = args["type"].as_str().unwrap_or("fact");
+    let room = args["room"].as_str();
+    let author = args["author"].as_str().unwrap_or("anonymous");
 
-    let id = uteke
-        .remember_typed(content, &tags, None, namespace, memory_type)
-        .map_err(|e| format!("Failed: {e}"))?;
+    let id = if let Some(room_id) = room {
+        uteke
+            .remember_in_room(
+                content,
+                &tags,
+                None,
+                namespace,
+                memory_type,
+                room_id,
+                author,
+            )
+            .map_err(|e| format!("Failed: {e}"))?
+    } else {
+        uteke
+            .remember_typed(content, &tags, None, namespace, memory_type)
+            .map_err(|e| format!("Failed: {e}"))?
+    };
 
     Ok(ToolResult {
         content: vec![McpContent::Text {

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -329,7 +329,10 @@ fn exec_list(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 
     let lines: Vec<String> = memories
         .iter()
-        .map(|m| format!("[{}] {} ({})", &m.id[..8], m.content, m.tags.join(", ")))
+        .map(|m| {
+            let short_id = m.id.get(..8).unwrap_or(&m.id);
+            format!("[{short_id}] {} ({})", m.content, m.tags.join(", "))
+        })
         .collect();
 
     Ok(ToolResult {

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -150,13 +150,14 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
 fn tool_remember() -> Value {
     serde_json::json!({
         "name": "uteke_remember",
-        "description": "Store a new memory in uteke. The content will be embedded and indexed for semantic search. Optionally specify tags for categorization and a room for collaborative memory.",
+        "description": "Store a new memory in uteke. The content will be embedded and indexed for semantic search.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "content": { "type": "string", "description": "The text content to remember" },
                 "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags for categorization (optional)" },
-                "namespace": { "type": "string", "description": "Namespace for isolation (default: 'default')" }
+                "namespace": { "type": "string", "description": "Namespace for isolation (default: 'default')" },
+                "type": { "type": "string", "description": "Memory type: fact, procedure, preference, decision, context, note, insight, reference, event (default: fact)" }
             },
             "required": ["content"]
         }
@@ -172,7 +173,9 @@ fn tool_recall() -> Value {
             "properties": {
                 "query": { "type": "string", "description": "The search query" },
                 "limit": { "type": "integer", "description": "Max results (default 5)", "default": 5 },
-                "namespace": { "type": "string", "description": "Namespace to search (default: 'default')" }
+                "namespace": { "type": "string", "description": "Namespace to search (default: 'default')" },
+                "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter by tags (optional)" },
+                "min_score": { "type": "number", "description": "Minimum similarity score 0..1 (default: 0.0)" }
             },
             "required": ["query"]
         }
@@ -188,6 +191,7 @@ fn tool_list() -> Value {
             "properties": {
                 "tag": { "type": "string", "description": "Filter by tag (optional)" },
                 "limit": { "type": "integer", "description": "Max results (default 20)", "default": 20 },
+                "offset": { "type": "integer", "description": "Pagination offset (default 0)", "default": 0 },
                 "namespace": { "type": "string", "description": "Namespace (optional)" }
             }
         }
@@ -230,9 +234,10 @@ fn exec_remember(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
     let namespace = args["namespace"].as_str();
+    let memory_type = args["type"].as_str().unwrap_or("fact");
 
     let id = uteke
-        .remember(content, &tags, None, namespace)
+        .remember_typed(content, &tags, None, namespace, memory_type)
         .map_err(|e| format!("Failed: {e}"))?;
 
     Ok(ToolResult {
@@ -249,8 +254,14 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let limit = args["limit"].as_u64().unwrap_or(5) as usize;
     let namespace = args["namespace"].as_str();
 
+    let tags_filter: Option<Vec<&str>> = args["tags"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>());
+    let tags_ref = tags_filter.as_deref();
+    let min_score = args["min_score"].as_f64().unwrap_or(0.0) as f32;
+
     let results = uteke
-        .recall(query, limit, None, namespace, 0.0)
+        .recall(query, limit, tags_ref, namespace, min_score)
         .map_err(|e| format!("Failed: {e}"))?;
 
     if results.is_empty() {
@@ -281,10 +292,11 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 fn exec_list(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let tag = args["tag"].as_str();
     let limit = args["limit"].as_u64().unwrap_or(20) as usize;
+    let offset = args["offset"].as_u64().unwrap_or(0) as usize;
     let namespace = args["namespace"].as_str();
 
     let memories = uteke
-        .list(tag, limit, 0, namespace)
+        .list(tag, limit, offset, namespace)
         .map_err(|e| format!("Failed: {e}"))?;
 
     if memories.is_empty() {

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -4,19 +4,9 @@
 //! Exposes uteke memory operations as MCP tools that AI coding agents
 //! (Claude Code, Cursor, Copilot, etc.) can call directly.
 //!
-//! ## MCP Tools Exposed
-//!
-//! | Tool | Description |
-//! |------|-------------|
-//! | `uteke_remember` | Store a new memory |
-//! | `uteke_recall` | Semantic search memories |
-//! | `uteke_list` | List/filter memories |
-//! | `uteke_forget` | Delete a memory |
-//! | `uteke_stats` | Get memory statistics |
-//!
 //! ## Usage
 //!
-//! Add to your MCP client config (e.g., Claude Code's `.claude/settings.json`):
+//! Add to your MCP client config:
 //!
 //! ```json
 //! {
@@ -29,63 +19,8 @@
 //! }
 //! ```
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::io::{self, BufRead, Write};
 use uteke_core::Uteke;
-
-// ── JSON-RPC types ──────────────────────────────────────────────────────────
-
-#[derive(Serialize)]
-struct JsonRpcResponse {
-    jsonrpc: &'static str,
-    id: Value,
-    result: Option<Value>,
-    error: Option<JsonRpcError>,
-}
-
-#[derive(Serialize)]
-struct JsonRpcError {
-    code: i32,
-    message: String,
-}
-
-#[derive(Deserialize)]
-struct JsonRpcRequest {
-    #[allow(dead_code)]
-    jsonrpc: String,
-    id: Option<Value>,
-    method: String,
-    params: Option<Value>,
-}
-
-// ── MCP Protocol types ──────────────────────────────────────────────────────
-
-#[derive(Serialize)]
-#[serde(tag = "role")]
-enum McpContent {
-    #[serde(rename = "text")]
-    Text { r#type: String, text: String },
-}
-
-#[derive(Serialize)]
-// Tool definitions are used via serde_json::json! in tool_*() functions below.
-// ToolDefinition struct kept for documentation purposes.
-#[allow(dead_code)]
-struct ToolDefinition {
-    name: String,
-    description: String,
-    input_schema: Value,
-}
-
-#[derive(Serialize)]
-struct ToolResult {
-    content: Vec<McpContent>,
-    #[serde(rename = "isError")]
-    is_error: bool,
-}
-
-// ── Main ────────────────────────────────────────────────────────────────────
 
 fn main() {
     let stdin = io::stdin();
@@ -100,379 +35,28 @@ fn main() {
     let uteke = match Uteke::open(&store_path) {
         Ok(u) => u,
         Err(e) => {
-            let resp = JsonRpcResponse {
-                jsonrpc: "2.0",
-                id: Value::Null,
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32603,
-                    message: format!("Failed to open uteke store: {e}"),
-                }),
-            };
-            let _ = writeln!(stdout, "{}", serde_json::to_string(&resp).unwrap());
+            eprintln!("Failed to open uteke store: {e}");
             std::process::exit(1);
         }
     };
 
-    // Read JSON-RPC messages from stdin (one per line)
+    // JSON-RPC over stdin/stdout (MCP stdio transport)
     for line in stdin.lock().lines() {
         let line = match line {
             Ok(l) => l,
-            Err(_) => break,
-        };
-
-        let request: JsonRpcRequest = match serde_json::from_str(&line) {
-            Ok(r) => r,
             Err(e) => {
-                let resp = JsonRpcResponse {
-                    jsonrpc: "2.0",
-                    id: Value::Null,
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32700,
-                        message: format!("Parse error: {e}"),
-                    }),
-                };
-                let _ = writeln!(stdout, "{}", serde_json::to_string(&resp).unwrap());
-                stdout.flush().ok();
-                continue;
+                eprintln!("Read error: {e}");
+                break;
             }
         };
 
-        let id = request.id.unwrap_or(Value::Null);
-        let result = handle_request(&uteke, &request.method, request.params);
+        if line.trim().is_empty() {
+            continue;
+        }
 
-        let resp = match result {
-            Ok(value) => JsonRpcResponse {
-                jsonrpc: "2.0",
-                id,
-                result: Some(value),
-                error: None,
-            },
-            Err(msg) => JsonRpcResponse {
-                jsonrpc: "2.0",
-                id,
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32603,
-                    message: msg,
-                }),
-            },
-        };
-
-        let _ = writeln!(stdout, "{}", serde_json::to_string(&resp).unwrap());
-        stdout.flush().ok();
+        // Delegate to the shared handler (#381).
+        let response = uteke_mcp::handle_jsonrpc(&uteke, &line);
+        let _ = writeln!(stdout, "{response}");
+        let _ = stdout.flush();
     }
-}
-
-fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<Value, String> {
-    match method {
-        "initialize" => Ok(serde_json::json!({
-            "protocolVersion": "2024-11-05",
-            "capabilities": {
-                "tools": {}
-            },
-            "serverInfo": {
-                "name": "uteke",
-                "version": env!("CARGO_PKG_VERSION")
-            }
-        })),
-
-        "notifications/initialized" => Ok(Value::Null),
-
-        "tools/list" => Ok(serde_json::json!({
-            "tools": [
-                tool_remember(),
-                tool_recall(),
-                tool_list(),
-                tool_forget(),
-                tool_stats(),
-            ]
-        })),
-
-        "tools/call" => {
-            let params = params.ok_or("Missing params for tools/call")?;
-            let tool_name = params["name"].as_str().ok_or("Missing tool name")?;
-            let arguments = params
-                .get("arguments")
-                .cloned()
-                .unwrap_or(Value::Object(Default::default()));
-
-            let result = match tool_name {
-                "uteke_remember" => exec_remember(uteke, &arguments)?,
-                "uteke_recall" => exec_recall(uteke, &arguments)?,
-                "uteke_list" => exec_list(uteke, &arguments)?,
-                "uteke_forget" => exec_forget(uteke, &arguments)?,
-                "uteke_stats" => exec_stats(uteke, &arguments)?,
-                _ => {
-                    return Err(format!("Unknown tool: {tool_name}"));
-                }
-            };
-
-            Ok(serde_json::to_value(result).map_err(|e| e.to_string())?)
-        }
-
-        "ping" => Ok(serde_json::json!({})),
-
-        _ => Err(format!("Unknown method: {method}")),
-    }
-}
-
-// ── Tool Definitions ────────────────────────────────────────────────────────
-
-fn tool_remember() -> Value {
-    serde_json::json!({
-        "name": "uteke_remember",
-        "description": "Store a new memory in uteke. The content will be embedded and indexed for semantic search. Optionally specify tags for categorization and a room for collaborative memory.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "content": { "type": "string", "description": "The content to remember" },
-                "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags for categorization" },
-                "type": { "type": "string", "enum": ["fact", "procedure", "preference", "decision", "context"], "description": "Memory type (default: fact)" },
-                "namespace": { "type": "string", "description": "Namespace for multi-agent isolation (default: 'default')" },
-                "room": { "type": "string", "description": "Room ID to link this memory to a collaborative context" },
-                "author": { "type": "string", "description": "Author attribution when storing in a room" }
-            },
-            "required": ["content"]
-        }
-    })
-}
-
-fn tool_recall() -> Value {
-    serde_json::json!({
-        "name": "uteke_recall",
-        "description": "Search memories by semantic similarity. Returns the most relevant memories matching the query. Uses hybrid search (vector + full-text) for best results.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "query": { "type": "string", "description": "The search query" },
-                "limit": { "type": "integer", "description": "Maximum results (default: 5)" },
-                "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter by tags" },
-                "namespace": { "type": "string", "description": "Filter by namespace" },
-                "min_score": { "type": "number", "description": "Minimum similarity score 0.0-1.0 (default: 0.0)" }
-            },
-            "required": ["query"]
-        }
-    })
-}
-
-fn tool_list() -> Value {
-    serde_json::json!({
-        "name": "uteke_list",
-        "description": "List memories with optional filters. Useful for browsing stored memories.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "tag": { "type": "string", "description": "Filter by tag" },
-                "limit": { "type": "integer", "description": "Maximum results (default: 20)" },
-                "offset": { "type": "integer", "description": "Pagination offset (default: 0)" },
-                "namespace": { "type": "string", "description": "Filter by namespace" }
-            }
-        }
-    })
-}
-
-fn tool_forget() -> Value {
-    serde_json::json!({
-        "name": "uteke_forget",
-        "description": "Delete a memory by ID. This is permanent and cannot be undone.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "id": { "type": "string", "description": "Memory ID (UUID) to delete" }
-            },
-            "required": ["id"]
-        }
-    })
-}
-
-fn tool_stats() -> Value {
-    serde_json::json!({
-        "name": "uteke_stats",
-        "description": "Get memory store statistics: total memories, unique tags, database size, aging tier counts.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "namespace": { "type": "string", "description": "Filter stats by namespace" }
-            }
-        }
-    })
-}
-
-// ── Tool Execution ──────────────────────────────────────────────────────────
-
-fn exec_remember(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let content = args["content"]
-        .as_str()
-        .ok_or("Missing 'content' parameter")?;
-    let tags: Vec<&str> = args
-        .get("tags")
-        .and_then(|t| t.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
-        .unwrap_or_default();
-    let memory_type = args["type"].as_str().unwrap_or("fact");
-    let namespace = args["namespace"].as_str();
-    let room = args["room"].as_str();
-    let author = args["author"].as_str();
-
-    let id = if let Some(room_id) = room {
-        let author_name = author.unwrap_or("mcp-client");
-        uteke
-            .remember_in_room(
-                content,
-                &tags,
-                None,
-                namespace,
-                memory_type,
-                room_id,
-                author_name,
-            )
-            .map_err(|e| format!("Failed to store memory: {e}"))?
-    } else {
-        uteke
-            .remember(content, &tags, None, namespace)
-            .map_err(|e| format!("Failed to store memory: {e}"))?
-    };
-
-    Ok(ToolResult {
-        content: vec![McpContent::Text {
-            r#type: "text".to_string(),
-            text: format!("Memory stored with ID: {id}"),
-        }],
-        is_error: false,
-    })
-}
-
-fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let query = args["query"].as_str().ok_or("Missing 'query' parameter")?;
-    let limit = args["limit"].as_u64().unwrap_or(5) as usize;
-    let tags: Vec<String> = args
-        .get("tags")
-        .and_then(|t| t.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-    let namespace = args["namespace"].as_str();
-    let min_score = args["min_score"].as_f64().unwrap_or(0.0) as f32;
-
-    let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
-
-    let results = uteke
-        .recall_hybrid(
-            query,
-            limit,
-            if tag_refs.is_empty() {
-                None
-            } else {
-                Some(&tag_refs)
-            },
-            namespace,
-            uteke_core::RecallStrategy::Hybrid,
-            min_score,
-        )
-        .map_err(|e| format!("Recall failed: {e}"))?;
-
-    let output: Vec<Value> = results
-        .iter()
-        .map(|r| {
-            serde_json::json!({
-                "id": r.memory.id,
-                "content": r.memory.content,
-                "score": format!("{:.3}", r.score),
-                "tags": r.memory.tags,
-                "namespace": r.memory.namespace,
-                "created_at": r.memory.created_at.to_rfc3339(),
-            })
-        })
-        .collect();
-
-    let text = if output.is_empty() {
-        "No memories found.".to_string()
-    } else {
-        serde_json::to_string_pretty(&output).unwrap_or_default()
-    };
-
-    Ok(ToolResult {
-        content: vec![McpContent::Text {
-            r#type: "text".to_string(),
-            text,
-        }],
-        is_error: false,
-    })
-}
-
-fn exec_list(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let tag = args["tag"].as_str();
-    let limit = args["limit"].as_u64().unwrap_or(20) as usize;
-    let offset = args["offset"].as_u64().unwrap_or(0) as usize;
-    let namespace = args["namespace"].as_str();
-
-    let memories = uteke
-        .list(tag, limit, offset, namespace)
-        .map_err(|e| format!("List failed: {e}"))?;
-
-    let output: Vec<Value> = memories
-        .iter()
-        .map(|m| {
-            serde_json::json!({
-                "id": m.id,
-                "content": m.content,
-                "tags": m.tags,
-                "namespace": m.namespace,
-                "created_at": m.created_at.to_rfc3339(),
-            })
-        })
-        .collect();
-
-    let text = if output.is_empty() {
-        "No memories found.".to_string()
-    } else {
-        serde_json::to_string_pretty(&output).unwrap_or_default()
-    };
-
-    Ok(ToolResult {
-        content: vec![McpContent::Text {
-            r#type: "text".to_string(),
-            text,
-        }],
-        is_error: false,
-    })
-}
-
-fn exec_forget(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let id = args["id"].as_str().ok_or("Missing 'id' parameter")?;
-
-    uteke
-        .forget(id)
-        .map_err(|e| format!("Forget failed: {e}"))?;
-
-    Ok(ToolResult {
-        content: vec![McpContent::Text {
-            r#type: "text".to_string(),
-            text: format!("Memory {id} deleted."),
-        }],
-        is_error: false,
-    })
-}
-
-fn exec_stats(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let namespace = args["namespace"].as_str();
-
-    let stats = uteke
-        .stats(namespace)
-        .map_err(|e| format!("Stats failed: {e}"))?;
-
-    let text = serde_json::to_string_pretty(&stats).unwrap_or_default();
-
-    Ok(ToolResult {
-        content: vec![McpContent::Text {
-            r#type: "text".to_string(),
-            text,
-        }],
-        is_error: false,
-    })
 }

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 uteke-core = { path = "../uteke-core", version = "0.2.0" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.2.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -866,13 +866,19 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
         (Method::Post, "/mcp") => {
             // Enforce a body size limit to prevent memory exhaustion
             // (CodeCora #397). 1 MiB is generous for JSON-RPC.
-            const MAX_MCP_BODY: usize = 1024 * 1024;
+            const MAX_MCP_BODY: u64 = 1024 * 1024;
+            // Check Content-Length and reject oversized requests.
+            let content_length = req
+                .headers()
+                .iter()
+                .find(|h| h.field.as_str() == "content-length")
+                .and_then(|h| h.value.as_str().parse::<u64>().ok())
+                .unwrap_or(0);
+            if content_length > MAX_MCP_BODY {
+                return ctx.error_response_for(req, 413, "Payload too large");
+            }
             let mut body = String::new();
-            if let Err(e) = req
-                .as_reader()
-                .take(MAX_MCP_BODY as u64)
-                .read_to_string(&mut body)
-            {
+            if let Err(e) = req.as_reader().take(MAX_MCP_BODY).read_to_string(&mut body) {
                 return ctx.error_response_for(req, 400, format!("Failed to read body: {e}"));
             }
             let response = uteke_mcp::handle_jsonrpc(&uteke, &body);

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -862,6 +862,24 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
             Err(e) => ctx.error_response_for(req, 400, e),
         },
 
+        // ── MCP JSON-RPC endpoint (#381) ───────────────────────────────
+        (Method::Post, "/mcp") => {
+            let mut body = String::new();
+            if let Err(e) = req.as_reader().read_to_string(&mut body) {
+                return ctx.error_response_for(req, 400, format!("Failed to read body: {e}"));
+            }
+            let response = uteke_mcp::handle_jsonrpc(&uteke, &body);
+            tiny_http::Response::from_string(response)
+                .with_header(
+                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                        .unwrap(),
+                )
+                .with_header(
+                    tiny_http::Header::from_bytes(&b"MCP-Protocol-Version"[..], &b"2025-06-18"[..])
+                        .unwrap(),
+                )
+        }
+
         // ── 404 ─────────────────────────────────────────────────────────
         _ => ctx.error_response_for(req, 404, "Not found"),
     }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -864,8 +864,15 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
 
         // ── MCP JSON-RPC endpoint (#381) ───────────────────────────────
         (Method::Post, "/mcp") => {
+            // Enforce a body size limit to prevent memory exhaustion
+            // (CodeCora #397). 1 MiB is generous for JSON-RPC.
+            const MAX_MCP_BODY: usize = 1024 * 1024;
             let mut body = String::new();
-            if let Err(e) = req.as_reader().read_to_string(&mut body) {
+            if let Err(e) = req
+                .as_reader()
+                .take(MAX_MCP_BODY as u64)
+                .read_to_string(&mut body)
+            {
                 return ctx.error_response_for(req, 400, format!("Failed to read body: {e}"));
             }
             let response = uteke_mcp::handle_jsonrpc(&uteke, &body);


### PR DESCRIPTION
Closes #381.

- Bump protocolVersion 2024-11-05 → 2025-06-18 (current MCP spec)
- Extract MCP handler into uteke_mcp library crate (shared between stdio + HTTP)
- New POST /mcp endpoint on uteke-server with MCP-Protocol-Version header
- Enables remote MCP clients without subprocess spawning

283 tests pass, clippy clean.