### PR TITLE
fix(#458): release workflow — changelog, filename order, double v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,11 @@ jobs:
           echo "" >> release-notes.md
           printf '### 📦 Binaries\n\nEach archive contains **two binaries**:\n- `uteke` — CLI tool\n- `uteke-serve` — HTTP server daemon\n\n' >> release-notes.md
           printf '| Platform | File |\n|----------|------|\n' >> release-notes.md
-          printf '| Linux (x86_64) | `uteke-%s-x86_64-unknown-linux-gnu.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| Linux (ARM64) | `uteke-%s-aarch64-unknown-linux-gnu.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| macOS (Apple Silicon) | `uteke-%s-aarch64-apple-darwin.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| Windows (x86_64) | `uteke-%s-x86_64-pc-windows-msvc.zip` |\n\n' "${VER}" >> release-notes.md
-          printf '### 🚀 Quick Start\n\n```bash\n# Quick install (Linux / macOS)\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Pin a specific version\nUTEKE_VERSION=v%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Store a memory\nuteke remember "Important context" --tags project\n\n# Recall by meaning\nuteke recall "what was that context?"\n\n# Start server for fast AI agent access\nuteke-serve --port 8767\n```\n\n' >> release-notes.md
+          printf '| Linux (x86_64) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
+          printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
+          printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\n' "${VER}" >> release-notes.md
+          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\n\n' "${VER}" >> release-notes.md
+          printf '### 🚀 Quick Start\n\n```bash\n# Quick install (Linux / macOS)\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Pin a specific version\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Store a memory\nuteke remember "Important context" --tags project\n\n# Recall by meaning\nuteke recall "what was that context?"\n\n# Start server for fast AI agent access\nuteke-serve --port 8767\n```\n\n' >> release-notes.md
           printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\n' >> release-notes.md
 
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,24 +51,8 @@
 - **move_document** now recomputes `has_children` on old parent after
   moving last child away.
 
-## [0.4.0] — 2026-06-22
-
-### Fixed
-
-- **Critical: server deadlock on POST /remember** (#442)
-  - RwLock deadlock in `remember_precomputed()`: the write lock on the
-    vector index was held when `auto_link_cosine()` tried to acquire a
-    read lock on the same RwLock. After 2-3 inserts, the server became
-    completely unresponsive.
-  - Fix: `drop(index)` before calling `auto_link_cosine()`.
-
-- **Cosine auto-linking never created edges** (#442)
-  - `auto_link_cosine()` deadlocked before reaching search/edge code.
-  - With the deadlock fixed, `similar_to` and `possible_duplicate`
-    edges are now created correctly on every `remember()`.
 
 ## [0.3.2] — 2026-06-22
- — 2026-06-22
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #458.

1. **CHANGELOG**: removed duplicate [0.4.0], fixed broken [0.3.2] header
2. **Filename mismatch**: `uteke-%s-TARGET` → `uteke-TARGET-%s`
3. **Double v**: `UTEKE_VERSION=v%s` → `UTEKE_VERSION=%s`