### PR TITLE
release: v0.4.3 — version string fix + release workflow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.4.3] — 2026-06-22
+
+### Fixed
+- **#463: Binary version mismatch** — Cargo.toml on main was 0.3.2
+  despite develop being 0.4.2. Merge conflicts resolved to wrong side.
+  Now all crates report correct version.
+- **#458: Release workflow** — filename order, double v, CHANGELOG dupes.
+- **#467: Bump actions/checkout v6 to v7.**
+
 ## [0.4.2] — 2026-06-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "dirs",
  "serde",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.4.2-green.svg" alt="v0.4.2" />
+  <img src="https://img.shields.io/badge/status-v0.4.3-green.svg" alt="v0.4.3" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.4.2-green.svg" alt="v0.4.2" />
+  <img src="https://img.shields.io/badge/status-v0.4.3-green.svg" alt="v0.4.3" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.2" }
+uteke-core = { path = "../uteke-core", version = "0.4.3" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.2" }
+uteke-core = { path = "../uteke-core", version = "0.4.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.2" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.4.2" }
+uteke-core = { path = "../uteke-core", version = "0.4.3" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.4.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
v0.4.3 patch.

Fix #463: binary version 0.3.2 → correct.
Fix #458: filename order, double v, CHANGELOG.
Bump actions/checkout v7 (#467).