### PR TITLE
fix: critical schema migration failure for existing databases (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.3.1] — 2026-06-21
+
+### Fixed
+
+- **Critical: schema migration failure for existing databases**
+  - DBs created with v0.2.x or earlier (schema v7) failed to open after
+    upgrading to v0.3.0. `CREATE INDEX ... ON memories(slug)` in the SCHEMA
+    constant was executed BEFORE migrations added the `slug` column.
+  - Fix: Split schema init into two phases. `SCHEMA` contains only
+    `CREATE TABLE` + safe indexes. `SCHEMA_INDEXES` (indexes on
+    migration-added columns) runs AFTER `ensure_schema_version()` completes.
+    Index creation is best-effort (errors logged, not fatal).
+  - The problematic indexes (`idx_memories_namespace`, `idx_memories_deprecated`,
+    `idx_memories_slug`) are now created post-migration.
+
 ## [0.3.0] — 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,11 +14,11 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3" }
+uteke-core = { path = "../uteke-core", version = "0.3.1" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 dirs = "6"
 toml = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -221,7 +221,7 @@ fn init_hermes(json: bool) -> Result<(), String> {
         .map_err(|e| format!("Failed to write __init__.py: {e}"))?;
 
     // plugin.yaml — Hermes plugin manifest.
-    let plugin_yaml = "name: uteke-tool\ndescription: Semantic memory recall and storage via uteke — includes room operations\nversion: 0.3.0\nauthor: CodeCoraDev\nactions:\n  - uteke\n";
+    let plugin_yaml = "name: uteke-tool\ndescription: Semantic memory recall and storage via uteke — includes room operations\nversion: 0.3.1\nauthor: CodeCoraDev\nactions:\n  - uteke\n";
     std::fs::write(plugin_dir.join("plugin.yaml"), plugin_yaml)
         .map_err(|e| format!("Failed to write plugin.yaml: {e}"))?;
 

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -3,7 +3,7 @@
 use crate::Error;
 use rusqlite::{params, OptionalExtension};
 
-use super::store::{CURRENT_SCHEMA_VERSION, SCHEMA};
+use super::store::{CURRENT_SCHEMA_VERSION, SCHEMA, SCHEMA_INDEXES};
 
 impl super::Store {
     /// Run initial schema creation + legacy column migrations.
@@ -24,13 +24,6 @@ impl super::Store {
                 )
                 .map_err(|e| Error::db("database operation", e))?;
         }
-
-        // Create namespace index (safe after column exists)
-        self.conn
-            .execute_batch(
-                "CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);",
-            )
-            .map_err(|e| Error::db("database operation", e))?;
 
         // Migration: add access tracking columns
         if !self.column_exists("access_count") {
@@ -72,14 +65,18 @@ impl super::Store {
                 .map_err(|e| Error::db("database operation", e))?;
         }
 
-        // Create deprecation index
-        self.conn
-            .execute_batch(
-                "CREATE INDEX IF NOT EXISTS idx_memories_deprecated ON memories(deprecated);",
-            )
-            .map_err(|e| Error::db("database operation", e))?;
-
+        // Run versioned migrations (adds slug, source, source_type, etc.)
         self.ensure_schema_version()?;
+
+        // Create indexes on migration-added columns AFTER migrations complete.
+        // These are safe now — all columns exist regardless of original DB version.
+        for stmt in SCHEMA_INDEXES {
+            // Best-effort: ignore errors if index already exists or column
+            // somehow still missing (shouldn't happen after migrations).
+            if let Err(e) = self.conn.execute_batch(stmt) {
+                tracing::debug!("Schema index (best-effort): {stmt} → {e}");
+            }
+        }
 
         Ok(())
     }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -5,6 +5,8 @@ use crate::Error;
 use rusqlite::Connection;
 
 /// Schema SQL for initial table creation.
+/// Base schema — CREATE TABLE statements only.
+/// Indexes on migration-added columns are in SCHEMA_INDEXES, run after migrations.
 pub(super) const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS memories (
     id TEXT PRIMARY KEY,
@@ -60,8 +62,6 @@ CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_id);
 
 -- memory_edges: typed auto-wired edges between memories (v8, #346).
--- Populated by pattern extraction on remember(): [[slug]], @tag, ^id, >uuid,
--- and legacy metadata.relationships JSON.
 CREATE TABLE IF NOT EXISTS memory_edges (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     source_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
@@ -74,12 +74,7 @@ CREATE INDEX IF NOT EXISTS idx_memory_edges_source ON memory_edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_memory_edges_target ON memory_edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_memory_edges_type ON memory_edges(edge_type);
 
--- slug: short identifier for [[slug]] auto-linking (v8, #346).
--- Not globally unique — resolution picks the most recently updated match
--- (see Store::resolve_slug). Use a unique slug per namespace for deterministic links.
-CREATE INDEX IF NOT EXISTS idx_memories_slug ON memories(slug) WHERE slug IS NOT NULL;
-
--- v9: Timeline events log (#347). Append-only audit trail per memory.
+-- v9: Timeline events log (#347).
 CREATE TABLE IF NOT EXISTS timeline_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
@@ -91,8 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_timeline_memory ON timeline_events(memory_id);
 CREATE INDEX IF NOT EXISTS idx_timeline_type ON timeline_events(event_type);
 CREATE INDEX IF NOT EXISTS idx_timeline_created ON timeline_events(created_at);
 
--- v11: Document engine (#406). Wiki/knowledge base support.
--- Full markdown content lives in documents, chunked summaries → embeddings.
+-- v11: Document engine (#406).
 CREATE TABLE IF NOT EXISTS documents (
     id TEXT PRIMARY KEY,
     slug TEXT NOT NULL COLLATE NOCASE,
@@ -127,6 +121,15 @@ CREATE TABLE IF NOT EXISTS document_chunks (
 CREATE INDEX IF NOT EXISTS idx_doc_chunks_doc ON document_chunks(document_id);
 CREATE INDEX IF NOT EXISTS idx_doc_chunks_heading ON document_chunks(heading);
 "#;
+
+/// Indexes that depend on migration-added columns.
+/// Run AFTER migrations complete so columns like `slug` exist.
+/// Each statement is executed individually with error tolerance.
+pub(super) const SCHEMA_INDEXES: &[&str] = &[
+    "CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);",
+    "CREATE INDEX IF NOT EXISTS idx_memories_deprecated ON memories(deprecated);",
+    "CREATE INDEX IF NOT EXISTS idx_memories_slug ON memories(slug) WHERE slug IS NOT NULL;",
+];
 
 /// Current schema version. Increment when adding migrations.
 pub(super) const CURRENT_SCHEMA_VERSION: i32 = 11;

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3" }
+uteke-core = { path = "../uteke-core", version = "0.3.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,14 +14,14 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.3" }
+uteke-core = { path = "../uteke-core", version = "0.3.1" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.3.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"
 tiny_http = "0.12"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 ctrlc = "3"
 uuid = "1"
 sha2 = "0.11"


### PR DESCRIPTION
## Critical Fix

**Bug:** DBs created with v0.2.x or earlier (schema ≤v7) failed to open after upgrading to v0.3.0. `CREATE INDEX ... ON memories(slug)` in the SCHEMA constant was executed BEFORE migrations added the `slug` column.

**Impact:** ALL existing users upgrading to v0.3.0 lose access to their data.

**Fix:** Split schema init into two phases:
1. `SCHEMA`: CREATE TABLE + safe indexes
2. `SCHEMA_INDEXES`: indexes on migration-added columns — run AFTER `ensure_schema_version()` completes

Index creation is best-effort (errors logged, not fatal).

**Verified:** Old DB (schema v7) now migrates v7→v8→v9→v10→v11 cleanly. Memory list, recall, edges, document create/list all work.

Version bump 0.3.0 → 0.3.1.