### PR TITLE
fix(#403): contradictory server log + misleading DB size label

### DIFF
--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -78,7 +78,15 @@ fn main() {
     }
 
     // Fallback: open local store
-    tracing::debug!("No server detected, using local store");
+    // This branch is reached when:
+    //   1. No server detected (server_available == false)
+    //   2. Server detected but command not supported via HTTP (aging, doctor, etc.)
+    // Log appropriately to avoid contradictory messages (#403).
+    if server_available {
+        tracing::debug!("Opening local store for server-unsupported command");
+    } else {
+        tracing::debug!("No server detected, using local store");
+    }
 
     let store_path = cli
         .store

--- a/crates/uteke-cli/src/output.rs
+++ b/crates/uteke-cli/src/output.rs
@@ -117,7 +117,7 @@ pub(crate) fn print_stats_human(stats: &uteke_core::StoreStats) {
     } else {
         format!("{:.1} MB", stats.db_size_bytes as f64 / (1024.0 * 1024.0))
     };
-    println!("  Database size:  {}", size_str);
+    println!("  Database size:  {}  (global, shared)", size_str);
 
     // Recall cache metrics
     let total_queries = stats.cache_hits + stats.cache_misses;

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -146,7 +146,7 @@ pub struct StoreStats {
     pub total_memories: usize,
     /// Number of unique tags.
     pub unique_tags: usize,
-    /// Database file size in bytes.
+    /// Database file size in bytes (global, shared across all namespaces).
     pub db_size_bytes: u64,
     /// Number of hot memories (accessed within 7 days).
     pub hot: usize,


### PR DESCRIPTION
## Summary

Fixes #403

### Bug 1: Contradictory server detection log
When server was detected but command unsupported via HTTP (aging, doctor, etc.), the fallback path logged `No server detected` — contradicting the earlier `Server detected` info log.

**Fix:** Now logs `Opening local store for server-unsupported command` when server IS available but command falls back to local.

### Bug 2: Misleading db_size_bytes
Stats reported global DB size alongside namespace-scoped memory count, making a 10-memory namespace appear to use 1.7 MB.

**Fix:** Added "(global, shared)" label in human output. Updated doc comment to clarify.

### Enhancement (deferred)
Aging defaults → deferred to #404 (configurable limits) in v0.3.0 scope.

**Milestone:** v0.2.1 — DX & Ecosystem