### PR TITLE
feat: configurable maintenance daemon — auto-aging + auto-dream via config

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -215,6 +215,32 @@ impl Default for ServerConfig {
     }
 }
 
+/// Maintenance daemon configuration (#442).
+/// Controls auto-aging and auto-dream background tasks in the server.
+#[derive(serde::Deserialize, Clone)]
+#[serde(default)]
+pub struct MaintenanceConfig {
+    /// Enable auto-aging: periodically clean up cold, stale memories.
+    pub auto_aging_enabled: bool,
+    /// Auto-aging interval in hours (default: 6).
+    pub auto_aging_interval_hours: u64,
+    /// Enable auto-dream: periodically run dream cycle (lint → dedup → orphans).
+    pub auto_dream_enabled: bool,
+    /// Auto-dream interval in days (default: 3).
+    pub auto_dream_interval_days: u64,
+}
+
+impl Default for MaintenanceConfig {
+    fn default() -> Self {
+        Self {
+            auto_aging_enabled: true,
+            auto_aging_interval_hours: 6,
+            auto_dream_enabled: true,
+            auto_dream_interval_days: 3,
+        }
+    }
+}
+
 /// Full uteke configuration, loaded from `uteke.toml`.
 #[derive(serde::Deserialize, Default, Clone)]
 #[serde(default)]
@@ -227,6 +253,7 @@ pub struct Config {
     pub recall: RecallConfig,
     pub server: ServerConfig,
     pub limits: LimitsConfig,
+    pub maintenance: MaintenanceConfig,
 }
 
 /// Configurable limits (#404).
@@ -630,6 +657,13 @@ impl Config {
 # max_tag_length = 50
 # max_payload_size = 10485760  # 10MB
 # default_recall_limit = 5
+
+[maintenance]
+# Auto-maintenance daemon (runs in server background)
+# auto_aging_enabled = true       # Clean up stale memories
+# auto_aging_interval_hours = 6   # Every 6 hours
+# auto_dream_enabled = true       # Run dream cycle (lint → dedup → orphans)
+# auto_dream_interval_days = 3    # Every 3 days
 "#;
         std::fs::write(&config_path, default).ok();
     }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -1621,64 +1621,95 @@ fn main() {
     }
 
     // Auto-aging background thread (#442 enhancement).
-    // Runs aging cleanup every 6 hours to remove cold, low-importance memories.
+    // Runs aging cleanup periodically to remove cold, low-importance memories.
+    let aging_enabled = config
+        .maintenance
+        .as_ref()
+        .and_then(|m| m.auto_aging_enabled)
+        .unwrap_or(true);
+    let aging_hours = config
+        .maintenance
+        .as_ref()
+        .and_then(|m| m.auto_aging_interval_hours)
+        .unwrap_or(6)
+        .max(1); // Minimum 1 hour to prevent busy loop
     let aging_uteke = Arc::clone(&uteke);
-    std::thread::spawn(move || {
-        let interval = std::time::Duration::from_secs(6 * 60 * 60); // 6 hours
-        loop {
-            std::thread::sleep(interval);
-            if SHUTDOWN.load(Ordering::SeqCst) {
-                break;
-            }
-            match aging_uteke.lock() {
-                Ok(u) => match u.aging_cleanup(180, 10000, None) {
-                    Ok(result) => {
-                        if result.deleted > 0 {
-                            info!("Auto-aging: cleaned up {} stale memories", result.deleted);
+    if aging_enabled {
+        info!("Auto-aging: enabled (every {aging_hours}h)");
+        std::thread::spawn(move || {
+            let interval = std::time::Duration::from_secs(aging_hours * 60 * 60);
+            loop {
+                std::thread::sleep(interval);
+                if SHUTDOWN.load(Ordering::SeqCst) {
+                    break;
+                }
+                match aging_uteke.lock() {
+                    Ok(u) => match u.aging_cleanup(180, 10000, None) {
+                        Ok(result) => {
+                            if result.deleted > 0 {
+                                info!("Auto-aging: cleaned up {} stale memories", result.deleted);
+                            }
                         }
+                        Err(e) => {
+                            warn!("Auto-aging failed: {e}");
+                        }
+                    },
+                    Err(_) => {
+                        tracing::debug!("Auto-aging: lock busy, skipping cycle");
                     }
-                    Err(e) => {
-                        warn!("Auto-aging failed: {e}");
-                    }
-                },
-                Err(_) => {
-                    // Lock contention — skip this cycle.
-                    tracing::debug!("Auto-aging: lock busy, skipping cycle");
                 }
             }
-        }
-    });
+        });
+    } else {
+        info!("Auto-aging: disabled");
+    }
 
     // Auto-dream background thread (#442 enhancement).
-    // Runs dream cycle every 3 days to maintain graph health.
+    // Runs dream cycle periodically to maintain graph health.
+    let dream_enabled = config
+        .maintenance
+        .as_ref()
+        .and_then(|m| m.auto_dream_enabled)
+        .unwrap_or(true);
+    let dream_days = config
+        .maintenance
+        .as_ref()
+        .and_then(|m| m.auto_dream_interval_days)
+        .unwrap_or(3)
+        .max(1); // Minimum 1 day to prevent busy loop
     let dream_uteke = Arc::clone(&uteke);
-    std::thread::spawn(move || {
-        let interval = std::time::Duration::from_secs(3 * 24 * 60 * 60); // 3 days
-        loop {
-            std::thread::sleep(interval);
-            if SHUTDOWN.load(Ordering::SeqCst) {
-                break;
-            }
-            match dream_uteke.lock() {
-                Ok(u) => match u.dream(None, false, &[]) {
-                    Ok(report) => {
-                        if report.total_changes > 0 {
-                            info!(
-                                "Auto-dream: {} changes, {} warnings ({}ms)",
-                                report.total_changes, report.total_warnings, report.duration_ms
-                            );
+    if dream_enabled {
+        info!("Auto-dream: enabled (every {dream_days}d)");
+        std::thread::spawn(move || {
+            let interval = std::time::Duration::from_secs(dream_days * 24 * 60 * 60);
+            loop {
+                std::thread::sleep(interval);
+                if SHUTDOWN.load(Ordering::SeqCst) {
+                    break;
+                }
+                match dream_uteke.lock() {
+                    Ok(u) => match u.dream(None, false, &[]) {
+                        Ok(report) => {
+                            if report.total_changes > 0 {
+                                info!(
+                                    "Auto-dream: {} changes, {} warnings ({}ms)",
+                                    report.total_changes, report.total_warnings, report.duration_ms
+                                );
+                            }
                         }
+                        Err(e) => {
+                            warn!("Auto-dream failed: {e}");
+                        }
+                    },
+                    Err(_) => {
+                        tracing::debug!("Auto-dream: lock busy, skipping cycle");
                     }
-                    Err(e) => {
-                        warn!("Auto-dream failed: {e}");
-                    }
-                },
-                Err(_) => {
-                    tracing::debug!("Auto-dream: lock busy, skipping cycle");
                 }
             }
-        }
-    });
+        });
+    } else {
+        info!("Auto-dream: disabled");
+    }
 
     // SIGINT handler
     ctrlc::set_handler(|| {
@@ -1730,6 +1761,15 @@ fn main() {
 struct ServerFileConfig {
     server: Option<ServerFileSection>,
     recall: Option<RecallFileSection>,
+    maintenance: Option<MaintenanceFileSection>,
+}
+
+#[derive(serde::Deserialize, Default, Clone)]
+struct MaintenanceFileSection {
+    auto_aging_enabled: Option<bool>,
+    auto_aging_interval_hours: Option<u64>,
+    auto_dream_enabled: Option<bool>,
+    auto_dream_interval_days: Option<u64>,
 }
 
 #[derive(serde::Deserialize, Default, Clone)]


### PR DESCRIPTION
## Changes

Auto-aging and auto-dream intervals are now configurable via `[maintenance]` in uteke.toml:

```toml
[maintenance]
auto_aging_enabled = true         # default: true
auto_aging_interval_hours = 6     # default: 6, min: 1
auto_dream_enabled = true         # default: true
auto_dream_interval_days = 3      # default: 3, min: 1
```

Server logs enabled/disabled status at startup. Both can be individually disabled.

**300 tests pass. Clippy clean. Fmt clean.**