### PR TITLE
release: v0.4.0 — SemVer correction (was v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - **move_document** now recomputes `has_children` on old parent after
   moving last child away.
 
-## [0.3.3] — 2026-06-22
+## [0.4.0] — 2026-06-22
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.3.3-green.svg" alt="v0.3.3" />
+  <img src="https://img.shields.io/badge/status-v0.4.0-green.svg" alt="v0.4.0" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.3.3-green.svg" alt="v0.3.3" />
+  <img src="https://img.shields.io/badge/status-v0.4.0-green.svg" alt="v0.4.0" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.3" }
+uteke-core = { path = "../uteke-core", version = "0.4.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.3" }
+uteke-core = { path = "../uteke-core", version = "0.4.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.3" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.3.3" }
+uteke-core = { path = "../uteke-core", version = "0.4.0" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.4.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
v0.3.2 added features (hierarchical docs, doc_search, document API) — that is a minor bump per SemVer, not a patch.

Rename v0.3.3 → v0.4.0.