### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.5.0] — 2026-06-27
+
 ### Added
 - **Hermes memory-provider plugin** — `uteke init --agent hermes --memory-provider`
   installs a `MemoryProvider` plugin to `~/.hermes/plugins/uteke/` that makes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.3" }
+uteke-core = { path = "../uteke-core", version = "0.5.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.3" }
+uteke-core = { path = "../uteke-core", version = "0.5.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.4.3" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.4.3" }
+uteke-core = { path = "../uteke-core", version = "0.5.0" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.5.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## v0.5.0 — 2026-06-27

### Added
- Hermes memory-provider plugin (uteke init --agent hermes --memory-provider)
- LLM-backed fact extraction on import (uteke import --extract)
- Configurable embedding endpoint path
- Default max_seq_length 256 → 2048
- Public store() accessor for downstream crates

### Changed
- rusqlite 0.31 → 0.40

After merge: tag v0.5.0 → release workflow → sync main