### PR TITLE
chore: bump status badge v0.4.3 → v0.5.0

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.4.3-green.svg" alt="v0.4.3" />
+  <img src="https://img.shields.io/badge/status-v0.5.0-green.svg" alt="v0.5.0" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.4.3-green.svg" alt="v0.4.3" />
+  <img src="https://img.shields.io/badge/status-v0.5.0-green.svg" alt="v0.5.0" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
Badge update only. Cargo.toml version bump will be done in release commit.