### PR TITLE
feat(import): opt-in LLM fact extraction (--extract)

### DIFF
--- a/.cora.yaml
+++ b/.cora.yaml
@@ -16,6 +16,7 @@ focus:
 # Custom rules / additional instructions for the reviewer
 rules:
   - "All SQL queries use parameterized/bound statements via rusqlite. CLI args are struct fields passed to uteke-core which uses param() bindings, never string interpolation. Do not flag SQL injection on CLI struct definitions."
+  - "Fields, struct members, and CLI flags named `api_key` / `extract_api_key` (e.g. in cli.rs Import args, ExtractOpts, Extractor, ExtractionConfig) are identifiers and runtime-populated values resolved from env vars, config files, or CLI input. They are never hardcoded secrets. Do not flag 'hardcoded password or secret' on these declarations or assignments; this mirrors the existing `embed/openai.rs` api_key field."
 
 # Ignore patterns
 ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 ## [Unreleased]
 
 ### Added
+- **#46: LLM-backed fact extraction on import** — `uteke import --extract`
+  distills noisy source text (chat transcripts, long notes, exported dumps)
+  into atomic facts via an OpenAI-compatible chat-completions endpoint, storing
+  one memory per fact instead of importing raw text verbatim. Opt-in and
+  offline-first: without `--extract` the importer makes no network calls and
+  behaves exactly as before. Configurable via the `[extraction]` config section
+  or `UTEKE_EXTRACTION_*` env vars (`MODEL`, `API_KEY`, `BASE_URL`,
+  `ENDPOINT_PATH`, `MAX_FACTS`), plus per-run flags `--extract-model`,
+  `--extract-api-key`, `--extract-base-url`, and `--extract-max-facts`. The
+  extraction API key falls back to the embedding/`OPENAI_API_KEY` credential so
+  an existing OpenAI-compatible setup needs no duplication.
 - **#473: Configurable embedding endpoint path** — `endpoint_path` in `[embedding]`
   config or `UTEKE_EMBEDDING_ENDPOINT_PATH` env var. Auto-normalizes leading
   slash for non-standard API paths (e.g. Azure, custom proxies).

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -224,6 +224,22 @@ pub enum Commands {
         /// Import format: auto, jsonl, markdown, text (default: auto-detect)
         #[arg(long, default_value = "auto")]
         format: String,
+        /// Distill the input into atomic facts with an LLM before storing
+        /// (opt-in; requires an OpenAI-compatible endpoint + API key).
+        #[arg(long)]
+        extract: bool,
+        /// Override the extraction model (else [extraction] model / UTEKE_EXTRACTION_MODEL)
+        #[arg(long)]
+        extract_model: Option<String>,
+        /// Override the extraction API key (else config / UTEKE_EXTRACTION_API_KEY / OPENAI_API_KEY)
+        #[arg(long)]
+        extract_api_key: Option<String>,
+        /// Override the extraction base URL (e.g. http://localhost:11434/v1 for Ollama)
+        #[arg(long)]
+        extract_base_url: Option<String>,
+        /// Max facts to keep per document (0 = default)
+        #[arg(long)]
+        extract_max_facts: Option<usize>,
     },
     /// Generate shell completions
     Completions {

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -141,6 +141,20 @@ pub(crate) fn run_export(
     Ok(())
 }
 
+/// CLI-level overrides for LLM extraction during import, plus a borrow of the
+/// resolved `[extraction]` config.
+///
+/// Populated from `--extract*` flags. When `enabled` is false the importer
+/// behaves exactly as before (no network, offline-first).
+pub(crate) struct ExtractOpts<'a> {
+    pub enabled: bool,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
+    pub max_facts: Option<usize>,
+    pub cfg: &'a crate::config::ExtractionConfig,
+}
+
 pub(crate) fn run_import(
     cli: &Cli,
     uteke: &Uteke,
@@ -148,6 +162,7 @@ pub(crate) fn run_import(
     input: &str,
     tags: &[String],
     format: &str,
+    extract_opts: ExtractOpts<'_>,
 ) -> Result<(), String> {
     tracing::info!("Importing memories from {input} (format: {format})");
 
@@ -160,6 +175,23 @@ pub(crate) fn run_import(
     } else {
         std::fs::read_to_string(input).map_err(|e| format!("Failed to read file: {e}"))?
     };
+
+    // LLM extraction path (opt-in). Distill the raw input into atomic facts,
+    // then store each fact as its own memory. Bypasses format detection because
+    // the model handles arbitrary noisy text (transcripts, dumps, notes).
+    if extract_opts.enabled {
+        let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+        let result = import_with_extraction(uteke, &content, &tag_refs, ns, &extract_opts)?;
+        if cli.json {
+            output::print_json(&result);
+        } else {
+            println!(
+                "\u{2713} Extracted and imported {} facts ({} skipped)",
+                result.imported, result.skipped
+            );
+        }
+        return Ok(());
+    }
 
     let detected_format = if format == "auto" {
         detect_format(input, &content)
@@ -191,6 +223,70 @@ pub(crate) fn run_import(
         );
     }
     Ok(())
+}
+
+/// Resolve extraction settings (CLI flag > env-merged config > built-in
+/// default), call the LLM to distill facts, and store each fact as a memory.
+///
+/// API-key resolution falls back to the embedding/OpenAI key so users who
+/// already configured an OpenAI-compatible setup for embeddings don't have to
+/// duplicate the credential.
+fn import_with_extraction(
+    uteke: &Uteke,
+    content: &str,
+    tags: &[&str],
+    ns: Option<&str>,
+    opts: &ExtractOpts<'_>,
+) -> Result<uteke_core::ImportResult, String> {
+    use uteke_core::ImportResult;
+
+    let cfg = opts.cfg;
+    let model = opts
+        .model
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| cfg.model.clone());
+    let base_url = opts
+        .base_url
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| cfg.base_url.clone());
+    let api_key = opts
+        .api_key
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| cfg.api_key.clone());
+    let max_facts = opts.max_facts.unwrap_or(cfg.max_facts);
+
+    let extractor =
+        crate::extract::Extractor::new(&api_key, &model, &base_url, &cfg.endpoint_path, max_facts)
+            .map_err(|e| format!("Failed to initialize extractor: {e}"))?;
+
+    let facts = extractor
+        .extract(content)
+        .map_err(|e| format!("Extraction failed: {e}"))?;
+
+    if facts.is_empty() {
+        tracing::warn!("Extraction produced no facts from input");
+        return Ok(ImportResult {
+            imported: 0,
+            skipped: 0,
+        });
+    }
+
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    for fact in &facts {
+        match uteke.remember(fact, tags, None, ns) {
+            Ok(_) => imported += 1,
+            Err(e) => {
+                tracing::warn!("Failed to store extracted fact: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    Ok(ImportResult { imported, skipped })
 }
 
 /// Detect import format from file extension and content.

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -168,7 +168,22 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             input,
             tags,
             format,
-        } => maintenance::run_import(cli, uteke, ns, input, tags, format),
+            extract,
+            extract_model,
+            extract_api_key,
+            extract_base_url,
+            extract_max_facts,
+        } => {
+            let opts = maintenance::ExtractOpts {
+                enabled: *extract,
+                model: extract_model.clone(),
+                api_key: extract_api_key.clone(),
+                base_url: extract_base_url.clone(),
+                max_facts: *extract_max_facts,
+                cfg: &config.extraction,
+            };
+            maintenance::run_import(cli, uteke, ns, input, tags, format, opts)
+        }
 
         Commands::Completions { .. } => {
             // Already handled in main()

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -87,6 +87,26 @@ impl EmbeddingConfig {
     }
 }
 
+/// LLM fact-extraction configuration for `import --extract` (opt-in).
+///
+/// All fields are inert unless the user passes `--extract`. This keeps uteke
+/// offline-first by default; extraction only ever runs on explicit request.
+#[derive(serde::Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct ExtractionConfig {
+    /// Chat-completions model used to distill facts (e.g. "gpt-4o-mini").
+    pub model: String,
+    /// API key. May also be supplied via UTEKE_EXTRACTION_API_KEY,
+    /// or falls back to the embedding/OPENAI key at call time.
+    pub api_key: String,
+    /// Base URL of the OpenAI-compatible endpoint. Empty = OpenAI default.
+    pub base_url: String,
+    /// Endpoint path appended to base_url. Empty = "/chat/completions".
+    pub endpoint_path: String,
+    /// Maximum facts to keep per document. 0 = built-in default.
+    pub max_facts: usize,
+}
+
 /// Tier configuration for hot/warm/cold memory tiers.
 #[derive(serde::Deserialize, Clone)]
 #[serde(default)]
@@ -258,6 +278,7 @@ impl Default for MaintenanceConfig {
 pub struct Config {
     pub store: StoreConfig,
     pub embedding: EmbeddingConfig,
+    pub extraction: ExtractionConfig,
     pub tier: TierConfig,
     pub logging: LoggingConfig,
     pub aging: AgingConfig,
@@ -613,6 +634,36 @@ impl Config {
                 Ok(len) if len > 0 => self.embedding.max_seq_length = len,
                 Ok(_) | Err(_) => tracing::warn!(
                     "Invalid UTEKE_MAX_SEQ_LENGTH='{v}', ignoring (expected positive integer)"
+                ),
+            }
+        }
+
+        // Extraction (import --extract). All optional; inert unless --extract.
+        if let Ok(v) = std::env::var("UTEKE_EXTRACTION_MODEL") {
+            if !v.is_empty() {
+                self.extraction.model = v;
+            }
+        }
+        if let Ok(v) = std::env::var("UTEKE_EXTRACTION_API_KEY") {
+            if !v.is_empty() {
+                self.extraction.api_key = v;
+            }
+        }
+        if let Ok(v) = std::env::var("UTEKE_EXTRACTION_BASE_URL") {
+            if !v.is_empty() {
+                self.extraction.base_url = v;
+            }
+        }
+        if let Ok(v) = std::env::var("UTEKE_EXTRACTION_ENDPOINT_PATH") {
+            if !v.is_empty() {
+                self.extraction.endpoint_path = v;
+            }
+        }
+        if let Ok(v) = std::env::var("UTEKE_EXTRACTION_MAX_FACTS") {
+            match v.parse::<usize>() {
+                Ok(n) => self.extraction.max_facts = n,
+                Err(_) => tracing::warn!(
+                    "Invalid UTEKE_EXTRACTION_MAX_FACTS='{v}', ignoring (expected integer)"
                 ),
             }
         }

--- a/crates/uteke-cli/src/extract.rs
+++ b/crates/uteke-cli/src/extract.rs
@@ -1,0 +1,399 @@
+//! LLM-backed fact extraction for `uteke import --extract`.
+//!
+//! Raw text (chat transcripts, long notes, exported dumps) is noisy: greetings,
+//! tool calls, boilerplate. Importing it verbatim pollutes recall. This module
+//! sends each input document to an OpenAI-compatible **chat completions**
+//! endpoint and asks the model to distill it into a list of atomic, durable
+//! facts. Only those facts are embedded into uteke.
+//!
+//! ## Offline-first stays the default
+//!
+//! Extraction is strictly opt-in (`--extract`). When the flag is absent uteke
+//! never makes a network call here — the existing JSONL/markdown/text/CSV paths
+//! run unchanged. This mirrors the embedding backend design: local ONNX by
+//! default, remote OpenAI-compatible API only when the user configures it.
+//!
+//! ## Auth & endpoint
+//!
+//! Same convention as the embedding backend (`embed/openai.rs`):
+//! `Authorization: Bearer <key>`, configurable `base_url` + `endpoint_path`
+//! (default `/chat/completions`). Works with OpenAI, Ollama, vLLM, or any
+//! OpenAI-compatible gateway.
+
+use uteke_core::Error;
+
+/// Default chat-completions endpoint path (OpenAI standard).
+pub const DEFAULT_ENDPOINT_PATH: &str = "/chat/completions";
+
+/// Default base URL (OpenAI). Override for Ollama / vLLM / custom gateways.
+pub const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// Default extraction model — cheap and capable enough for summarization.
+pub const DEFAULT_MODEL: &str = "gpt-4o-mini";
+
+/// Default ceiling on facts extracted per document. Keeps a runaway model from
+/// flooding the store from one huge transcript.
+pub const DEFAULT_MAX_FACTS: usize = 20;
+
+/// Request timeout. Extraction over a long document can be slow, so this is
+/// more generous than the embedding client's 30s.
+const REQUEST_TIMEOUT_SECS: u64 = 120;
+
+/// The instruction that turns raw text into atomic facts. Kept terse and
+/// strict so models return clean, parseable output.
+const SYSTEM_PROMPT: &str = "You extract durable, atomic facts from the user's text for a long-term memory store. \
+Rules:\n\
+- Output ONLY a JSON array of strings. No prose, no markdown, no code fences.\n\
+- Each string is ONE self-contained fact, decision, preference, or piece of context worth remembering later.\n\
+- Drop greetings, filler, tool output, navigation, and anything ephemeral.\n\
+- Resolve pronouns and make each fact understandable on its own.\n\
+- Prefer specific facts (names, dates, numbers, decisions) over vague summaries.\n\
+- If the text contains nothing worth remembering, output an empty array: []";
+
+/// An OpenAI-compatible chat-completions client used for fact extraction.
+#[derive(Debug)]
+pub struct Extractor {
+    client: reqwest::blocking::Client,
+    api_key: String,
+    base_url: String,
+    endpoint_path: String,
+    model: String,
+    max_facts: usize,
+}
+
+impl Extractor {
+    /// Build a new extractor.
+    ///
+    /// `api_key` is required (extraction always hits a remote model). Endpoint
+    /// resolution mirrors the embedding backend: empty `endpoint_path` falls
+    /// back to [`DEFAULT_ENDPOINT_PATH`]; a path without a leading slash is
+    /// normalized.
+    pub fn new(
+        api_key: &str,
+        model: &str,
+        base_url: &str,
+        endpoint_path: &str,
+        max_facts: usize,
+    ) -> Result<Self, Error> {
+        if api_key.is_empty() {
+            return Err(Error::Validation(
+                "Extraction requires an API key (set UTEKE_EXTRACTION_API_KEY, \
+                 or [extraction] api_key in uteke.toml, or pass --extract-api-key)"
+                    .into(),
+            ));
+        }
+        let base = if base_url.is_empty() {
+            DEFAULT_BASE_URL
+        } else {
+            base_url
+        };
+        validate_base_url(base)?;
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| Error::generic(format!("Failed to build HTTP client: {e}")))?;
+
+        let endpoint = normalize_endpoint_path(endpoint_path);
+        let model = if model.is_empty() {
+            DEFAULT_MODEL
+        } else {
+            model
+        };
+        let max_facts = if max_facts == 0 {
+            DEFAULT_MAX_FACTS
+        } else {
+            max_facts
+        };
+
+        Ok(Self {
+            client,
+            api_key: api_key.to_string(),
+            base_url: base.to_string(),
+            endpoint_path: endpoint,
+            model: model.to_string(),
+            max_facts,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        format!("{base}{}", self.endpoint_path)
+    }
+
+    /// Extract atomic facts from a single document.
+    ///
+    /// Returns the parsed list of facts (already truncated to `max_facts`).
+    /// An empty vec means the model found nothing worth keeping.
+    pub fn extract(&self, text: &str) -> Result<Vec<String>, Error> {
+        if text.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let user_prompt = format!(
+            "Extract up to {} facts from the following text:\n\n{}",
+            self.max_facts, text
+        );
+
+        let body = serde_json::json!({
+            "model": self.model,
+            "messages": [
+                { "role": "system", "content": SYSTEM_PROMPT },
+                { "role": "user", "content": user_prompt },
+            ],
+            "temperature": 0.0,
+        });
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .map_err(|e| Error::generic(format!("Extraction request failed: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().unwrap_or_default();
+            return Err(Error::generic(format!(
+                "Extraction endpoint returned HTTP {status}: {detail}"
+            )));
+        }
+
+        let parsed: ChatResponse = resp
+            .json()
+            .map_err(|e| Error::generic(format!("Failed to parse extraction response: {e}")))?;
+
+        let content = parsed
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .ok_or_else(|| Error::generic("Extraction response had no choices"))?;
+
+        let mut facts = parse_facts(&content);
+        facts.truncate(self.max_facts);
+        Ok(facts)
+    }
+}
+
+/// Normalize an endpoint path: empty -> default, ensure leading slash.
+fn normalize_endpoint_path(path: &str) -> String {
+    if path.is_empty() {
+        DEFAULT_ENDPOINT_PATH.to_string()
+    } else if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
+/// Validate that a base URL has an http(s) scheme and parses.
+///
+/// Mirrors `uteke_core::embed::validate_base_url`, which is `pub(crate)` and
+/// therefore not reachable from this crate.
+fn validate_base_url(base_url: &str) -> Result<(), Error> {
+    let trimmed = base_url.trim();
+    if trimmed.is_empty() {
+        return Err(Error::Validation("base_url must not be empty".into()));
+    }
+    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+        return Err(Error::Validation(format!(
+            "base_url must start with 'http://' or 'https://' (got '{trimmed}')"
+        )));
+    }
+    if reqwest::Url::parse(trimmed).is_err() {
+        return Err(Error::Validation(format!(
+            "base_url is not a valid URL: '{trimmed}'"
+        )));
+    }
+    Ok(())
+}
+
+/// Parse the model's reply into a clean list of facts.
+///
+/// Models are asked for a bare JSON array of strings, but real-world output
+/// varies: code fences, a stray sentence before the array, or a fallback to
+/// line-delimited text. This handles all three defensively so a slightly
+/// chatty model doesn't abort the whole import.
+fn parse_facts(content: &str) -> Vec<String> {
+    let cleaned = strip_code_fences(content.trim());
+
+    // Preferred path: a JSON array of strings somewhere in the reply.
+    if let Some(arr) = extract_json_array(cleaned) {
+        if let Ok(values) = serde_json::from_str::<Vec<serde_json::Value>>(arr) {
+            let facts: Vec<String> = values
+                .into_iter()
+                .filter_map(|v| match v {
+                    serde_json::Value::String(s) => Some(s),
+                    // Tolerate models that return objects like {"fact": "..."}.
+                    serde_json::Value::Object(map) => map
+                        .get("fact")
+                        .or_else(|| map.get("text"))
+                        .or_else(|| map.get("content"))
+                        .and_then(|x| x.as_str())
+                        .map(|s| s.to_string()),
+                    _ => None,
+                })
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            return dedup(facts);
+        }
+    }
+
+    // Fallback: treat each non-empty line as a fact, stripping list markers.
+    let facts: Vec<String> = cleaned
+        .lines()
+        .map(|l| l.trim().trim_start_matches(['-', '*', '•']).trim())
+        .map(strip_leading_number)
+        .filter(|l| l.len() > 2)
+        .map(|l| l.to_string())
+        .collect();
+    dedup(facts)
+}
+
+/// Remove a leading ```...``` / ``` fence wrapper if present.
+fn strip_code_fences(s: &str) -> &str {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix("```") {
+        // Drop optional language tag on the first line.
+        let after_lang = rest.find('\n').map(|i| &rest[i + 1..]).unwrap_or("");
+        return after_lang
+            .trim_end()
+            .strip_suffix("```")
+            .unwrap_or(after_lang)
+            .trim();
+    }
+    s
+}
+
+/// Find the outermost `[...]` JSON array substring, if any.
+fn extract_json_array(s: &str) -> Option<&str> {
+    let start = s.find('[')?;
+    let end = s.rfind(']')?;
+    if end > start {
+        Some(&s[start..=end])
+    } else {
+        None
+    }
+}
+
+/// Strip a leading "1. " / "2) " enumeration marker.
+fn strip_leading_number(s: &str) -> &str {
+    let trimmed = s.trim_start();
+    let digits: String = trimmed.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return trimmed;
+    }
+    let rest = &trimmed[digits.len()..];
+    if let Some(after) = rest.strip_prefix('.').or_else(|| rest.strip_prefix(')')) {
+        after.trim_start()
+    } else {
+        trimmed
+    }
+}
+
+/// Drop duplicate and empty facts while preserving order.
+fn dedup(facts: Vec<String>) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::with_capacity(facts.len());
+    for f in facts {
+        let f = f.trim().to_string();
+        if !f.is_empty() && !seen.iter().any(|x| x == &f) {
+            seen.push(f);
+        }
+    }
+    seen
+}
+
+#[derive(serde::Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatMessage {
+    content: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_api_key() {
+        let err =
+            Extractor::new("", DEFAULT_MODEL, DEFAULT_BASE_URL, "", DEFAULT_MAX_FACTS).unwrap_err();
+        assert!(format!("{err}").contains("API key"));
+    }
+
+    #[test]
+    fn endpoint_defaults_and_normalizes() {
+        let e = Extractor::new("k", "", "https://api.openai.com/v1/", "", 0).unwrap();
+        assert_eq!(e.endpoint(), "https://api.openai.com/v1/chat/completions");
+        assert_eq!(e.model, DEFAULT_MODEL);
+        assert_eq!(e.max_facts, DEFAULT_MAX_FACTS);
+    }
+
+    #[test]
+    fn endpoint_path_without_slash_normalized() {
+        let e = Extractor::new("k", "m", "https://gw.example.com/v1", "v1/chat", 5).unwrap();
+        assert_eq!(e.endpoint(), "https://gw.example.com/v1/v1/chat");
+        assert_eq!(e.max_facts, 5);
+    }
+
+    #[test]
+    fn parses_clean_json_array() {
+        let facts = parse_facts(r#"["User prefers Indonesian", "Bootcamp has 8 sessions"]"#);
+        assert_eq!(
+            facts,
+            vec!["User prefers Indonesian", "Bootcamp has 8 sessions"]
+        );
+    }
+
+    #[test]
+    fn parses_json_array_inside_code_fence() {
+        let raw = "```json\n[\"Fact A\", \"Fact B\"]\n```";
+        assert_eq!(parse_facts(raw), vec!["Fact A", "Fact B"]);
+    }
+
+    #[test]
+    fn parses_array_with_preamble() {
+        let raw = "Here are the facts:\n[\"Only this matters\"]";
+        assert_eq!(parse_facts(raw), vec!["Only this matters"]);
+    }
+
+    #[test]
+    fn parses_object_array_with_fact_key() {
+        let raw = r#"[{"fact": "Deadline is July 31"}, {"fact": "Promo is 65 percent"}]"#;
+        assert_eq!(
+            parse_facts(raw),
+            vec!["Deadline is July 31", "Promo is 65 percent"]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_line_parsing() {
+        let raw = "- First fact\n- Second fact\n1. Third fact";
+        assert_eq!(
+            parse_facts(raw),
+            vec!["First fact", "Second fact", "Third fact"]
+        );
+    }
+
+    #[test]
+    fn empty_array_yields_no_facts() {
+        assert!(parse_facts("[]").is_empty());
+    }
+
+    #[test]
+    fn dedups_repeated_facts() {
+        let raw = r#"["Same", "Same", "Different"]"#;
+        assert_eq!(parse_facts(raw), vec!["Same", "Different"]);
+    }
+}

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -3,6 +3,7 @@
 mod cli;
 mod commands;
 mod config;
+mod extract;
 mod init;
 mod logging;
 mod output;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -359,6 +359,59 @@ uteke aging cleanup --older-than-days 180 --yes
 | `preview` | `--older-than-days N` (default 180), `--max-access-count N` (default 1) | Dry-run preview of cleanup candidates |
 | `cleanup` | `--older-than-days N` (default 180), `--max-access-count N` (default 1), `--yes` | Delete aged memories (`--yes` skips confirmation) |
 
+## uteke import
+
+Import memories from a file (or stdin with `-`). Format is auto-detected from
+the extension and content; override with `--format`.
+
+```bash
+# Import JSONL exported by `uteke export`
+uteke import memories.jsonl
+
+# Import markdown/plain text (split into chunks)
+uteke import notes.md --tags imported,notes
+```
+
+### LLM fact extraction (`--extract`)
+
+Raw source material (chat transcripts, long notes, exported dumps) is noisy:
+greetings, filler, boilerplate. Importing it verbatim pollutes recall. With
+`--extract`, uteke first sends the text to an OpenAI-compatible chat-completions
+endpoint, asks the model to distill it into atomic facts, and stores one memory
+per fact.
+
+This is opt-in. Without `--extract`, import makes no network calls and stays
+fully offline.
+
+```bash
+# Distill a transcript into atomic facts before storing
+uteke import session.txt --extract \
+  --extract-model gpt-4o-mini \
+  --extract-base-url https://api.openai.com/v1 \
+  --extract-api-key sk-...
+
+# Use a local Ollama model
+uteke import notes.md --extract \
+  --extract-model llama3.1 \
+  --extract-base-url http://localhost:11434/v1
+```
+
+Settings resolve in this order: CLI flag > `UTEKE_EXTRACTION_*` env var >
+`[extraction]` config section > built-in default. The API key falls back to the
+embedding / `OPENAI_API_KEY` credential, so an existing OpenAI-compatible setup
+needs no duplicate key.
+
+| Flag | Description |
+|------|-------------|
+| `--extract` | Enable LLM extraction (off by default) |
+| `--extract-model <M>` | Override the chat model |
+| `--extract-base-url <U>` | Override the endpoint base URL |
+| `--extract-api-key <K>` | Override the API key |
+| `--extract-max-facts <N>` | Cap facts kept per document (0 = default) |
+
+See [configuration](#extraction) for the `[extraction]` config block and
+`UTEKE_EXTRACTION_*` environment variables.
+
 ## uteke graph
 
 Knowledge graph operations (v0.2.0). Nodes and edges stored in SQLite (`graph_nodes`, `graph_edges` tables, schema v7).
@@ -545,7 +598,7 @@ uteke timeline <memory-id> --json
 | `uteke prune` | Remove deprecated/expired memories |
 | `uteke stats` | Show store statistics with tier breakdown |
 | `uteke export` | Export memories to JSONL (no embeddings) |
-| `uteke import <file>` | Import memories from JSONL/Markdown/text |
+| `uteke import <file>` | Import memories from JSONL/Markdown/text (`--extract` distills with an LLM) |
 | `uteke doctor` | Health check (DB, index, model, consistency) |
 | `uteke verify` | Verify DB and index consistency |
 | `uteke verify-checksums --binary <path>` | Verify binary integrity against SHA256 checksums |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,35 @@ To migrate, run `uteke repair` after switching backends — it rebuilds the vect
 UTEKE_ALLOW_DIM_MISMATCH=1 uteke repair
 ```
 
+## Fact Extraction
+
+Configure LLM-backed fact extraction for `uteke import --extract`. This is
+**opt-in**: the section is inert unless you pass `--extract`. When you do, uteke
+sends source text to an OpenAI-compatible chat-completions endpoint and stores
+the distilled atomic facts. This is the only feature that makes outbound LLM
+calls; everything else stays offline.
+
+```toml
+[extraction]
+model = "gpt-4o-mini"        # chat model (or UTEKE_EXTRACTION_MODEL)
+api_key = ""                 # or UTEKE_EXTRACTION_API_KEY; falls back to the
+                             # embedding / OPENAI_API_KEY credential
+base_url = ""                # OpenAI-compatible base URL. Empty = OpenAI default
+endpoint_path = ""           # custom API path. Empty = /chat/completions
+max_facts = 0                # cap facts per document. 0 = built-in default
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `model` | `""` | Chat model used to distill facts |
+| `api_key` | `""` | API key (falls back to embedding/`OPENAI_API_KEY`) |
+| `base_url` | `""` | OpenAI-compatible base URL. Empty = OpenAI default |
+| `endpoint_path` | `""` | API path appended to base_url. Empty = `/chat/completions` |
+| `max_facts` | `0` | Cap facts kept per document. 0 = built-in default |
+
+Resolution order per field: CLI flag (`--extract-*`) > `UTEKE_EXTRACTION_*` env
+var > `[extraction]` config > built-in default.
+
 ## Recall Threshold
 
 Control minimum similarity score for recall results:
@@ -213,6 +242,11 @@ Resolution order (highest priority first):
 | `UTEKE_EMBEDDING_ENDPOINT_PATH` | `[embedding] endpoint_path` | — | Custom API path (default: `/embeddings`) |
 | `UTEKE_EMBEDDING_DIMS` | `[embedding] dims` | `0` (auto) | Force embedding dimensionality |
 | `UTEKE_MAX_SEQ_LENGTH` | `[embedding] max_seq_length` | `2048` | Max tokens per embedding input |
+| `UTEKE_EXTRACTION_MODEL` | `[extraction] model` | — | Chat model for `import --extract` |
+| `UTEKE_EXTRACTION_API_KEY` | `[extraction] api_key` | — | API key. Fallback: embedding key / `OPENAI_API_KEY` |
+| `UTEKE_EXTRACTION_BASE_URL` | `[extraction] base_url` | OpenAI default | OpenAI-compatible endpoint base URL |
+| `UTEKE_EXTRACTION_ENDPOINT_PATH` | `[extraction] endpoint_path` | — | Custom API path (default: `/chat/completions`) |
+| `UTEKE_EXTRACTION_MAX_FACTS` | `[extraction] max_facts` | `0` (default) | Cap facts kept per document |
 
 ### Docker Example
 


### PR DESCRIPTION
## What

Adds `uteke import --extract`: an opt-in flag that distills noisy source text into atomic facts via an OpenAI-compatible chat-completions endpoint, storing one memory per fact instead of importing raw text verbatim.

## Why

Raw source material (chat transcripts, long notes, exported dumps) is full of greetings, filler, and boilerplate. Importing it verbatim pollutes recall: a query matches a "thanks bro" line as easily as a real fact. Extraction turns a messy transcript into clean, self-contained statements that actually retrieve well.

Example, a noisy transcript in:

```
halo bro apa kabar
oke jadi bootcamp batch 1 jadwalnya 4-31 Juli 2026, online, tiap Sabtu Minggu, total 8 sesi.
makasih ya
mentornya ada Aji Anaz spesialis Hermes.
```

facts out (one memory each):

```
- Bootcamp batch 1 runs 4-31 July 2026.
- Bootcamp batch 1 is held online every Saturday and Sunday.
- Bootcamp batch 1 has 8 sessions in total.
- Aji Anaz is a Hermes specialist.
```

## Design

- **Opt-in and offline-first.** Without `--extract`, import makes zero network calls and behaves exactly as before. The `[extraction]` config is inert unless the flag is passed. This is the only feature that ever makes an outbound LLM call.
- **Follows the existing embedding-backend pattern**: `reqwest` blocking client, bearer auth, `base_url` + `endpoint_path`, URL validation, mirroring `embed/openai.rs`. Nothing new conceptually, the project already speaks to OpenAI-compatible endpoints for embeddings.
- **No new dependencies.** Uses `reqwest` + `serde_json` already in the tree.
- **Config resolution** per field: CLI flag (`--extract-*`) > `UTEKE_EXTRACTION_*` env > `[extraction]` config > built-in default. The API key falls back to the embedding / `OPENAI_API_KEY` credential so an existing setup needs no duplicate key.
- Works with OpenAI, Ollama (`http://localhost:11434/v1`), vLLM, or any OpenAI-compatible gateway.

## Relates to #46

#46 ("import from external knowledge sources") was partially landed for structured/Obsidian inputs. This completes the goal for the messy free-form case: noisy transcripts and dumps that need distillation, not just parsing. Happy to adjust scope or framing if you'd rather this live behind a feature flag or as a separate subcommand.

## Tests

- 9 new unit tests for the extraction module (response parsing across clean JSON, code-fenced JSON, object arrays, line fallback, dedup; endpoint normalization; empty-key rejection).
- Full suite green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (39 cli + 274 core, 0 failures).
- Verified end-to-end against a live OpenAI-compatible endpoint: a noisy transcript distilled into clean atomic facts, stored and recalled correctly.

## Docs

- `CHANGELOG.md` (Unreleased)
- `docs/cli-reference.md` (new `uteke import` section + extraction flags)
- `docs/configuration.md` (new `[extraction]` section + `UTEKE_EXTRACTION_*` env vars)