### PR TITLE
docs: update CHANGELOG, roadmap, and getting-started for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@
 - **#472: Default max_seq_length increased to 2048** — ONNX embedding backend
   now defaults to 2048 tokens (was 256). Configurable via `max_seq_length` in
   config or `UTEKE_MAX_SEQ_LENGTH` env var.
+- **#466: Public `store()` accessor** — `Uteke::store()` exposes the internal
+  `Store` handle for downstream crates that need direct room/tag operations.
+
+### Changed
+- **rusqlite 0.31 → 0.40** — upgraded to match CorIn's dependency. All
+  `COUNT(*)` results and `LIMIT`/`OFFSET` bindings migrated from `usize` to `i64`
+  (rusqlite ≥0.32 breaking change).
 
 ## [0.4.3] — 2026-06-22
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -195,7 +195,13 @@ uteke export > memories.jsonl
 
 # Import on another machine
 uteke import memories.jsonl
+
+# Import with LLM fact extraction (distills raw text into atomic facts)
+uteke import notes.txt --extract
 ```
+
+> 💡 **Hermes users?** Install uteke as an automatic memory provider:
+> `uteke init --agent hermes --memory-provider`. See [Hermes integration](integrations/hermes.md).
 
 ## Troubleshooting
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,26 @@ title: Roadmap
 
 Demand-gated — we build what people actually use. Track progress on [GitHub Issues](https://github.com/codecoradev/uteke/issues).
 
+## v0.5.0 — LLM Extraction & Hermes Integration `:soon:`
+
+- [#46 LLM fact extraction on import](https://github.com/codecoradev/uteke/issues/46) `✓ Done`
+  - `uteke import --extract` distills noisy text into atomic facts
+- Hermes memory-provider plugin `✓ Done`
+  - Automatic recall + extraction, no daemon required
+- Configurable embedding endpoint path `✓ Done`
+- Default max_seq_length 256 → 2048 `✓ Done`
+- Public `store()` accessor for downstream crates `✓ Done`
+- rusqlite 0.31 → 0.40 upgrade `✓ Done`
+
+## v0.4.x — Polish & Stability `✓ Released 2026-06-22–24`
+
+- Hierarchical documents — depth-10 tree engine `✓ Done`
+- Hybrid document search (semantic + FTS5 + RRF) `✓ Done`
+- MCP tools: `uteke_context`, `uteke_dream` `✓ Done`
+- Auto-dream (3-day cycle) + configurable maintenance daemon `✓ Done`
+- Dedup on insert (cosine ≥ 0.95) + pinned memory protection `✓ Done`
+- Binary version mismatch fix, release workflow fixes `✓ Done`
+
 ## v0.3.0 — Graph RAG `✓ Released 2026-06-21`
 
 - [#401 Cosine auto-linking + dedup](https://github.com/codecoradev/uteke/issues/401) `✓ Done`


### PR DESCRIPTION
## Changes

1. CHANGELOG.md — add missing entries (store() accessor, rusqlite 0.40)
2. docs/roadmap.md — add v0.4.x and v0.5.0 sections
3. docs/getting-started.md — mention --extract and Hermes memory-provider

Docs only, no code changes.