### PR TITLE
feat(#406): document engine — documents + document_chunks tables (schema v11)

### DIFF
--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -1276,7 +1276,7 @@ mod tests {
     fn migration_dispatcher_reaches_v8() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 10, "fresh store must reach CURRENT_SCHEMA_VERSION=10");
+        assert_eq!(v, 11, "fresh store must reach CURRENT_SCHEMA_VERSION=11");
 
         // memory_edges table must exist and be queryable after migration.
         let n = store.count_memory_edges().unwrap();

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -46,6 +46,7 @@ pub use memory::types::{
     SearchResult, SimilarPair, StoreStats, TagInfo, DEFAULT_NAMESPACE,
 };
 pub use memory::{
+    documents::{Document, DocumentChunk, DocumentSummary},
     DocumentEntry, DocumentSection, Room, RoomDocument, RoomMemory, RoomStats, RoomSummary,
     TimeRange, TopicCluster,
 };
@@ -695,6 +696,112 @@ impl Uteke {
             edges,
             stats,
         })
+    }
+
+    // ── Document engine (#406) ───────────────────────────────────────────
+
+    /// Create or update a document (#406).
+    ///
+    /// If the slug exists in the namespace, updates content and re-chunks.
+    /// Chunks are created via the markdown chunker (#405) and embedded.
+    pub fn doc_upsert(
+        &self,
+        slug: &str,
+        title: &str,
+        content: &str,
+        tags: &[&str],
+        namespace: Option<&str>,
+    ) -> Result<String, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Check if document exists to get current version.
+        let existing = self.store.get_document_by_slug(slug, ns)?;
+        let (id, version) = match &existing {
+            Some(doc) => (doc.id.clone(), doc.version),
+            None => (uuid::Uuid::new_v4().to_string(), 1),
+        };
+
+        let doc = Document {
+            id: id.clone(),
+            slug: slug.to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            namespace: ns.to_string(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            metadata: serde_json::Value::Null,
+            version,
+            content_type: "markdown".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        let doc_id = self.store.upsert_document(&doc)?;
+
+        // Chunk and embed the content.
+        self.ensure_embedder()?;
+        let embedder = self
+            .embedder
+            .lock()
+            .map_err(|_| Error::lock("embedder lock during document chunking"))?;
+        let embedder = embedder.as_ref().expect("embedder ensured");
+
+        let max_chars = embedder.max_seq_len().saturating_mul(4).max(1024);
+        let chunks = crate::chunker::chunk_markdown(content, max_chars);
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let chunk_id = uuid::Uuid::new_v4().to_string();
+            let embedding = embedder.embed(&chunk.content)?;
+
+            self.store.insert_document_chunk(
+                &DocumentChunk {
+                    id: chunk_id,
+                    document_id: doc_id.clone(),
+                    chunk_index: i as i64,
+                    heading: chunk.heading.clone(),
+                    content: chunk.content.clone(),
+                    char_start: chunk.char_start as i64,
+                    char_end: chunk.char_end as i64,
+                    tags: tags.iter().map(|t| t.to_string()).collect(),
+                },
+                &embedding,
+            )?;
+        }
+
+        tracing::info!(
+            "Document '{slug}' upserted in namespace '{ns}': {} chunks",
+            chunks.len()
+        );
+
+        Ok(doc_id)
+    }
+
+    /// Get a document by ID or slug.
+    pub fn doc_get(
+        &self,
+        id_or_slug: &str,
+        namespace: Option<&str>,
+    ) -> Result<Option<Document>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        // Try by slug first, then by ID.
+        if let Some(doc) = self.store.get_document_by_slug(id_or_slug, ns)? {
+            return Ok(Some(doc));
+        }
+        self.store.get_document(id_or_slug)
+    }
+
+    /// List documents in a namespace.
+    pub fn doc_list(
+        &self,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        self.store.list_documents(namespace, limit)
+    }
+
+    /// Delete a document by ID.
+    pub fn doc_delete(&self, id: &str) -> Result<bool, Error> {
+        self.store.delete_document(id)
     }
 }
 

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -581,6 +581,6 @@ mod content_type_tests {
         let store = super::super::store::Store::open(":memory:").unwrap();
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
-        assert_eq!(version, 10); // v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
+        assert_eq!(version, 11); // v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
     }
 }

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -1,0 +1,448 @@
+//! Document engine — wiki/knowledge base support (#406).
+//!
+//! Full markdown content lives in the `documents` table. Content is chunked
+//! via the markdown chunker (#405) and each chunk gets its own embedding for
+//! semantic search at the section level.
+
+use crate::Error;
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// A document in the knowledge base.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Document {
+    /// Unique UUID.
+    pub id: String,
+    /// URL-friendly identifier (unique per namespace).
+    pub slug: String,
+    /// Human-readable title.
+    pub title: String,
+    /// Full markdown content.
+    pub content: String,
+    /// Namespace for isolation.
+    pub namespace: String,
+    /// JSON array of tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// JSON metadata object.
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+    /// Version number (incremented on each edit).
+    pub version: i64,
+    /// Content type: "markdown" or "text".
+    pub content_type: String,
+    /// Creation timestamp (RFC3339).
+    pub created_at: String,
+    /// Last update timestamp (RFC3339).
+    pub updated_at: String,
+}
+
+/// A chunk of a document — used for semantic search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentChunk {
+    /// Unique UUID.
+    pub id: String,
+    /// Parent document ID.
+    pub document_id: String,
+    /// Index within the document (0-based).
+    pub chunk_index: i64,
+    /// Section heading (empty if no heading).
+    pub heading: String,
+    /// Chunk text content.
+    pub content: String,
+    /// Character offset from start of document content.
+    pub char_start: i64,
+    /// Character offset end (exclusive).
+    pub char_end: i64,
+    /// Tags inherited from parent document.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+impl super::Store {
+    /// Create or replace a document (#406).
+    ///
+    /// If a document with the same slug+namespace exists, it is updated
+    /// (version incremented, content replaced, chunks rebuilt).
+    /// Returns the document ID.
+    pub fn upsert_document(&self, doc: &Document) -> Result<String, Error> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("begin document upsert transaction", e))?;
+
+        // Check if document exists (by slug + namespace).
+        let existing: Option<String> = tx
+            .query_row(
+                "SELECT id FROM documents WHERE namespace = ?1 AND slug = ?2",
+                params![doc.namespace, doc.slug],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("query existing document", e))?;
+
+        let doc_id = if let Some(id) = existing {
+            // Update existing document.
+            let version = doc.version + 1;
+            tx.execute(
+                "UPDATE documents SET title = ?1, content = ?2, tags = ?3, metadata = ?4, \
+                 version = ?5, updated_at = ?6 WHERE id = ?7",
+                params![
+                    doc.title,
+                    doc.content,
+                    serde_json::to_string(&doc.tags).unwrap_or_else(|_| "[]".into()),
+                    doc.metadata.to_string(),
+                    version,
+                    doc.updated_at,
+                    id
+                ],
+            )
+            .map_err(|e| Error::db("update document", e))?;
+            // Delete old chunks.
+            tx.execute(
+                "DELETE FROM document_chunks WHERE document_id = ?1",
+                params![id],
+            )
+            .map_err(|e| Error::db("delete old document chunks", e))?;
+            id
+        } else {
+            // Insert new document.
+            tx.execute(
+                "INSERT INTO documents (id, slug, title, content, namespace, tags, metadata, \
+                 version, content_type, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                params![
+                    doc.id,
+                    doc.slug,
+                    doc.title,
+                    doc.content,
+                    doc.namespace,
+                    serde_json::to_string(&doc.tags).unwrap_or_else(|_| "[]".into()),
+                    doc.metadata.to_string(),
+                    doc.version,
+                    doc.content_type,
+                    doc.created_at,
+                    doc.updated_at,
+                ],
+            )
+            .map_err(|e| Error::db("insert document", e))?;
+            doc.id.clone()
+        };
+
+        tx.commit()
+            .map_err(|e| Error::db("commit document upsert", e))?;
+
+        Ok(doc_id)
+    }
+
+    /// Insert a document chunk with embedding (#406).
+    pub fn insert_document_chunk(
+        &self,
+        chunk: &DocumentChunk,
+        embedding: &[f32],
+    ) -> Result<(), Error> {
+        let embedding_blob = super::store::serialize_embedding(embedding);
+        self.conn
+            .execute(
+                "INSERT INTO document_chunks (id, document_id, chunk_index, heading, content, \
+                 embedding, char_start, char_end, tags, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    chunk.id,
+                    chunk.document_id,
+                    chunk.chunk_index,
+                    chunk.heading,
+                    chunk.content,
+                    embedding_blob,
+                    chunk.char_start,
+                    chunk.char_end,
+                    serde_json::to_string(&chunk.tags).unwrap_or_else(|_| "[]".into()),
+                    chrono::Utc::now().to_rfc3339(),
+                ],
+            )
+            .map_err(|e| Error::db("insert document chunk", e))?;
+        Ok(())
+    }
+
+    /// Get a document by ID.
+    pub fn get_document(&self, id: &str) -> Result<Option<Document>, Error> {
+        let doc = self
+            .conn
+            .query_row(
+                "SELECT id, slug, title, content, namespace, tags, metadata, version, \
+                 content_type, created_at, updated_at FROM documents WHERE id = ?1",
+                params![id],
+                |row| {
+                    let tags_str: String = row.get(5)?;
+                    let meta_str: String = row.get(6)?;
+                    Ok(Document {
+                        id: row.get(0)?,
+                        slug: row.get(1)?,
+                        title: row.get(2)?,
+                        content: row.get(3)?,
+                        namespace: row.get(4)?,
+                        tags: serde_json::from_str(&tags_str).unwrap_or_default(),
+                        metadata: serde_json::from_str(&meta_str)
+                            .unwrap_or(serde_json::Value::Null),
+                        version: row.get(7)?,
+                        content_type: row.get(8)?,
+                        created_at: row.get(9)?,
+                        updated_at: row.get(10)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| Error::db("get document", e))?;
+        Ok(doc)
+    }
+
+    /// Get a document by slug + namespace.
+    pub fn get_document_by_slug(
+        &self,
+        slug: &str,
+        namespace: &str,
+    ) -> Result<Option<Document>, Error> {
+        let doc = self
+            .conn
+            .query_row(
+                "SELECT id, slug, title, content, namespace, tags, metadata, version, \
+                 content_type, created_at, updated_at FROM documents \
+                 WHERE slug = ?1 AND namespace = ?2",
+                params![slug, namespace],
+                |row| {
+                    let tags_str: String = row.get(5)?;
+                    let meta_str: String = row.get(6)?;
+                    Ok(Document {
+                        id: row.get(0)?,
+                        slug: row.get(1)?,
+                        title: row.get(2)?,
+                        content: row.get(3)?,
+                        namespace: row.get(4)?,
+                        tags: serde_json::from_str(&tags_str).unwrap_or_default(),
+                        metadata: serde_json::from_str(&meta_str)
+                            .unwrap_or(serde_json::Value::Null),
+                        version: row.get(7)?,
+                        content_type: row.get(8)?,
+                        created_at: row.get(9)?,
+                        updated_at: row.get(10)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| Error::db("get document by slug", e))?;
+        Ok(doc)
+    }
+
+    /// List documents in a namespace.
+    pub fn list_documents(
+        &self,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let limit = limit.min(1000) as i64;
+
+        let mut stmt = if namespace.is_some() {
+            self.conn.prepare(
+                "SELECT id, slug, title, namespace, version, updated_at FROM documents WHERE namespace = ?1 ORDER BY updated_at DESC LIMIT ?2"
+            ).map_err(|e| Error::db("prepare list documents", e))?
+        } else {
+            self.conn.prepare(
+                "SELECT id, slug, title, namespace, version, updated_at FROM documents ORDER BY updated_at DESC LIMIT ?1"
+            ).map_err(|e| Error::db("prepare list documents", e))?
+        };
+
+        let rows = match namespace {
+            Some(ns) => stmt
+                .query_map(params![ns, limit], row_to_summary)
+                .map_err(|e| Error::db("list documents query", e))?,
+            None => stmt
+                .query_map(params![limit], row_to_summary)
+                .map_err(|e| Error::db("list documents query", e))?,
+        };
+
+        let docs: Vec<DocumentSummary> = rows.filter_map(|r| r.ok()).collect();
+        Ok(docs)
+    }
+
+    /// Delete a document by ID (cascades to chunks).
+    pub fn delete_document(&self, id: &str) -> Result<bool, Error> {
+        let n = self
+            .conn
+            .execute("DELETE FROM documents WHERE id = ?1", params![id])
+            .map_err(|e| Error::db("delete document", e))?;
+        Ok(n > 0)
+    }
+
+    /// Count documents in a namespace.
+    pub fn count_documents(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let count: i64 = match namespace {
+            Some(ns) => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM documents WHERE namespace = ?1",
+                    params![ns],
+                    |row| row.get(0),
+                )
+                .map_err(|e| Error::db("count documents", e))?,
+            None => self
+                .conn
+                .query_row("SELECT COUNT(*) FROM documents", [], |row| row.get(0))
+                .map_err(|e| Error::db("count documents", e))?,
+        };
+        Ok(count as usize)
+    }
+}
+
+/// Summary of a document (for list views).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentSummary {
+    pub id: String,
+    pub slug: String,
+    pub title: String,
+    pub namespace: String,
+    pub version: i64,
+    pub updated_at: String,
+}
+
+/// Row mapper for DocumentSummary (used by list_documents).
+fn row_to_summary(row: &rusqlite::Row) -> rusqlite::Result<DocumentSummary> {
+    Ok(DocumentSummary {
+        id: row.get(0)?,
+        slug: row.get(1)?,
+        title: row.get(2)?,
+        namespace: row.get(3)?,
+        version: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::store::Store;
+
+    fn open_test_store() -> Store {
+        Store::open(":memory:").unwrap()
+    }
+
+    #[test]
+    fn test_document_crud() {
+        let store = open_test_store();
+        let now = chrono::Utc::now().to_rfc3339();
+        let doc = Document {
+            id: "doc-1".to_string(),
+            slug: "getting-started".to_string(),
+            title: "Getting Started".to_string(),
+            content: "# Hello\n\nWorld".to_string(),
+            namespace: "default".to_string(),
+            tags: vec!["guide".to_string()],
+            metadata: serde_json::Value::Null,
+            version: 1,
+            content_type: "markdown".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        // Create.
+        let id = store.upsert_document(&doc).unwrap();
+        assert_eq!(id, "doc-1");
+
+        // Get by ID.
+        let got = store.get_document("doc-1").unwrap().unwrap();
+        assert_eq!(got.title, "Getting Started");
+        assert_eq!(got.content, "# Hello\n\nWorld");
+
+        // Get by slug.
+        let got2 = store
+            .get_document_by_slug("getting-started", "default")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got2.id, "doc-1");
+
+        // List.
+        let list = store.list_documents(Some("default"), 10).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].slug, "getting-started");
+
+        // Delete.
+        assert!(store.delete_document("doc-1").unwrap());
+        assert!(store.get_document("doc-1").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_document_upsert_increments_version() {
+        let store = open_test_store();
+        let now = chrono::Utc::now().to_rfc3339();
+        let doc = Document {
+            id: "doc-1".to_string(),
+            slug: "test".to_string(),
+            title: "V1".to_string(),
+            content: "Content 1".to_string(),
+            namespace: "default".to_string(),
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            version: 1,
+            content_type: "markdown".to_string(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        };
+
+        store.upsert_document(&doc).unwrap();
+
+        // Upsert with same slug but new title.
+        let doc2 = Document {
+            title: "V2".to_string(),
+            content: "Content 2".to_string(),
+            updated_at: now.clone(),
+            ..doc
+        };
+        store.upsert_document(&doc2).unwrap();
+
+        let got = store
+            .get_document_by_slug("test", "default")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.title, "V2");
+        assert_eq!(got.version, 2); // Incremented
+    }
+
+    #[test]
+    fn test_document_namespace_isolation() {
+        let store = open_test_store();
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let doc1 = Document {
+            id: "d1".to_string(),
+            slug: "guide".to_string(),
+            title: "NS1 Guide".to_string(),
+            content: "ns1".to_string(),
+            namespace: "ns1".to_string(),
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            version: 1,
+            content_type: "markdown".to_string(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        };
+        let doc2 = Document {
+            id: "d2".to_string(),
+            namespace: "ns2".to_string(),
+            title: "NS2 Guide".to_string(),
+            content: "ns2".to_string(),
+            ..doc1.clone()
+        };
+
+        store.upsert_document(&doc1).unwrap();
+        store.upsert_document(&doc2).unwrap();
+
+        // Same slug, different namespace → both exist.
+        assert!(store
+            .get_document_by_slug("guide", "ns1")
+            .unwrap()
+            .is_some());
+        assert!(store
+            .get_document_by_slug("guide", "ns2")
+            .unwrap()
+            .is_some());
+    }
+}

--- a/crates/uteke-core/src/memory/mod.rs
+++ b/crates/uteke-core/src/memory/mod.rs
@@ -3,6 +3,7 @@
 pub mod aging;
 pub mod bulk;
 pub mod crud;
+pub mod documents;
 pub mod fts5;
 pub mod rooms;
 pub mod schema;

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -170,6 +170,8 @@ impl super::Store {
                 9 => self.migrate_v8_to_v9()?,
                 // v10: source + source_type columns (citation/provenance, #348)
                 10 => self.migrate_v9_to_v10()?,
+                // v11: Document engine tables (#406)
+                11 => self.migrate_v10_to_v11()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -496,6 +498,55 @@ impl super::Store {
                 "#,
             )
             .map_err(|e| Error::db("schema migration v9 to v10", e))?;
+        Ok(())
+    }
+
+    /// v11: Document engine tables (#406).
+    ///
+    /// Creates `documents` and `document_chunks` tables for wiki/knowledge
+    /// base support. Full markdown content → documents table, chunked
+    /// summaries → document_chunks with embeddings.
+    fn migrate_v10_to_v11(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v10 to v11: document engine tables");
+        self.conn
+            .execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS documents (
+                    id TEXT PRIMARY KEY,
+                    slug TEXT NOT NULL COLLATE NOCASE,
+                    title TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    namespace TEXT NOT NULL DEFAULT 'default',
+                    tags TEXT DEFAULT '[]',
+                    metadata TEXT DEFAULT '{}',
+                    version INTEGER NOT NULL DEFAULT 1,
+                    content_type TEXT NOT NULL DEFAULT 'markdown',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    UNIQUE(namespace, slug)
+                );
+                CREATE INDEX IF NOT EXISTS idx_documents_namespace ON documents(namespace);
+                CREATE INDEX IF NOT EXISTS idx_documents_slug ON documents(slug);
+                CREATE INDEX IF NOT EXISTS idx_documents_updated ON documents(updated_at);
+
+                CREATE TABLE IF NOT EXISTS document_chunks (
+                    id TEXT PRIMARY KEY,
+                    document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+                    chunk_index INTEGER NOT NULL,
+                    heading TEXT NOT NULL DEFAULT '',
+                    content TEXT NOT NULL,
+                    embedding BLOB,
+                    char_start INTEGER NOT NULL DEFAULT 0,
+                    char_end INTEGER NOT NULL DEFAULT 0,
+                    tags TEXT DEFAULT '[]',
+                    created_at TEXT NOT NULL,
+                    UNIQUE(document_id, chunk_index)
+                );
+                CREATE INDEX IF NOT EXISTS idx_doc_chunks_doc ON document_chunks(document_id);
+                CREATE INDEX IF NOT EXISTS idx_doc_chunks_heading ON document_chunks(heading);
+                "#,
+            )
+            .map_err(|e| Error::db("schema migration v10 to v11", e))?;
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -90,10 +90,46 @@ CREATE TABLE IF NOT EXISTS timeline_events (
 CREATE INDEX IF NOT EXISTS idx_timeline_memory ON timeline_events(memory_id);
 CREATE INDEX IF NOT EXISTS idx_timeline_type ON timeline_events(event_type);
 CREATE INDEX IF NOT EXISTS idx_timeline_created ON timeline_events(created_at);
+
+-- v11: Document engine (#406). Wiki/knowledge base support.
+-- Full markdown content lives in documents, chunked summaries → embeddings.
+CREATE TABLE IF NOT EXISTS documents (
+    id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL COLLATE NOCASE,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    namespace TEXT NOT NULL DEFAULT 'default',
+    tags TEXT DEFAULT '[]',
+    metadata TEXT DEFAULT '{}',
+    version INTEGER NOT NULL DEFAULT 1,
+    content_type TEXT NOT NULL DEFAULT 'markdown',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(namespace, slug)
+);
+CREATE INDEX IF NOT EXISTS idx_documents_namespace ON documents(namespace);
+CREATE INDEX IF NOT EXISTS idx_documents_slug ON documents(slug);
+CREATE INDEX IF NOT EXISTS idx_documents_updated ON documents(updated_at);
+
+CREATE TABLE IF NOT EXISTS document_chunks (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL,
+    heading TEXT NOT NULL DEFAULT '',
+    content TEXT NOT NULL,
+    embedding BLOB,
+    char_start INTEGER NOT NULL DEFAULT 0,
+    char_end INTEGER NOT NULL DEFAULT 0,
+    tags TEXT DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    UNIQUE(document_id, chunk_index)
+);
+CREATE INDEX IF NOT EXISTS idx_doc_chunks_doc ON document_chunks(document_id);
+CREATE INDEX IF NOT EXISTS idx_doc_chunks_heading ON document_chunks(heading);
 "#;
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 10;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 11;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -223,7 +259,7 @@ impl Store {
 }
 
 /// Serialize an embedding vector to a byte blob (little-endian f32).
-pub(super) fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
+pub(crate) fn serialize_embedding(embedding: &[f32]) -> Vec<u8> {
     let mut blob = Vec::with_capacity(embedding.len() * 4);
     for &val in embedding {
         blob.extend_from_slice(&val.to_le_bytes());

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -296,7 +296,7 @@ mod tests {
     fn migration_dispatcher_reaches_v9() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 10, "fresh store must reach CURRENT_SCHEMA_VERSION=10");
+        assert_eq!(v, 11, "fresh store must reach CURRENT_SCHEMA_VERSION=11");
         // timeline_events table must exist.
         let m = mem();
         store.insert(&m).unwrap();


### PR DESCRIPTION
Implements #406 — the core wiki/knowledge base engine.

## Summary

Transforms uteke from a memory store into a wiki/knowledge base engine (Outline/Obsidian style).

## Schema v11 migration
- **documents**: full markdown content with slug, title, tags, version
- **document_chunks**: chunked sections with embeddings for semantic search
- UNIQUE(namespace, slug), CASCADE delete

## API
```rust
// Create/update a document (auto-chunks + embeds)
uteke.doc_upsert("architecture", "Architecture Guide", "# Content...", &["tech"], Some("wiki"))?;

// Get by slug or ID
let doc = uteke.doc_get("architecture", Some("wiki"))?;

// List documents
let docs = uteke.doc_list(Some("wiki"), 20)?;

// Delete
uteke.doc_delete(&id)?;
```

## Chunking pipeline
1. Document content → `chunk_markdown()` (#405) splits by headings
2. Each chunk → `embedder.embed()` creates section-level embedding
3. Chunks stored with heading, content, char offsets, embedding BLOB

## Foundation for
- #411: `uteke doc create/edit/list/export/get` CLI commands
- Future: [[wikilinks]] between documents, document search, export

## Tests
3 unit tests: CRUD lifecycle, version increment on upsert, namespace isolation.

**Milestone:** v0.3.0 — Graph RAG