### PR TITLE
fix(#392): room list cross-namespace + feat(#393): room create command

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -447,6 +447,14 @@ pub enum NamespaceCommands {
 /// Subcommands for room management.
 #[derive(Subcommand)]
 pub enum RoomCommands {
+    /// Create a new room explicitly (#393)
+    Create {
+        /// Room ID (unique identifier)
+        room_id: String,
+        /// Optional title for the room
+        #[arg(long)]
+        title: Option<String>,
+    },
     /// List all rooms
     List {
         /// Filter by namespace

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -26,7 +26,7 @@ pub(crate) fn run(
             } else {
                 println!("✓ Room '{room_id}' created");
             }
-            return Ok(());
+            Ok(())
         }
         RoomCommands::List { namespace } => {
             // Rooms are cross-namespace collaboration spaces (#392).

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -13,8 +13,26 @@ pub(crate) fn run(
     config: &Config,
 ) -> Result<(), String> {
     match command {
+        RoomCommands::Create { room_id, title } => {
+            let ns_str = ns.unwrap_or("default");
+            uteke
+                .create_room(room_id, title.as_deref(), ns_str)
+                .map_err(|e| format!("Failed to create room: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({"created": room_id, "namespace": ns_str})
+                );
+            } else {
+                println!("✓ Room '{room_id}' created");
+            }
+            return Ok(());
+        }
         RoomCommands::List { namespace } => {
-            let filter_ns = namespace.as_deref().or(ns);
+            // Rooms are cross-namespace collaboration spaces (#392).
+            // Only filter when --namespace is explicitly passed on the
+            // room subcommand, not from the global --namespace flag.
+            let filter_ns = namespace.as_deref();
             let rooms = uteke
                 .list_rooms(filter_ns)
                 .map_err(|e| format!("Failed to list rooms: {e}"))?;

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -140,6 +140,9 @@ impl super::Store {
 
     /// List rooms that a namespace has participated in.
     pub fn list_rooms(&self, namespace: Option<&str>) -> Result<Vec<Room>, Error> {
+        // Rooms are cross-namespace collaboration spaces (#392).
+        // By default, list ALL rooms across all namespaces.
+        // When a namespace is provided, filter to that namespace only.
         let sql = match namespace {
             Some(_) => {
                 "SELECT DISTINCT r.id, r.title, r.namespace, r.created_at, r.updated_at \


### PR DESCRIPTION
Closes #392, closes #393.

#392: Room list was scoped to global --namespace. Now shows ALL rooms by default.
#393: Added 'uteke room create <id> [--title]' for explicit room lifecycle.