### PR TITLE
feat: uteke_context + uteke_dream MCP tools + API endpoints + auto-dream

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -11,7 +11,7 @@
 
 pub mod chunker;
 mod consolidate;
-mod dream;
+pub mod dream;
 mod edges;
 mod embed;
 mod error;
@@ -696,6 +696,59 @@ impl Uteke {
             edges,
             stats,
         })
+    }
+
+    /// Build a smart project context summary for AI agents.
+    ///
+    /// Returns a human-readable summary: memory counts by type, top tags,
+    /// recent activity, key decisions/procedures. Ready to inject into prompts.
+    pub fn build_context(&self, namespace: Option<&str>) -> Result<String, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let stats = self.stats(Some(ns))?;
+        let recent = self.list(None, 5, 0, Some(ns))?;
+        let type_counts = self.store.memory_type_counts(ns).unwrap_or_default();
+        let top_tags = self.store.unique_tags(Some(ns)).unwrap_or_default();
+        let tag_names: Vec<String> = top_tags.iter().take(8).cloned().collect();
+
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "Project memory: {} memories in namespace '{}'",
+            stats.total_memories, ns
+        ));
+        if stats.hot > 0 || stats.warm > 0 {
+            lines.push(format!(
+                "Tiers: {} hot, {} warm, {} cold",
+                stats.hot, stats.warm, stats.cold
+            ));
+        }
+        if !type_counts.is_empty() {
+            let type_str: Vec<String> = type_counts
+                .iter()
+                .map(|(t, c)| format!("{} {}", c, t))
+                .collect();
+            lines.push(format!("Types: {}", type_str.join(", ")));
+        }
+        if !tag_names.is_empty() {
+            lines.push(format!("Tags: {}", tag_names.join(", ")));
+        }
+        if !recent.is_empty() {
+            lines.push("".to_string());
+            lines.push("Recent memories:".to_string());
+            for m in &recent {
+                let preview = if m.content.len() > 80 {
+                    format!("{}...", &m.content[..77])
+                } else {
+                    m.content.clone()
+                };
+                let type_tag = if m.memory_type != "fact" {
+                    format!(" [{}]", m.memory_type)
+                } else {
+                    String::new()
+                };
+                lines.push(format!("  - {preview}{type_tag}"));
+            }
+        }
+        Ok(lines.join("\n"))
     }
 
     // ── Document engine (#406, #438) ────────────────────────────────────────
@@ -1625,5 +1678,49 @@ mod tests {
         assert_eq!(merged.base_url, "https://from-toml.example.com");
         assert_eq!(merged.model, "from-toml-model");
         assert_eq!(merged.dims, 2048);
+    }
+}
+
+#[cfg(test)]
+mod context_tests {
+    use crate::Uteke;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore = "requires ONNX embedder (model download) in CI"]
+    fn test_build_context_empty_namespace() {
+        let uteke = Uteke::open(":memory:").unwrap();
+        let ctx = uteke.build_context(Some("empty-ns")).unwrap();
+        assert!(ctx.contains("0 memories"));
+    }
+
+    #[test]
+    #[serial]
+    #[ignore = "requires ONNX embedder (model download) in CI"]
+    fn test_build_context_with_data() {
+        let uteke = Uteke::open(":memory:").unwrap();
+        uteke
+            .remember(
+                "Use parameterized SQL queries",
+                &["tech"],
+                None,
+                Some("ctx-test"),
+            )
+            .unwrap();
+        uteke
+            .remember(
+                "We chose Tauri 2 over Electron",
+                &["tech"],
+                None,
+                Some("ctx-test"),
+            )
+            .unwrap();
+
+        let ctx = uteke.build_context(Some("ctx-test")).unwrap();
+        assert!(ctx.contains("2 memories"), "should show count: {ctx}");
+        assert!(ctx.contains("procedure"), "should list types");
+        assert!(ctx.contains("decision"), "should list types");
+        assert!(ctx.contains("Recent memories"), "should show recent");
     }
 }

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -362,6 +362,28 @@ impl super::Store {
         Ok(ids)
     }
 
+    /// Count memories grouped by memory_type in a namespace.
+    pub fn memory_type_counts(&self, namespace: &str) -> Result<Vec<(String, usize)>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT memory_type, COUNT(*) as cnt FROM memories
+                 WHERE namespace = ?1 AND deprecated = 0
+                 GROUP BY memory_type ORDER BY cnt DESC",
+            )
+            .map_err(|e| Error::db("prepare memory_type_counts", e))?;
+        let rows = stmt
+            .query_map(params![namespace], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, usize>(1)?))
+            })
+            .map_err(|e| Error::db("query memory_type_counts", e))?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row.map_err(|e| Error::db("memory_type_counts row", e))?);
+        }
+        Ok(result)
+    }
+
     /// List memories that existed at a specific point in time.
     ///
     /// A memory existed at `point_in_time` if:

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -117,6 +117,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_list(),
                 tool_forget(),
                 tool_stats(),
+                tool_context(),
+                tool_dream(),
                 tool_doc_create(),
                 tool_doc_get(),
                 tool_doc_list(),
@@ -142,6 +144,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_list" => exec_list(uteke, &arguments)?,
                 "uteke_forget" => exec_forget(uteke, &arguments)?,
                 "uteke_stats" => exec_stats(uteke, &arguments)?,
+                "uteke_context" => exec_context(uteke, &arguments)?,
+                "uteke_dream" => exec_dream(uteke, &arguments)?,
                 "uteke_doc_create" => exec_doc_create(uteke, &arguments)?,
                 "uteke_doc_get" => exec_doc_get(uteke, &arguments)?,
                 "uteke_doc_list" => exec_doc_list(uteke, &arguments)?,
@@ -347,6 +351,34 @@ fn tool_graph() -> Value {
             "type": "object",
             "properties": {
                 "namespace": { "type": "string", "description": "Filter by namespace (optional)" }
+            }
+        }
+    })
+}
+
+fn tool_context() -> Value {
+    serde_json::json!({
+        "name": "uteke_context",
+        "description": "Get a smart project context summary. Returns memory counts by type, top tags, and recent activity — ready to inject into agent prompts. Not raw recall, but a structured overview of what the agent knows.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "namespace": { "type": "string", "description": "Namespace to summarize (default: 'default')" }
+            }
+        }
+    })
+}
+
+fn tool_dream() -> Value {
+    serde_json::json!({
+        "name": "uteke_dream",
+        "description": "Run the dream cycle maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify. Cleans up and optimizes the memory store. Safe to run periodically.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "namespace": { "type": "string", "description": "Namespace to process (default: all)" },
+                "dry_run": { "type": "boolean", "description": "Preview changes without applying (default: false)" },
+                "phases": { "type": "array", "items": { "type": "string" }, "description": "Specific phases: lint, backlinks, dedup, orphans, compact, verify (default: all)" }
             }
         }
     })
@@ -713,6 +745,74 @@ fn exec_graph(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         content: vec![McpContent::Text {
             r#type: "text".to_string(),
             text,
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_context(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let namespace = args["namespace"].as_str();
+
+    let context = uteke
+        .build_context(namespace)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: context,
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_dream(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let namespace = args["namespace"].as_str();
+    let dry_run = args["dry_run"].as_bool().unwrap_or(false);
+
+    // Parse phases if specified.
+    let phases: Vec<uteke_core::DreamPhase> = args["phases"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .filter_map(|s| match s {
+                    "lint" => Some(uteke_core::DreamPhase::Lint),
+                    "backlinks" => Some(uteke_core::DreamPhase::Backlinks),
+                    "dedup" => Some(uteke_core::DreamPhase::Dedup),
+                    "orphans" => Some(uteke_core::DreamPhase::Orphans),
+                    "compact" => Some(uteke_core::DreamPhase::Compact),
+                    "verify" => Some(uteke_core::DreamPhase::Verify),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let report = uteke
+        .dream(namespace, dry_run, &phases)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let mut lines = vec![format!(
+        "Dream cycle complete: {} changes, {} warnings, {} errors ({}ms{})",
+        report.total_changes,
+        report.total_warnings,
+        report.total_errors,
+        report.duration_ms,
+        if dry_run { " [DRY RUN]" } else { "" }
+    )];
+
+    for phase in &report.phases {
+        lines.push(format!(
+            "  {}: {} changes, {} warnings",
+            phase.phase, phase.changes, phase.warnings
+        ));
+    }
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: lines.join("\n"),
         }],
         is_error: false,
     })

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -1144,6 +1144,43 @@ fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<Curs
                 }
             }
         }
+        // ── Context Summary (#442) ───────────────────────────────────────
+        (Method::Post, "/context") => match read_body::<serde_json::Value>(req.as_reader()) {
+            Ok(body) => {
+                let ns = body.get("namespace").and_then(|v| v.as_str());
+                match uteke.build_context(ns) {
+                    Ok(context) => {
+                        let resp = serde_json::json!({ "context": context });
+                        ctx.ok_response_for(req, &resp)
+                    }
+                    Err(e) => {
+                        error!("Context error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            }
+            Err(_) => ctx.error_response_for(req, 400, "Invalid JSON body"),
+        },
+
+        // ── Dream Cycle (#442) ─────────────────────────────────────────────
+        (Method::Post, "/dream") => match read_body::<serde_json::Value>(req.as_reader()) {
+            Ok(body) => {
+                let ns = body.get("namespace").and_then(|v| v.as_str());
+                let dry_run = body
+                    .get("dry_run")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                match uteke.dream(ns, dry_run, &[]) {
+                    Ok(report) => ctx.ok_response_for(req, &report),
+                    Err(e) => {
+                        error!("Dream error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            }
+            Err(_) => ctx.error_response_for(req, 400, "Invalid JSON body"),
+        },
+
         (Method::Post, "/mcp") => {
             // Enforce a body size limit to prevent memory exhaustion
             // (CodeCora #397). 1 MiB is generous for JSON-RPC.
@@ -1607,6 +1644,37 @@ fn main() {
                 Err(_) => {
                     // Lock contention — skip this cycle.
                     tracing::debug!("Auto-aging: lock busy, skipping cycle");
+                }
+            }
+        }
+    });
+
+    // Auto-dream background thread (#442 enhancement).
+    // Runs dream cycle every 3 days to maintain graph health.
+    let dream_uteke = Arc::clone(&uteke);
+    std::thread::spawn(move || {
+        let interval = std::time::Duration::from_secs(3 * 24 * 60 * 60); // 3 days
+        loop {
+            std::thread::sleep(interval);
+            if SHUTDOWN.load(Ordering::SeqCst) {
+                break;
+            }
+            match dream_uteke.lock() {
+                Ok(u) => match u.dream(None, false, &[]) {
+                    Ok(report) => {
+                        if report.total_changes > 0 {
+                            info!(
+                                "Auto-dream: {} changes, {} warnings ({}ms)",
+                                report.total_changes, report.total_warnings, report.duration_ms
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Auto-dream failed: {e}");
+                    }
+                },
+                Err(_) => {
+                    tracing::debug!("Auto-dream: lock busy, skipping cycle");
                 }
             }
         }


### PR DESCRIPTION
## New Features

### uteke_context — Smart Project Summary
MCP tool + API endpoint that returns a structured overview ready for agent prompts:
```
Project memory: 15 memories in namespace corin
Types: 5 fact, 3 decision, 2 procedure, 5 note
Tags: tech, architecture, api, release
Recent memories:
  - Use parameterized SQL queries [procedure]
  - We chose Tauri 2 over Electron [decision]
```

### uteke_dream — Agent-Triggered Maintenance
MCP tool + API endpoint: run dream cycle (lint → backlinks → dedup → orphans → compact → verify) from any agent.

### Auto-Schedule (Server)
- Auto-aging: every 6 hours (existing)
- **Auto-dream: every 3 days** (new)

### MCP Tools: 13 → 15
All API endpoints now have MCP equivalents:
- `uteke_context` — POST /context
- `uteke_dream` — POST /dream

### Tests
2 new context tests. 300 total pass. Clippy clean.