### PR TITLE
fix: add uteke-mcp README + publish to crates.io + widen dep versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,10 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-core --allow-dirty
         continue-on-error: true
 
+      - name: Publish uteke-mcp
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-mcp --allow-dirty
+        continue-on-error: true
+
       - name: Publish uteke-cli
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-cli --allow-dirty
         continue-on-error: true

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2.0" }
+uteke-core = { path = "../uteke-core", version = "0.2" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2.0" }
+uteke-core = { path = "../uteke-core", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-mcp/README.md
+++ b/crates/uteke-mcp/README.md
@@ -1,0 +1,40 @@
+# uteke-mcp
+
+MCP (Model Context Protocol) server for [uteke](https://github.com/codecoradev/uteke) — expose persistent semantic memory to AI coding agents.
+
+## Overview
+
+`uteke-mcp` bridges the [uteke](https://github.com/codecoradev/uteke) memory engine with MCP-compatible AI agents (Claude Desktop, Cursor, etc.) via JSON-RPC over stdio.
+
+## Transports
+
+- **stdio** — `uteke-mcp` binary (JSON-RPC over stdin/stdout)
+- **HTTP** — `POST /mcp` endpoint on `uteke-serve` (Streamable HTTP transport, protocol `2025-06-18`)
+
+## Quick Start
+
+```bash
+# Build
+cargo build -p uteke-mcp
+
+# Run as stdio MCP server
+uteke-mcp
+
+# Or add to your agent config
+hermes mcp add uteke --command uteke-mcp
+```
+
+## Tools Exposed
+
+| Tool | Description |
+|------|-------------|
+| `uteke_remember` | Store a memory |
+| `uteke_recall` | Semantic recall by meaning |
+| `uteke_search` | Keyword text search |
+| `uteke_stats` | Memory store statistics |
+| `uteke_forget` | Delete a memory by ID |
+| `uteke_list` | List memories |
+
+## License
+
+Apache-2.0

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2.0" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.2.0" }
+uteke-core = { path = "../uteke-core", version = "0.2" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## Summary

Post-release fix for v0.2.1 crates.io publishing.

### Issues Found After v0.2.1 Release
1. **uteke-mcp not published** — crate was missing from release workflow's `publish-crates` job. `uteke-server` depends on it but publish failed silently (`continue-on-error: true`).
2. **uteke-mcp missing README.md** — `readme = "README.md"` in Cargo.toml but file didn't exist. crates.io rejects it.
3. **Internal dep versions too strict** — pinned to `"0.2.0"` exact, should be `"0.2"` for SemVer compatibility.

### Changes
- Added `crates/uteke-mcp/README.md` with overview, transports, tools, quick start
- Updated release workflow: publish order is now `core → mcp → cli → server`
- Widened internal deps: `"0.2.0"` → `"0.2"` in all 3 crates

### Test
- ✅ `cargo publish -p uteke-mcp --dry-run` passes
- ✅ Build, test, clippy all clean

**Note:** After merge, will manually publish uteke-mcp + uteke-server to crates.io (core and cli already published successfully in v0.2.1 release run).