### PR TITLE
feat(#404): configurable limits — env vars + config section

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -226,6 +226,37 @@ pub struct Config {
     pub aging: AgingConfig,
     pub recall: RecallConfig,
     pub server: ServerConfig,
+    pub limits: LimitsConfig,
+}
+
+/// Configurable limits (#404).
+/// All limits can be overridden via config or env vars.
+#[derive(serde::Deserialize, Clone)]
+#[serde(default)]
+pub struct LimitsConfig {
+    /// Maximum memory content length in characters. Set to 0 to disable.
+    pub max_content_length: usize,
+    /// Maximum number of tags per memory.
+    pub max_tags_count: usize,
+    /// Maximum single tag length in characters.
+    pub max_tag_length: usize,
+    /// Maximum payload size for server API in bytes.
+    pub max_payload_size: usize,
+    /// Default recall limit when --limit not specified.
+    pub default_recall_limit: usize,
+}
+
+impl Default for LimitsConfig {
+    fn default() -> Self {
+        // Env var overrides with fallback to defaults.
+        Self {
+            max_content_length: env_or("UTEKE_MAX_CONTENT_LENGTH", 100_000),
+            max_tags_count: env_or("UTEKE_MAX_TAGS_COUNT", 20),
+            max_tag_length: env_or("UTEKE_MAX_TAG_LENGTH", 50),
+            max_payload_size: env_or("UTEKE_MAX_PAYLOAD_SIZE", 10_485_760),
+            default_recall_limit: env_or("UTEKE_DEFAULT_RECALL_LIMIT", 5),
+        }
+    }
 }
 
 impl Config {
@@ -590,6 +621,15 @@ impl Config {
 # enabled = false
 # host = "127.0.0.1"
 # port = 8767
+
+[limits]
+# Configurable limits (#404). Override via config or env vars:
+# UTEKE_MAX_CONTENT_LENGTH, UTEKE_MAX_TAGS_COUNT, etc.
+# max_content_length = 100000  # Set to 0 to disable
+# max_tags_count = 20
+# max_tag_length = 50
+# max_payload_size = 10485760  # 10MB
+# default_recall_limit = 5
 "#;
         std::fs::write(&config_path, default).ok();
     }
@@ -633,6 +673,14 @@ impl Config {
 // ── Legacy migration ────────────────────────────────────────────────────────
 
 /// Migrate legacy `~/.uteke/config.toml` → `~/.uteke/uteke.toml`.
+/// Read an env var as a type T, falling back to default if unset or invalid.
+fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
 fn migrate_legacy_global() {
     let home = match dirs::home_dir() {
         Some(h) => h,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -56,32 +56,51 @@ pub use embed::{Embedder, OnnxEmbedder};
 pub use error::{format_bytes, Error};
 pub use types::{DoctorCheck, DoctorReport, DoctorStatus, RepairReport, VerifyReport};
 
-/// Maximum memory content length (characters).
-pub const MAX_CONTENT_LENGTH: usize = 10_000;
+/// Maximum memory content length (characters) — default, overridable via config (#404).
+pub const MAX_CONTENT_LENGTH: usize = 100_000;
 /// Maximum number of tags per memory.
 pub const MAX_TAGS_COUNT: usize = 20;
 /// Maximum single tag length (characters).
 pub const MAX_TAG_LENGTH: usize = 50;
 /// Maximum payload size for server API (bytes).
-pub const MAX_PAYLOAD_SIZE: usize = 1_048_576; // 1MB
+pub const MAX_PAYLOAD_SIZE: usize = 10_485_760; // 10MB
 
 /// Validate input parameters before processing.
+/// Uses default limits. For configurable limits, use `validate_input_with_limits`.
 pub fn validate_input(content: &str, tags: &[impl AsRef<str>]) -> Result<(), Error> {
+    validate_input_with_limits(
+        content,
+        tags,
+        MAX_CONTENT_LENGTH,
+        MAX_TAGS_COUNT,
+        MAX_TAG_LENGTH,
+    )
+}
+
+/// Validate input with configurable limits (#404).
+/// Set max_content_length to 0 to disable content length check.
+pub fn validate_input_with_limits(
+    content: &str,
+    tags: &[impl AsRef<str>],
+    max_content_length: usize,
+    max_tags_count: usize,
+    max_tag_length: usize,
+) -> Result<(), Error> {
     if content.trim().is_empty() {
         return Err(Error::Validation("Content must not be empty".into()));
     }
-    if content.len() > MAX_CONTENT_LENGTH {
+    if max_content_length > 0 && content.len() > max_content_length {
         return Err(Error::Validation(format!(
             "Content too long: {} chars (max {})",
             content.len(),
-            MAX_CONTENT_LENGTH
+            max_content_length
         )));
     }
-    if tags.len() > MAX_TAGS_COUNT {
+    if tags.len() > max_tags_count {
         return Err(Error::Validation(format!(
             "Too many tags: {} (max {})",
             tags.len(),
-            MAX_TAGS_COUNT
+            max_tags_count
         )));
     }
     for tag in tags {
@@ -89,11 +108,11 @@ pub fn validate_input(content: &str, tags: &[impl AsRef<str>]) -> Result<(), Err
         if t.is_empty() {
             return Err(Error::Validation("Tags must not be empty".into()));
         }
-        if t.len() > MAX_TAG_LENGTH {
+        if max_tag_length > 0 && t.len() > max_tag_length {
             return Err(Error::Validation(format!(
                 "Tag too long: {} chars (max {})",
                 t.len(),
-                MAX_TAG_LENGTH
+                max_tag_length
             )));
         }
     }


### PR DESCRIPTION
## Summary

Implements #404.

### Changes
- **MAX_CONTENT_LENGTH**: 10,000 → 100,000 (10x increase). Document engine (#406) needs larger content. Set to 0 to disable.
- **MAX_PAYLOAD_SIZE**: 1MB → 10MB (for document uploads)
- Added  struct with env var overrides: , , , , 
- Added  section to default  template
- Added  for custom limit validation
- Original  delegates with default constants (backward compatible)

### Test
- ✅ 283 unit tests passed
- ✅ Clippy clean
- ✅ Fmt clean

**Milestone:** v0.3.0 — Graph RAG
**Unblocks:** #406 (document engine)