### PR TITLE
fix(#442): server deadlock on remember + cosine auto-linking never fires

### DIFF
--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -225,6 +225,10 @@ impl crate::Uteke {
                  Index entry can be rebuilt via `uteke repair`."
             );
         }
+        // Drop the write lock BEFORE auto_link_cosine to prevent deadlock.
+        // auto_link_cosine needs a read lock on the same index — holding
+        // the write lock here would deadlock (#442).
+        drop(index);
 
         // Cosine-similarity auto-linking (#401).
         // Must run AFTER index.insert() so the new memory is searchable.


### PR DESCRIPTION
## Critical Fix for #442

### Root Cause: RwLock Deadlock

`remember_precomputed()` holds an `RwLockWriteGuard` on the vector index (variable `index`). It then calls `auto_link_cosine()`, which tries to acquire `self.index.read()` — a **read lock on the same RwLock** while the write lock is still held.

This deadlocks the thread permanently. After 2-3 `remember()` calls, the server `Mutex<Uteke>` is held by the deadlocked thread, making the entire server unresponsive (even `GET /health` hangs).

### Fix

Add `drop(index)` before calling `auto_link_cosine()`. The index entry has already been inserted and saved, so the write lock is no longer needed.

### Also Fixes: No Edges Created

`auto_link_cosine()` was never reaching the search/edge-creation code because it deadlocked on the first `self.index.read()` attempt. With the deadlock fixed, `similar_to` and `possible_duplicate` edges will now be created correctly.

### Test
- 300 unit tests pass
- Clippy clean, fmt clean