### PR TITLE
feat: expose store() accessor on Uteke

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -664,6 +664,11 @@ impl Uteke {
         &self.store.conn
     }
 
+    /// Borrow the underlying store for room/tag/document operations.
+    pub fn store(&self) -> &crate::memory::store::Store {
+        &self.store
+    }
+
     /// Get graph nodes + edges for visualization (#408).
     ///
     /// Returns all nodes and edges in the knowledge graph, optionally


### PR DESCRIPTION
CorIn needs access to Store for room/tag operations (rooms, unique_tags) that aren't delegated through Uteke's own methods.

Added: `pub fn store(&self) -> &Store`

Depends on #465 (rusqlite 0.40 upgrade).