### PR TITLE
fix(#394): include binary name+version in schema mismatch error

### DIFF
--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -124,7 +124,8 @@ impl super::Store {
             Some(v) => {
                 return Err(Error::db_msg(format!(
                     "database schema version {v} is newer than supported version {CURRENT_SCHEMA_VERSION}; \
-                     please upgrade uteke"
+                     please upgrade uteke (current binary: uteke-core v{}, schema v{CURRENT_SCHEMA_VERSION})",
+                    env!("CARGO_PKG_VERSION")
                 )));
             }
         }


### PR DESCRIPTION
Closes #394. Quick fix — error message now includes 'current binary: uteke-core v0.2.0, schema v10'.