### PR TITLE
fix(#463): binary version string — Cargo.toml 0.3.2 → 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.2" }
+uteke-core = { path = "../uteke-core", version = "0.4.2" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.2" }
+uteke-core = { path = "../uteke-core", version = "0.4.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.3.2" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.3.2" }
+uteke-core = { path = "../uteke-core", version = "0.4.2" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.4.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
Fixes #463.

Root cause: develop→main merge conflicts resolved to main side, leaving Cargo.toml at 0.3.2 on main despite develop being at 0.4.2.

Tag v0.4.2 built from main → binary reports 0.3.2.

Fix: bump Cargo.toml + inter-crate deps to 0.4.2 on main.