### PR TITLE
sync: develop -> main for v0.3.2 release

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.2.0
+- **Version:** 0.3.1
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -249,8 +249,15 @@ Principle: **Red CI = there's a problem. Investigate first, don't assume.**
 
 Before tagging:
 1. All PRs for the version must be merged to develop
-2. Docs updated (CHANGELOG, README, cli-reference, roadmap)
-3. Version bumped in Cargo.toml + inter-crate deps
+2. **Documentation MUST be updated first — no exceptions:**
+   - `README.md` + `README.id.md` — badge version, new features list
+   - `CHANGELOG.md` — new `[X.Y.Z]` section with all changes
+   - `docs/cli-reference.md` — new commands, flags, API endpoints
+   - `docs/configuration.md` — new config sections, env vars
+   - `docs/architecture.md` — new subsystems, schema changes
+   - `docs/roadmap.md` — milestone section with closed issues
+   - `docs/integrations/hermes.md` — plugin changes if applicable
+3. Version bumped in `Cargo.toml` + inter-crate deps + `plugin.yaml`
 4. develop → main merged via PR
 5. `cargo publish --dry-run` passes locally
 6. Get approval from project owner
@@ -414,7 +421,7 @@ docs: update CLI reference for metadata flags
 # Build
 cargo build --workspace
 
-# Test (108 unit tests)
+# Test (295 unit tests)
 cargo test --workspace
 
 # Format + Lint

--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.3.1
+- **Version:** 0.3.2
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -89,7 +89,7 @@ crates/uteke-server/src/
 ### Schema Versioning
 
 - `schema_version` table with integer counter
-- Current: **v7** (knowledge graph tables)
+- Current: **v11** (document engine + knowledge graph + timeline + citations)
 - Auto-migration on upgrade, zero data loss
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.3.2] — 2026-06-22
+
+### Fixed
+
+- **Harden schema migrations for partially-migrated databases** (#435)
+  - `migrate_v9_to_v10` now uses `column_exists()` guard before `ALTER TABLE
+    ADD COLUMN` for `source` and `source_type`. Prevents "duplicate column
+    name" crash on databases that were partially migrated by a buggy binary
+    (e.g. v0.3.0 which ran SCHEMA_INDEXES before migrations).
+  - `migrate_v7_to_v8` now creates `idx_memories_slug` index as a separate
+    statement instead of inside `execute_batch`, producing clearer error
+    messages on failure.
+
+### Docs
+
+- Added detailed documentation checklist to AGENT.md release process (#434).
+
 ## [0.3.1] — 2026-06-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.3.1-green.svg" alt="v0.3.1" />
+  <img src="https://img.shields.io/badge/status-v0.3.2-green.svg" alt="v0.3.2" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.1" }
+uteke-core = { path = "../uteke-core", version = "0.3.2" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -397,10 +397,18 @@ impl super::Store {
                 CREATE INDEX IF NOT EXISTS idx_memory_edges_source ON memory_edges(source_id);
                 CREATE INDEX IF NOT EXISTS idx_memory_edges_target ON memory_edges(target_id);
                 CREATE INDEX IF NOT EXISTS idx_memory_edges_type ON memory_edges(edge_type);
-                CREATE INDEX IF NOT EXISTS idx_memories_slug ON memories(slug) WHERE slug IS NOT NULL;
                 "#,
             )
             .map_err(|e| Error::db("schema migration v7 to v8", e))?;
+
+        // Slug index — hard failure since slug column was just added above.
+        // If this somehow fails, the migration must not proceed (slug lookups
+        // would break without the index on a non-trivial dataset).
+        self.conn
+            .execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_memories_slug ON memories(slug) WHERE slug IS NOT NULL;",
+            )
+            .map_err(|e| Error::db("schema migration v7 to v8 (slug index)", e))?;
 
         // Backfill edges from legacy metadata.relationships JSON.
         // Shape: { "relationships": [{ "type": "supersedes", "target": "<uuid>" }, ...] }
@@ -487,14 +495,23 @@ impl super::Store {
     /// `source_type = 'unknown'` (legacy data without source info).
     fn migrate_v9_to_v10(&self) -> Result<(), Error> {
         tracing::info!("Applying schema migration v9 to v10: source columns");
-        self.conn
-            .execute_batch(
-                r#"
-                ALTER TABLE memories ADD COLUMN source TEXT;
-                ALTER TABLE memories ADD COLUMN source_type TEXT NOT NULL DEFAULT 'unknown';
-                "#,
-            )
-            .map_err(|e| Error::db("schema migration v9 to v10", e))?;
+        // Guard with column_exists to handle partially-migrated databases
+        // (e.g. fresh v0.3.0 DBs that already have these columns via SCHEMA).
+        if !self.column_exists("source") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN source TEXT;")
+                .map_err(|e| Error::db("schema migration v9 to v10", e))?;
+        }
+        if !self.column_exists("source_type") {
+            // NOTE: DEFAULT 'unknown' for migrated rows — these are legacy
+            // memories without source info. Fresh rows (via SCHEMA) use
+            // DEFAULT 'user' since the code always sets source_type explicitly.
+            self.conn
+                .execute_batch(
+                    "ALTER TABLE memories ADD COLUMN source_type TEXT NOT NULL DEFAULT 'unknown';",
+                )
+                .map_err(|e| Error::db("schema migration v9 to v10", e))?;
+        }
         Ok(())
     }
 

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.1" }
+uteke-core = { path = "../uteke-core", version = "0.3.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.1" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.3.1" }
+uteke-core = { path = "../uteke-core", version = "0.3.2" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.3.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.3.1**.
+Complete reference for all uteke commands. Version **0.3.2**.
 
 ## Global Flags
 


### PR DESCRIPTION
Sync develop to main for v0.3.2 tag + release.

Commits included:
- 86aec90 release: v0.3.2 — schema migration hardening
- 39f4bbe fix: harden schema migrations for partially-migrated databases (#435)
- ab4b712 docs: add detailed documentation checklist to AGENT.md release process (#434)

Release workflow will be triggered by v0.3.2 tag after merge.