### PR TITLE
release: v0.3.2 — schema migration hardening

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.3.1
+- **Version:** 0.3.2
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -89,7 +89,7 @@ crates/uteke-server/src/
 ### Schema Versioning
 
 - `schema_version` table with integer counter
-- Current: **v7** (knowledge graph tables)
+- Current: **v11** (document engine + knowledge graph + timeline + citations)
 - Auto-migration on upgrade, zero data loss
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.3.2] — 2026-06-22
+
+### Fixed
+
+- **Harden schema migrations for partially-migrated databases** (#435)
+  - `migrate_v9_to_v10` now uses `column_exists()` guard before `ALTER TABLE
+    ADD COLUMN` for `source` and `source_type`. Prevents "duplicate column
+    name" crash on databases that were partially migrated by a buggy binary
+    (e.g. v0.3.0 which ran SCHEMA_INDEXES before migrations).
+  - `migrate_v7_to_v8` now creates `idx_memories_slug` index as a separate
+    statement instead of inside `execute_batch`, producing clearer error
+    messages on failure.
+
+### Docs
+
+- Added detailed documentation checklist to AGENT.md release process (#434).
+
 ## [0.3.1] — 2026-06-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.3.1-green.svg" alt="v0.3.1" />
+  <img src="https://img.shields.io/badge/status-v0.3.2-green.svg" alt="v0.3.2" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.1" }
+uteke-core = { path = "../uteke-core", version = "0.3.2" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.1" }
+uteke-core = { path = "../uteke-core", version = "0.3.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.1" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.3.1" }
+uteke-core = { path = "../uteke-core", version = "0.3.2" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.3.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.3.1**.
+Complete reference for all uteke commands. Version **0.3.2**.
 
 ## Global Flags
 


### PR DESCRIPTION
## Summary

Bump version from 0.3.1 → 0.3.2 with documentation updates.

### Changes
- **Cargo.toml**: version bump across workspace + all inter-crate deps
- **CHANGELOG.md**: new  entry documenting #435 (migration hardening) and #434 (docs checklist)
- **AGENT.md**: version 0.3.1 → 0.3.2, schema version v7 → v11
- **README.md**: badge update
- **docs/cli-reference.md**: version update

### What's in this release
- #435: Harden schema migrations — `column_exists()` guard in `migrate_v9_to_v10`, separated slug index creation
- #434: Documentation checklist for release process

### Files changed
8 files, +26 -9