### PR TITLE
release: v0.3.0 — Graph RAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,56 @@
+## [0.3.0] — 2026-06-21
+
+### Added
+
+- **Document engine — wiki/knowledge base** (#406)
+  - Schema v11: `documents` + `document_chunks` tables
+  - Full markdown content with slug, title, tags, version
+  - Auto-chunking via markdown chunker (#405) + per-chunk embeddings
+  - Foundation for Obsidian/Outline-style wiki
+
+- **Document CLI commands** (#411)
+  - `uteke doc create/get/list/delete/export`
+  - Accept content from --file, --content, or stdin
+  - Auto-derive title from first heading
+
+- **Markdown/prose chunker** (#405)
+  - Split by headings (levels 1-6), respect code block fences
+  - Paragraph-level fallback for oversized sections
+  - `TextChunk { heading, content, level, char_start, char_end }`
+
+- **Embed-aware chunking** (#407)
+  - `chunk_markdown_embed_aware()` derives chunk size from `embedder.max_seq_len()`
+  - ~4 chars per token heuristic
+
+- **Cosine-based auto-linking + dedup** (#401)
+  - `auto_link_cosine()` runs after every `remember()`
+  - `similar_to` edge when cosine >= 0.80
+  - `possible_duplicate` edge when cosine >= 0.92
+  - Namespace-scoped (no cross-namespace links)
+
+- **Configurable limits** (#404)
+  - `LimitsConfig` struct with env var overrides
+  - MAX_CONTENT_LENGTH: 10K → 100K
+  - `[limits]` section in uteke.toml
+
+- **`/graph` API endpoint** (#408)
+  - `GET /graph` returns all nodes + edges + stats as JSON
+  - For visualization clients
+
+- **View-only API key** (#409)
+  - `--read-only-token` for GET-only access
+  - Dual-role: Admin (full) + ReadOnly (GET only)
+  - Env vars: `UTEKE_AUTH_TOKEN`, `UTEKE_READ_ONLY_TOKEN`
+
+- **Hermes plugin room_remember** (#410)
+  - New `room_remember` action in plugin template
+
+### Changed
+
+- Schema version bumped from v10 to v11
+- Internal dependency versions widened from `0.2.0` to `0.3`
+- `serialize_embedding` visibility changed to `pub(crate)`
+
 ## [0.2.1] — 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2" }
+uteke-core = { path = "../uteke-core", version = "0.3" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -221,7 +221,7 @@ fn init_hermes(json: bool) -> Result<(), String> {
         .map_err(|e| format!("Failed to write __init__.py: {e}"))?;
 
     // plugin.yaml — Hermes plugin manifest.
-    let plugin_yaml = "name: uteke-tool\ndescription: Semantic memory recall and storage via uteke — includes room operations\nversion: 0.2.1\nauthor: CodeCoraDev\nactions:\n  - uteke\n";
+    let plugin_yaml = "name: uteke-tool\ndescription: Semantic memory recall and storage via uteke — includes room operations\nversion: 0.3.0\nauthor: CodeCoraDev\nactions:\n  - uteke\n";
     std::fs::write(plugin_dir.join("plugin.yaml"), plugin_yaml)
         .map_err(|e| format!("Failed to write plugin.yaml: {e}"))?;
 

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2" }
+uteke-core = { path = "../uteke-core", version = "0.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.2" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.2" }
+uteke-core = { path = "../uteke-core", version = "0.3" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## 🚀 Release v0.3.0 — Graph RAG

Version bump 0.2.1 → 0.3.0.

### Highlights

**Wiki/Knowledge Base (Obsidian/Outline style):**
- Document engine (#406): documents + document_chunks tables (schema v11)
- Document CLI (#411): `uteke doc create/get/list/delete/export`
- Auto-chunking + per-chunk embeddings for semantic document search

**Graph Intelligence:**
- Cosine auto-linking (#401): similar_to + possible_duplicate edges on every remember()
- /graph API (#408): JSON endpoint for graph visualization

**Chunking:**
- Markdown/prose chunker (#405): heading-aware splitting
- Embed-aware chunking (#407): chunk size derived from embedder token limit

**Server:**
- View-only API key (#409): dual-role token model (admin + read-only)
- Configurable limits (#404): env var overrides

**Integration:**
- Hermes plugin room_remember (#410)

### Schema
v10 → v11 (document engine tables)

### Tests
295 unit tests passed. Clippy clean. Fmt clean.

**Milestone:** v0.3.0 — Graph RAG (11/11 issues closed)