### PR TITLE
feat: configurable embedding endpoint path (#473)

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -44,6 +44,10 @@ pub struct EmbeddingConfig {
     /// - Ollama: http://localhost:11434
     /// - Azure OpenAI: your endpoint base
     pub base_url: String,
+    /// Embedding endpoint path appended to base_url. Empty string = "/embeddings" (OpenAI standard).
+    /// Override for non-standard OpenAI-compatible APIs, e.g. CodeCora Embed uses "/embed" (#473).
+    /// Can also be supplied via UTEKE_EMBEDDING_ENDPOINT_PATH.
+    pub endpoint_path: String,
     /// Embedding dimensions. 0 = use backend/model default.
     /// Override only when you know your model's output dim.
     pub dims: usize,
@@ -57,6 +61,7 @@ impl Default for EmbeddingConfig {
             max_seq_length: 256,
             api_key: String::new(),
             base_url: String::new(),
+            endpoint_path: String::new(),
             dims: 0,
         }
     }
@@ -388,6 +393,9 @@ impl Config {
             if emb.contains_key("base_url") {
                 self.embedding.base_url = overlay.embedding.base_url.clone();
             }
+            if emb.contains_key("endpoint_path") {
+                self.embedding.endpoint_path = overlay.embedding.endpoint_path.clone();
+            }
             if emb.contains_key("dims") {
                 self.embedding.dims = overlay.embedding.dims;
             }
@@ -585,6 +593,11 @@ impl Config {
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_BASE_URL") {
             if !v.is_empty() {
                 self.embedding.base_url = v;
+            }
+        }
+        if let Ok(v) = std::env::var("UTEKE_EMBEDDING_ENDPOINT_PATH") {
+            if !v.is_empty() {
+                self.embedding.endpoint_path = v;
             }
         }
         if let Ok(v) = std::env::var("UTEKE_EMBEDDING_DIMS") {

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -102,6 +102,7 @@ fn main() {
         uteke_core::EmbeddingSettings {
             api_key: config.embedding.api_key.clone(),
             base_url: config.embedding.base_url.clone(),
+            endpoint_path: config.embedding.endpoint_path.clone(),
             model: config.embedding.model.clone(),
             dims: config.embedding.dims,
         },

--- a/crates/uteke-core/src/embed/openai.rs
+++ b/crates/uteke-core/src/embed/openai.rs
@@ -254,14 +254,8 @@ mod tests {
         assert!(msg.contains("http"), "got: {msg}");
 
         // Empty string.
-        let err = OpenAiEmbedder::new(
-            "k",
-            DEFAULT_MODEL,
-            "",
-            DEFAULT_ENDPOINT_PATH,
-            DEFAULT_DIMS,
-        )
-        .unwrap_err();
+        let err = OpenAiEmbedder::new("k", DEFAULT_MODEL, "", DEFAULT_ENDPOINT_PATH, DEFAULT_DIMS)
+            .unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("empty") || msg.contains("http"), "got: {msg}");
 
@@ -283,7 +277,8 @@ mod tests {
 
     #[test]
     fn empty_endpoint_path_uses_default() {
-        let e = OpenAiEmbedder::new("k", DEFAULT_MODEL, DEFAULT_BASE_URL, "", DEFAULT_DIMS).unwrap();
+        let e =
+            OpenAiEmbedder::new("k", DEFAULT_MODEL, DEFAULT_BASE_URL, "", DEFAULT_DIMS).unwrap();
         assert_eq!(e.endpoint(), "https://api.openai.com/v1/embeddings");
     }
 

--- a/crates/uteke-core/src/embed/openai.rs
+++ b/crates/uteke-core/src/embed/openai.rs
@@ -23,6 +23,11 @@ pub const DEFAULT_MODEL: &str = "text-embedding-3-small";
 /// Default dimensions for [`DEFAULT_MODEL`].
 pub const DEFAULT_DIMS: usize = 1536;
 
+/// Default endpoint path (OpenAI standard). Override via `endpoint_path`
+/// config or `UTEKE_EMBEDDING_ENDPOINT_PATH` env var for non-standard
+/// OpenAI-compatible APIs (#473).
+pub const DEFAULT_ENDPOINT_PATH: &str = "/embeddings";
+
 /// OpenAI max sequence length in tokens (clamped by the API).
 pub const MAX_SEQ_LEN: usize = 8191;
 
@@ -32,6 +37,7 @@ pub struct OpenAiEmbedder {
     client: reqwest::blocking::Client,
     api_key: String,
     base_url: String,
+    endpoint_path: String,
     model: String,
     dims: usize,
 }
@@ -41,7 +47,16 @@ impl OpenAiEmbedder {
     ///
     /// `api_key` is required; resolution from env/config is the caller's job
     /// (see `lib.rs::ensure_embedder`).
-    pub fn new(api_key: &str, model: &str, base_url: &str, dims: usize) -> Result<Self, Error> {
+    ///
+    /// `endpoint_path` is the API path appended to `base_url` (e.g. `/embeddings`
+    /// or `/embed`). Pass empty string to use [`DEFAULT_ENDPOINT_PATH`].
+    pub fn new(
+        api_key: &str,
+        model: &str,
+        base_url: &str,
+        endpoint_path: &str,
+        dims: usize,
+    ) -> Result<Self, Error> {
         if api_key.is_empty() {
             return Err(Error::Validation(
                 "OpenAI embedder requires an API key (set UTEKE_EMBEDDING_API_KEY or OPENAI_API_KEY)".into(),
@@ -52,10 +67,23 @@ impl OpenAiEmbedder {
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| Error::generic(format!("Failed to build HTTP client: {e}")))?;
+        let endpoint = if endpoint_path.is_empty() {
+            DEFAULT_ENDPOINT_PATH.to_string()
+        } else {
+            // Normalize: ensure leading slash so base_url + path always
+            // produces a valid URL (CodeCora review #473).
+            let path = endpoint_path;
+            if path.starts_with('/') {
+                path.to_string()
+            } else {
+                format!("/{path}")
+            }
+        };
         Ok(Self {
             client,
             api_key: api_key.to_string(),
             base_url: base_url.to_string(),
+            endpoint_path: endpoint,
             model: model.to_string(),
             dims,
         })
@@ -63,7 +91,7 @@ impl OpenAiEmbedder {
 
     fn endpoint(&self) -> String {
         let base = self.base_url.trim_end_matches('/');
-        format!("{base}/embeddings")
+        format!("{base}{}", self.endpoint_path)
     }
 }
 
@@ -147,8 +175,14 @@ mod tests {
 
     #[test]
     fn rejects_empty_api_key() {
-        let err =
-            OpenAiEmbedder::new("", DEFAULT_MODEL, DEFAULT_BASE_URL, DEFAULT_DIMS).unwrap_err();
+        let err = OpenAiEmbedder::new(
+            "",
+            DEFAULT_MODEL,
+            DEFAULT_BASE_URL,
+            DEFAULT_ENDPOINT_PATH,
+            DEFAULT_DIMS,
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("API key"), "got: {msg}");
     }
@@ -159,6 +193,7 @@ mod tests {
             "k",
             DEFAULT_MODEL,
             "https://api.openai.com/v1/",
+            DEFAULT_ENDPOINT_PATH,
             DEFAULT_DIMS,
         )
         .unwrap();
@@ -170,12 +205,20 @@ mod tests {
         assert_eq!(DEFAULT_MODEL, "text-embedding-3-small");
         assert_eq!(DEFAULT_DIMS, 1536);
         assert_eq!(DEFAULT_BASE_URL, "https://api.openai.com/v1");
+        assert_eq!(DEFAULT_ENDPOINT_PATH, "/embeddings");
         assert_eq!(MAX_SEQ_LEN, 8191);
     }
 
     #[test]
     fn embedder_name_and_dims() {
-        let e = OpenAiEmbedder::new("k", DEFAULT_MODEL, DEFAULT_BASE_URL, 3072).unwrap();
+        let e = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            DEFAULT_BASE_URL,
+            DEFAULT_ENDPOINT_PATH,
+            3072,
+        )
+        .unwrap();
         assert_eq!(e.name(), "openai");
         assert_eq!(e.dims(), 3072);
         assert_eq!(e.max_seq_len(), MAX_SEQ_LEN);
@@ -199,22 +242,75 @@ mod tests {
     #[test]
     fn rejects_invalid_base_url() {
         // Schemeless URL — CodeCora #155.
-        let err =
-            OpenAiEmbedder::new("k", DEFAULT_MODEL, "api.openai.com/v1", DEFAULT_DIMS).unwrap_err();
+        let err = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            "api.openai.com/v1",
+            DEFAULT_ENDPOINT_PATH,
+            DEFAULT_DIMS,
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("http"), "got: {msg}");
 
         // Empty string.
-        let err = OpenAiEmbedder::new("k", DEFAULT_MODEL, "", DEFAULT_DIMS).unwrap_err();
+        let err = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            "",
+            DEFAULT_ENDPOINT_PATH,
+            DEFAULT_DIMS,
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("empty") || msg.contains("http"), "got: {msg}");
 
         // Unparseable.
-        let err = OpenAiEmbedder::new("k", DEFAULT_MODEL, "https://", DEFAULT_DIMS).unwrap_err();
+        let err = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            "https://",
+            DEFAULT_ENDPOINT_PATH,
+            DEFAULT_DIMS,
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("valid URL") || msg.contains("http"),
             "got: {msg}"
         );
+    }
+
+    #[test]
+    fn empty_endpoint_path_uses_default() {
+        let e = OpenAiEmbedder::new("k", DEFAULT_MODEL, DEFAULT_BASE_URL, "", DEFAULT_DIMS).unwrap();
+        assert_eq!(e.endpoint(), "https://api.openai.com/v1/embeddings");
+    }
+
+    #[test]
+    fn custom_endpoint_path() {
+        let e = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            "https://codecora-embed.example.com/v1",
+            "/embed",
+            DEFAULT_DIMS,
+        )
+        .unwrap();
+        assert_eq!(e.endpoint(), "https://codecora-embed.example.com/v1/embed");
+    }
+
+    #[test]
+    fn endpoint_path_without_leading_slash_normalized() {
+        let e = OpenAiEmbedder::new(
+            "k",
+            DEFAULT_MODEL,
+            "https://codecora-embed.example.com/v1",
+            "embed",
+            DEFAULT_DIMS,
+        )
+        .unwrap();
+        // Should auto-prepend "/"
+        assert_eq!(e.endpoint(), "https://codecora-embed.example.com/v1/embed");
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -230,8 +230,8 @@ impl EmbeddingSettings {
             .or_else(|| env_or("OPENAI_API_KEY"))
             .unwrap_or_else(|| input.api_key.clone());
         let base_url = env_or("UTEKE_EMBEDDING_BASE_URL").unwrap_or_else(|| input.base_url.clone());
-        let endpoint_path = env_or("UTEKE_EMBEDDING_ENDPOINT_PATH")
-            .unwrap_or_else(|| input.endpoint_path.clone());
+        let endpoint_path =
+            env_or("UTEKE_EMBEDDING_ENDPOINT_PATH").unwrap_or_else(|| input.endpoint_path.clone());
         let model = env_or("UTEKE_EMBEDDING_MODEL").unwrap_or_else(|| input.model.clone());
         let dims = std::env::var("UTEKE_EMBEDDING_DIMS")
             .ok()
@@ -1631,6 +1631,7 @@ mod tests {
         let input = EmbeddingSettings {
             api_key: "sk-config".to_string(),
             base_url: "https://config.example.com".to_string(),
+            endpoint_path: String::new(),
             model: "config-model".to_string(),
             dims: 1024,
         };
@@ -1653,8 +1654,9 @@ mod tests {
         std::env::set_var("UTEKE_EMBEDDING_API_KEY", "");
         std::env::set_var("UTEKE_EMBEDDING_MODEL", "");
         let input = EmbeddingSettings {
-            api_key: "sk-from-config".to_string(),
+            api_key: "***".to_string(),
             base_url: "https://config.example.com".to_string(),
+            endpoint_path: String::new(),
             model: "config-model".to_string(),
             dims: 1536,
         };
@@ -1680,8 +1682,9 @@ mod tests {
         std::env::remove_var("UTEKE_EMBEDDING_MODEL");
         std::env::remove_var("UTEKE_EMBEDDING_DIMS");
         let input = EmbeddingSettings {
-            api_key: "sk-config-only".to_string(),
+            api_key: "***".to_string(),
             base_url: "https://from-toml.example.com".to_string(),
+            endpoint_path: String::new(),
             model: "from-toml-model".to_string(),
             dims: 2048,
         };

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1654,7 +1654,7 @@ mod tests {
         std::env::set_var("UTEKE_EMBEDDING_API_KEY", "");
         std::env::set_var("UTEKE_EMBEDDING_MODEL", "");
         let input = EmbeddingSettings {
-            api_key: "***".to_string(),
+            api_key: "sk-from-config".to_string(),
             base_url: "https://config.example.com".to_string(),
             endpoint_path: String::new(),
             model: "config-model".to_string(),
@@ -1682,7 +1682,7 @@ mod tests {
         std::env::remove_var("UTEKE_EMBEDDING_MODEL");
         std::env::remove_var("UTEKE_EMBEDDING_DIMS");
         let input = EmbeddingSettings {
-            api_key: "***".to_string(),
+            api_key: "sk-config-only".to_string(),
             base_url: "https://from-toml.example.com".to_string(),
             endpoint_path: String::new(),
             model: "from-toml-model".to_string(),

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -206,6 +206,9 @@ pub struct EmbeddingSettings {
     pub api_key: String,
     /// Custom endpoint. Empty = backend default.
     pub base_url: String,
+    /// Endpoint path appended to base_url. Empty = "/embeddings" (OpenAI standard).
+    /// Override for non-standard OpenAI-compatible APIs (#473).
+    pub endpoint_path: String,
     /// Model name. Empty = backend default.
     pub model: String,
     /// Force dims. 0 = backend/model default.
@@ -227,6 +230,8 @@ impl EmbeddingSettings {
             .or_else(|| env_or("OPENAI_API_KEY"))
             .unwrap_or_else(|| input.api_key.clone());
         let base_url = env_or("UTEKE_EMBEDDING_BASE_URL").unwrap_or_else(|| input.base_url.clone());
+        let endpoint_path = env_or("UTEKE_EMBEDDING_ENDPOINT_PATH")
+            .unwrap_or_else(|| input.endpoint_path.clone());
         let model = env_or("UTEKE_EMBEDDING_MODEL").unwrap_or_else(|| input.model.clone());
         let dims = std::env::var("UTEKE_EMBEDDING_DIMS")
             .ok()
@@ -236,6 +241,7 @@ impl EmbeddingSettings {
         Self {
             api_key,
             base_url,
+            endpoint_path,
             model,
             dims,
         }
@@ -580,6 +586,7 @@ impl Uteke {
                         &cfg.api_key,
                         &model,
                         &base_url,
+                        &cfg.endpoint_path,
                         dims,
                     )?)
                 }


### PR DESCRIPTION
## Summary

Add `endpoint_path` config field and `UTEKE_EMBEDDING_ENDPOINT_PATH` env var override for OpenAI-compatible backends that use non-standard paths.

**Problem:** uteke hardcodes `/embeddings` as the endpoint path. CodeCora Embed (Modal) uses `/embed`, causing HTTP 404.

**Solution:** Configurable `endpoint_path` with `/embeddings` default (zero breaking change).

### Changes

| File | Change |
|------|--------|
| `crates/uteke-core/src/embed/openai.rs` | Add `endpoint_path` field, `DEFAULT_ENDPOINT_PATH` constant, normalize leading slash, update all tests + add 2 new tests |
| `crates/uteke-cli/src/config.rs` | Add `endpoint_path` to `EmbeddingConfig` (struct + default + TOML merge + ENV override) |
| `crates/uteke-core/src/lib.rs` | Add `endpoint_path` to `EmbeddingSettings` + resolve + pass to constructor |

### Usage

```toml
[embedding]
backend = "openai"
base_url = "https://codecora-embed.example.com/v1"
endpoint_path = "/embed"  # default: "/embeddings"
```

Or via ENV:
```bash
UTEKE_EMBEDDING_ENDPOINT_PATH=/embed uteke recall "query"
```

### Safeguards
- Empty endpoint_path → /embeddings (OpenAI standard)
- Missing leading slash auto-normalized (Cora review)
- All existing tests updated, 2 new tests added

Closes #473