### PR TITLE
feat: hierarchical documents with depth-10 tree engine + doc_search (#438 #440)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "serde",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -433,6 +433,17 @@ pub enum DocCommands {
         #[arg(long, default_value = "50")]
         limit: usize,
     },
+    /// Search documents by query (semantic + FTS5)
+    Search {
+        /// Search query
+        query: String,
+        /// Maximum results
+        #[arg(long, default_value = "10")]
+        limit: usize,
+        /// Search mode: semantic, fts, or hybrid (default)
+        #[arg(long, default_value = "hybrid")]
+        mode: String,
+    },
     /// Delete a document by ID (cascades to children, #438)
     Delete {
         /// Document ID

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -364,7 +364,7 @@ pub enum Commands {
     },
 }
 
-/// Document subcommands (#411).
+/// Document subcommands (#411, #438).
 #[derive(Subcommand)]
 pub enum DocCommands {
     /// Create or update a document from a file or stdin
@@ -383,6 +383,9 @@ pub enum DocCommands {
         /// Tags (comma-separated)
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
+        /// Parent document slug (for hierarchical documents, #438)
+        #[arg(long)]
+        parent: Option<String>,
     },
     /// Get a document by slug or ID
     Get {
@@ -394,8 +397,43 @@ pub enum DocCommands {
         /// Maximum results
         #[arg(long, default_value = "20")]
         limit: usize,
+        /// Show as tree hierarchy (#438)
+        #[arg(long)]
+        tree: bool,
     },
-    /// Delete a document by ID
+    /// List children of a document (#438)
+    Children {
+        /// Parent document slug or ID
+        parent: String,
+        /// Maximum results
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
+    /// Move a document to a new parent or root (#438)
+    Move {
+        /// Document slug or ID to move
+        id_or_slug: String,
+        /// New parent document slug (omit to move to root)
+        #[arg(long)]
+        parent: Option<String>,
+    },
+    /// Show breadcrumb path from root to a document (#438)
+    Breadcrumbs {
+        /// Document slug or ID
+        id_or_slug: String,
+    },
+    /// List all descendants of a document (#438)
+    Descendants {
+        /// Document slug or ID
+        id_or_slug: String,
+        /// Maximum depth (0 = unlimited)
+        #[arg(long, default_value = "0")]
+        max_depth: u32,
+        /// Maximum results
+        #[arg(long, default_value = "50")]
+        limit: usize,
+    },
+    /// Delete a document by ID (cascades to children, #438)
     Delete {
         /// Document ID
         id: String,

--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -308,7 +308,7 @@ pub(crate) fn run(
 
         DocCommands::Delete { id } => {
             let (deleted, subtree_size) = uteke
-                .doc_delete(id)
+                .doc_delete(id, ns)
                 .map_err(|e| format!("Failed to delete document: {e}"))?;
             if deleted {
                 if cli.json {

--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -1,4 +1,4 @@
-//! Document CLI commands (#411).
+//! Document CLI commands (#411, #438).
 
 use crate::cli::{Cli, DocCommands};
 use crate::output;
@@ -22,6 +22,7 @@ pub(crate) fn run(
             file,
             content,
             tags,
+            parent,
         } => {
             // Get content from --content, --file, or stdin.
             let doc_content = if let Some(c) = content {
@@ -52,16 +53,24 @@ pub(crate) fn run(
             });
 
             let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+            let parent_ref = parent.as_deref();
             let id = uteke
-                .doc_upsert(slug, &doc_title, &doc_content, &tag_refs, ns)
+                .doc_upsert_with_parent(slug, &doc_title, &doc_content, &tag_refs, ns, parent_ref)
                 .map_err(|e| format!("Failed to create document: {e}"))?;
 
             if cli.json {
-                println!("{{\"id\": \"{id}\", \"slug\": \"{slug}\", \"status\": \"created\"}}");
+                let parent_json = parent
+                    .as_ref()
+                    .map(|p| format!(r#", "parent": "{p}""#))
+                    .unwrap_or_default();
+                println!(r#"{{"id": "{id}", "slug": "{slug}"{parent_json}, "status": "created"}}"#);
             } else {
-                println!("\u{2713} Document '{slug}' created (id: {id})");
+                println!("✓ Document '{slug}' created (id: {id})");
                 println!("  Title: {doc_title}");
                 println!("  Size:  {} chars", doc_content.len());
+                if let Some(p) = parent {
+                    println!("  Parent: {p}");
+                }
             }
         }
 
@@ -74,9 +83,12 @@ pub(crate) fn run(
                     if cli.json {
                         output::print_json(&d);
                     } else {
-                        println!("Title: {}", d.title);
+                        println!("Title: {} (depth: {})", d.title, d.depth);
                         println!("Slug:  {}", d.slug);
                         println!("v{} | {} | {}", d.version, d.content_type, d.updated_at);
+                        if let Some(ref pid) = d.parent_id {
+                            println!("Parent: {pid}");
+                        }
                         if !d.tags.is_empty() {
                             println!("Tags:  {}", d.tags.join(", "));
                         }
@@ -90,17 +102,88 @@ pub(crate) fn run(
             }
         }
 
-        DocCommands::List { limit } => {
-            let docs = uteke
-                .doc_list(ns, *limit)
-                .map_err(|e| format!("Failed to list documents: {e}"))?;
+        DocCommands::List { limit, tree } => {
+            let docs = if *tree {
+                uteke
+                    .doc_list_roots(ns, *limit)
+                    .map_err(|e| format!("Failed to list root documents: {e}"))?
+            } else {
+                uteke
+                    .doc_list(ns, *limit)
+                    .map_err(|e| format!("Failed to list documents: {e}"))?
+            };
             if cli.json {
                 output::print_json(&docs);
             } else if docs.is_empty() {
                 println!("No documents found.");
             } else {
-                println!("Documents");
-                println!("─────────────────────────────────────────────────────");
+                if *tree {
+                    // Print tree structure.
+                    let indent = "  ";
+                    let mut stack: Vec<(String, usize)> = docs
+                        .iter()
+                        .map(|d| (d.id.clone(), 0))
+                        .collect();
+                    while let Some((current_id, current_depth)) = stack.pop() {
+                        let children = uteke
+                            .doc_list_children(&current_id, ns, 1000)
+                            .unwrap_or_default();
+                        let prefix: String = indent.repeat(current_depth);
+                        if let Some(parent) = docs.iter().find(|d| d.id == current_id) {
+                            let tree_char = if children.is_empty() { "├─" } else { "┬─" };
+                            println!(
+                                "{prefix}{tree_char} {:<20} {:<30} v{}",
+                                &parent.slug[..parent.slug.len().min(20)],
+                                &parent.title[..parent.title.len().min(30)],
+                                parent.version
+                            );
+                        }
+                        for child in children.into_iter().rev() {
+                            stack.push((child.id, current_depth + 1));
+                        }
+                    }
+                } else {
+                    println!("Documents");
+                    println!(
+                        "─────────────────────────────────────────────────────"
+                    );
+                    for d in &docs {
+                        let depth_indicator = if d.depth > 0 {
+                            format!("  {}", "›".repeat(d.depth as usize))
+                        } else {
+                            String::new()
+                        };
+                        println!(
+                            "  {:<20} {:<30} v{}  {}{}",
+                            &d.slug[..d.slug.len().min(20)],
+                            &d.title[..d.title.len().min(30)],
+                            d.version,
+                            &d.updated_at[..10],
+                            depth_indicator
+                        );
+                    }
+                }
+                println!();
+                println!("{} document(s)", docs.len());
+            }
+        }
+
+        DocCommands::Children {
+            parent,
+            limit,
+        } => {
+            let docs = uteke
+                .doc_list_children(parent, ns, *limit)
+                .map_err(|e| format!("Failed to list children: {e}"))?;
+            if cli.json {
+                output::print_json(&docs);
+            } else if docs.is_empty() {
+                println!("No children for '{parent}'.");
+            } else {
+                println!("Children of '{parent}'");
+                println!(
+                    "─────────────────────────────────────────────────────"
+                );
                 for d in &docs {
                     println!(
                         "  {:<20} {:<30} v{}  {}",
@@ -111,19 +194,106 @@ pub(crate) fn run(
                     );
                 }
                 println!();
-                println!("{} document(s)", docs.len());
+                println!("{} child(ren)", docs.len());
+            }
+        }
+
+        DocCommands::Move {
+            id_or_slug,
+            parent,
+        } => {
+            let new_parent = parent.as_deref();
+            let affected = uteke
+                .doc_move(id_or_slug, new_parent, ns)
+                .map_err(|e| format!("Failed to move document: {e}"))?;
+            if cli.json {
+                println!(
+                    r#"{{"moved": "{id_or_slug}", "parent": "{}", "affected": {affected}}}"#,
+                    new_parent.unwrap_or("(root)")
+                );
+            } else {
+                let dest = new_parent.unwrap_or("(root)");
+                println!("✓ Moved '{id_or_slug}' → {dest}");
+                println!("  {affected} document(s) updated");
+            }
+        }
+
+        DocCommands::Breadcrumbs { id_or_slug } => {
+            let crumbs = uteke
+                .doc_breadcrumbs(id_or_slug, ns)
+                .map_err(|e| format!("Failed to get breadcrumbs: {e}"))?;
+            if cli.json {
+                output::print_json(&crumbs);
+            } else if crumbs.is_empty() {
+                println!("No breadcrumbs found (root document).");
+            } else {
+                println!("Path to '{id_or_slug}'");
+                println!(
+                    "─────────────────────────────────────────────────────"
+                );
+                for (i, d) in crumbs.iter().enumerate() {
+                    let connector = if i == crumbs.len() - 1 {
+                        "└─"
+                    } else {
+                        "├─"
+                    };
+                    println!("  {connector} {} (depth: {})", d.slug, d.depth);
+                }
+            }
+        }
+
+        DocCommands::Descendants {
+            id_or_slug,
+            max_depth,
+            limit,
+        } => {
+            let max = if *max_depth == 0 {
+                None
+            } else {
+                Some(*max_depth as i64)
+            };
+            let docs = uteke
+                .doc_list_descendants(id_or_slug, ns, max, *limit)
+                .map_err(|e| format!("Failed to list descendants: {e}"))?;
+            if cli.json {
+                output::print_json(&docs);
+            } else if docs.is_empty() {
+                println!("No descendants for '{id_or_slug}'.");
+            } else {
+                println!("Descendants of '{id_or_slug}'");
+                println!(
+                    "─────────────────────────────────────────────────────"
+                );
+                for d in &docs {
+                    let indent = "  ".repeat(d.depth as usize);
+                    println!(
+                        "{indent}{:<20} {:<30} d{}",
+                        &d.slug[..d.slug.len().min(20)],
+                        &d.title[..d.title.len().min(30)],
+                        d.depth
+                    );
+                }
+                println!();
+                println!("{} descendant(s)", docs.len());
             }
         }
 
         DocCommands::Delete { id } => {
-            let deleted = uteke
+            let (deleted, subtree_size) = uteke
                 .doc_delete(id)
                 .map_err(|e| format!("Failed to delete document: {e}"))?;
             if deleted {
                 if cli.json {
-                    println!("{{\"deleted\": \"{id}\"}}");
+                    println!(
+                        r#"{{"deleted": "{id}", "subtree_size": {subtree_size}}}"#
+                    );
                 } else {
-                    println!("\u{2713} Document deleted: {id}");
+                    println!("✓ Document deleted: {id}");
+                    if subtree_size > 1 {
+                        println!(
+                            "  {subtree_size} document(s) removed (cascade)"
+                        );
+                    }
                 }
             } else {
                 return Err(format!("Document not found: {id}"));

--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -120,17 +120,19 @@ pub(crate) fn run(
                 if *tree {
                     // Print tree structure.
                     let indent = "  ";
-                    let mut stack: Vec<(String, usize)> = docs
-                        .iter()
-                        .map(|d| (d.id.clone(), 0))
-                        .collect();
+                    let mut stack: Vec<(String, usize)> =
+                        docs.iter().map(|d| (d.id.clone(), 0)).collect();
                     while let Some((current_id, current_depth)) = stack.pop() {
                         let children = uteke
                             .doc_list_children(&current_id, ns, 1000)
                             .unwrap_or_default();
                         let prefix: String = indent.repeat(current_depth);
                         if let Some(parent) = docs.iter().find(|d| d.id == current_id) {
-                            let tree_char = if children.is_empty() { "├─" } else { "┬─" };
+                            let tree_char = if children.is_empty() {
+                                "├─"
+                            } else {
+                                "┬─"
+                            };
                             println!(
                                 "{prefix}{tree_char} {:<20} {:<30} v{}",
                                 &parent.slug[..parent.slug.len().min(20)],
@@ -144,9 +146,7 @@ pub(crate) fn run(
                     }
                 } else {
                     println!("Documents");
-                    println!(
-                        "─────────────────────────────────────────────────────"
-                    );
+                    println!("─────────────────────────────────────────────────────");
                     for d in &docs {
                         let depth_indicator = if d.depth > 0 {
                             format!("  {}", "›".repeat(d.depth as usize))
@@ -168,10 +168,7 @@ pub(crate) fn run(
             }
         }
 
-        DocCommands::Children {
-            parent,
-            limit,
-        } => {
+        DocCommands::Children { parent, limit } => {
             let docs = uteke
                 .doc_list_children(parent, ns, *limit)
                 .map_err(|e| format!("Failed to list children: {e}"))?;
@@ -181,9 +178,7 @@ pub(crate) fn run(
                 println!("No children for '{parent}'.");
             } else {
                 println!("Children of '{parent}'");
-                println!(
-                    "─────────────────────────────────────────────────────"
-                );
+                println!("─────────────────────────────────────────────────────");
                 for d in &docs {
                     println!(
                         "  {:<20} {:<30} v{}  {}",
@@ -198,10 +193,7 @@ pub(crate) fn run(
             }
         }
 
-        DocCommands::Move {
-            id_or_slug,
-            parent,
-        } => {
+        DocCommands::Move { id_or_slug, parent } => {
             let new_parent = parent.as_deref();
             let affected = uteke
                 .doc_move(id_or_slug, new_parent, ns)
@@ -228,9 +220,7 @@ pub(crate) fn run(
                 println!("No breadcrumbs found (root document).");
             } else {
                 println!("Path to '{id_or_slug}'");
-                println!(
-                    "─────────────────────────────────────────────────────"
-                );
+                println!("─────────────────────────────────────────────────────");
                 for (i, d) in crumbs.iter().enumerate() {
                     let connector = if i == crumbs.len() - 1 {
                         "└─"
@@ -261,9 +251,7 @@ pub(crate) fn run(
                 println!("No descendants for '{id_or_slug}'.");
             } else {
                 println!("Descendants of '{id_or_slug}'");
-                println!(
-                    "─────────────────────────────────────────────────────"
-                );
+                println!("─────────────────────────────────────────────────────");
                 for d in &docs {
                     let indent = "  ".repeat(d.depth as usize);
                     println!(
@@ -284,15 +272,11 @@ pub(crate) fn run(
                 .map_err(|e| format!("Failed to delete document: {e}"))?;
             if deleted {
                 if cli.json {
-                    println!(
-                        r#"{{"deleted": "{id}", "subtree_size": {subtree_size}}}"#
-                    );
+                    println!(r#"{{"deleted": "{id}", "subtree_size": {subtree_size}}}"#);
                 } else {
                     println!("✓ Document deleted: {id}");
                     if subtree_size > 1 {
-                        println!(
-                            "  {subtree_size} document(s) removed (cascade)"
-                        );
+                        println!("  {subtree_size} document(s) removed (cascade)");
                     }
                 }
             } else {

--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -266,6 +266,50 @@ pub(crate) fn run(
             }
         }
 
+        DocCommands::Search {
+            query,
+            limit,
+            mode,
+        } => {
+            let results = uteke
+                .doc_search(query, ns, *limit, mode)
+                .map_err(|e| format!("Failed to search documents: {e}"))?;
+            if cli.json {
+                output::print_json(&results);
+            } else if results.is_empty() {
+                println!("No documents found for '{query}'.");
+            } else {
+                println!("Search results for '{query}' (mode: {mode})");
+                println!("─────────────────────────────────────────────────────");
+                for r in &results {
+                    let depth_indicator = if r.document.depth > 0 {
+                        format!("  {}", "›".repeat(r.document.depth as usize))
+                    } else {
+                        String::new()
+                    };
+                    println!(
+                        "  {:<20} {:<30} {:.3} {}",
+                        &r.document.slug[..r.document.slug.len().min(20)],
+                        &r.document.title[..r.document.title.len().min(30)],
+                        r.score,
+                        depth_indicator
+                    );
+                    if !r.chunk_heading.is_empty() {
+                        println!(
+                            "    ↳ {}",
+                            &r.chunk_heading[..r.chunk_heading.len().min(60)]
+                        );
+                    }
+                    if !r.chunk_snippet.is_empty() {
+                        let snippet = &r.chunk_snippet[..r.chunk_snippet.len().min(80)];
+                        println!("    \"{}\"", snippet);
+                    }
+                }
+                println!();
+                println!("{} result(s)", results.len());
+            }
+        }
+
         DocCommands::Delete { id } => {
             let (deleted, subtree_size) = uteke
                 .doc_delete(id)

--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -266,11 +266,7 @@ pub(crate) fn run(
             }
         }
 
-        DocCommands::Search {
-            query,
-            limit,
-            mode,
-        } => {
+        DocCommands::Search { query, limit, mode } => {
             let results = uteke
                 .doc_search(query, ns, *limit, mode)
                 .map_err(|e| format!("Failed to search documents: {e}"))?;

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -1276,7 +1276,7 @@ mod tests {
     fn migration_dispatcher_reaches_v8() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 11, "fresh store must reach CURRENT_SCHEMA_VERSION=11");
+        assert_eq!(v, 12, "fresh store must reach CURRENT_SCHEMA_VERSION=12");
 
         // memory_edges table must exist and be queryable after migration.
         let n = store.count_memory_edges().unwrap();

--- a/crates/uteke-core/src/error.rs
+++ b/crates/uteke-core/src/error.rs
@@ -64,6 +64,11 @@ impl Error {
         Error::Lock { context }
     }
 
+    /// Validation error — user input or business rule violation.
+    pub fn validation(msg: impl Into<String>) -> Self {
+        Error::Validation(msg.into())
+    }
+
     /// Generic error with a message.
     pub fn generic(msg: impl Into<String>) -> Self {
         Error::Generic(msg.into())

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -698,12 +698,13 @@ impl Uteke {
         })
     }
 
-    // ── Document engine (#406) ───────────────────────────────────────────
+    // ── Document engine (#406, #438) ────────────────────────────────────────
 
-    /// Create or update a document (#406).
+    /// Create or update a document (#406, #438).
     ///
     /// If the slug exists in the namespace, updates content and re-chunks.
     /// Chunks are created via the markdown chunker (#405) and embedded.
+    /// Optional parent slug for hierarchical documents.
     pub fn doc_upsert(
         &self,
         slug: &str,
@@ -712,14 +713,58 @@ impl Uteke {
         tags: &[&str],
         namespace: Option<&str>,
     ) -> Result<String, Error> {
+        self.doc_upsert_with_parent(slug, title, content, tags, namespace, None)
+    }
+
+    /// Create or update a document with optional parent (#438).
+    ///
+    /// If `parent_slug` is Some, the document is created as a child of that
+    /// parent document. Depth and path are computed automatically.
+    /// Max depth is 10 — returns error if exceeded.
+    pub fn doc_upsert_with_parent(
+        &self,
+        slug: &str,
+        title: &str,
+        content: &str,
+        tags: &[&str],
+        namespace: Option<&str>,
+        parent_slug: Option<&str>,
+    ) -> Result<String, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         let now = chrono::Utc::now().to_rfc3339();
+
+        // Resolve parent if specified.
+        let (parent_id, parent_path, parent_depth) = match parent_slug {
+            Some(ps) => {
+                let parent = self
+                    .store
+                    .get_document_by_slug(ps, ns)?
+                    .ok_or_else(|| Error::validation(format!("parent document '{ps}' not found")))?;
+                if parent.depth >= 9 {
+                    return Err(Error::Validation(
+                        "maximum document depth of 10 would be exceeded".into(),
+                    ));
+                }
+                (
+                    Some(parent.id.clone()),
+                    parent.path,
+                    parent.depth + 1,
+                )
+            }
+            None => (None, String::new(), 0),
+        };
 
         // Check if document exists to get current version.
         let existing = self.store.get_document_by_slug(slug, ns)?;
         let (id, version) = match &existing {
             Some(doc) => (doc.id.clone(), doc.version),
             None => (uuid::Uuid::new_v4().to_string(), 1),
+        };
+
+        let path = if let Some(ref pid) = parent_id {
+            format!("{}{}/", parent_path, id)
+        } else {
+            format!("/{}/", id)
         };
 
         let doc = Document {
@@ -734,6 +779,11 @@ impl Uteke {
             content_type: "markdown".to_string(),
             created_at: now.clone(),
             updated_at: now,
+            parent_id,
+            path,
+            depth: parent_depth,
+            sort_order: 0,
+            has_children: false,
         };
 
         let doc_id = self.store.upsert_document(&doc)?;
@@ -799,8 +849,86 @@ impl Uteke {
         self.store.list_documents(namespace, limit)
     }
 
-    /// Delete a document by ID.
-    pub fn doc_delete(&self, id: &str) -> Result<bool, Error> {
+    /// List root documents (no parent) in a namespace (#438).
+    pub fn doc_list_roots(
+        &self,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        self.store.list_root_documents(namespace, limit)
+    }
+
+    /// List children of a document (#438).
+    pub fn doc_list_children(
+        &self,
+        parent_id_or_slug: &str,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        // Resolve slug to ID first.
+        let parent_id = match self.store.get_document_by_slug(parent_id_or_slug, ns)? {
+            Some(doc) => doc.id,
+            None => parent_id_or_slug.to_string(),
+        };
+        self.store.list_document_children(&parent_id, limit)
+    }
+
+    /// List all descendants of a document (#438).
+    pub fn doc_list_descendants(
+        &self,
+        id_or_slug: &str,
+        namespace: Option<&str>,
+        max_depth: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        self.store.list_descendants(id_or_slug, ns, max_depth, limit)
+    }
+
+    /// Get breadcrumbs from root to a document (#438).
+    pub fn doc_breadcrumbs(
+        &self,
+        id_or_slug: &str,
+        namespace: Option<&str>,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        self.store.get_breadcrumbs(id_or_slug, ns)
+    }
+
+    /// Move a document to a new parent or root (#438).
+    pub fn doc_move(
+        &self,
+        id_or_slug: &str,
+        new_parent_slug: Option<&str>,
+        namespace: Option<&str>,
+    ) -> Result<usize, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let doc = self
+            .store
+            .get_document_by_slug(id_or_slug, ns)?
+            .or_else(|| self.store.get_document(id_or_slug).unwrap_or(None))
+            .ok_or_else(|| Error::validation("document not found for move"))?;
+
+        let new_parent_id = match new_parent_slug {
+            Some(ps) => {
+                let parent = self
+                    .store
+                    .get_document_by_slug(ps, ns)?
+                    .ok_or_else(|| Error::validation(&format!("parent document '{ps}' not found")))?;
+                Some(parent.id)
+            }
+            None => None,
+        };
+
+        let parent_id_ref = new_parent_id.as_deref();
+        self.store.move_document(&doc.id, parent_id_ref, None)
+    }
+
+    /// Delete a document by ID or slug (#438).
+    ///
+    /// Cascades to children and chunks. Returns (deleted, subtree_size).
+    pub fn doc_delete(&self, id: &str) -> Result<(bool, usize), Error> {
         self.store.delete_document(id)
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -736,20 +736,15 @@ impl Uteke {
         // Resolve parent if specified.
         let (parent_id, parent_path, parent_depth) = match parent_slug {
             Some(ps) => {
-                let parent = self
-                    .store
-                    .get_document_by_slug(ps, ns)?
-                    .ok_or_else(|| Error::validation(format!("parent document '{ps}' not found")))?;
+                let parent = self.store.get_document_by_slug(ps, ns)?.ok_or_else(|| {
+                    Error::validation(format!("parent document '{ps}' not found"))
+                })?;
                 if parent.depth >= 9 {
                     return Err(Error::Validation(
                         "maximum document depth of 10 would be exceeded".into(),
                     ));
                 }
-                (
-                    Some(parent.id.clone()),
-                    parent.path,
-                    parent.depth + 1,
-                )
+                (Some(parent.id.clone()), parent.path, parent.depth + 1)
             }
             None => (None, String::new(), 0),
         };
@@ -883,7 +878,8 @@ impl Uteke {
         limit: usize,
     ) -> Result<Vec<DocumentSummary>, Error> {
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        self.store.list_descendants(id_or_slug, ns, max_depth, limit)
+        self.store
+            .list_descendants(id_or_slug, ns, max_depth, limit)
     }
 
     /// Get breadcrumbs from root to a document (#438).
@@ -912,10 +908,9 @@ impl Uteke {
 
         let new_parent_id = match new_parent_slug {
             Some(ps) => {
-                let parent = self
-                    .store
-                    .get_document_by_slug(ps, ns)?
-                    .ok_or_else(|| Error::validation(&format!("parent document '{ps}' not found")))?;
+                let parent = self.store.get_document_by_slug(ps, ns)?.ok_or_else(|| {
+                    Error::validation(&format!("parent document '{ps}' not found"))
+                })?;
                 Some(parent.id)
             }
             None => None,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -783,16 +783,31 @@ impl Uteke {
 
         let doc_id = self.store.upsert_document(&doc)?;
 
+        // Delete old chunks on update (re-chunking).
+        let old_chunk_ids = self.store.delete_chunks_for_documents(&[doc_id.clone()])?;
+
         // Chunk and embed the content.
         self.ensure_embedder()?;
         let embedder = self
             .embedder
             .lock()
             .map_err(|_| Error::lock("embedder lock during document chunking"))?;
-        let embedder = embedder.as_ref().expect("embedder ensured");
+        let embedder = embedder.as_ref().expect("embedder ensured above");
 
         let max_chars = embedder.max_seq_len().saturating_mul(4).max(1024);
         let chunks = crate::chunker::chunk_markdown(content, max_chars);
+
+        // Acquire usearch write lock for chunk index inserts.
+        let mut index = self
+            .index
+            .write()
+            .map_err(|_| Error::lock("index write lock during doc chunking"))?;
+
+        // Remove old chunk entries from usearch.
+        for old_id in &old_chunk_ids {
+            let key = format!("chunk:{}", old_id);
+            index.remove(&key);
+        }
 
         for (i, chunk) in chunks.iter().enumerate() {
             let chunk_id = uuid::Uuid::new_v4().to_string();
@@ -800,7 +815,7 @@ impl Uteke {
 
             self.store.insert_document_chunk(
                 &DocumentChunk {
-                    id: chunk_id,
+                    id: chunk_id.clone(),
                     document_id: doc_id.clone(),
                     chunk_index: i as i64,
                     heading: chunk.heading.clone(),
@@ -811,6 +826,23 @@ impl Uteke {
                 },
                 &embedding,
             )?;
+
+            // Insert chunk embedding into usearch with "chunk:" prefix.
+            let index_key = format!("chunk:{}", chunk_id);
+            if let Err(e) = index.insert(&index_key, &embedding) {
+                tracing::warn!(
+                    "Failed to insert chunk {} into vector index: {}",
+                    chunk_id,
+                    e
+                );
+            }
+        }
+
+        if let Err(e) = index.save() {
+            tracing::warn!(
+                "Failed to persist vector index after doc chunking: {}",
+                e
+            );
         }
 
         tracing::info!(
@@ -923,8 +955,263 @@ impl Uteke {
     /// Delete a document by ID or slug (#438).
     ///
     /// Cascades to children and chunks. Returns (deleted, subtree_size).
+    /// Also removes chunk embeddings from usearch index.
     pub fn doc_delete(&self, id: &str) -> Result<(bool, usize), Error> {
-        self.store.delete_document(id)
+        // Collect all document IDs in the subtree before deletion.
+        let ns = DEFAULT_NAMESPACE;
+        let subtree = self
+            .store
+            .list_descendants(id, ns, None, 10000)
+            .unwrap_or_default();
+
+        // Get the main document ID too.
+        let main_id = match self.store.get_document(id)? {
+            Some(d) => d.id,
+            None => self
+                .store
+                .get_document_by_slug(id, ns)?
+                .map(|d| d.id)
+                .unwrap_or_default(),
+        };
+
+        let all_ids: Vec<String> = subtree
+            .iter()
+            .map(|d| d.id.clone())
+            .chain(std::iter::once(main_id.clone()))
+            .collect();
+
+        // Get chunk IDs to remove from usearch.
+        let chunk_ids = self
+            .store
+            .delete_chunks_for_documents(&all_ids)
+            .unwrap_or_default();
+
+        let (deleted, subtree_size) = self.store.delete_document(id)?;
+
+        // Remove chunk entries from usearch index.
+        if !chunk_ids.is_empty() {
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during doc delete"))?;
+            for chunk_id in &chunk_ids {
+                let key = format!("chunk:{}", chunk_id);
+                index.remove(&key);
+            }
+            let _ = index.save();
+        }
+
+        Ok((deleted, subtree_size))
+    }
+
+    /// Search documents using semantic (vector) and/or FTS5 (keyword) search.
+    ///
+    /// - **semantic**: embeds query, searches usearch index for chunk matches,
+    ///   then joins back to document metadata. Requires embedding model.
+    /// - **fts**: keyword search on title/slug via FTS5. Always available.
+    /// - **hybrid** (default): runs both, deduplicates by document ID, merges
+    ///   scores with reciprocal rank fusion (RRF).
+    pub fn doc_search(
+        &self,
+        query: &str,
+        namespace: Option<&str>,
+        limit: usize,
+        mode: &str,
+    ) -> Result<Vec<crate::memory::documents::DocumentSearchResult>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let limit = limit.min(50);
+
+        match mode {
+            "semantic" => self.doc_search_semantic(query, ns, limit),
+            "fts" => self.doc_search_fts(query, ns, limit),
+            _ => self.doc_search_hybrid(query, ns, limit),
+        }
+    }
+
+    fn doc_search_semantic(
+        &self,
+        query: &str,
+        ns: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::memory::documents::DocumentSearchResult>, Error> {
+        use crate::memory::documents::DocumentSearchResult;
+
+        self.ensure_embedder()?;
+        let query_embedding = self
+            .embedder
+            .lock()
+            .map_err(|_| Error::lock("embedder lock during doc search"))?
+            .as_ref()
+            .expect("embedder ensured above")
+            .embed(query)?;
+
+        let index = self
+            .index
+            .read()
+            .map_err(|_| Error::lock("index read lock during doc search"))?;
+
+        // Search usearch — request more candidates, filter chunk: prefixed results.
+        let k = (limit * 10).min(index.len()).max(1);
+        let candidates = index.search(&query_embedding, k, k * 4);
+
+        // Filter for chunk: prefixed IDs only.
+        let chunk_hits: Vec<(String, f32)> = candidates
+            .into_iter()
+            .filter(|(id, _)| id.starts_with("chunk:"))
+            .take(limit * 3)
+            .collect();
+
+        if chunk_hits.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Extract chunk IDs (strip "chunk:" prefix).
+        let chunk_ids: Vec<String> = chunk_hits.iter().map(|(id, _)| id[6..].to_string()).collect();
+
+        // Get chunk data from SQLite.
+        let chunks = self.store.get_chunks_by_ids(&chunk_ids)?;
+
+        // Build results: group by document, take best score per doc.
+        let mut doc_scores: std::collections::HashMap<String, (DocumentSummary, String, String, f32)> =
+            std::collections::HashMap::new();
+
+        for ((chunk_key, distance), (chunk_id, doc_id, heading, content)) in
+            chunk_hits.iter().zip(chunks.iter())
+        {
+            let score = crate::memory::vector::cosine_distance_to_similarity(*distance);
+
+            // Get document summary from store.
+            if let Ok(Some(doc)) = self.store.get_document(doc_id) {
+                let summary = crate::memory::documents::DocumentSummary {
+                    id: doc.id.clone(),
+                    slug: doc.slug.clone(),
+                    title: doc.title.clone(),
+                    namespace: doc.namespace.clone(),
+                    version: doc.version,
+                    updated_at: doc.updated_at.clone(),
+                    parent_id: doc.parent_id.clone(),
+                    depth: doc.depth,
+                    has_children: doc.has_children,
+                    sort_order: doc.sort_order,
+                };
+
+                // Keep best score per document.
+                let entry = doc_scores.entry(doc_id.clone());
+                entry
+                    .and_modify(|(_, h, s, old_score)| {
+                        if score > *old_score {
+                            *old_score = score;
+                            *h = heading.clone();
+                            *s = content.clone();
+                        }
+                    })
+                    .or_insert((summary, heading.clone(), content.clone(), score));
+            }
+        }
+
+        let mut results: Vec<DocumentSearchResult> = doc_scores
+            .into_values()
+            .map(|(document, chunk_heading, chunk_snippet, score)| DocumentSearchResult {
+                document,
+                chunk_heading,
+                chunk_snippet: if chunk_snippet.len() > 200 {
+                    format!("{}...", &chunk_snippet[..200])
+                } else {
+                    chunk_snippet
+                },
+                score,
+                mode: "semantic".to_string(),
+            })
+            .collect();
+
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.truncate(limit);
+
+        Ok(results)
+    }
+
+    fn doc_search_fts(
+        &self,
+        query: &str,
+        ns: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::memory::documents::DocumentSearchResult>, Error> {
+        use crate::memory::documents::DocumentSearchResult;
+
+        let docs = self
+            .store
+            .search_documents_fts(query, Some(ns), limit)
+            .unwrap_or_default();
+
+        Ok(docs
+            .into_iter()
+            .enumerate()
+            .map(|(i, document)| DocumentSearchResult {
+                document,
+                chunk_heading: String::new(),
+                chunk_snippet: String::new(),
+                score: 1.0 / (i as f32 + 1.0), // Rank-based score
+                mode: "fts".to_string(),
+            })
+            .collect())
+    }
+
+    fn doc_search_hybrid(
+        &self,
+        query: &str,
+        ns: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::memory::documents::DocumentSearchResult>, Error> {
+        use crate::memory::documents::DocumentSearchResult;
+
+        let semantic_results = self.doc_search_semantic(query, ns, limit * 2).unwrap_or_default();
+        let fts_results = self.doc_search_fts(query, ns, limit * 2).unwrap_or_default();
+
+        // Reciprocal Rank Fusion (RRF): score = sum(1 / (k + rank))
+        let rrf_k: f32 = 60.0;
+        let mut fused: std::collections::HashMap<String, DocumentSearchResult> =
+            std::collections::HashMap::new();
+
+        for (rank, result) in semantic_results.iter().enumerate() {
+            let rrf_score = 1.0 / (rrf_k + (rank as f32 + 1.0));
+            let entry = fused.entry(result.document.id.clone());
+            entry
+                .and_modify(|e| {
+                    e.score += rrf_score;
+                    // Prefer semantic chunk info when available.
+                    if !result.chunk_heading.is_empty() && e.chunk_heading.is_empty() {
+                        e.chunk_heading = result.chunk_heading.clone();
+                        e.chunk_snippet = result.chunk_snippet.clone();
+                    }
+                })
+                .or_insert_with(|| DocumentSearchResult {
+                    document: result.document.clone(),
+                    chunk_heading: result.chunk_heading.clone(),
+                    chunk_snippet: result.chunk_snippet.clone(),
+                    score: rrf_score,
+                    mode: "hybrid".to_string(),
+                });
+        }
+
+        for (rank, result) in fts_results.iter().enumerate() {
+            let rrf_score = 1.0 / (rrf_k + (rank as f32 + 1.0));
+            let entry = fused.entry(result.document.id.clone());
+            entry
+                .and_modify(|e| e.score += rrf_score)
+                .or_insert_with(|| DocumentSearchResult {
+                    document: result.document.clone(),
+                    chunk_heading: result.chunk_heading.clone(),
+                    chunk_snippet: result.chunk_snippet.clone(),
+                    score: rrf_score,
+                    mode: "hybrid".to_string(),
+                });
+        }
+
+        let mut results: Vec<DocumentSearchResult> = fused.into_values().collect();
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.truncate(limit);
+
+        Ok(results)
     }
 }
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -955,9 +955,9 @@ impl Uteke {
     ///
     /// Cascades to children and chunks. Returns (deleted, subtree_size).
     /// Also removes chunk embeddings from usearch index.
-    pub fn doc_delete(&self, id: &str) -> Result<(bool, usize), Error> {
+    pub fn doc_delete(&self, id: &str, namespace: Option<&str>) -> Result<(bool, usize), Error> {
         // Collect all document IDs in the subtree before deletion.
-        let ns = DEFAULT_NAMESPACE;
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         let subtree = self
             .store
             .list_descendants(id, ns, None, 10000)
@@ -1071,7 +1071,7 @@ impl Uteke {
             .collect();
 
         // Get chunk data from SQLite.
-        let chunks = self.store.get_chunks_by_ids(&chunk_ids)?;
+        let chunks = self.store.get_chunks_by_ids_ordered(&chunk_ids)?;
 
         // Build results: group by document, take best score per doc.
         let mut doc_scores: std::collections::HashMap<

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -756,7 +756,7 @@ impl Uteke {
             None => (uuid::Uuid::new_v4().to_string(), 1),
         };
 
-        let path = if let Some(ref pid) = parent_id {
+        let path = if let Some(ref _pid) = parent_id {
             format!("{}{}/", parent_path, id)
         } else {
             format!("/{}/", id)
@@ -784,7 +784,9 @@ impl Uteke {
         let doc_id = self.store.upsert_document(&doc)?;
 
         // Delete old chunks on update (re-chunking).
-        let old_chunk_ids = self.store.delete_chunks_for_documents(&[doc_id.clone()])?;
+        let old_chunk_ids = self
+            .store
+            .delete_chunks_for_documents(std::slice::from_ref(&doc_id))?;
 
         // Chunk and embed the content.
         self.ensure_embedder()?;
@@ -839,10 +841,7 @@ impl Uteke {
         }
 
         if let Err(e) = index.save() {
-            tracing::warn!(
-                "Failed to persist vector index after doc chunking: {}",
-                e
-            );
+            tracing::warn!("Failed to persist vector index after doc chunking: {}", e);
         }
 
         tracing::info!(
@@ -1031,7 +1030,7 @@ impl Uteke {
     fn doc_search_semantic(
         &self,
         query: &str,
-        ns: &str,
+        _ns: &str,
         limit: usize,
     ) -> Result<Vec<crate::memory::documents::DocumentSearchResult>, Error> {
         use crate::memory::documents::DocumentSearchResult;
@@ -1066,16 +1065,21 @@ impl Uteke {
         }
 
         // Extract chunk IDs (strip "chunk:" prefix).
-        let chunk_ids: Vec<String> = chunk_hits.iter().map(|(id, _)| id[6..].to_string()).collect();
+        let chunk_ids: Vec<String> = chunk_hits
+            .iter()
+            .map(|(id, _)| id[6..].to_string())
+            .collect();
 
         // Get chunk data from SQLite.
         let chunks = self.store.get_chunks_by_ids(&chunk_ids)?;
 
         // Build results: group by document, take best score per doc.
-        let mut doc_scores: std::collections::HashMap<String, (DocumentSummary, String, String, f32)> =
-            std::collections::HashMap::new();
+        let mut doc_scores: std::collections::HashMap<
+            String,
+            (DocumentSummary, String, String, f32),
+        > = std::collections::HashMap::new();
 
-        for ((chunk_key, distance), (chunk_id, doc_id, heading, content)) in
+        for ((_chunk_key, distance), (_chunk_id, doc_id, heading, content)) in
             chunk_hits.iter().zip(chunks.iter())
         {
             let score = crate::memory::vector::cosine_distance_to_similarity(*distance);
@@ -1111,20 +1115,26 @@ impl Uteke {
 
         let mut results: Vec<DocumentSearchResult> = doc_scores
             .into_values()
-            .map(|(document, chunk_heading, chunk_snippet, score)| DocumentSearchResult {
-                document,
-                chunk_heading,
-                chunk_snippet: if chunk_snippet.len() > 200 {
-                    format!("{}...", &chunk_snippet[..200])
-                } else {
-                    chunk_snippet
+            .map(
+                |(document, chunk_heading, chunk_snippet, score)| DocumentSearchResult {
+                    document,
+                    chunk_heading,
+                    chunk_snippet: if chunk_snippet.len() > 200 {
+                        format!("{}...", &chunk_snippet[..200])
+                    } else {
+                        chunk_snippet
+                    },
+                    score,
+                    mode: "semantic".to_string(),
                 },
-                score,
-                mode: "semantic".to_string(),
-            })
+            )
             .collect();
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         results.truncate(limit);
 
         Ok(results)
@@ -1164,8 +1174,12 @@ impl Uteke {
     ) -> Result<Vec<crate::memory::documents::DocumentSearchResult>, Error> {
         use crate::memory::documents::DocumentSearchResult;
 
-        let semantic_results = self.doc_search_semantic(query, ns, limit * 2).unwrap_or_default();
-        let fts_results = self.doc_search_fts(query, ns, limit * 2).unwrap_or_default();
+        let semantic_results = self
+            .doc_search_semantic(query, ns, limit * 2)
+            .unwrap_or_default();
+        let fts_results = self
+            .doc_search_fts(query, ns, limit * 2)
+            .unwrap_or_default();
 
         // Reciprocal Rank Fusion (RRF): score = sum(1 / (k + rank))
         let rrf_k: f32 = 60.0;
@@ -1208,7 +1222,11 @@ impl Uteke {
         }
 
         let mut results: Vec<DocumentSearchResult> = fused.into_values().collect();
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         results.truncate(limit);
 
         Ok(results)

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -940,7 +940,7 @@ impl Uteke {
         let new_parent_id = match new_parent_slug {
             Some(ps) => {
                 let parent = self.store.get_document_by_slug(ps, ns)?.ok_or_else(|| {
-                    Error::validation(&format!("parent document '{ps}' not found"))
+                    Error::validation(format!("parent document '{ps}' not found"))
                 })?;
                 Some(parent.id)
             }

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -581,6 +581,6 @@ mod content_type_tests {
         let store = super::super::store::Store::open(":memory:").unwrap();
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
-        assert_eq!(version, 11); // v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
+        assert_eq!(version, 12); // v12 = hierarchical docs (#438); v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
     }
 }

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -716,7 +716,7 @@ impl super::Store {
 
         tx.commit().map_err(|e| Error::db("commit move", e))?;
 
-        Ok((n + 1) as usize)
+        Ok(n + 1)
     }
 
     /// Delete a document by ID (cascades to children and chunks).

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -103,6 +103,23 @@ pub struct DocumentSummary {
     pub sort_order: i64,
 }
 
+/// Result from document search (semantic or FTS5).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentSearchResult {
+    /// Matched document summary.
+    pub document: DocumentSummary,
+    /// Matched chunk heading (empty if FTS match).
+    #[serde(default)]
+    pub chunk_heading: String,
+    /// Matched chunk text snippet (empty if FTS match).
+    #[serde(default)]
+    pub chunk_snippet: String,
+    /// Relevance score (cosine similarity for semantic, rank-based for FTS).
+    pub score: f32,
+    /// Search mode that produced this result.
+    pub mode: String,
+}
+
 /// Row mapper for Document (full document queries).
 fn row_to_document(row: &rusqlite::Row) -> rusqlite::Result<Document> {
     let tags_str: String = row.get(5)?;
@@ -720,6 +737,135 @@ impl super::Store {
                 .map_err(|e| Error::db("count documents", e))?,
         };
         Ok(count as usize)
+    }
+
+    /// FTS5 search on documents (title + slug).
+    ///
+    /// Returns matching document summaries ordered by FTS5 rank.
+    /// Best-effort: returns empty if FTS table doesn't exist.
+    pub fn search_documents_fts(
+        &self,
+        query: &str,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let limit = limit.min(100) as i64;
+        let sql = if namespace.is_some() {
+            "SELECT d.id, d.slug, d.title, d.namespace, d.version, d.updated_at, \
+             d.parent_id, d.depth, d.has_children, d.sort_order \
+             FROM documents d JOIN documents_fts fts ON d.rowid = fts.rowid \
+             WHERE documents_fts MATCH ?1 AND d.namespace = ?2 \
+             ORDER BY rank LIMIT ?3"
+        } else {
+            "SELECT d.id, d.slug, d.title, d.namespace, d.version, d.updated_at, \
+             d.parent_id, d.depth, d.has_children, d.sort_order \
+             FROM documents d JOIN documents_fts fts ON d.rowid = fts.rowid \
+             WHERE documents_fts MATCH ?1 \
+             ORDER BY rank LIMIT ?2"
+        };
+
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::db("prepare FTS search", e))?;
+
+        let rows = match namespace {
+            Some(ns) => stmt
+                .query_map(params![query, ns, limit], row_to_summary)
+                .map_err(|e| Error::db("FTS search query", e))?,
+            None => stmt
+                .query_map(params![query, limit], row_to_summary)
+                .map_err(|e| Error::db("FTS search query", e))?,
+        };
+
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Get document chunks by their IDs (for semantic search result enrichment).
+    ///
+    /// Returns chunk data needed for search result display.
+    pub fn get_chunks_by_ids(
+        &self,
+        chunk_ids: &[String],
+    ) -> Result<Vec<(String, String, String, String)>, Error> {
+        if chunk_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = chunk_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT id, document_id, heading, content FROM document_chunks WHERE id IN ({})",
+            placeholders
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::db("prepare get chunks by ids", e))?;
+
+        let params: Vec<&dyn rusqlite::types::ToSql> = chunk_ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+
+        let rows = stmt
+            .query_map(params.as_slice(), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })
+            .map_err(|e| Error::db("get chunks by ids query", e))?;
+
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Delete chunks belonging to a set of document IDs.
+    ///
+    /// Used during document update to clear old chunks before re-chunking.
+    /// Returns the IDs of deleted chunks (for usearch cleanup).
+    pub fn delete_chunks_for_documents(&self, doc_ids: &[String]) -> Result<Vec<String>, Error> {
+        if doc_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = doc_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let select_sql = format!(
+            "SELECT id FROM document_chunks WHERE document_id IN ({})",
+            placeholders
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&select_sql)
+            .map_err(|e| Error::db("prepare select chunk ids", e))?;
+
+        let params: Vec<&dyn rusqlite::types::ToSql> = doc_ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+
+        let ids: Vec<String> = stmt
+            .query_map(params.as_slice(), |row| row.get::<_, String>(0))
+            .map_err(|e| Error::db("select chunk ids", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let delete_sql = format!(
+            "DELETE FROM document_chunks WHERE document_id IN ({})",
+            placeholders
+        );
+        let params2: Vec<&dyn rusqlite::types::ToSql> = doc_ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+        let mut del_stmt = self
+            .conn
+            .prepare(&delete_sql)
+            .map_err(|e| Error::db("prepare delete chunks", e))?;
+        del_stmt
+            .execute(params2.as_slice())
+            .map_err(|e| Error::db("delete chunks", e))?;
+
+        Ok(ids)
     }
 }
 

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -573,22 +573,23 @@ impl super::Store {
             .map_err(|e| Error::db("begin move transaction", e))?;
 
         // Fetch current state BEFORE any mutation.
-        let current: Option<(String, String, i64)> = tx
+        let current: Option<(String, String, i64, Option<String>)> = tx
             .query_row(
-                "SELECT id, path, depth FROM documents WHERE id = ?1",
+                "SELECT id, path, depth, parent_id FROM documents WHERE id = ?1",
                 params![doc_id],
                 |row| {
                     Ok((
                         row.get::<_, String>(0)?,
                         row.get::<_, String>(1)?,
                         row.get::<_, i64>(2)?,
+                        row.get::<_, Option<String>>(3)?,
                     ))
                 },
             )
             .optional()
             .map_err(|e| Error::db("fetch current document for move", e))?;
 
-        let (cur_id, old_path, old_depth) = match current {
+        let (cur_id, old_path, old_depth, old_parent_id) = match current {
             Some(v) => v,
             None => return Ok(0),
         };
@@ -681,13 +682,7 @@ impl super::Store {
             .execute(
                 "UPDATE documents SET path = REPLACE(path, ?1, ?2), depth = depth + ?3 \
                  WHERE path LIKE ?4 AND id != ?5",
-                params![
-                    old_path_exact,
-                    new_path,
-                    depth_diff,
-                    format!("{}/%", cur_id),
-                    doc_id,
-                ],
+                params![old_path_exact, new_path, depth_diff, old_prefix, doc_id,],
             )
             .map_err(|e| Error::db("update descendant paths", e))?;
 
@@ -700,6 +695,25 @@ impl super::Store {
             .map_err(|e| Error::db("update new parent has_children", e))?;
         }
 
+        // Recompute old parent's has_children flag (may have lost last child).
+        if let Some(ref old_parent) = old_parent_id {
+            // Only recompute if moving away from old parent (not moving to root).
+            if new_parent_id != old_parent.as_deref() {
+                let has_any: bool = tx
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM documents WHERE parent_id = ?1 LIMIT 1)",
+                        params![old_parent],
+                        |row| row.get(0),
+                    )
+                    .unwrap_or(false);
+                tx.execute(
+                    "UPDATE documents SET has_children = ?2 WHERE id = ?1",
+                    params![old_parent, has_any as i64],
+                )
+                .map_err(|e| Error::db("update old parent has_children", e))?;
+            }
+        }
+
         tx.commit().map_err(|e| Error::db("commit move", e))?;
 
         Ok((n + 1) as usize)
@@ -710,11 +724,27 @@ impl super::Store {
     /// Returns (deleted, subtree_size).
     pub fn delete_document(&self, id: &str) -> Result<(bool, usize), Error> {
         let subtree_size = self.count_descendants(id)?;
+        // Fetch the document's path for cascade delete.
+        let path: String = self
+            .conn
+            .query_row(
+                "SELECT path FROM documents WHERE id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .unwrap_or_default();
+        let cascade_prefix = if path.is_empty() {
+            format!("/{}/%", id) // fallback: try UUID-based prefix
+        } else if path.ends_with('/') {
+            format!("{}%", path)
+        } else {
+            format!("{}/%", path)
+        };
         let n = self
             .conn
             .execute(
                 "DELETE FROM documents WHERE id = ?1 OR path LIKE ?2",
-                params![id, format!("/{}/%", id)],
+                params![id, cascade_prefix],
             )
             .map_err(|e| Error::db("delete document", e))?;
         Ok((n > 0, subtree_size))
@@ -818,6 +848,22 @@ impl super::Store {
             .map_err(|e| Error::db("get chunks by ids query", e))?;
 
         Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Get chunks by IDs, preserving the order of the input `chunk_ids` list.
+    ///
+    /// Used by doc_search to align with usearch result ordering.
+    pub fn get_chunks_by_ids_ordered(
+        &self,
+        chunk_ids: &[String],
+    ) -> Result<Vec<(String, String, String, String)>, Error> {
+        let all = self.get_chunks_by_ids(chunk_ids)?;
+        let map: std::collections::HashMap<String, (String, String, String, String)> =
+            all.into_iter().map(|c| (c.0.clone(), c)).collect();
+        Ok(chunk_ids
+            .iter()
+            .filter_map(|id| map.get(id).cloned())
+            .collect())
     }
 
     /// Delete chunks belonging to a set of document IDs.

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -411,15 +411,16 @@ impl super::Store {
         };
         let path_prefix = format!("{}/", doc.path);
 
-        let rows = if let Some(max) = max_depth {
+        if let Some(max) = max_depth {
             let mut stmt = self.conn.prepare(
                 "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents WHERE path LIKE ?1 AND depth <= ?2 \
                  ORDER BY path, sort_order LIMIT ?3",
             ).map_err(|e| Error::db("prepare list descendants", e))?;
-            stmt.query_map(params![path_prefix, max, limit], row_to_summary)
-                .map_err(|e| Error::db("list descendants query", e))?
+            let rows = stmt.query_map(params![path_prefix, max, limit], row_to_summary)
+                .map_err(|e| Error::db("list descendants query", e))?;
+            Ok(rows.filter_map(|r| r.ok()).collect())
         } else {
             let mut stmt = self.conn.prepare(
                 "SELECT id, slug, title, namespace, version, updated_at, \
@@ -427,11 +428,10 @@ impl super::Store {
                  FROM documents WHERE path LIKE ?1 \
                  ORDER BY path, sort_order LIMIT ?2",
             ).map_err(|e| Error::db("prepare list descendants", e))?;
-            stmt.query_map(params![path_prefix, limit], row_to_summary)
-                .map_err(|e| Error::db("list descendants query", e))?
-        };
-
-        Ok(rows.filter_map(|r| r.ok()).collect())
+            let rows = stmt.query_map(params![path_prefix, limit], row_to_summary)
+                .map_err(|e| Error::db("list descendants query", e))?;
+            Ok(rows.filter_map(|r| r.ok()).collect())
+        }
     }
 
     /// Get breadcrumbs from root to a document.

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -420,7 +420,11 @@ impl super::Store {
                 .get_document(id_or_slug)?
                 .ok_or_else(|| Error::validation("document not found for descendants query"))?,
         };
-        let path_prefix = format!("{}/", doc.path);
+        let path_prefix = if doc.path.ends_with('/') {
+            doc.path.clone()
+        } else {
+            format!("{}/", doc.path)
+        };
 
         if let Some(max) = max_depth {
             let mut stmt = self
@@ -520,7 +524,11 @@ impl super::Store {
         if path.is_empty() {
             return Ok(0);
         }
-        let prefix = format!("{}/", path);
+        let prefix = if path.ends_with('/') {
+            path.to_string()
+        } else {
+            format!("{}/", path)
+        };
         let count: i64 = self
             .conn
             .query_row(
@@ -568,7 +576,11 @@ impl super::Store {
             None => return Ok(0),
         };
 
-        let old_prefix = format!("{}/", old_path);
+        let old_prefix = if old_path.ends_with('/') {
+            old_path.to_string()
+        } else {
+            format!("{}/", old_path)
+        };
 
         // Safety checks.
         if let Some(parent) = new_parent_id {

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -698,7 +698,7 @@ impl super::Store {
         // Recompute old parent's has_children flag (may have lost last child).
         if let Some(ref old_parent) = old_parent_id {
             // Only recompute if moving away from old parent (not moving to root).
-            if new_parent_id.map(|s| s.as_str()) != Some(old_parent.as_str()) {
+            if new_parent_id.as_deref() != Some(old_parent.as_ref()) {
                 let has_any: bool = tx
                     .query_row(
                         "SELECT EXISTS(SELECT 1 FROM documents WHERE parent_id = ?1 LIMIT 1)",

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -576,10 +576,10 @@ impl super::Store {
             None => return Ok(0),
         };
 
-        let old_prefix = if old_path.ends_with('/') {
-            format!("{}%", old_path)
+        let (old_path_exact, old_prefix) = if old_path.ends_with('/') {
+            (old_path.clone(), format!("{}%", old_path))
         } else {
-            format!("{}/%", old_path)
+            (old_path.to_string(), format!("{}/%", old_path))
         };
 
         // Safety checks.
@@ -665,7 +665,7 @@ impl super::Store {
                 "UPDATE documents SET path = REPLACE(path, ?1, ?2), depth = depth + ?3 \
                  WHERE path LIKE ?4 AND id != ?5",
                 params![
-                    old_prefix,
+                    old_path_exact,
                     new_path,
                     depth_diff,
                     format!("{}/%", cur_id),

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -421,9 +421,9 @@ impl super::Store {
                 .ok_or_else(|| Error::validation("document not found for descendants query"))?,
         };
         let path_prefix = if doc.path.ends_with('/') {
-            doc.path.clone()
+            format!("{}%", doc.path)
         } else {
-            format!("{}/", doc.path)
+            format!("{}/%", doc.path)
         };
 
         if let Some(max) = max_depth {
@@ -432,12 +432,12 @@ impl super::Store {
                 .prepare(
                     "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
-                 FROM documents WHERE path LIKE ?1 AND depth <= ?2 \
+                 FROM documents WHERE path LIKE ?1 AND id != ?4 AND depth <= ?2 \
                  ORDER BY path, sort_order LIMIT ?3",
                 )
                 .map_err(|e| Error::db("prepare list descendants", e))?;
             let rows = stmt
-                .query_map(params![path_prefix, max, limit], row_to_summary)
+                .query_map(params![path_prefix, max, limit, doc.id], row_to_summary)
                 .map_err(|e| Error::db("list descendants query", e))?;
             Ok(rows.filter_map(|r| r.ok()).collect())
         } else {
@@ -446,12 +446,12 @@ impl super::Store {
                 .prepare(
                     "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
-                 FROM documents WHERE path LIKE ?1 \
+                 FROM documents WHERE path LIKE ?1 AND id != ?3 \
                  ORDER BY path, sort_order LIMIT ?2",
                 )
                 .map_err(|e| Error::db("prepare list descendants", e))?;
             let rows = stmt
-                .query_map(params![path_prefix, limit], row_to_summary)
+                .query_map(params![path_prefix, limit, doc.id], row_to_summary)
                 .map_err(|e| Error::db("list descendants query", e))?;
             Ok(rows.filter_map(|r| r.ok()).collect())
         }
@@ -525,15 +525,15 @@ impl super::Store {
             return Ok(0);
         }
         let prefix = if path.ends_with('/') {
-            path.to_string()
+            format!("{}%", path)
         } else {
-            format!("{}/", path)
+            format!("{}/%", path)
         };
         let count: i64 = self
             .conn
             .query_row(
-                "SELECT COUNT(*) FROM documents WHERE path LIKE ?1",
-                params![prefix],
+                "SELECT COUNT(*) FROM documents WHERE path LIKE ?1 AND id != ?2",
+                params![prefix, doc_id],
                 |row| row.get(0),
             )
             .map_err(|e| Error::db("count descendants", e))?;
@@ -577,9 +577,9 @@ impl super::Store {
         };
 
         let old_prefix = if old_path.ends_with('/') {
-            old_path.to_string()
+            format!("{}%", old_path)
         } else {
-            format!("{}/", old_path)
+            format!("{}/%", old_path)
         };
 
         // Safety checks.

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -3,10 +3,16 @@
 //! Full markdown content lives in the `documents` table. Content is chunked
 //! via the markdown chunker (#405) and each chunk gets its own embedding for
 //! semantic search at the section level.
+//!
+//! #438: Hierarchical documents with depth-10 support.
+//! Uses hybrid adjacency list + materialized path for O(1) subtree queries.
 
 use crate::Error;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
+
+/// Maximum depth for document hierarchy.
+pub const MAX_DEPTH: i64 = 10;
 
 /// A document in the knowledge base.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +41,21 @@ pub struct Document {
     pub created_at: String,
     /// Last update timestamp (RFC3339).
     pub updated_at: String,
+    /// Parent document ID (NULL = root).
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    /// Materialized path for O(1) subtree queries (e.g. "/uuid/uuid/").
+    #[serde(default)]
+    pub path: String,
+    /// Depth in tree (0 = root).
+    #[serde(default)]
+    pub depth: i64,
+    /// Manual ordering within siblings.
+    #[serde(default)]
+    pub sort_order: i64,
+    /// Whether this document has children (denormalized).
+    #[serde(default)]
+    pub has_children: bool,
 }
 
 /// A chunk of a document — used for semantic search.
@@ -59,8 +80,71 @@ pub struct DocumentChunk {
     pub tags: Vec<String>,
 }
 
+/// Summary of a document (for list views).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentSummary {
+    pub id: String,
+    pub slug: String,
+    pub title: String,
+    pub namespace: String,
+    pub version: i64,
+    pub updated_at: String,
+    /// Parent document ID (NULL = root).
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    /// Depth in tree (0 = root).
+    #[serde(default)]
+    pub depth: i64,
+    /// Whether this document has children.
+    #[serde(default)]
+    pub has_children: bool,
+    /// Manual ordering within siblings.
+    #[serde(default)]
+    pub sort_order: i64,
+}
+
+/// Row mapper for Document (full document queries).
+fn row_to_document(row: &rusqlite::Row) -> rusqlite::Result<Document> {
+    let tags_str: String = row.get(5)?;
+    let meta_str: String = row.get(6)?;
+    Ok(Document {
+        id: row.get(0)?,
+        slug: row.get(1)?,
+        title: row.get(2)?,
+        content: row.get(3)?,
+        namespace: row.get(4)?,
+        tags: serde_json::from_str(&tags_str).unwrap_or_default(),
+        metadata: serde_json::from_str(&meta_str).unwrap_or(serde_json::Value::Null),
+        version: row.get(7)?,
+        content_type: row.get(8)?,
+        created_at: row.get(9)?,
+        updated_at: row.get(10)?,
+        parent_id: row.get(11)?,
+        path: row.get(12)?,
+        depth: row.get(13)?,
+        sort_order: row.get(14)?,
+        has_children: row.get::<_, i64>(15).map(|v| v != 0).unwrap_or(false),
+    })
+}
+
+/// Row mapper for DocumentSummary (list/tree queries).
+fn row_to_summary(row: &rusqlite::Row) -> rusqlite::Result<DocumentSummary> {
+    Ok(DocumentSummary {
+        id: row.get(0)?,
+        slug: row.get(1)?,
+        title: row.get(2)?,
+        namespace: row.get(3)?,
+        version: row.get(4)?,
+        updated_at: row.get(5)?,
+        parent_id: row.get(6)?,
+        depth: row.get(7)?,
+        has_children: row.get::<_, i64>(8).map(|v| v != 0).unwrap_or(false),
+        sort_order: row.get(9)?,
+    })
+}
+
 impl super::Store {
-    /// Create or replace a document (#406).
+    /// Create or replace a document (#406, #438).
     ///
     /// If a document with the same slug+namespace exists, it is updated
     /// (version incremented, content replaced, chunks rebuilt).
@@ -86,7 +170,8 @@ impl super::Store {
             let version = doc.version + 1;
             tx.execute(
                 "UPDATE documents SET title = ?1, content = ?2, tags = ?3, metadata = ?4, \
-                 version = ?5, updated_at = ?6 WHERE id = ?7",
+                 version = ?5, updated_at = ?6, parent_id = ?7, path = ?8, depth = ?9, \
+                 sort_order = ?10 WHERE id = ?11",
                 params![
                     doc.title,
                     doc.content,
@@ -94,6 +179,10 @@ impl super::Store {
                     doc.metadata.to_string(),
                     version,
                     doc.updated_at,
+                    doc.parent_id,
+                    doc.path,
+                    doc.depth,
+                    doc.sort_order,
                     id
                 ],
             )
@@ -109,8 +198,8 @@ impl super::Store {
             // Insert new document.
             tx.execute(
                 "INSERT INTO documents (id, slug, title, content, namespace, tags, metadata, \
-                 version, content_type, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                 version, content_type, created_at, updated_at, parent_id, path, depth, sort_order) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
                 params![
                     doc.id,
                     doc.slug,
@@ -123,9 +212,21 @@ impl super::Store {
                     doc.content_type,
                     doc.created_at,
                     doc.updated_at,
+                    doc.parent_id,
+                    doc.path,
+                    doc.depth,
+                    doc.sort_order,
                 ],
             )
             .map_err(|e| Error::db("insert document", e))?;
+            // Update parent's has_children flag.
+            if let Some(ref pid) = doc.parent_id {
+                tx.execute(
+                    "UPDATE documents SET has_children = 1 WHERE id = ?1",
+                    params![pid],
+                )
+                .map_err(|e| Error::db("update parent has_children", e))?;
+            }
             doc.id.clone()
         };
 
@@ -170,26 +271,10 @@ impl super::Store {
             .conn
             .query_row(
                 "SELECT id, slug, title, content, namespace, tags, metadata, version, \
-                 content_type, created_at, updated_at FROM documents WHERE id = ?1",
+                 content_type, created_at, updated_at, parent_id, path, depth, \
+                 sort_order, has_children FROM documents WHERE id = ?1",
                 params![id],
-                |row| {
-                    let tags_str: String = row.get(5)?;
-                    let meta_str: String = row.get(6)?;
-                    Ok(Document {
-                        id: row.get(0)?,
-                        slug: row.get(1)?,
-                        title: row.get(2)?,
-                        content: row.get(3)?,
-                        namespace: row.get(4)?,
-                        tags: serde_json::from_str(&tags_str).unwrap_or_default(),
-                        metadata: serde_json::from_str(&meta_str)
-                            .unwrap_or(serde_json::Value::Null),
-                        version: row.get(7)?,
-                        content_type: row.get(8)?,
-                        created_at: row.get(9)?,
-                        updated_at: row.get(10)?,
-                    })
-                },
+                row_to_document,
             )
             .optional()
             .map_err(|e| Error::db("get document", e))?;
@@ -206,27 +291,11 @@ impl super::Store {
             .conn
             .query_row(
                 "SELECT id, slug, title, content, namespace, tags, metadata, version, \
-                 content_type, created_at, updated_at FROM documents \
+                 content_type, created_at, updated_at, parent_id, path, depth, \
+                 sort_order, has_children FROM documents \
                  WHERE slug = ?1 AND namespace = ?2",
                 params![slug, namespace],
-                |row| {
-                    let tags_str: String = row.get(5)?;
-                    let meta_str: String = row.get(6)?;
-                    Ok(Document {
-                        id: row.get(0)?,
-                        slug: row.get(1)?,
-                        title: row.get(2)?,
-                        content: row.get(3)?,
-                        namespace: row.get(4)?,
-                        tags: serde_json::from_str(&tags_str).unwrap_or_default(),
-                        metadata: serde_json::from_str(&meta_str)
-                            .unwrap_or(serde_json::Value::Null),
-                        version: row.get(7)?,
-                        content_type: row.get(8)?,
-                        created_at: row.get(9)?,
-                        updated_at: row.get(10)?,
-                    })
-                },
+                row_to_document,
             )
             .optional()
             .map_err(|e| Error::db("get document by slug", e))?;
@@ -243,11 +312,15 @@ impl super::Store {
 
         let mut stmt = if namespace.is_some() {
             self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at FROM documents WHERE namespace = ?1 ORDER BY updated_at DESC LIMIT ?2"
+                "SELECT id, slug, title, namespace, version, updated_at, \
+                 parent_id, depth, has_children, sort_order \
+                 FROM documents WHERE namespace = ?1 ORDER BY updated_at DESC LIMIT ?2",
             ).map_err(|e| Error::db("prepare list documents", e))?
         } else {
             self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at FROM documents ORDER BY updated_at DESC LIMIT ?1"
+                "SELECT id, slug, title, namespace, version, updated_at, \
+                 parent_id, depth, has_children, sort_order \
+                 FROM documents ORDER BY updated_at DESC LIMIT ?1",
             ).map_err(|e| Error::db("prepare list documents", e))?
         };
 
@@ -264,13 +337,334 @@ impl super::Store {
         Ok(docs)
     }
 
-    /// Delete a document by ID (cascades to chunks).
-    pub fn delete_document(&self, id: &str) -> Result<bool, Error> {
+    /// List root documents (parent_id IS NULL) in a namespace.
+    pub fn list_root_documents(
+        &self,
+        namespace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let limit = limit.min(1000) as i64;
+
+        let mut stmt = if namespace.is_some() {
+            self.conn.prepare(
+                "SELECT id, slug, title, namespace, version, updated_at, \
+                 parent_id, depth, has_children, sort_order \
+                 FROM documents WHERE namespace = ?1 AND parent_id IS NULL \
+                 ORDER BY sort_order, updated_at DESC LIMIT ?2",
+            ).map_err(|e| Error::db("prepare list root documents", e))?
+        } else {
+            self.conn.prepare(
+                "SELECT id, slug, title, namespace, version, updated_at, \
+                 parent_id, depth, has_children, sort_order \
+                 FROM documents WHERE parent_id IS NULL \
+                 ORDER BY sort_order, updated_at DESC LIMIT ?1",
+            ).map_err(|e| Error::db("prepare list root documents", e))?
+        };
+
+        let rows = match namespace {
+            Some(ns) => stmt
+                .query_map(params![ns, limit], row_to_summary)
+                .map_err(|e| Error::db("list root documents query", e))?,
+            None => stmt
+                .query_map(params![limit], row_to_summary)
+                .map_err(|e| Error::db("list root documents query", e))?,
+        };
+
+        let docs: Vec<DocumentSummary> = rows.filter_map(|r| r.ok()).collect();
+        Ok(docs)
+    }
+
+    /// List direct children of a document.
+    pub fn list_document_children(
+        &self,
+        parent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let limit = limit.min(1000) as i64;
+        let mut stmt = self.conn.prepare(
+            "SELECT id, slug, title, namespace, version, updated_at, \
+             parent_id, depth, has_children, sort_order \
+             FROM documents WHERE parent_id = ?1 \
+             ORDER BY sort_order, updated_at DESC LIMIT ?2",
+        ).map_err(|e| Error::db("prepare list children", e))?;
+
+        let rows = stmt
+            .query_map(params![parent_id, limit], row_to_summary)
+            .map_err(|e| Error::db("list children query", e))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Get all descendants of a document (subtree) via path prefix scan.
+    pub fn list_descendants(
+        &self,
+        id_or_slug: &str,
+        namespace: &str,
+        max_depth: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let limit = limit.min(1000) as i64;
+        let doc = match self.get_document_by_slug(id_or_slug, namespace)? {
+            Some(d) => d,
+            None => self
+                .get_document(id_or_slug)?
+                .ok_or_else(|| Error::validation("document not found for descendants query"))?,
+        };
+        let path_prefix = format!("{}/", doc.path);
+
+        let rows = if let Some(max) = max_depth {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, slug, title, namespace, version, updated_at, \
+                 parent_id, depth, has_children, sort_order \
+                 FROM documents WHERE path LIKE ?1 AND depth <= ?2 \
+                 ORDER BY path, sort_order LIMIT ?3",
+            ).map_err(|e| Error::db("prepare list descendants", e))?;
+            stmt.query_map(params![path_prefix, max, limit], row_to_summary)
+                .map_err(|e| Error::db("list descendants query", e))?
+        } else {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, slug, title, namespace, version, updated_at, \
+                 parent_id, depth, has_children, sort_order \
+                 FROM documents WHERE path LIKE ?1 \
+                 ORDER BY path, sort_order LIMIT ?2",
+            ).map_err(|e| Error::db("prepare list descendants", e))?;
+            stmt.query_map(params![path_prefix, limit], row_to_summary)
+                .map_err(|e| Error::db("list descendants query", e))?
+        };
+
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Get breadcrumbs from root to a document.
+    pub fn get_breadcrumbs(
+        &self,
+        id_or_slug: &str,
+        namespace: &str,
+    ) -> Result<Vec<DocumentSummary>, Error> {
+        let doc = match self.get_document_by_slug(id_or_slug, namespace)? {
+            Some(d) => d,
+            None => self
+                .get_document(id_or_slug)?
+                .ok_or_else(|| Error::validation("document not found for breadcrumbs query"))?,
+        };
+
+        // Extract UUIDs from path: "/uuid1/uuid2/uuid3/"
+        let uuids: Vec<&str> = doc.path.split('/').filter(|s| !s.is_empty()).collect();
+
+        if uuids.is_empty() {
+            return Ok(vec![DocumentSummary {
+                id: doc.id,
+                slug: doc.slug,
+                title: doc.title,
+                namespace: doc.namespace,
+                version: doc.version,
+                updated_at: doc.updated_at,
+                parent_id: None,
+                depth: 0,
+                has_children: doc.has_children,
+                sort_order: doc.sort_order,
+            }]);
+        }
+
+        let placeholders: String = uuids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let query = format!(
+            "SELECT id, slug, title, namespace, version, updated_at, \
+             parent_id, depth, has_children, sort_order \
+             FROM documents WHERE id IN ({}) ORDER BY depth",
+            placeholders
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&query)
+            .map_err(|e| Error::db("prepare breadcrumbs", e))?;
+        let params: Vec<&dyn rusqlite::types::ToSql> =
+            uuids.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+        let rows = stmt
+            .query_map(params.as_slice(), row_to_summary)
+            .map_err(|e| Error::db("breadcrumbs query", e))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Count subtree size (number of descendants) for a document.
+    pub fn count_descendants(&self, doc_id: &str) -> Result<usize, Error> {
+        let path: String = self
+            .conn
+            .query_row(
+                "SELECT path FROM documents WHERE id = ?1",
+                params![doc_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("get path for count", e))?
+            .unwrap_or_default();
+        if path.is_empty() {
+            return Ok(0);
+        }
+        let prefix = format!("{}/", path);
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM documents WHERE path LIKE ?1",
+                params![prefix],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("count descendants", e))?;
+        Ok(count as usize)
+    }
+
+    /// Move a document to a new parent (re-parent subtree).
+    ///
+    /// Updates path, depth, and sort_order for the moved node and all descendants.
+    /// Returns the number of documents affected.
+    pub fn move_document(
+        &self,
+        doc_id: &str,
+        new_parent_id: Option<&str>,
+        new_sort_order: Option<i64>,
+    ) -> Result<usize, Error> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("begin move transaction", e))?;
+
+        // Fetch current state BEFORE any mutation.
+        let current: Option<(String, String, i64)> = tx
+            .query_row(
+                "SELECT id, path, depth FROM documents WHERE id = ?1",
+                params![doc_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?)),
+            )
+            .optional()
+            .map_err(|e| Error::db("fetch current document for move", e))?;
+
+        let (cur_id, old_path, old_depth) = match current {
+            Some(v) => v,
+            None => return Ok(0),
+        };
+
+        let old_prefix = format!("{}/", old_path);
+
+        // Safety checks.
+        if let Some(parent) = new_parent_id {
+            if parent == doc_id {
+                return Err(Error::validation("cannot move document into itself"));
+            }
+            let parent_path: String = tx
+                .query_row(
+                    "SELECT path FROM documents WHERE id = ?1",
+                    params![parent],
+                    |row| row.get(0),
+                )
+                .unwrap_or_default();
+            if !old_path.is_empty() && parent_path.starts_with(&old_path) {
+                return Err(Error::validation(
+                    "cannot move document into its own descendant",
+                ));
+            }
+            // Depth guard: max 10.
+            let parent_depth: i64 = tx
+                .query_row(
+                    "SELECT depth FROM documents WHERE id = ?1",
+                    params![parent],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
+            let new_depth = parent_depth + 1;
+            let max_child_depth: i64 = tx
+                .query_row(
+                    "SELECT MAX(depth) FROM documents WHERE path LIKE ?1",
+                    params![old_prefix],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .unwrap_or(None)
+                .unwrap_or(old_depth);
+            let depth_diff = new_depth - old_depth;
+            if max_child_depth + depth_diff > MAX_DEPTH {
+                return Err(Error::validation(
+                    "move would exceed maximum depth of 10",
+                ));
+            }
+        }
+
+        // Compute new path and depth.
+        let (new_path, new_depth) = if let Some(parent) = new_parent_id {
+            let parent_path: String = tx
+                .query_row(
+                    "SELECT path FROM documents WHERE id = ?1",
+                    params![parent],
+                    |row| row.get(0),
+                )
+                .unwrap_or_default();
+            let parent_depth: i64 = tx
+                .query_row(
+                    "SELECT depth FROM documents WHERE id = ?1",
+                    params![parent],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
+            let path = if parent_path.is_empty() {
+                format!("/{}/", cur_id)
+            } else {
+                format!("{}{}/", parent_path, cur_id)
+            };
+            (path, parent_depth + 1)
+        } else {
+            (format!("/{}/", cur_id), 0)
+        };
+
+        let sort = new_sort_order.unwrap_or(0);
+        let depth_diff = new_depth - old_depth;
+
+        // Update the moving document.
+        tx.execute(
+            "UPDATE documents SET parent_id = ?1, path = ?2, depth = ?3, sort_order = ?4 \
+             WHERE id = ?5",
+            params![new_parent_id, new_path, new_depth, sort, doc_id],
+        )
+        .map_err(|e| Error::db("update moved document", e))?;
+
+        // Update all descendants: replace old prefix with new prefix, adjust depth.
+        let n = tx
+            .execute(
+                "UPDATE documents SET path = REPLACE(path, ?1, ?2), depth = depth + ?3 \
+                 WHERE path LIKE ?4 AND id != ?5",
+                params![
+                    old_prefix,
+                    new_path,
+                    depth_diff,
+                    format!("{}/%", cur_id),
+                    doc_id,
+                ],
+            )
+            .map_err(|e| Error::db("update descendant paths", e))?;
+
+        // Update new parent's has_children flag.
+        if let Some(parent) = new_parent_id {
+            tx.execute(
+                "UPDATE documents SET has_children = 1 WHERE id = ?1",
+                params![parent],
+            )
+            .map_err(|e| Error::db("update new parent has_children", e))?;
+        }
+
+        tx.commit()
+            .map_err(|e| Error::db("commit move", e))?;
+
+        Ok((n + 1) as usize)
+    }
+
+    /// Delete a document by ID (cascades to children and chunks).
+    ///
+    /// Returns (deleted, subtree_size).
+    pub fn delete_document(&self, id: &str) -> Result<(bool, usize), Error> {
+        let subtree_size = self.count_descendants(id)?;
         let n = self
             .conn
-            .execute("DELETE FROM documents WHERE id = ?1", params![id])
+            .execute(
+                "DELETE FROM documents WHERE id = ?1 OR path LIKE ?2",
+                params![id, format!("/{}/%", id)],
+            )
             .map_err(|e| Error::db("delete document", e))?;
-        Ok(n > 0)
+        Ok((n > 0, subtree_size))
     }
 
     /// Count documents in a namespace.
@@ -293,29 +687,6 @@ impl super::Store {
     }
 }
 
-/// Summary of a document (for list views).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DocumentSummary {
-    pub id: String,
-    pub slug: String,
-    pub title: String,
-    pub namespace: String,
-    pub version: i64,
-    pub updated_at: String,
-}
-
-/// Row mapper for DocumentSummary (used by list_documents).
-fn row_to_summary(row: &rusqlite::Row) -> rusqlite::Result<DocumentSummary> {
-    Ok(DocumentSummary {
-        id: row.get(0)?,
-        slug: row.get(1)?,
-        title: row.get(2)?,
-        namespace: row.get(3)?,
-        version: row.get(4)?,
-        updated_at: row.get(5)?,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,23 +696,41 @@ mod tests {
         Store::open(":memory:").unwrap()
     }
 
-    #[test]
-    fn test_document_crud() {
-        let store = open_test_store();
+    fn make_doc(id: &str, slug: &str, title: &str) -> Document {
         let now = chrono::Utc::now().to_rfc3339();
-        let doc = Document {
-            id: "doc-1".to_string(),
-            slug: "getting-started".to_string(),
-            title: "Getting Started".to_string(),
+        Document {
+            id: id.to_string(),
+            slug: slug.to_string(),
+            title: title.to_string(),
             content: "# Hello\n\nWorld".to_string(),
             namespace: "default".to_string(),
-            tags: vec!["guide".to_string()],
+            tags: vec![],
             metadata: serde_json::Value::Null,
             version: 1,
             content_type: "markdown".to_string(),
             created_at: now.clone(),
             updated_at: now,
-        };
+            parent_id: None,
+            path: format!("/{}/", id),
+            depth: 0,
+            sort_order: 0,
+            has_children: false,
+        }
+    }
+
+    fn make_child_doc(id: &str, slug: &str, title: &str, parent_id: &str, parent_path: &str) -> Document {
+        let mut doc = make_doc(id, slug, title);
+        doc.parent_id = Some(parent_id.to_string());
+        doc.path = format!("{}{}/", parent_path, id);
+        doc.depth = parent_path.split('/').filter(|s| !s.is_empty()).count() as i64;
+        doc.sort_order = 0;
+        doc
+    }
+
+    #[test]
+    fn test_document_crud() {
+        let store = open_test_store();
+        let doc = make_doc("doc-1", "getting-started", "Getting Started");
 
         // Create.
         let id = store.upsert_document(&doc).unwrap();
@@ -350,7 +739,8 @@ mod tests {
         // Get by ID.
         let got = store.get_document("doc-1").unwrap().unwrap();
         assert_eq!(got.title, "Getting Started");
-        assert_eq!(got.content, "# Hello\n\nWorld");
+        assert_eq!(got.depth, 0);
+        assert!(got.parent_id.is_none());
 
         // Get by slug.
         let got2 = store
@@ -365,84 +755,162 @@ mod tests {
         assert_eq!(list[0].slug, "getting-started");
 
         // Delete.
-        assert!(store.delete_document("doc-1").unwrap());
+        let (deleted, subtree) = store.delete_document("doc-1").unwrap();
+        assert!(deleted);
+        assert_eq!(subtree, 0);
         assert!(store.get_document("doc-1").unwrap().is_none());
     }
 
     #[test]
     fn test_document_upsert_increments_version() {
         let store = open_test_store();
-        let now = chrono::Utc::now().to_rfc3339();
-        let doc = Document {
-            id: "doc-1".to_string(),
-            slug: "test".to_string(),
-            title: "V1".to_string(),
-            content: "Content 1".to_string(),
-            namespace: "default".to_string(),
-            tags: vec![],
-            metadata: serde_json::Value::Null,
-            version: 1,
-            content_type: "markdown".to_string(),
-            created_at: now.clone(),
-            updated_at: now.clone(),
-        };
+        let doc = make_doc("doc-1", "test", "V1");
 
         store.upsert_document(&doc).unwrap();
 
-        // Upsert with same slug but new title.
-        let doc2 = Document {
-            title: "V2".to_string(),
-            content: "Content 2".to_string(),
-            updated_at: now.clone(),
-            ..doc
-        };
+        let doc2 = Document { title: "V2".to_string(), content: "Content 2".to_string(), ..doc.clone() };
         store.upsert_document(&doc2).unwrap();
 
-        let got = store
-            .get_document_by_slug("test", "default")
-            .unwrap()
-            .unwrap();
+        let got = store.get_document_by_slug("test", "default").unwrap().unwrap();
         assert_eq!(got.title, "V2");
-        assert_eq!(got.version, 2); // Incremented
+        assert_eq!(got.version, 2);
     }
 
     #[test]
     fn test_document_namespace_isolation() {
         let store = open_test_store();
-        let now = chrono::Utc::now().to_rfc3339();
 
-        let doc1 = Document {
-            id: "d1".to_string(),
-            slug: "guide".to_string(),
-            title: "NS1 Guide".to_string(),
-            content: "ns1".to_string(),
-            namespace: "ns1".to_string(),
-            tags: vec![],
-            metadata: serde_json::Value::Null,
-            version: 1,
-            content_type: "markdown".to_string(),
-            created_at: now.clone(),
-            updated_at: now.clone(),
-        };
-        let doc2 = Document {
-            id: "d2".to_string(),
-            namespace: "ns2".to_string(),
-            title: "NS2 Guide".to_string(),
-            content: "ns2".to_string(),
-            ..doc1.clone()
-        };
+        let doc1 = make_doc("d1", "guide", "NS1 Guide");
+        let doc1 = Document { namespace: "ns1".to_string(), ..doc1 };
+        let doc2 = make_doc("d2", "guide", "NS2 Guide");
+        let doc2 = Document { id: "d2".to_string(), namespace: "ns2".to_string(), ..doc2 };
 
         store.upsert_document(&doc1).unwrap();
         store.upsert_document(&doc2).unwrap();
 
-        // Same slug, different namespace → both exist.
-        assert!(store
-            .get_document_by_slug("guide", "ns1")
-            .unwrap()
-            .is_some());
-        assert!(store
-            .get_document_by_slug("guide", "ns2")
-            .unwrap()
-            .is_some());
+        assert!(store.get_document_by_slug("guide", "ns1").unwrap().is_some());
+        assert!(store.get_document_by_slug("guide", "ns2").unwrap().is_some());
+    }
+
+    #[test]
+    fn test_hierarchy_tree() {
+        let store = open_test_store();
+
+        // Root.
+        let root = make_doc("root", "company", "Company");
+        store.upsert_document(&root).unwrap();
+
+        // Child L1.
+        let child1 = make_child_doc("eng", "engineering", "Engineering", "root", "/root/");
+        store.upsert_document(&child1).unwrap();
+
+        // Child L2.
+        let child2 = make_child_doc("backend", "backend", "Backend", "eng", "/root/eng/");
+        store.upsert_document(&child2).unwrap();
+
+        // Verify parent has_children.
+        let root_doc = store.get_document("root").unwrap().unwrap();
+        assert!(root_doc.has_children);
+
+        // List children.
+        let children = store.list_document_children("root", 10).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].slug, "engineering");
+
+        // List descendants.
+        let descendants = store.list_descendants("company", "default", None, 100).unwrap();
+        assert_eq!(descendants.len(), 2); // eng + backend
+
+        // Breadcrumbs.
+        let crumbs = store.get_breadcrumbs("backend", "default").unwrap();
+        assert_eq!(crumbs.len(), 3); // company -> engineering -> backend
+        assert_eq!(crumbs[0].slug, "company");
+        assert_eq!(crumbs[2].slug, "backend");
+
+        // Count descendants.
+        assert_eq!(store.count_descendants("root").unwrap(), 2);
+        assert_eq!(store.count_descendants("eng").unwrap(), 1);
+    }
+
+    #[test]
+    fn test_hierarchy_delete_cascade() {
+        let store = open_test_store();
+
+        let root = make_doc("root", "root", "Root");
+        store.upsert_document(&root).unwrap();
+        let child = make_child_doc("child", "child", "Child", "root", "/root/");
+        store.upsert_document(&child).unwrap();
+        let grandchild = make_child_doc("gc", "grandchild", "GC", "child", "/root/child/");
+        store.upsert_document(&grandchild).unwrap();
+
+        // Delete root → cascades to child + grandchild.
+        let (deleted, subtree) = store.delete_document("root").unwrap();
+        assert!(deleted);
+        assert_eq!(subtree, 2);
+
+        assert!(store.get_document("child").unwrap().is_none());
+        assert!(store.get_document("gc").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_hierarchy_move() {
+        let store = open_test_store();
+
+        let root = make_doc("root", "root", "Root");
+        store.upsert_document(&root).unwrap();
+        let parent_a = make_child_doc("pa", "parent-a", "Parent A", "root", "/root/");
+        store.upsert_document(&parent_a).unwrap();
+        let parent_b = make_child_doc("pb", "parent-b", "Parent B", "root", "/root/");
+        store.upsert_document(&parent_b).unwrap();
+        let child = make_child_doc("child", "child", "Child", "pa", "/root/pa/");
+        store.upsert_document(&child).unwrap();
+
+        // Move child from pa to pb.
+        let affected = store.move_document("child", Some("pb"), None).unwrap();
+        assert_eq!(affected, 1);
+
+        // Verify new parent.
+        let child_doc = store.get_document("child").unwrap().unwrap();
+        assert_eq!(child_doc.parent_id.as_deref(), Some("pb"));
+        assert_eq!(child_doc.path, "/root/pb/child/");
+        assert_eq!(child_doc.depth, 2);
+
+        // Move to root.
+        let affected = store.move_document("child", None, Some(99)).unwrap();
+        assert_eq!(affected, 1);
+        let child_doc = store.get_document("child").unwrap().unwrap();
+        assert!(child_doc.parent_id.is_none());
+        assert_eq!(child_doc.depth, 0);
+        assert_eq!(child_doc.sort_order, 99);
+    }
+
+    #[test]
+    fn test_hierarchy_move_self_reference() {
+        let store = open_test_store();
+        let root = make_doc("root", "root", "Root");
+        store.upsert_document(&root).unwrap();
+
+        // Can't move into itself.
+        let result = store.move_document("root", Some("root"), None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hierarchy_list_root_documents() {
+        let store = open_test_store();
+
+        let root1 = make_doc("r1", "root1", "Root 1");
+        let root2 = make_doc("r2", "root2", "Root 2");
+        store.upsert_document(&root1).unwrap();
+        store.upsert_document(&root2).unwrap();
+
+        let child = make_child_doc("c1", "child1", "Child", "r1", "/r1/");
+        store.upsert_document(&child).unwrap();
+
+        let roots = store.list_root_documents(Some("default"), 10).unwrap();
+        assert_eq!(roots.len(), 2);
+
+        let all = store.list_documents(Some("default"), 10).unwrap();
+        assert_eq!(all.len(), 3);
     }
 }

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -698,7 +698,7 @@ impl super::Store {
         // Recompute old parent's has_children flag (may have lost last child).
         if let Some(ref old_parent) = old_parent_id {
             // Only recompute if moving away from old parent (not moving to root).
-            if new_parent_id != old_parent.as_deref() {
+            if new_parent_id.map(|s| s.as_str()) != Some(old_parent.as_str()) {
                 let has_any: bool = tx
                     .query_row(
                         "SELECT EXISTS(SELECT 1 FROM documents WHERE parent_id = ?1 LIMIT 1)",

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -311,17 +311,21 @@ impl super::Store {
         let limit = limit.min(1000) as i64;
 
         let mut stmt = if namespace.is_some() {
-            self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at, \
+            self.conn
+                .prepare(
+                    "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents WHERE namespace = ?1 ORDER BY updated_at DESC LIMIT ?2",
-            ).map_err(|e| Error::db("prepare list documents", e))?
+                )
+                .map_err(|e| Error::db("prepare list documents", e))?
         } else {
-            self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at, \
+            self.conn
+                .prepare(
+                    "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents ORDER BY updated_at DESC LIMIT ?1",
-            ).map_err(|e| Error::db("prepare list documents", e))?
+                )
+                .map_err(|e| Error::db("prepare list documents", e))?
         };
 
         let rows = match namespace {
@@ -346,19 +350,23 @@ impl super::Store {
         let limit = limit.min(1000) as i64;
 
         let mut stmt = if namespace.is_some() {
-            self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at, \
+            self.conn
+                .prepare(
+                    "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents WHERE namespace = ?1 AND parent_id IS NULL \
                  ORDER BY sort_order, updated_at DESC LIMIT ?2",
-            ).map_err(|e| Error::db("prepare list root documents", e))?
+                )
+                .map_err(|e| Error::db("prepare list root documents", e))?
         } else {
-            self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at, \
+            self.conn
+                .prepare(
+                    "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents WHERE parent_id IS NULL \
                  ORDER BY sort_order, updated_at DESC LIMIT ?1",
-            ).map_err(|e| Error::db("prepare list root documents", e))?
+                )
+                .map_err(|e| Error::db("prepare list root documents", e))?
         };
 
         let rows = match namespace {
@@ -381,12 +389,15 @@ impl super::Store {
         limit: usize,
     ) -> Result<Vec<DocumentSummary>, Error> {
         let limit = limit.min(1000) as i64;
-        let mut stmt = self.conn.prepare(
-            "SELECT id, slug, title, namespace, version, updated_at, \
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, slug, title, namespace, version, updated_at, \
              parent_id, depth, has_children, sort_order \
              FROM documents WHERE parent_id = ?1 \
              ORDER BY sort_order, updated_at DESC LIMIT ?2",
-        ).map_err(|e| Error::db("prepare list children", e))?;
+            )
+            .map_err(|e| Error::db("prepare list children", e))?;
 
         let rows = stmt
             .query_map(params![parent_id, limit], row_to_summary)
@@ -412,23 +423,31 @@ impl super::Store {
         let path_prefix = format!("{}/", doc.path);
 
         if let Some(max) = max_depth {
-            let mut stmt = self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at, \
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents WHERE path LIKE ?1 AND depth <= ?2 \
                  ORDER BY path, sort_order LIMIT ?3",
-            ).map_err(|e| Error::db("prepare list descendants", e))?;
-            let rows = stmt.query_map(params![path_prefix, max, limit], row_to_summary)
+                )
+                .map_err(|e| Error::db("prepare list descendants", e))?;
+            let rows = stmt
+                .query_map(params![path_prefix, max, limit], row_to_summary)
                 .map_err(|e| Error::db("list descendants query", e))?;
             Ok(rows.filter_map(|r| r.ok()).collect())
         } else {
-            let mut stmt = self.conn.prepare(
-                "SELECT id, slug, title, namespace, version, updated_at, \
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT id, slug, title, namespace, version, updated_at, \
                  parent_id, depth, has_children, sort_order \
                  FROM documents WHERE path LIKE ?1 \
                  ORDER BY path, sort_order LIMIT ?2",
-            ).map_err(|e| Error::db("prepare list descendants", e))?;
-            let rows = stmt.query_map(params![path_prefix, limit], row_to_summary)
+                )
+                .map_err(|e| Error::db("prepare list descendants", e))?;
+            let rows = stmt
+                .query_map(params![path_prefix, limit], row_to_summary)
                 .map_err(|e| Error::db("list descendants query", e))?;
             Ok(rows.filter_map(|r| r.ok()).collect())
         }
@@ -476,8 +495,10 @@ impl super::Store {
             .conn
             .prepare(&query)
             .map_err(|e| Error::db("prepare breadcrumbs", e))?;
-        let params: Vec<&dyn rusqlite::types::ToSql> =
-            uuids.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+        let params: Vec<&dyn rusqlite::types::ToSql> = uuids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
         let rows = stmt
             .query_map(params.as_slice(), row_to_summary)
             .map_err(|e| Error::db("breadcrumbs query", e))?;
@@ -531,7 +552,13 @@ impl super::Store {
             .query_row(
                 "SELECT id, path, depth FROM documents WHERE id = ?1",
                 params![doc_id],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?)),
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
             )
             .optional()
             .map_err(|e| Error::db("fetch current document for move", e))?;
@@ -579,9 +606,7 @@ impl super::Store {
                 .unwrap_or(old_depth);
             let depth_diff = new_depth - old_depth;
             if max_child_depth + depth_diff > MAX_DEPTH {
-                return Err(Error::validation(
-                    "move would exceed maximum depth of 10",
-                ));
+                return Err(Error::validation("move would exceed maximum depth of 10"));
             }
         }
 
@@ -646,8 +671,7 @@ impl super::Store {
             .map_err(|e| Error::db("update new parent has_children", e))?;
         }
 
-        tx.commit()
-            .map_err(|e| Error::db("commit move", e))?;
+        tx.commit().map_err(|e| Error::db("commit move", e))?;
 
         Ok((n + 1) as usize)
     }
@@ -718,7 +742,13 @@ mod tests {
         }
     }
 
-    fn make_child_doc(id: &str, slug: &str, title: &str, parent_id: &str, parent_path: &str) -> Document {
+    fn make_child_doc(
+        id: &str,
+        slug: &str,
+        title: &str,
+        parent_id: &str,
+        parent_path: &str,
+    ) -> Document {
         let mut doc = make_doc(id, slug, title);
         doc.parent_id = Some(parent_id.to_string());
         doc.path = format!("{}{}/", parent_path, id);
@@ -768,10 +798,17 @@ mod tests {
 
         store.upsert_document(&doc).unwrap();
 
-        let doc2 = Document { title: "V2".to_string(), content: "Content 2".to_string(), ..doc.clone() };
+        let doc2 = Document {
+            title: "V2".to_string(),
+            content: "Content 2".to_string(),
+            ..doc.clone()
+        };
         store.upsert_document(&doc2).unwrap();
 
-        let got = store.get_document_by_slug("test", "default").unwrap().unwrap();
+        let got = store
+            .get_document_by_slug("test", "default")
+            .unwrap()
+            .unwrap();
         assert_eq!(got.title, "V2");
         assert_eq!(got.version, 2);
     }
@@ -781,15 +818,28 @@ mod tests {
         let store = open_test_store();
 
         let doc1 = make_doc("d1", "guide", "NS1 Guide");
-        let doc1 = Document { namespace: "ns1".to_string(), ..doc1 };
+        let doc1 = Document {
+            namespace: "ns1".to_string(),
+            ..doc1
+        };
         let doc2 = make_doc("d2", "guide", "NS2 Guide");
-        let doc2 = Document { id: "d2".to_string(), namespace: "ns2".to_string(), ..doc2 };
+        let doc2 = Document {
+            id: "d2".to_string(),
+            namespace: "ns2".to_string(),
+            ..doc2
+        };
 
         store.upsert_document(&doc1).unwrap();
         store.upsert_document(&doc2).unwrap();
 
-        assert!(store.get_document_by_slug("guide", "ns1").unwrap().is_some());
-        assert!(store.get_document_by_slug("guide", "ns2").unwrap().is_some());
+        assert!(store
+            .get_document_by_slug("guide", "ns1")
+            .unwrap()
+            .is_some());
+        assert!(store
+            .get_document_by_slug("guide", "ns2")
+            .unwrap()
+            .is_some());
     }
 
     #[test]
@@ -818,7 +868,9 @@ mod tests {
         assert_eq!(children[0].slug, "engineering");
 
         // List descendants.
-        let descendants = store.list_descendants("company", "default", None, 100).unwrap();
+        let descendants = store
+            .list_descendants("company", "default", None, 100)
+            .unwrap();
         assert_eq!(descendants.len(), 2); // eng + backend
 
         // Breadcrumbs.

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -698,7 +698,7 @@ impl super::Store {
         // Recompute old parent's has_children flag (may have lost last child).
         if let Some(ref old_parent) = old_parent_id {
             // Only recompute if moving away from old parent (not moving to root).
-            if new_parent_id.as_deref() != Some(old_parent.as_ref()) {
+            if new_parent_id != Some(old_parent.as_ref()) {
                 let has_any: bool = tx
                     .query_row(
                         "SELECT EXISTS(SELECT 1 FROM documents WHERE parent_id = ?1 LIMIT 1)",

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -589,22 +589,34 @@ impl super::Store {
         }
         if !self.column_exists_in("documents", "path") {
             self.conn
-                .execute("ALTER TABLE documents ADD COLUMN path TEXT NOT NULL DEFAULT ''", [])
+                .execute(
+                    "ALTER TABLE documents ADD COLUMN path TEXT NOT NULL DEFAULT ''",
+                    [],
+                )
                 .map_err(|e| Error::db("migration v12: add path", e))?;
         }
         if !self.column_exists_in("documents", "depth") {
             self.conn
-                .execute("ALTER TABLE documents ADD COLUMN depth INTEGER NOT NULL DEFAULT 0", [])
+                .execute(
+                    "ALTER TABLE documents ADD COLUMN depth INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )
                 .map_err(|e| Error::db("migration v12: add depth", e))?;
         }
         if !self.column_exists_in("documents", "sort_order") {
             self.conn
-                .execute("ALTER TABLE documents ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0", [])
+                .execute(
+                    "ALTER TABLE documents ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )
                 .map_err(|e| Error::db("migration v12: add sort_order", e))?;
         }
         if !self.column_exists_in("documents", "has_children") {
             self.conn
-                .execute("ALTER TABLE documents ADD COLUMN has_children INTEGER NOT NULL DEFAULT 0", [])
+                .execute(
+                    "ALTER TABLE documents ADD COLUMN has_children INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )
                 .map_err(|e| Error::db("migration v12: add has_children", e))?;
         }
 

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -631,6 +631,19 @@ impl super::Store {
             let _ = self.conn.execute(idx, []);
         }
 
+        // FTS5 virtual table for documents (title + slug search).
+        // Best-effort: skip if FTS5 is not available (e.g., custom SQLite builds).
+        let fts = [
+            "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content='documents', content_rowid='rowid')",
+            // Triggers to keep FTS in sync with documents table.
+            "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN INSERT INTO documents_fts(rowid, title, slug) VALUES (new.rowid, new.title, new.slug); END",
+            "CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN UPDATE documents_fts SET title = new.title, slug = new.slug WHERE rowid = new.rowid; END",
+            "CREATE TRIGGER IF NOT EXISTS documents_fts_delete AFTER DELETE ON documents BEGIN DELETE FROM documents_fts WHERE rowid = old.rowid; END",
+        ];
+        for sql in &fts {
+            let _ = self.conn.execute(sql, []);
+        }
+
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -169,6 +169,8 @@ impl super::Store {
                 10 => self.migrate_v9_to_v10()?,
                 // v11: Document engine tables (#406)
                 11 => self.migrate_v10_to_v11()?,
+                // v12: Hierarchical documents (#438)
+                12 => self.migrate_v11_to_v12()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -330,6 +332,14 @@ impl super::Store {
     pub(super) fn column_exists(&self, column: &str) -> bool {
         self.conn
             .prepare("SELECT * FROM memories LIMIT 0")
+            .map(|stmt| stmt.column_names().iter().any(|n| n == &column))
+            .unwrap_or(false)
+    }
+
+    /// Check if a column exists in a specific table.
+    pub(super) fn column_exists_in(&self, table: &str, column: &str) -> bool {
+        self.conn
+            .prepare(&format!("SELECT * FROM {table} LIMIT 0"))
             .map(|stmt| stmt.column_names().iter().any(|n| n == &column))
             .unwrap_or(false)
     }
@@ -561,6 +571,54 @@ impl super::Store {
                 "#,
             )
             .map_err(|e| Error::db("schema migration v10 to v11", e))?;
+        Ok(())
+    }
+
+    /// v12: Hierarchical documents (#438).
+    ///
+    /// Adds parent_id, path (materialized), depth, sort_order, has_children
+    /// columns to the documents table for tree support with depth 10.
+    fn migrate_v11_to_v12(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v11 to v12: hierarchical documents");
+
+        // Add hierarchy columns with column_exists guards for idempotency.
+        if !self.column_exists_in("documents", "parent_id") {
+            self.conn
+                .execute("ALTER TABLE documents ADD COLUMN parent_id TEXT REFERENCES documents(id) ON DELETE CASCADE", [])
+                .map_err(|e| Error::db("migration v12: add parent_id", e))?;
+        }
+        if !self.column_exists_in("documents", "path") {
+            self.conn
+                .execute("ALTER TABLE documents ADD COLUMN path TEXT NOT NULL DEFAULT ''", [])
+                .map_err(|e| Error::db("migration v12: add path", e))?;
+        }
+        if !self.column_exists_in("documents", "depth") {
+            self.conn
+                .execute("ALTER TABLE documents ADD COLUMN depth INTEGER NOT NULL DEFAULT 0", [])
+                .map_err(|e| Error::db("migration v12: add depth", e))?;
+        }
+        if !self.column_exists_in("documents", "sort_order") {
+            self.conn
+                .execute("ALTER TABLE documents ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0", [])
+                .map_err(|e| Error::db("migration v12: add sort_order", e))?;
+        }
+        if !self.column_exists_in("documents", "has_children") {
+            self.conn
+                .execute("ALTER TABLE documents ADD COLUMN has_children INTEGER NOT NULL DEFAULT 0", [])
+                .map_err(|e| Error::db("migration v12: add has_children", e))?;
+        }
+
+        // Create indexes (best-effort — tolerate "already exists").
+        let indexes = [
+            "CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path)",
+            "CREATE INDEX IF NOT EXISTS idx_documents_parent ON documents(parent_id)",
+            "CREATE INDEX IF NOT EXISTS idx_documents_depth ON documents(depth)",
+            "CREATE INDEX IF NOT EXISTS idx_documents_sort ON documents(parent_id, sort_order)",
+        ];
+        for idx in &indexes {
+            let _ = self.conn.execute(idx, []);
+        }
+
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -86,7 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_timeline_memory ON timeline_events(memory_id);
 CREATE INDEX IF NOT EXISTS idx_timeline_type ON timeline_events(event_type);
 CREATE INDEX IF NOT EXISTS idx_timeline_created ON timeline_events(created_at);
 
--- v11: Document engine (#406).
+-- v11: Document engine (#406, #438).
 CREATE TABLE IF NOT EXISTS documents (
     id TEXT PRIMARY KEY,
     slug TEXT NOT NULL COLLATE NOCASE,
@@ -99,11 +99,20 @@ CREATE TABLE IF NOT EXISTS documents (
     content_type TEXT NOT NULL DEFAULT 'markdown',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
+    parent_id TEXT REFERENCES documents(id) ON DELETE CASCADE,
+    path TEXT NOT NULL DEFAULT '',
+    depth INTEGER NOT NULL DEFAULT 0,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    has_children INTEGER NOT NULL DEFAULT 0,
     UNIQUE(namespace, slug)
 );
 CREATE INDEX IF NOT EXISTS idx_documents_namespace ON documents(namespace);
 CREATE INDEX IF NOT EXISTS idx_documents_slug ON documents(slug);
 CREATE INDEX IF NOT EXISTS idx_documents_updated ON documents(updated_at);
+CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path);
+CREATE INDEX IF NOT EXISTS idx_documents_parent ON documents(parent_id);
+CREATE INDEX IF NOT EXISTS idx_documents_depth ON documents(depth);
+CREATE INDEX IF NOT EXISTS idx_documents_sort ON documents(parent_id, sort_order);
 
 CREATE TABLE IF NOT EXISTS document_chunks (
     id TEXT PRIMARY KEY,
@@ -132,7 +141,7 @@ pub(super) const SCHEMA_INDEXES: &[&str] = &[
 ];
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 11;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 12;
 
 /// Persistent SQLite store for memories.
 pub struct Store {

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -296,7 +296,7 @@ mod tests {
     fn migration_dispatcher_reaches_v9() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 11, "fresh store must reach CURRENT_SCHEMA_VERSION=11");
+        assert_eq!(v, 12, "fresh store must reach CURRENT_SCHEMA_VERSION=12");
         // timeline_events table must exist.
         let m = mem();
         store.insert(&m).unwrap();


### PR DESCRIPTION
## Summary

Implements hierarchical documents engine (depth-10 tree) and hybrid document search for Uteke.

**Closes:** #438, #440

### Features

1. **Hierarchical Documents** (schema v12)
   - `parent_id`, `path` (materialized), `depth`, `sort_order`, `has_children` columns
   - Tree operations: create with parent, children, descendants, move, breadcrumbs
   - `MAX_DEPTH = 10` enforced in `move_document()`

2. **doc_search** — 3 search modes:
   - `semantic`: usearch chunk embeddings with `chunk:` prefix
   - `fts`: FTS5 keyword search on title/slug
   - `hybrid` (default): RRF fusion of semantic + FTS (k=60)

3. **Chunk lifecycle management**
   - Embeddings auto-inserted into usearch on document upsert
   - Old chunks cleaned from usearch on update/delete
   - `get_chunks_by_ids_ordered()` preserves usearch score ordering

4. **CLI**: `uteke doc search <query> --mode <semantic|fts|hybrid> --limit N`

### Schema Changes (v11 → v12)

- `ALTER TABLE documents ADD COLUMN parent_id TEXT`
- `ALTER TABLE documents ADD COLUMN path TEXT DEFAULT ''`
- `ALTER TABLE documents ADD COLUMN depth INTEGER DEFAULT 0`
- `ALTER TABLE documents ADD COLUMN sort_order INTEGER DEFAULT 0`
- `ALTER TABLE documents ADD COLUMN has_children INTEGER DEFAULT 0`
- FTS5 virtual table `documents_fts(title, slug, content)` with sync triggers

### Bug Fixes (from CodeCora review)

- **move_document**: Fixed descendant LIKE predicate to use `old_prefix` (full materialized path) instead of `cur_id` (UUID only)
- **delete_document**: Fixed cascade delete to fetch document path first, build correct prefix instead of hardcoded `/{uuid}/%`
- **doc_delete**: Added `namespace` parameter instead of hardcoding `DEFAULT_NAMESPACE`
- **move_document**: Added recompute of `has_children` on old parent after moving last child away
- **get_chunks_by_ids_ordered**: New method to preserve input ordering for usearch score alignment

### CodeCora Status

CodeCora shows findings from earlier commits before bug fixes were applied. All actionable findings have been resolved:

| Category | Status |
|----------|--------|
| Path predicates (move/delete) | ✅ Fixed |
| Namespace handling | ✅ Fixed |
| Old parent has_children | ✅ Fixed |
| Chunk ordering | ✅ Fixed |
| sec-sql-concat | 🟢 FP — table names are internal constants, never user input |
| column_exists_in | 🟢 FP — only called with hardcoded table names |
| LIKE without % | 🟢 FP — format! explicitly adds % |
| unwrap_or_default | 🟢 Design — intentional graceful degradation |
| max_depth absolute | 🟢 Design — consistent with stored depth values |

### Test plan

- [x] CI: Build, Check, Test, Clippy, Format all pass
- [x] CI: Cargo Audit, Trivy FS pass
- [x] CI: Cora AI Review pass
- [ ] Manual: hierarchical doc CRUD with nesting
- [ ] Manual: doc_search semantic/fts/hybrid modes
- [ ] Manual: move operation with path recomputation
- [ ] Manual: delete cascade with chunk cleanup