### PR TITLE
chore: sync develop to main — uteke-mcp publish fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,10 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-core --allow-dirty
         continue-on-error: true
 
+      - name: Publish uteke-mcp
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-mcp --allow-dirty
+        continue-on-error: true
+
       - name: Publish uteke-cli
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-cli --allow-dirty
         continue-on-error: true

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2.0" }
+uteke-core = { path = "../uteke-core", version = "0.2" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2.0" }
+uteke-core = { path = "../uteke-core", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-mcp/README.md
+++ b/crates/uteke-mcp/README.md
@@ -1,0 +1,40 @@
+# uteke-mcp
+
+MCP (Model Context Protocol) server for [uteke](https://github.com/codecoradev/uteke) — expose persistent semantic memory to AI coding agents.
+
+## Overview
+
+`uteke-mcp` bridges the [uteke](https://github.com/codecoradev/uteke) memory engine with MCP-compatible AI agents (Claude Desktop, Cursor, etc.) via JSON-RPC over stdio.
+
+## Transports
+
+- **stdio** — `uteke-mcp` binary (JSON-RPC over stdin/stdout)
+- **HTTP** — `POST /mcp` endpoint on `uteke-serve` (Streamable HTTP transport, protocol `2025-06-18`)
+
+## Quick Start
+
+```bash
+# Build
+cargo build -p uteke-mcp
+
+# Run as stdio MCP server
+uteke-mcp
+
+# Or add to your agent config
+hermes mcp add uteke --command uteke-mcp
+```
+
+## Tools Exposed
+
+| Tool | Description |
+|------|-------------|
+| `uteke_remember` | Store a memory |
+| `uteke_recall` | Semantic recall by meaning |
+| `uteke_search` | Keyword text search |
+| `uteke_stats` | Memory store statistics |
+| `uteke_forget` | Delete a memory by ID |
+| `uteke_list` | List memories |
+
+## License
+
+Apache-2.0

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2.0" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.2.0" }
+uteke-core = { path = "../uteke-core", version = "0.2" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## Summary

Follow-up to v0.2.1 release. Sync the uteke-mcp publish fix (#417) to main so crates.io publishing can complete.

### What Changed
- Added uteke-mcp README.md (required by crates.io)
- Added uteke-mcp to release workflow publish sequence
- Widened internal dependency versions from "0.2.0" to "0.2"

After merge, will re-tag v0.2.1 to trigger release workflow with the fix.