### PR TITLE
feat: add document API endpoints to uteke-serve

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -309,6 +309,26 @@ When adding new parameters to the CLI, **don't forget to update server mode too.
 4. API docs
 5. CLI reference docs
 
+### Function ↔ API ↔ CLI Parity (v0.4.0)
+
+Every public function in `lib.rs` MUST have a corresponding CLI command AND HTTP endpoint. No orphan features.
+
+| lib.rs function | CLI command | HTTP endpoint | Status |
+|-----------------|-------------|---------------|--------|
+| `doc_upsert` / `doc_upsert_with_parent` | `uteke doc create [--parent]` | `POST /doc/create` | ✅ |
+| `doc_get` | `uteke doc get` | `POST /doc/get` | ✅ |
+| `doc_list` / `doc_list_roots` / `doc_list_children` | `uteke doc list [--tree] [--roots-only]` | `POST /doc/list` | ✅ |
+| `doc_search` (semantic/fts/hybrid) | `uteke doc search [--mode]` | `POST /doc/search` | ✅ |
+| `doc_move` | `uteke doc move [--parent]` | `POST /doc/move` | ✅ |
+| `doc_delete` | `uteke doc delete` | `DELETE /doc/delete` | ✅ |
+| `doc_breadcrumbs` | *(via --tree display)* | *(not exposed)* | ⚠️ CLI-only |
+| `doc_list_descendants` | *(via --tree display)* | *(not exposed)* | ⚠️ CLI-only |
+| `doc_export` | `uteke doc export` | *(not exposed)* | ⚠️ CLI-only |
+
+Notes:
+- `doc_breadcrumbs` and `doc_list_descendants` are used internally by CLI `--tree` but don't need standalone API endpoints yet.
+- `doc_export` is CLI-only (bulk export, not needed for real-time API).
+
 ### Metadata in JSON Blob — Post-Filter, Not SQL Filter
 
 Entity, category, and meta are stored as JSON in the `metadata` column. This means:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## [0.4.0] — 2026-06-22
+
+### Added
+
+- **Hierarchical documents — depth-10 tree engine** (#438 #440)
+  - Schema v12: `parent_id`, `path` (materialized), `depth`, `sort_order`,
+    `has_children` columns on documents table
+  - Tree operations: create with parent, children, descendants, move,
+    breadcrumbs
+  - `MAX_DEPTH = 10` enforced in `move_document()`
+  - `uteke doc create --parent <slug>`, `uteke doc children`, `uteke doc
+    descendants`, `uteke doc move`, `uteke doc breadcrumbs`
+  - `uteke doc list --tree` for indented tree view
+
+- **Hybrid document search** (#440)
+  - `uteke doc search <query>` with 3 modes:
+    - `semantic`: usearch chunk embeddings with `chunk:` prefix
+    - `fts`: FTS5 keyword search on title and slug
+    - `hybrid` (default): Reciprocal Rank Fusion of semantic + FTS (k=60)
+  - FTS5 virtual table `documents_fts(title, slug, content)` with
+    INSERT/UPDATE/DELETE sync triggers
+  - Chunk embeddings auto-inserted into usearch on document upsert
+  - Old chunks cleaned from usearch on update and delete
+
+### Fixed
+
+- **move_document descendant path predicate** used UUID instead of full
+  materialized path. Descendants of nested documents were not updated after
+  move operations.
+- **delete_document cascade** hardcoded `/{uuid}/%` prefix that never
+  matched actual materialized paths. Now fetches document path first.
+- **doc_delete namespace** hardcoded `DEFAULT_NAMESPACE`. Now accepts
+  `namespace: Option<&str>` parameter.
+- **move_document** now recomputes `has_children` on old parent after
+  moving last child away.
+
 ## [0.3.2] — 2026-06-22
 
 ### Fixed

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -71,14 +71,6 @@ struct DocMoveRequest {
     namespace: Option<String>,
 }
 
-#[derive(Deserialize)]
-struct DocDeleteParams {
-    id: Option<String>,
-    slug: Option<String>,
-    #[serde(default)]
-    namespace: Option<String>,
-}
-
 fn default_search_mode() -> String {
     "hybrid".to_string()
 }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -15,6 +15,92 @@ use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use tracing::{error, info, warn};
 use uteke_core::Uteke;
 
+// ── Document Types ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct DocCreateRequest {
+    slug: String,
+    title: Option<String>,
+    content: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    namespace: Option<String>,
+    #[serde(default)]
+    parent: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DocGetRequest {
+    id: Option<String>,
+    slug: Option<String>,
+    #[serde(default)]
+    namespace: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DocListParams {
+    #[serde(default)]
+    namespace: Option<String>,
+    #[serde(default = "default_limit")]
+    limit: usize,
+    #[serde(default)]
+    roots_only: bool,
+    #[serde(default)]
+    parent: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DocSearchRequest {
+    query: String,
+    #[serde(default = "default_limit")]
+    limit: usize,
+    #[serde(default)]
+    namespace: Option<String>,
+    #[serde(default = "default_search_mode")]
+    mode: String,
+}
+
+#[derive(Deserialize)]
+struct DocMoveRequest {
+    id: Option<String>,
+    slug: Option<String>,
+    #[serde(default)]
+    new_parent: Option<String>,
+    #[serde(default)]
+    namespace: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DocDeleteParams {
+    id: Option<String>,
+    slug: Option<String>,
+    #[serde(default)]
+    namespace: Option<String>,
+}
+
+fn default_search_mode() -> String {
+    "hybrid".to_string()
+}
+
+// ── Document endpoint helpers ─────────────────────────────────────────
+
+fn resolve_doc_id(req: &DocGetRequest) -> Result<&str, &'static str> {
+    match (&req.id, &req.slug) {
+        (Some(id), _) => Ok(id),
+        (_, Some(slug)) => Ok(slug),
+        _ => Err("provide either 'id' or 'slug'"),
+    }
+}
+
+fn resolve_doc_id_move(req: &DocMoveRequest) -> Result<&str, &'static str> {
+    match (&req.id, &req.slug) {
+        (Some(id), _) => Ok(id),
+        (_, Some(slug)) => Ok(slug),
+        _ => Err("provide either 'id' or 'slug'"),
+    }
+}
+
 // ── Types ───────────────────────────────────────────────────────────────────
 
 #[derive(Deserialize)]
@@ -1096,6 +1182,165 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
                 )
         }
 
+        // ── Document: Create / Upsert ────────────────────────────────────
+        (Method::Post, "/doc/create") => match read_body::<DocCreateRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
+                let parent = req_data.parent.as_deref();
+                match uteke.doc_upsert_with_parent(
+                    &req_data.slug,
+                    req_data.title.as_deref().unwrap_or(""),
+                    &req_data.content,
+                    &tag_refs,
+                    ns(&req_data.namespace),
+                    parent,
+                ) {
+                    Ok(id) => ctx.ok_response_for(
+                        req,
+                        &serde_json::json!({"id": id, "slug": req_data.slug}),
+                    ),
+                    Err(e) => {
+                        if e.to_string().contains("already exists") {
+                            ctx.error_response_for(
+                                req,
+                                409,
+                                format!("document slug '{}' already exists", req_data.slug),
+                            )
+                        } else if e.to_string().contains("maximum")
+                            || e.to_string().contains("parent")
+                        {
+                            ctx.error_response_for(req, 400, e.to_string())
+                        } else {
+                            error!("doc create error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Document: Get ───────────────────────────────────────────────
+        (Method::Post, "/doc/get") => match read_body::<DocGetRequest>(req.as_reader()) {
+            Ok(req_data) => match resolve_doc_id(&req_data) {
+                Ok(id_or_slug) => match uteke.doc_get(id_or_slug, ns(&req_data.namespace)) {
+                    Ok(Some(doc)) => ctx.ok_response_for(req, &doc),
+                    Ok(None) => ctx.error_response_for(
+                        req,
+                        404,
+                        format!("document not found: {id_or_slug}"),
+                    ),
+                    Err(e) => {
+                        error!("doc get error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                },
+                Err(e) => ctx.error_response_for(req, 400, e),
+            },
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Document: List ─────────────────────────────────────────────
+        (Method::Post, "/doc/list") => match read_body::<DocListParams>(req.as_reader()) {
+            Ok(params) => {
+                let result = if params.roots_only {
+                    uteke.doc_list_roots(ns(&params.namespace), params.limit)
+                } else if let Some(ref parent) = params.parent {
+                    uteke.doc_list_children(parent, ns(&params.namespace), params.limit)
+                } else {
+                    uteke.doc_list(ns(&params.namespace), params.limit)
+                };
+                match result {
+                    Ok(docs) => ctx.ok_response_for(req, &docs),
+                    Err(e) => {
+                        error!("doc list error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Document: Search ────────────────────────────────────────────
+        (Method::Post, "/doc/search") => match read_body::<DocSearchRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                match uteke.doc_search(
+                    &req_data.query,
+                    ns(&req_data.namespace),
+                    req_data.limit,
+                    &req_data.mode,
+                ) {
+                    Ok(results) => ctx.ok_response_for(req, &results),
+                    Err(e) => {
+                        if e.to_string().contains("embed") {
+                            ctx.error_response_for(
+                                req,
+                                503,
+                                "embedding model not available for semantic search",
+                            )
+                        } else {
+                            error!("doc search error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Document: Move ───────────────────────────────────────────────
+        (Method::Post, "/doc/move") => match read_body::<DocMoveRequest>(req.as_reader()) {
+            Ok(req_data) => match resolve_doc_id_move(&req_data) {
+                Ok(id_or_slug) => {
+                    let new_parent = req_data.new_parent.as_deref();
+                    match uteke.doc_move(id_or_slug, new_parent, ns(&req_data.namespace)) {
+                        Ok(moved) => ctx.ok_response_for(req, &serde_json::json!({"moved": moved})),
+                        Err(e) => {
+                            if e.to_string().contains("not found") {
+                                ctx.error_response_for(req, 404, e.to_string())
+                            } else {
+                                error!("doc move error: {e}");
+                                ctx.error_response_for(req, 500, "Internal server error")
+                            }
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            },
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Document: Delete ─────────────────────────────────────────────
+        (Method::Delete, p) if p == "/doc/delete" || p.starts_with("/doc/delete?") => {
+            let url = req.url().to_string();
+            let ns_param = parse_query(&url, "namespace");
+            let id = parse_query(&url, "id");
+            let slug = parse_query(&url, "slug");
+
+            let id_or_slug = match (&id, &slug) {
+                (Some(id), _) => id.as_str(),
+                (_, Some(slug)) => slug.as_str(),
+                _ => {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "provide either 'id' or 'slug' query parameter",
+                    );
+                }
+            };
+
+            match uteke.doc_delete(id_or_slug, ns_param.as_deref()) {
+                Ok((deleted, subtree)) => ctx.ok_response_for(
+                    req,
+                    &serde_json::json!({"deleted": deleted, "subtree_size": subtree}),
+                ),
+                Err(e) => {
+                    error!("doc delete error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
+            }
+        }
+
         // ── 404 ─────────────────────────────────────────────────────────
         _ => ctx.error_response_for(req, 404, "Not found"),
     }
@@ -1221,6 +1466,16 @@ fn main() {
                 println!("  POST /room/document        → {{ room_id }} → {{ document }}");
                 println!("  POST /room/stats           → {{ room_id }} → room stats");
                 println!("  DEL  /room/delete          → {{ room_id }} → {{ deleted }}");
+                println!();
+                println!("  Document endpoints:");
+                println!("  POST /doc/create          → {{ slug, content, title?, tags?, parent? }} → {{ id, slug }}");
+                println!("  POST /doc/get              → {{ id | slug }} → {{ document }}");
+                println!("  POST /doc/list             → {{ namespace?, limit?, roots_only?, parent? }} → [documents]");
+                println!("  POST /doc/search            → {{ query, mode?, namespace?, limit? }} → [results]");
+                println!(
+                    "  POST /doc/move              → {{ id | slug, new_parent? }} → {{ moved }}"
+                );
+                println!("  DEL  /doc/delete?id=UUID    → {{ deleted, subtree_size }}");
                 std::process::exit(0);
             }
             _ => {

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -1313,9 +1313,9 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
         // ── Document: Delete ─────────────────────────────────────────────
         (Method::Delete, p) if p == "/doc/delete" || p.starts_with("/doc/delete?") => {
             let url = req.url().to_string();
-            let ns_param = parse_query(&url, "namespace");
-            let id = parse_query(&url, "id");
-            let slug = parse_query(&url, "slug");
+            let ns_param = parse_query_param(&url, "namespace");
+            let id = parse_query_param(&url, "id");
+            let slug = parse_query_param(&url, "slug");
 
             let id_or_slug = match (&id, &slug) {
                 (Some(id), _) => id.as_str(),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -595,6 +595,12 @@ When `[server] enabled = true` is set in config, the CLI auto-routes commands th
 | POST | `/room/document` | Generate document from room |
 | POST | `/room/stats` | Room statistics |
 | DELETE | `/room/delete` | Delete a room |
+| POST | `/doc/create` | Create/upsert document (#438) |
+| POST | `/doc/get` | Get document by id or slug |
+| POST | `/doc/list` | List documents (roots_only, parent filter) |
+| POST | `/doc/search` | Hybrid/semantic/FTS document search (#440) |
+| POST | `/doc/move` | Move document to new parent (#438) |
+| DELETE | `/doc/delete?id=` | Delete document with cascade |
 | POST | `/mcp` | MCP JSON-RPC endpoint (#381) |
 
 ### MCP Server
@@ -614,9 +620,9 @@ curl -X POST http://127.0.0.1:8767/mcp \
 
 Protocol version: `2025-06-18` (Streamable HTTP spec).
 
-## Document Commands (#406, #411)
+## Document Commands (#406, #411, #438, #440)
 
-Wiki/knowledge base engine — full markdown documents with auto-chunking and semantic search.
+Wiki/knowledge base engine — hierarchical documents with auto-chunking, tree operations, and hybrid search.
 
 ### `uteke doc create`
 
@@ -631,6 +637,9 @@ uteke doc create notes --content "# Notes\n\nQuick notes" --title "My Notes"
 
 # From stdin
 cat README.md | uteke doc create readme --file -
+
+# As child of another document
+uteke doc create chapter1 --parent book --file ch1.md
 ```
 
 | Flag | Description |
@@ -639,6 +648,7 @@ cat README.md | uteke doc create readme --file -
 | `--file <path>` | Read content from file (`-` for stdin) |
 | `--content <text>` | Inline content (alternative to `--file`) |
 | `--tags <tags>` | Comma-separated tags |
+| `--parent <slug>` | Parent document slug (creates as child, #438) |
 
 ### `uteke doc get`
 
@@ -655,13 +665,46 @@ List documents in the current namespace.
 
 ```bash
 uteke doc list --limit 20
+uteke doc list --tree          # Indented tree view
+uteke doc list --roots-only   # Root documents only
+```
+
+| Flag | Description |
+|------|-------------|
+| `--limit <n>` | Max results (default: 20) |
+| `--tree` | Show as indented tree (recursive children) |
+| `--roots-only` | Show only root documents (no parent) |
+
+### `uteke doc search`
+
+Search documents using hybrid, semantic, or FTS5 search (#440).
+
+```bash
+uteke doc search "authentication flow"
+uteke doc search "database" --mode semantic
+uteke doc search "API reference" --mode fts --limit 5
+```
+
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | `hybrid` (default), `semantic`, or `fts` |
+| `--limit <n>` | Max results (default: 5) |
+
+### `uteke doc move`
+
+Move a document to a new parent or root (#438).
+
+```bash
+uteke doc move chapter1 --parent new-book
+uteke doc move orphan-doc               # Move to root
 ```
 
 ### `uteke doc delete`
 
-Delete a document by ID (cascades to chunks).
+Delete a document by ID or slug (cascades to children and chunks).
 
 ```bash
+uteke doc delete architecture
 uteke doc delete <id>
 ```
 


### PR DESCRIPTION
## Summary

Add HTTP API endpoints for all document operations in `uteke-serve`, ensuring CLI and API feature parity.

### Endpoints Added

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/doc/create` | Create/upsert document (slug, content, tags, parent) |
| POST | `/doc/get` | Get document by id or slug |
| POST | `/doc/list` | List documents (roots_only, parent filter, namespace) |
| POST | `/doc/search` | Hybrid/semantic/FTS document search |
| POST | `/doc/move` | Move document to new parent |
| DELETE | `/doc/delete?id=` | Delete document with cascade |

### Request/Response Format

All POST endpoints accept JSON body. All endpoints accept `namespace` parameter.

**POST /doc/create**
```json
{ "slug": "guide", "content": "# Guide\n...", "title": "Guide", "tags": ["wiki"], "parent": "parent-slug", "namespace": "default" }
→ { "id": "uuid", "slug": "guide" }
```

**POST /doc/get**
```json
{ "id": "uuid" } or { "slug": "guide" }
→ { "id", "slug", "title", "content", "tags", "parent_id", "depth", "has_children", ... }
```

**POST /doc/list**
```json
{ "namespace": "default", "limit": 20, "roots_only": false, "parent": "parent-slug" }
→ [{ "id", "slug", "title", "depth", "has_children", ... }]
```

**POST /doc/search**
```json
{ "query": "authentication", "mode": "hybrid", "namespace": "default", "limit": 10 }
→ [{ "document": {...}, "chunk_heading", "chunk_snippet", "score", "mode" }]
```

**POST /doc/move**
```json
{ "id": "uuid", "new_parent": "new-parent-slug" }
→ { "moved": 1 }
```

**DELETE /doc/delete?id=uuid&namespace=default**
```json
→ { "deleted": true, "subtree_size": 3 }
```

### Changes

- `crates/uteke-server/src/main.rs`: Added request structs, helper functions, 6 endpoint handlers, startup banner
- `CHANGELOG.md`: Added v0.4.0 entry (includes hierarchical docs + doc search from PR #439)