### PR TITLE
release: v0.4.1 — MCP sync + dedup + auto-daemon + namespace fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.4.1] — 2026-06-22
+
+### Added
+- **uteke_context MCP tool** — smart project summary for agent prompts
+- **uteke_dream MCP tool** — trigger dream cycle from any agent
+- **POST /context** and **POST /dream** API endpoints
+- **Auto-dream** — server background thread runs dream every 3 days
+- **Configurable maintenance daemon** — [maintenance] config section
+- **Safe aging defaults** — pinned protection, max 100/cycle, configurable thresholds
+- **Dedup on insert** — cosine >= 0.95 returns existing memory ID
+
+### Fixed
+- **#442: server deadlock** — RwLock deadlock in remember_precomputed
+- **#448: recall without namespace** — now searches ALL namespaces (was: only "default")
+- **Pinned memories could be deleted** by aging cleanup — added pinned=0 guard
+- **Schema migration v7→v11** — indexes now created after migrations complete
+
 ## [0.4.0] — 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.4.0-green.svg" alt="v0.4.0" />
+  <img src="https://img.shields.io/badge/status-v0.4.1-green.svg" alt="v0.4.1" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.4.0-green.svg" alt="v0.4.0" />
+  <img src="https://img.shields.io/badge/status-v0.4.1-green.svg" alt="v0.4.1" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.0" }
+uteke-core = { path = "../uteke-core", version = "0.4.1" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.0" }
+uteke-core = { path = "../uteke-core", version = "0.4.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.0" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.4.0" }
+uteke-core = { path = "../uteke-core", version = "0.4.1" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.4.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
v0.4.1 patch release.

### Added
- uteke_context + uteke_dream MCP tools (15 total)
- POST /context + POST /dream API endpoints
- Dedup on insert (cosine >= 0.95)
- Configurable auto-aging + auto-dream daemon
- Safe aging: pinned protection, max 100/cycle

### Fixed
- #442: server deadlock (RwLock)
- #448: recall without namespace now searches ALL
- Pinned memories protected from aging
- Schema migration hardening

300 tests pass.