### PR TITLE
docs: sync v0.3.1 documentation to main

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.2.1-green.svg" alt="v0.2.1" />
+  <img src="https://img.shields.io/badge/status-v0.3.1-green.svg" alt="v0.3.1" />
 </p>
 
 <p align="center">
@@ -88,6 +88,11 @@ AI agent melupakan semua hal antar sesi. Uteke memberikan mereka memori persiste
 - 🔍 **Orphan Detection** — Temukan memori terputus dengan importance rendah
 - 📎 **Citations** — Atribusi sumber pada setiap memori (URL, file, user, import)
 - 🔌 **MCP Server** — JSON-RPC via stdio + Streamable HTTP transport
+- 📝 **Document Engine** — Wiki/knowledge base dengan `uteke doc create/get/list` + auto-chunking
+- 🤖 **Cosine Auto-Linking** — Otomatis membuat edge `similar_to` antar memory terkait
+- 🌐 **Graph API** — Endpoint `GET /graph` mengembalikan nodes + edges JSON untuk visualisasi
+- 🔑 **View-Only API Keys** — Token read-only untuk akses GET saja ke server
+- 📄 **Markdown Chunker** — Membagi dokumen berdasarkan heading, respect code block dan token limit
 - 📥 **Import/Export** — Backup dan restore berbasis JSONL
 
 📖 [Dokumentasi lengkap](docs/getting-started.md) · [Referensi CLI](docs/cli-reference.md) · [Konfigurasi](docs/configuration.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.2.1-green.svg" alt="v0.2.1" />
+  <img src="https://img.shields.io/badge/status-v0.3.1-green.svg" alt="v0.3.1" />
 </p>
 
 <p align="center">
@@ -96,6 +96,11 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 - 🔍 **Orphan Detection** — Find disconnected, low-importance memories for cleanup
 - 📎 **Citations** — Source attribution on every memory (URL, file, user, import)
 - 🔌 **MCP Server** — JSON-RPC over stdio + Streamable HTTP transport
+- 📝 **Document Engine** — Wiki/knowledge base with `uteke doc create/get/list` and auto-chunking
+- 🤖 **Cosine Auto-Linking** — Automatically creates `similar_to` edges between related memories
+- 🌐 **Graph API** — `GET /graph` endpoint returns nodes + edges JSON for visualization
+- 🔑 **View-Only API Keys** — Read-only tokens for safe GET-only access to the server
+- 📄 **Markdown Chunker** — Splits documents by headings, respects code blocks and token limits
 
 📖 [Full documentation](docs/getting-started.md) · [CLI reference](docs/cli-reference.md) · [Configuration](docs/configuration.md)
 
@@ -105,7 +110,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (283 unit tests)
+cargo test --workspace         # Test (295 unit tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,3 +225,58 @@ Benchmarked on Oracle Cloud ARM (Ampere Altra), CPU-only, no GPU.
 | Embedder requires Mutex | Architectural | ONNX tokenizer internally uses `&mut self` |
 | Consolidate is O(n²) | Algorithm | Pairwise cosine — slow above 1K memories |
 | FTS5-only score is placeholder | Design | BM25 can't normalize to 0..1; actual ranking via RRF |
+
+## Document Engine (#406)
+
+Full markdown content → SQLite (`documents` table), chunked summaries → embeddings (`document_chunks`).
+
+### Schema (v11)
+
+```sql
+-- Full documents with unlimited content
+documents: id, slug, title, content, namespace, tags, metadata,
+           version, content_type, created_at, updated_at
+
+-- Chunked sections with per-chunk embeddings
+document_chunks: id, document_id, chunk_index, heading, content,
+                 embedding BLOB, char_start, char_end, tags
+```
+
+### Chunking Pipeline
+
+1. Document content → `chunk_markdown()` (#405) splits by headings
+2. Each chunk → `embedder.embed()` creates section-level embedding
+3. Chunks stored with heading, content, char offsets, embedding BLOB
+
+Chunk size derived from `embedder.max_seq_len()` (#407): ~4 chars per token.
+
+- ONNX (256 tokens): 1,024 chars/chunk
+- OpenAI (8191 tokens): 32,764 chars/chunk
+
+### Search Paths
+
+1. Direct ID/slug → SQLite PK → full content
+2. Semantic → embed query → ANN chunk search → resolve to document
+3. FTS5 → full text across all document content
+4. Graph → BFS from entity → connected documents
+
+## Cosine Auto-Linking (#401)
+
+After every `remember()`, the vector index is searched for the top-20 most similar memories:
+
+- Cosine ≥ 0.80 → `similar_to` edge
+- Cosine ≥ 0.92 → `possible_duplicate` edge
+
+Edges are namespace-scoped (no cross-namespace links). Best-effort: errors logged, never fail `remember()`.
+
+## Graph API (#408)
+
+`GET /graph` returns all graph nodes, edges, and stats as JSON for visualization clients:
+
+```json
+{
+  "nodes": [{ "id": "...", "label": "...", "entity_type": "..." }],
+  "edges": [{ "source_id": "...", "target_id": "...", "relation": "..." }],
+  "stats": { "node_count": N, "edge_count": N }
+}
+```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.2.1**.
+Complete reference for all uteke commands. Version **0.3.1**.
 
 ## Global Flags
 
@@ -613,3 +613,106 @@ curl -X POST http://127.0.0.1:8767/mcp \
 ```
 
 Protocol version: `2025-06-18` (Streamable HTTP spec).
+
+## Document Commands (#406, #411)
+
+Wiki/knowledge base engine — full markdown documents with auto-chunking and semantic search.
+
+### `uteke doc create`
+
+Create or update a document from file, content, or stdin.
+
+```bash
+# From file
+uteke doc create architecture --file guide.md --tags wiki,tech
+
+# From inline content
+uteke doc create notes --content "# Notes\n\nQuick notes" --title "My Notes"
+
+# From stdin
+cat README.md | uteke doc create readme --file -
+```
+
+| Flag | Description |
+|------|-------------|
+| `--title <title>` | Document title (auto-derived from first `#` heading if omitted) |
+| `--file <path>` | Read content from file (`-` for stdin) |
+| `--content <text>` | Inline content (alternative to `--file`) |
+| `--tags <tags>` | Comma-separated tags |
+
+### `uteke doc get`
+
+Get a document by slug or ID.
+
+```bash
+uteke doc get architecture
+uteke doc get architecture --json
+```
+
+### `uteke doc list`
+
+List documents in the current namespace.
+
+```bash
+uteke doc list --limit 20
+```
+
+### `uteke doc delete`
+
+Delete a document by ID (cascades to chunks).
+
+```bash
+uteke doc delete <id>
+```
+
+### `uteke doc export`
+
+Export all documents as JSON or markdown.
+
+```bash
+uteke doc export           # markdown to stdout
+uteke doc export --json    # JSON to stdout
+```
+
+## Graph API (#408)
+
+The server exposes a graph visualization endpoint:
+
+```bash
+# All nodes + edges + stats
+curl http://127.0.0.1:8767/graph
+
+# Response: { nodes: [...], edges: [...], stats: {...} }
+```
+
+## Server Authentication (#409)
+
+Dual-role API token model:
+
+| Flag / Env | Role | Access |
+|------------|------|--------|
+| `--auth-token` / `UTEKE_AUTH_TOKEN` | Admin | All endpoints (GET, POST, DELETE) |
+| `--read-only-token` / `UTEKE_READ_ONLY_TOKEN` | ReadOnly | GET endpoints only (403 on writes) |
+
+```bash
+# Start with dual tokens
+uteke-serve --auth-token admin-secret --read-only-token viewer-key
+
+# Read-only client (GET only)
+curl -H "Authorization: Bearer viewer-key" http://127.0.0.1:8767/stats
+
+# Write attempt fails
+curl -X POST -H "Authorization: Bearer viewer-key" ...  # 403 Forbidden
+```
+
+## Configurable Limits (#404)
+
+All limits can be overridden via env vars or `[limits]` config section:
+
+| Env Var | Config Key | Default | Description |
+|---------|-----------|---------|-------------|
+| `UTEKE_MAX_CONTENT_LENGTH` | `max_content_length` | 100000 | Max memory content (chars, 0=disable) |
+| `UTEKE_MAX_TAGS_COUNT` | `max_tags_count` | 20 | Max tags per memory |
+| `UTEKE_MAX_TAG_LENGTH` | `max_tag_length` | 50 | Max single tag length (chars) |
+| `UTEKE_MAX_PAYLOAD_SIZE` | `max_payload_size` | 10485760 | Max server payload (bytes) |
+| `UTEKE_DEFAULT_RECALL_LIMIT` | `default_recall_limit` | 5 | Default recall limit |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,3 +301,48 @@ Logs are written to `~/.uteke/logs/uteke.log` with daily rotation:
 ```
 
 Non-blocking async writer — logging never blocks memory operations. Rotated files are kept until manually deleted.
+
+## Configurable Limits (#404)
+
+All hardcoded limits can be overridden via env vars or the `[limits]` section:
+
+```toml
+[limits]
+max_content_length = 100000   # Max memory content (chars). 0 = disable
+max_tags_count = 20           # Max tags per memory
+max_tag_length = 50           # Max single tag length (chars)
+max_payload_size = 10485760   # Max server payload (bytes, default 10MB)
+default_recall_limit = 5      # Default recall limit
+```
+
+Environment variables override config values:
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `UTEKE_MAX_CONTENT_LENGTH` | 100000 | Max memory content length |
+| `UTEKE_MAX_TAGS_COUNT` | 20 | Max tags per memory |
+| `UTEKE_MAX_TAG_LENGTH` | 50 | Max tag length |
+| `UTEKE_MAX_PAYLOAD_SIZE` | 10485760 | Max server payload |
+| `UTEKE_DEFAULT_RECALL_LIMIT` | 5 | Default recall limit |
+
+## View-Only API Token (#409)
+
+The server supports dual-role authentication:
+
+```toml
+[server]
+enabled = true
+host = "127.0.0.1"
+port = 8767
+```
+
+```bash
+# Start with admin + read-only tokens
+uteke-serve --auth-token admin-secret --read-only-token viewer-key
+
+# Or via env vars
+UTEKE_AUTH_TOKEN=admin-secret UTEKE_READ_ONLY_TOKEN=viewer-key uteke-serve
+```
+
+Read-only tokens can only access GET endpoints (recall, search, list, stats, graph, health).
+POST/DELETE operations return `403 Forbidden`.

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -18,7 +18,7 @@ Hermes Agent
 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
-### 2. Auto-install Hermes plugin (v0.2.1+)
+### 2. Auto-install Hermes plugin (v0.3.0+)
 
 ```bash
 uteke init --agent hermes
@@ -63,12 +63,13 @@ uteke(action="forget", id="abc12345")
 uteke(action="stats")
 ```
 
-### Room Operations (v0.2.1+, #395)
+### Room Operations (v0.3.0+, #395, #410)
 
 Rooms enable multi-agent collaborative memory — multiple agents share a room and contribute memories with author attribution.
 
 ```python
 # Create a shared room
+uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 uteke(action="room_create", room_id="sprint-planning", title="Sprint Planning")
 
 # Add a memory to a room (use remember with room_id)
@@ -117,6 +118,7 @@ The MCP server provides the same tools via JSON-RPC (protocol version `2025-06-1
 | `list` | List memories |
 | `forget` | Delete memory |
 | `stats` | Store statistics |
+| `room_remember` | Store memory in a room with author |
 | `room_create` | Create a room |
 | `room_recall` | Recall from a room |
 | `room_list` | List all rooms |
@@ -150,6 +152,6 @@ The MCP server provides the same tools via JSON-RPC (protocol version `2025-06-1
 
 ## Requirements
 
-- uteke v0.2.1+ (includes `uteke-mcp` binary)
+- uteke v0.3.0+ (includes `uteke-mcp` binary)
 - `uteke-serve` running (daemon mode)
 - Python 3.7+ (stdlib only — no pip install needed)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,26 @@ title: Roadmap
 
 Demand-gated — we build what people actually use. Track progress on [GitHub Issues](https://github.com/codecoradev/uteke/issues).
 
+## v0.3.0 — Graph RAG `✓ Released 2026-06-21`
+
+- [#401 Cosine auto-linking + dedup](https://github.com/codecoradev/uteke/issues/401) `✓ Done`
+  - `similar_to` (≥0.80) and `possible_duplicate` (≥0.92) edges
+- [#404 Configurable limits](https://github.com/codecoradev/uteke/issues/404) `✓ Done`
+  - Env vars + `[limits]` config section
+- [#405 Markdown/prose chunker](https://github.com/codecoradev/uteke/issues/405) `✓ Done`
+  - Heading-aware splitting, code block protection
+- [#406 Document engine](https://github.com/codecoradev/uteke/issues/406) `✓ Done`
+  - Wiki/knowledge base, schema v11, documents + document_chunks
+- [#407 Embed-aware chunking](https://github.com/codecoradev/uteke/issues/407) `✓ Done`
+  - Chunk size from `embedder.max_seq_len()`
+- [#408 /graph API endpoint](https://github.com/codecoradev/uteke/issues/408) `✓ Done`
+  - Nodes + edges JSON for visualization
+- [#409 View-only API key](https://github.com/codecoradev/uteke/issues/409) `✓ Done`
+  - Dual-role tokens (admin + read-only)
+- [#410 Hermes plugin room_remember](https://github.com/codecoradev/uteke/issues/410) `✓ Done`
+- [#411 Document CLI commands](https://github.com/codecoradev/uteke/issues/411) `✓ Done`
+  - `uteke doc create/get/list/delete/export`
+
 ## v0.2.1 — DX & Ecosystem `✓ Released 2026-06-21`
 
 - [#337 OpenAI + Ollama embedding backends](https://github.com/codecoradev/uteke/issues/337) `✓ Done`


### PR DESCRIPTION
Sync updated docs (v0.3.1 features) to main for website deployment.