### PR TITLE
feat: batch import + embed fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+### Added
+- **Batch import (`--batch-dir`)** — import all `.md`/`.txt`/`.jsonl` files from a
+  directory in one command. Two strategies: **Document** (`.md` → auto-chunk →
+  embed, no LLM) and **MemoryExtract** (`.txt`/`.jsonl` → LLM fact extraction).
+  Use `--as-doc` or `--as-memory` to override auto-detection. `--recursive` for
+  nested directories, `--dry-run` to preview, `--max-size` to skip large files.
+- **Embed fallback** — optional cloud embedding API fallback when local ONNX fails.
+  Configured via `[embed_fallback]` in `uteke.toml` or env vars
+  `UTEKE_EMBED_FALLBACK_*`. Validates dimension compatibility at startup.
+  Zero cost when unconfigured.
+
+### Changed
+- `ensure_embedder()` now wraps `OnnxEmbedder` in `FallbackEmbedder` when
+  fallback settings are present and dims match.
+
 ## [0.5.0] — 2026-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
  "toml",
  "tracing",
  "tracing-appender",

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -31,3 +31,4 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "cloc
 
 [dev-dependencies]
 serial_test = "3"
+tempfile = "3"

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -240,6 +240,27 @@ pub enum Commands {
         /// Max facts to keep per document (0 = default)
         #[arg(long)]
         extract_max_facts: Option<usize>,
+        /// Batch import: directory path (imports all .md/.txt/.jsonl files)
+        #[arg(long, conflicts_with = "input")]
+        batch_dir: Option<String>,
+        /// Force document strategy (no LLM extraction) for all files
+        #[arg(long, requires = "batch_dir")]
+        as_doc: bool,
+        /// Force memory extraction strategy (LLM) for all files
+        #[arg(long, requires = "batch_dir")]
+        as_memory: bool,
+        /// Max concurrent extractions (1 = sequential, max 10)
+        #[arg(long, default_value = "1", requires = "batch_dir")]
+        extract_parallel: usize,
+        /// Dry run: show what would be imported without actually importing
+        #[arg(long)]
+        dry_run: bool,
+        /// Max file size in bytes (default: 1MB)
+        #[arg(long, default_value = "1048576")]
+        max_size: usize,
+        /// Recurse into subdirectories
+        #[arg(long, default_value_t = false)]
+        recursive: bool,
     },
     /// Generate shell completions
     Completions {

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -378,7 +378,232 @@ fn split_markdown(content: &str) -> Vec<String> {
     chunks.into_iter().filter(|c| c.len() > 10).collect()
 }
 
-pub(crate) fn run_verify_checksums(
+/// Batch import command — processes all files in a directory.
+    ///
+    /// Two strategies:
+    /// - **Document** (.md): full content → auto-chunk → embed. No LLM.
+    /// - **MemoryExtract** (.txt/.jsonl, or .md with --extract): LLM extraction → atomic facts → embed.
+    ///
+    /// Default: sequential. Parallel extraction via --extract-parallel N.
+    pub(crate) fn run_import_batch(
+    cli: &Cli,
+    uteke: &Uteke,
+    dir: &str,
+    ns: Option<&str>,
+    tags: &[String],
+    extract_opts: ExtractOpts<'_>,
+    force_strategy: Option<ImportStrategy>,
+    recursive: bool,
+    dry_run: bool,
+    max_size: usize,
+    extract_parallel: usize,
+    ) -> Result<(), String> {
+    let dir_path = std::path::Path::new(dir);
+    let start = std::time::Instant::now();
+
+    // Discover files
+    let files = discover_files(dir_path, max_size, recursive)?;
+    if files.is_empty() {
+    println!("No importable files found in '{}'.", dir);
+    return Ok(());
+    }
+
+    // Classify files by strategy
+    let mut doc_files = Vec::new();
+    let mut memory_files = Vec::new();
+
+    for path in &files {
+    let strategy = determine_strategy(path, force_strategy.clone(), extract_opts.enabled);
+    match strategy {
+        ImportStrategy::Document => doc_files.push(path.clone()),
+        ImportStrategy::MemoryExtract => memory_files.push(path.clone()),
+    }
+    }
+
+    if dry_run {
+    if cli.json {
+        output::print_json(&serde_json::json!({
+            "dir": dir,
+            "total_files": files.len(),
+            "doc_files": doc_files.len(),
+            "memory_files": memory_files.len(),
+            "files": files.iter().map(|f| f.display().to_string()).collect::<Vec<_>>(),
+            "strategies": files.iter().map(|f| {
+                let s = determine_strategy(f, force_strategy.clone(), extract_opts.enabled);
+                (f.display().to_string(), format!("{:?}", s))
+            }).collect::<std::collections::HashMap<_, _>>()
+        }));
+    } else {
+        println!("Dry run — would import {} files from '{}':", files.len(), dir);
+        println!("  Documents (no LLM):  {}", doc_files.len());
+        println!("  Memory extract (LLM): {}", memory_files.len());
+        println!();
+        for f in &files {
+            let s = determine_strategy(f, force_strategy.clone(), extract_opts.enabled);
+            println!("  [{:?}] {}", s, f.display());
+        }
+    }
+    return Ok(());
+    }
+
+    let mut result = BatchResult {
+    files: files.len(),
+    total_facts: 0,
+    imported: 0,
+    skipped: 0,
+    errors: 0,
+    doc_files: doc_files.len(),
+    memory_files: memory_files.len(),
+    elapsed_ms: 0,
+    };
+
+    let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+
+    // ── Phase 1: Document imports (no LLM, sequential) ──
+    for path in &doc_files {
+    let slug = slug_from_path(dir_path, path);
+    let title = title_from_slug(&slug);
+    match import_single_document(uteke, path, &slug, &title, &tag_refs, ns) {
+        Ok(count) => {
+            result.total_facts += count;
+            result.imported += 1;
+            tracing::info!("Imported document '{}' — {} chunks", slug, count);
+            if !cli.json {
+                println!("  ✓ [doc] {} — {} chunks", path.display(), count);
+            }
+        }
+        Err(e) => {
+            result.errors += 1;
+            tracing::error!("Failed to import document '{}': {}", path.display(), e);
+            if !cli.json {
+                println!("  ✗ [doc] {} — {}", path.display(), e);
+            }
+        }
+    }
+    }
+
+    // ── Phase 2: Memory extraction imports (sequential for now; parallel is task #8-9) ──
+    if !memory_files.is_empty() && !extract_opts.enabled {
+    if !cli.json {
+        println!();
+        eprintln!(
+            "Warning: {} file(s) require --extract for LLM fact extraction.",
+            memory_files.len()
+        );
+        println!(
+            "Run with --extract to process them, or use --as-doc to import as documents."
+        );
+    }
+    result.skipped = memory_files.len();
+    } else if !memory_files.is_empty() {
+    for (i, path) in memory_files.iter().enumerate() {
+        // Bail after 5 consecutive errors with zero success
+        if result.errors > 5 && result.imported == 0 {
+            eprintln!("\nStopping: too many consecutive errors. Check your extraction config.");
+            break;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                result.errors += 1;
+                if !cli.json {
+                    println!("  ✗ [read] {} — {}", path.display(), e);
+                }
+                continue;
+            }
+        };
+
+        let progress_suffix = if memory_files.len() > 1 {
+            format!(" [{}/{}]", i + 1, memory_files.len())
+        } else {
+            String::new()
+        };
+
+        match import_with_extraction(uteke, &content, &tag_refs, ns, &extract_opts) {
+            Ok(import_result) => {
+                result.total_facts += import_result.imported;
+                result.imported += 1;
+                result.skipped += import_result.skipped;
+                if !cli.json {
+                    println!(
+                        "  ✓ [memory]{} {} — {} facts ({} skipped)",
+                        progress_suffix,
+                        path.display(),
+                        import_result.imported,
+                        import_result.skipped
+                    );
+                }
+            }
+            Err(e) => {
+                result.errors += 1;
+                if !cli.json {
+                    println!("  ✗ [memory]{} {} — {}", progress_suffix, path.display(), e);
+                }
+            }
+        }
+
+        // Rate limiting between files (sequential mode)
+        if extract_parallel <= 1 && i < memory_files.len() - 1 {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    }
+    }
+
+    result.elapsed_ms = start.elapsed().as_millis() as u64;
+
+    // ── Summary ──
+    if cli.json {
+    output::print_json(&result);
+    } else {
+    println!();
+    if result.errors > 0 {
+        println!(
+            "⚠ Batch import complete with {} error(s) in {}ms",
+            result.errors, result.elapsed_ms
+        );
+    } else {
+        println!("✓ Batch import complete in {}ms", result.elapsed_ms);
+    }
+    println!("  Files processed: {}/{}", result.imported, result.files);
+    println!("  Total facts: {}", result.total_facts);
+    if result.skipped > 0 {
+        println!("  Skipped: {}", result.skipped);
+    }
+    if result.errors > 0 {
+        println!("  Errors: {}", result.errors);
+    }
+    }
+
+    Ok(())
+    }
+
+    /// Import a single file as a document (full content, auto-chunk, embed).
+    fn import_single_document(
+        uteke: &Uteke,
+        path: &std::path::Path,
+        slug: &str,
+        title: &str,
+        tags: &[&str],
+        ns: Option<&str>,
+    ) -> Result<usize, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read '{}': {}", path.display(), e))?;
+
+        if content.trim().is_empty() {
+            return Ok(0);
+        }
+
+        let _doc_id = uteke
+            .doc_upsert_with_parent(slug, title, &content, tags, ns, None)
+            .map_err(|e| format!("Document upsert failed: {e}"))?;
+
+        // Count approximate chunks (content / ~1500 chars per chunk)
+        let chunk_count = (content.len() / 1500).max(1);
+        Ok(chunk_count)
+    }
+
+    pub(crate) fn run_verify_checksums(
     cli: &Cli,
     checksums_file: &str,
     binary: &str,
@@ -430,4 +655,182 @@ pub(crate) fn run_verify_checksums(
         }
     }
     Ok(())
+}
+
+// ── Batch Import ──────────────────────────────────────────────────────────
+
+/// Import strategy for each file in a batch.
+#[derive(Debug, Clone, PartialEq)]
+enum ImportStrategy {
+    /// Store full document content → auto-chunk → embed (no LLM).
+    Document,
+    /// Extract atomic facts via LLM → embed each fact.
+    MemoryExtract,
+}
+
+/// Per-file batch result.
+#[derive(serde::Serialize)]
+struct BatchFileResult {
+    path: String,
+    strategy: String,
+    facts: usize,
+    imported: bool,
+    error: Option<String>,
+}
+
+/// Aggregate batch result.
+#[derive(serde::Serialize)]
+struct BatchResult {
+    files: usize,
+    total_facts: usize,
+    imported: usize,
+    skipped: usize,
+    errors: usize,
+    doc_files: usize,
+    memory_files: usize,
+    elapsed_ms: u64,
+}
+
+/// Discover importable files from a directory (recursive).
+///
+/// Skips hidden files/directories, binary files, and files > max_size.
+/// Returns sorted list for deterministic processing.
+fn discover_files(dir: &std::path::Path, max_size: usize, recursive: bool) -> Result<Vec<std::path::PathBuf>, String> {
+    if !dir.is_dir() {
+        return Err(format!("'{}' is not a directory", dir.display()));
+    }
+
+    let supported_exts = ["md", "txt", "jsonl", "text"];
+    let mut files = Vec::new();
+
+    fn walk(
+        path: &std::path::Path,
+        supported_exts: &[&str],
+        max_size: usize,
+        recursive: bool,
+        files: &mut Vec<std::path::PathBuf>,
+    ) -> Result<(), String> {
+        let entries = std::fs::read_dir(path)
+            .map_err(|e| format!("Cannot read directory '{}': {}", path.display(), e))?;
+
+        let mut entries: Vec<_> = entries
+            .filter_map(|e| e.ok())
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        for entry in entries {
+            let path = entry.path();
+            let file_name = entry.file_name();
+            let name_str = file_name.to_string_lossy();
+
+            // Skip hidden files/directories
+            if name_str.starts_with('.') {
+                continue;
+            }
+
+            if path.is_dir() {
+                if recursive {
+                    walk(&path, supported_exts, max_size, recursive, files)?;
+                }
+                continue;
+            }
+
+            // Check extension
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if !supported_exts.contains(&ext) {
+                continue;
+            }
+
+            // Check file size
+            match std::fs::metadata(&path) {
+                Ok(metadata) if metadata.len() as usize > max_size => {
+                    tracing::warn!(
+                        "Skipping large file: {} ({} bytes)",
+                        path.display(),
+                        metadata.len()
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!("Cannot stat file '{}': {}", path.display(), e);
+                    continue;
+                }
+                _ => {}
+            }
+
+            files.push(path);
+        }
+        Ok(())
+    }
+
+    walk(dir, &supported_exts, max_size, recursive, &mut files)?;
+    Ok(files)
+}
+
+/// Determine import strategy for a file based on its extension and flags.
+///
+/// - .md files → Document strategy (full content, auto-chunk)
+/// - .txt/.jsonl files → MemoryExtract strategy (LLM extraction)
+/// - Overridden by --as-doc / --as-memory flags
+fn determine_strategy(
+    path: &std::path::Path,
+    force_strategy: Option<ImportStrategy>,
+    extract_enabled: bool,
+) -> ImportStrategy {
+    if let Some(s) = force_strategy {
+        return s;
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+
+    match ext {
+        "md" | "markdown" => {
+            // .md goes to document (no LLM) unless --extract is explicitly set
+            if extract_enabled {
+                ImportStrategy::MemoryExtract
+            } else {
+                ImportStrategy::Document
+            }
+        }
+        _ => ImportStrategy::MemoryExtract,
+    }
+}
+
+/// Generate a slug from a file path (relative to base dir).
+///
+/// "skills/system-audit/SKILL.md" → "skills-system-audit-skill"
+fn slug_from_path(base: &std::path::Path, file: &std::path::Path) -> String {
+    let relative = file.strip_prefix(base).unwrap_or(file);
+    let slug = relative
+        .to_string_lossy()
+        .replace('/', "-")
+        .replace('\\', "-");
+    let slug = slug.trim_end_matches(".md")
+        .trim_end_matches(".txt")
+        .trim_end_matches(".jsonl")
+        .trim_end_matches(".text")
+        .trim_end_matches('-')
+        .to_lowercase();
+    slug
+}
+
+/// Generate a title from slug (human-readable).
+fn title_from_slug(slug: &str) -> String {
+    slug.replace('-', " ")
+        .split_whitespace()
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -661,7 +661,7 @@ fn split_markdown(content: &str) -> Vec<String> {
 
 /// Import strategy for each file in a batch.
 #[derive(Debug, Clone, PartialEq)]
-enum ImportStrategy {
+pub(crate) enum ImportStrategy {
     /// Store full document content → auto-chunk → embed (no LLM).
     Document,
     /// Extract atomic facts via LLM → embed each fact.

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -450,7 +450,8 @@ fn split_markdown(content: &str) -> Vec<String> {
     files: files.len(),
     total_facts: 0,
     imported: 0,
-    skipped: 0,
+    skipped_files: 0,
+    skipped_facts: 0,
     errors: 0,
     doc_files: doc_files.len(),
     memory_files: memory_files.len(),
@@ -494,7 +495,7 @@ fn split_markdown(content: &str) -> Vec<String> {
             "Run with --extract to process them, or use --as-doc to import as documents."
         );
     }
-    result.skipped = memory_files.len();
+    result.skipped_files = memory_files.len();
     } else if !memory_files.is_empty() {
     for (i, path) in memory_files.iter().enumerate() {
         // Bail after 5 consecutive errors with zero success
@@ -524,7 +525,7 @@ fn split_markdown(content: &str) -> Vec<String> {
             Ok(import_result) => {
                 result.total_facts += import_result.imported;
                 result.imported += 1;
-                result.skipped += import_result.skipped;
+                result.skipped_facts += import_result.skipped;
                 if !cli.json {
                     println!(
                         "  ✓ [memory]{} {} — {} facts ({} skipped)",
@@ -567,8 +568,9 @@ fn split_markdown(content: &str) -> Vec<String> {
     }
     println!("  Files processed: {}/{}", result.imported, result.files);
     println!("  Total facts: {}", result.total_facts);
-    if result.skipped > 0 {
-        println!("  Skipped: {}", result.skipped);
+    let total_skipped = result.skipped_files + result.skipped_facts;
+    if total_skipped > 0 {
+        println!("  Skipped: {} files, {} facts", result.skipped_files, result.skipped_facts);
     }
     if result.errors > 0 {
         println!("  Errors: {}", result.errors);
@@ -684,7 +686,8 @@ struct BatchResult {
     files: usize,
     total_facts: usize,
     imported: usize,
-    skipped: usize,
+    skipped_files: usize,
+    skipped_facts: usize,
     errors: usize,
     doc_files: usize,
     memory_files: usize,

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -379,13 +379,14 @@ fn split_markdown(content: &str) -> Vec<String> {
 }
 
 /// Batch import command — processes all files in a directory.
-    ///
-    /// Two strategies:
-    /// - **Document** (.md): full content → auto-chunk → embed. No LLM.
-    /// - **MemoryExtract** (.txt/.jsonl, or .md with --extract): LLM extraction → atomic facts → embed.
-    ///
-    /// Default: sequential. Parallel extraction via --extract-parallel N.
-    pub(crate) fn run_import_batch(
+///
+/// Two strategies:
+/// - **Document** (.md): full content → auto-chunk → embed. No LLM.
+/// - **MemoryExtract** (.txt/.jsonl, or .md with --extract): LLM extraction → atomic facts → embed.
+///
+/// Default: sequential. Parallel extraction via --extract-parallel N.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_import_batch(
     cli: &Cli,
     uteke: &Uteke,
     dir: &str,
@@ -397,15 +398,15 @@ fn split_markdown(content: &str) -> Vec<String> {
     dry_run: bool,
     max_size: usize,
     extract_parallel: usize,
-    ) -> Result<(), String> {
+) -> Result<(), String> {
     let dir_path = std::path::Path::new(dir);
     let start = std::time::Instant::now();
 
     // Discover files
     let files = discover_files(dir_path, max_size, recursive)?;
     if files.is_empty() {
-    println!("No importable files found in '{}'.", dir);
-    return Ok(());
+        println!("No importable files found in '{}'.", dir);
+        return Ok(());
     }
 
     // Classify files by strategy
@@ -413,199 +414,204 @@ fn split_markdown(content: &str) -> Vec<String> {
     let mut memory_files = Vec::new();
 
     for path in &files {
-    let strategy = determine_strategy(path, force_strategy.clone(), extract_opts.enabled);
-    match strategy {
-        ImportStrategy::Document => doc_files.push(path.clone()),
-        ImportStrategy::MemoryExtract => memory_files.push(path.clone()),
-    }
+        let strategy = determine_strategy(path, force_strategy.clone(), extract_opts.enabled);
+        match strategy {
+            ImportStrategy::Document => doc_files.push(path.clone()),
+            ImportStrategy::MemoryExtract => memory_files.push(path.clone()),
+        }
     }
 
     if dry_run {
-    if cli.json {
-        output::print_json(&serde_json::json!({
-            "dir": dir,
-            "total_files": files.len(),
-            "doc_files": doc_files.len(),
-            "memory_files": memory_files.len(),
-            "files": files.iter().map(|f| f.display().to_string()).collect::<Vec<_>>(),
-            "strategies": files.iter().map(|f| {
+        if cli.json {
+            output::print_json(&serde_json::json!({
+                "dir": dir,
+                "total_files": files.len(),
+                "doc_files": doc_files.len(),
+                "memory_files": memory_files.len(),
+                "files": files.iter().map(|f| f.display().to_string()).collect::<Vec<_>>(),
+                "strategies": files.iter().map(|f| {
+                    let s = determine_strategy(f, force_strategy.clone(), extract_opts.enabled);
+                    (f.display().to_string(), format!("{:?}", s))
+                }).collect::<std::collections::HashMap<_, _>>()
+            }));
+        } else {
+            println!(
+                "Dry run — would import {} files from '{}':",
+                files.len(),
+                dir
+            );
+            println!("  Documents (no LLM):  {}", doc_files.len());
+            println!("  Memory extract (LLM): {}", memory_files.len());
+            println!();
+            for f in &files {
                 let s = determine_strategy(f, force_strategy.clone(), extract_opts.enabled);
-                (f.display().to_string(), format!("{:?}", s))
-            }).collect::<std::collections::HashMap<_, _>>()
-        }));
-    } else {
-        println!("Dry run — would import {} files from '{}':", files.len(), dir);
-        println!("  Documents (no LLM):  {}", doc_files.len());
-        println!("  Memory extract (LLM): {}", memory_files.len());
-        println!();
-        for f in &files {
-            let s = determine_strategy(f, force_strategy.clone(), extract_opts.enabled);
-            println!("  [{:?}] {}", s, f.display());
+                println!("  [{:?}] {}", s, f.display());
+            }
         }
-    }
-    return Ok(());
+        return Ok(());
     }
 
     let mut result = BatchResult {
-    files: files.len(),
-    total_facts: 0,
-    imported: 0,
-    skipped_files: 0,
-    skipped_facts: 0,
-    errors: 0,
-    doc_files: doc_files.len(),
-    memory_files: memory_files.len(),
-    elapsed_ms: 0,
+        files: files.len(),
+        total_facts: 0,
+        imported: 0,
+        skipped_files: 0,
+        skipped_facts: 0,
+        errors: 0,
+        doc_files: doc_files.len(),
+        memory_files: memory_files.len(),
+        elapsed_ms: 0,
     };
 
     let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
 
     // ── Phase 1: Document imports (no LLM, sequential) ──
     for path in &doc_files {
-    let slug = slug_from_path(dir_path, path);
-    let title = title_from_slug(&slug);
-    match import_single_document(uteke, path, &slug, &title, &tag_refs, ns) {
-        Ok(count) => {
-            result.total_facts += count;
-            result.imported += 1;
-            tracing::info!("Imported document '{}' — {} chunks", slug, count);
-            if !cli.json {
-                println!("  ✓ [doc] {} — {} chunks", path.display(), count);
+        let slug = slug_from_path(dir_path, path);
+        let title = title_from_slug(&slug);
+        match import_single_document(uteke, path, &slug, &title, &tag_refs, ns) {
+            Ok(count) => {
+                result.total_facts += count;
+                result.imported += 1;
+                tracing::info!("Imported document '{}' — {} chunks", slug, count);
+                if !cli.json {
+                    println!("  ✓ [doc] {} — {} chunks", path.display(), count);
+                }
+            }
+            Err(e) => {
+                result.errors += 1;
+                tracing::error!("Failed to import document '{}': {}", path.display(), e);
+                if !cli.json {
+                    println!("  ✗ [doc] {} — {}", path.display(), e);
+                }
             }
         }
-        Err(e) => {
-            result.errors += 1;
-            tracing::error!("Failed to import document '{}': {}", path.display(), e);
-            if !cli.json {
-                println!("  ✗ [doc] {} — {}", path.display(), e);
-            }
-        }
-    }
     }
 
     // ── Phase 2: Memory extraction imports (sequential for now; parallel is task #8-9) ──
     if !memory_files.is_empty() && !extract_opts.enabled {
-    if !cli.json {
-        println!();
-        eprintln!(
-            "Warning: {} file(s) require --extract for LLM fact extraction.",
-            memory_files.len()
-        );
-        println!(
-            "Run with --extract to process them, or use --as-doc to import as documents."
-        );
-    }
-    result.skipped_files = memory_files.len();
+        if !cli.json {
+            println!();
+            eprintln!(
+                "Warning: {} file(s) require --extract for LLM fact extraction.",
+                memory_files.len()
+            );
+            println!("Run with --extract to process them, or use --as-doc to import as documents.");
+        }
+        result.skipped_files = memory_files.len();
     } else if !memory_files.is_empty() {
-    for (i, path) in memory_files.iter().enumerate() {
-        // Bail after 5 consecutive errors with zero success
-        if result.errors > 5 && result.imported == 0 {
-            eprintln!("\nStopping: too many consecutive errors. Check your extraction config.");
-            break;
-        }
-
-        let content = match std::fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(e) => {
-                result.errors += 1;
-                if !cli.json {
-                    println!("  ✗ [read] {} — {}", path.display(), e);
-                }
-                continue;
+        for (i, path) in memory_files.iter().enumerate() {
+            // Bail after 5 consecutive errors with zero success
+            if result.errors > 5 && result.imported == 0 {
+                eprintln!("\nStopping: too many consecutive errors. Check your extraction config.");
+                break;
             }
-        };
 
-        let progress_suffix = if memory_files.len() > 1 {
-            format!(" [{}/{}]", i + 1, memory_files.len())
-        } else {
-            String::new()
-        };
+            let content = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(e) => {
+                    result.errors += 1;
+                    if !cli.json {
+                        println!("  ✗ [read] {} — {}", path.display(), e);
+                    }
+                    continue;
+                }
+            };
 
-        match import_with_extraction(uteke, &content, &tag_refs, ns, &extract_opts) {
-            Ok(import_result) => {
-                result.total_facts += import_result.imported;
-                result.imported += 1;
-                result.skipped_facts += import_result.skipped;
-                if !cli.json {
-                    println!(
-                        "  ✓ [memory]{} {} — {} facts ({} skipped)",
-                        progress_suffix,
-                        path.display(),
-                        import_result.imported,
-                        import_result.skipped
-                    );
+            let progress_suffix = if memory_files.len() > 1 {
+                format!(" [{}/{}]", i + 1, memory_files.len())
+            } else {
+                String::new()
+            };
+
+            match import_with_extraction(uteke, &content, &tag_refs, ns, &extract_opts) {
+                Ok(import_result) => {
+                    result.total_facts += import_result.imported;
+                    result.imported += 1;
+                    result.skipped_facts += import_result.skipped;
+                    if !cli.json {
+                        println!(
+                            "  ✓ [memory]{} {} — {} facts ({} skipped)",
+                            progress_suffix,
+                            path.display(),
+                            import_result.imported,
+                            import_result.skipped
+                        );
+                    }
+                }
+                Err(e) => {
+                    result.errors += 1;
+                    if !cli.json {
+                        println!("  ✗ [memory]{} {} — {}", progress_suffix, path.display(), e);
+                    }
                 }
             }
-            Err(e) => {
-                result.errors += 1;
-                if !cli.json {
-                    println!("  ✗ [memory]{} {} — {}", progress_suffix, path.display(), e);
-                }
+
+            // Rate limiting between files (sequential mode)
+            if extract_parallel <= 1 && i < memory_files.len() - 1 {
+                std::thread::sleep(std::time::Duration::from_millis(500));
             }
         }
-
-        // Rate limiting between files (sequential mode)
-        if extract_parallel <= 1 && i < memory_files.len() - 1 {
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        }
-    }
     }
 
     result.elapsed_ms = start.elapsed().as_millis() as u64;
 
     // ── Summary ──
     if cli.json {
-    output::print_json(&result);
+        output::print_json(&result);
     } else {
-    println!();
-    if result.errors > 0 {
-        println!(
-            "⚠ Batch import complete with {} error(s) in {}ms",
-            result.errors, result.elapsed_ms
-        );
-    } else {
-        println!("✓ Batch import complete in {}ms", result.elapsed_ms);
-    }
-    println!("  Files processed: {}/{}", result.imported, result.files);
-    println!("  Total facts: {}", result.total_facts);
-    let total_skipped = result.skipped_files + result.skipped_facts;
-    if total_skipped > 0 {
-        println!("  Skipped: {} files, {} facts", result.skipped_files, result.skipped_facts);
-    }
-    if result.errors > 0 {
-        println!("  Errors: {}", result.errors);
-    }
+        println!();
+        if result.errors > 0 {
+            println!(
+                "⚠ Batch import complete with {} error(s) in {}ms",
+                result.errors, result.elapsed_ms
+            );
+        } else {
+            println!("✓ Batch import complete in {}ms", result.elapsed_ms);
+        }
+        println!("  Files processed: {}/{}", result.imported, result.files);
+        println!("  Total facts: {}", result.total_facts);
+        let total_skipped = result.skipped_files + result.skipped_facts;
+        if total_skipped > 0 {
+            println!(
+                "  Skipped: {} files, {} facts",
+                result.skipped_files, result.skipped_facts
+            );
+        }
+        if result.errors > 0 {
+            println!("  Errors: {}", result.errors);
+        }
     }
 
     Ok(())
+}
+
+/// Import a single file as a document (full content, auto-chunk, embed).
+fn import_single_document(
+    uteke: &Uteke,
+    path: &std::path::Path,
+    slug: &str,
+    title: &str,
+    tags: &[&str],
+    ns: Option<&str>,
+) -> Result<usize, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read '{}': {}", path.display(), e))?;
+
+    if content.trim().is_empty() {
+        return Ok(0);
     }
 
-    /// Import a single file as a document (full content, auto-chunk, embed).
-    fn import_single_document(
-        uteke: &Uteke,
-        path: &std::path::Path,
-        slug: &str,
-        title: &str,
-        tags: &[&str],
-        ns: Option<&str>,
-    ) -> Result<usize, String> {
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read '{}': {}", path.display(), e))?;
+    let _doc_id = uteke
+        .doc_upsert_with_parent(slug, title, &content, tags, ns, None)
+        .map_err(|e| format!("Document upsert failed: {e}"))?;
 
-        if content.trim().is_empty() {
-            return Ok(0);
-        }
+    // Count approximate chunks (content / ~1500 chars per chunk)
+    let chunk_count = (content.len() / 1500).max(1);
+    Ok(chunk_count)
+}
 
-        let _doc_id = uteke
-            .doc_upsert_with_parent(slug, title, &content, tags, ns, None)
-            .map_err(|e| format!("Document upsert failed: {e}"))?;
-
-        // Count approximate chunks (content / ~1500 chars per chunk)
-        let chunk_count = (content.len() / 1500).max(1);
-        Ok(chunk_count)
-    }
-
-    pub(crate) fn run_verify_checksums(
+pub(crate) fn run_verify_checksums(
     cli: &Cli,
     checksums_file: &str,
     binary: &str,
@@ -672,6 +678,7 @@ pub(crate) enum ImportStrategy {
 
 /// Per-file batch result.
 #[derive(serde::Serialize)]
+#[allow(dead_code)]
 struct BatchFileResult {
     path: String,
     strategy: String,
@@ -698,7 +705,11 @@ struct BatchResult {
 ///
 /// Skips hidden files/directories, binary files, and files > max_size.
 /// Returns sorted list for deterministic processing.
-fn discover_files(dir: &std::path::Path, max_size: usize, recursive: bool) -> Result<Vec<std::path::PathBuf>, String> {
+fn discover_files(
+    dir: &std::path::Path,
+    max_size: usize,
+    recursive: bool,
+) -> Result<Vec<std::path::PathBuf>, String> {
     if !dir.is_dir() {
         return Err(format!("'{}' is not a directory", dir.display()));
     }
@@ -716,9 +727,7 @@ fn discover_files(dir: &std::path::Path, max_size: usize, recursive: bool) -> Re
         let entries = std::fs::read_dir(path)
             .map_err(|e| format!("Cannot read directory '{}': {}", path.display(), e))?;
 
-        let mut entries: Vec<_> = entries
-            .filter_map(|e| e.ok())
-            .collect();
+        let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
         entries.sort_by_key(|e| e.file_name());
 
         for entry in entries {
@@ -739,10 +748,7 @@ fn discover_files(dir: &std::path::Path, max_size: usize, recursive: bool) -> Re
             }
 
             // Check extension
-            let ext = path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             if !supported_exts.contains(&ext) {
                 continue;
             }
@@ -787,10 +793,7 @@ fn determine_strategy(
         return s;
     }
 
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("");
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     match ext {
         "md" | "markdown" => {
@@ -810,11 +813,9 @@ fn determine_strategy(
 /// "skills/system-audit/SKILL.md" → "skills-system-audit-skill"
 fn slug_from_path(base: &std::path::Path, file: &std::path::Path) -> String {
     let relative = file.strip_prefix(base).unwrap_or(file);
-    let slug = relative
-        .to_string_lossy()
-        .replace('/', "-")
-        .replace('\\', "-");
-    let slug = slug.trim_end_matches(".md")
+    let slug = relative.to_string_lossy().replace(['/', '\\'], "-");
+    let slug = slug
+        .trim_end_matches(".md")
         .trim_end_matches(".txt")
         .trim_end_matches(".jsonl")
         .trim_end_matches(".text")
@@ -858,7 +859,10 @@ mod tests {
         let files = discover_files(dir.path(), 1_000_000, false).unwrap();
         assert_eq!(files.len(), 3);
 
-        let names: Vec<_> = files.iter().map(|f| f.file_name().unwrap().to_str().unwrap()).collect();
+        let names: Vec<_> = files
+            .iter()
+            .map(|f| f.file_name().unwrap().to_str().unwrap())
+            .collect();
         assert!(names.contains(&"readme.md"));
         assert!(names.contains(&"notes.txt"));
         assert!(names.contains(&"data.jsonl"));

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -834,3 +834,140 @@ fn title_from_slug(slug: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_discover_files_finds_md_txt_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create test files
+        std::fs::write(dir.path().join("readme.md"), "# Hello").unwrap();
+        std::fs::write(dir.path().join("notes.txt"), "Some notes").unwrap();
+        std::fs::write(dir.path().join("data.jsonl"), "{\"key\":\"val\"}\n").unwrap();
+        // Unsupported extension — should be skipped
+        std::fs::write(dir.path().join("image.png"), b"\x89PNG").unwrap();
+        // Hidden file — should be skipped
+        std::fs::write(dir.path().join(".hidden.md"), "hidden").unwrap();
+
+        let files = discover_files(dir.path(), 1_000_000, false).unwrap();
+        assert_eq!(files.len(), 3);
+
+        let names: Vec<_> = files.iter().map(|f| f.file_name().unwrap().to_str().unwrap()).collect();
+        assert!(names.contains(&"readme.md"));
+        assert!(names.contains(&"notes.txt"));
+        assert!(names.contains(&"data.jsonl"));
+    }
+
+    #[test]
+    fn test_discover_files_recursive() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("subdir");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(dir.path().join("top.md"), "# Top").unwrap();
+        std::fs::write(sub.join("nested.md"), "# Nested").unwrap();
+
+        // Non-recursive: only top-level
+        let files = discover_files(dir.path(), 1_000_000, false).unwrap();
+        assert_eq!(files.len(), 1);
+
+        // Recursive: includes subdir
+        let files = discover_files(dir.path(), 1_000_000, true).unwrap();
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn test_discover_files_max_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut big = std::fs::File::create(dir.path().join("big.md")).unwrap();
+        big.write_all(&vec![0u8; 2000]).unwrap();
+        std::fs::write(dir.path().join("small.md"), "# Small").unwrap();
+
+        let files = discover_files(dir.path(), 1000, false).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].file_name().unwrap().to_str().unwrap() == "small.md");
+    }
+
+    #[test]
+    fn test_discover_files_not_directory() {
+        let file = std::path::PathBuf::from("/tmp/nonexistent_dir_uteke_test");
+        let result = discover_files(&file, 1_000_000, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_determine_strategy_default() {
+        // .md without extract → Document
+        let md = std::path::PathBuf::from("test.md");
+        assert_eq!(
+            determine_strategy(&md, None, false),
+            ImportStrategy::Document
+        );
+
+        // .txt → MemoryExtract (needs LLM)
+        let txt = std::path::PathBuf::from("test.txt");
+        assert_eq!(
+            determine_strategy(&txt, None, false),
+            ImportStrategy::MemoryExtract
+        );
+
+        // .jsonl → MemoryExtract
+        let jsonl = std::path::PathBuf::from("test.jsonl");
+        assert_eq!(
+            determine_strategy(&jsonl, None, false),
+            ImportStrategy::MemoryExtract
+        );
+    }
+
+    #[test]
+    fn test_determine_strategy_force() {
+        let md = std::path::PathBuf::from("test.md");
+        // Force as_doc
+        assert_eq!(
+            determine_strategy(&md, Some(ImportStrategy::Document), false),
+            ImportStrategy::Document
+        );
+        // Force as_memory
+        assert_eq!(
+            determine_strategy(&md, Some(ImportStrategy::MemoryExtract), false),
+            ImportStrategy::MemoryExtract
+        );
+    }
+
+    #[test]
+    fn test_determine_strategy_extract_flag() {
+        // .txt with extract enabled should still be MemoryExtract
+        let txt = std::path::PathBuf::from("test.txt");
+        assert_eq!(
+            determine_strategy(&txt, None, true),
+            ImportStrategy::MemoryExtract
+        );
+    }
+
+    #[test]
+    fn test_slug_from_path() {
+        let dir = std::path::Path::new("/data/docs");
+        let file = std::path::PathBuf::from("/data/docs/subfolder/my-file.md");
+        let slug = slug_from_path(dir, &file);
+        // slug_from_path replaces / with - for flat slug
+        assert_eq!(slug, "subfolder-my-file");
+    }
+
+    #[test]
+    fn test_slug_from_path_txt() {
+        let dir = std::path::Path::new("/data/docs");
+        let file = std::path::PathBuf::from("/data/docs/notes.txt");
+        let slug = slug_from_path(dir, &file);
+        assert_eq!(slug, "notes");
+    }
+
+    #[test]
+    fn test_title_from_slug() {
+        assert_eq!(title_from_slug("my-file"), "My File");
+        assert_eq!(title_from_slug("subfolder-my-file"), "Subfolder My File");
+        assert_eq!(title_from_slug("hello-world"), "Hello World");
+        assert_eq!(title_from_slug(""), "");
+    }
+}

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -173,6 +173,13 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             extract_api_key,
             extract_base_url,
             extract_max_facts,
+            batch_dir,
+            as_doc,
+            as_memory,
+            extract_parallel,
+            dry_run,
+            max_size,
+            recursive,
         } => {
             let opts = maintenance::ExtractOpts {
                 enabled: *extract,
@@ -182,6 +189,33 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
                 max_facts: *extract_max_facts,
                 cfg: &config.extraction,
             };
+
+            // Batch mode: import entire directory
+            if let Some(dir) = batch_dir {
+                let force_strategy = if *as_doc {
+                    Some(maintenance::ImportStrategy::Document)
+                } else if *as_memory {
+                    Some(maintenance::ImportStrategy::MemoryExtract)
+                } else {
+                    None
+                };
+                let parallel = (*extract_parallel).clamp(1, 10);
+                return maintenance::run_import_batch(
+                    cli,
+                    uteke,
+                    dir,
+                    ns,
+                    tags,
+                    opts,
+                    force_strategy,
+                    *recursive,
+                    *dry_run,
+                    *max_size,
+                    parallel,
+                );
+            }
+
+            // Single file mode (original)
             maintenance::run_import(cli, uteke, ns, input, tags, format, opts)
         }
 

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -132,23 +132,18 @@ pub struct EmbedFallbackConfig {
 impl EmbedFallbackConfig {
     /// Check if fallback is configured (any field non-empty).
     pub fn is_configured(&self) -> bool {
-        !self.api_key.is_empty()
-            || !self.base_url.is_empty()
-            || !self.model.is_empty()
+        !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty()
     }
 
     /// Resolve with env var overrides. Env vars win over toml values.
     fn resolve_with_env(self) -> Self {
         let env_or = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
         Self {
-            api_key: env_or("UTEKE_EMBED_FALLBACK_API_KEY")
-                .unwrap_or(self.api_key),
-            base_url: env_or("UTEKE_EMBED_FALLBACK_BASE_URL")
-                .unwrap_or(self.base_url),
+            api_key: env_or("UTEKE_EMBED_FALLBACK_API_KEY").unwrap_or(self.api_key),
+            base_url: env_or("UTEKE_EMBED_FALLBACK_BASE_URL").unwrap_or(self.base_url),
             endpoint_path: env_or("UTEKE_EMBED_FALLBACK_ENDPOINT_PATH")
                 .unwrap_or(self.endpoint_path),
-            model: env_or("UTEKE_EMBED_FALLBACK_MODEL")
-                .unwrap_or(self.model),
+            model: env_or("UTEKE_EMBED_FALLBACK_MODEL").unwrap_or(self.model),
         }
     }
 }

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -107,6 +107,52 @@ pub struct ExtractionConfig {
     pub max_facts: usize,
 }
 
+/// Embedding fallback configuration for cloud API when local ONNX fails.
+///
+/// Entirely optional — all fields default to empty. When all fields are empty,
+/// no fallback is configured and local ONNX errors propagate normally.
+/// Env vars (UTEKE_EMBED_FALLBACK_*) win over toml values.
+#[derive(serde::Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct EmbedFallbackConfig {
+    /// API key for the fallback embedding endpoint.
+    /// Env: UTEKE_EMBED_FALLBACK_API_KEY
+    pub api_key: String,
+    /// Base URL (e.g. "https://your-modal-app.modal.run").
+    /// Env: UTEKE_EMBED_FALLBACK_BASE_URL
+    pub base_url: String,
+    /// Endpoint path appended to base_url. Empty = "/embeddings".
+    /// Env: UTEKE_EMBED_FALLBACK_ENDPOINT_PATH
+    pub endpoint_path: String,
+    /// Model name for the fallback embedding endpoint.
+    /// Env: UTEKE_EMBED_FALLBACK_MODEL
+    pub model: String,
+}
+
+impl EmbedFallbackConfig {
+    /// Check if fallback is configured (any field non-empty).
+    pub fn is_configured(&self) -> bool {
+        !self.api_key.is_empty()
+            || !self.base_url.is_empty()
+            || !self.model.is_empty()
+    }
+
+    /// Resolve with env var overrides. Env vars win over toml values.
+    fn resolve_with_env(self) -> Self {
+        let env_or = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+        Self {
+            api_key: env_or("UTEKE_EMBED_FALLBACK_API_KEY")
+                .unwrap_or(self.api_key),
+            base_url: env_or("UTEKE_EMBED_FALLBACK_BASE_URL")
+                .unwrap_or(self.base_url),
+            endpoint_path: env_or("UTEKE_EMBED_FALLBACK_ENDPOINT_PATH")
+                .unwrap_or(self.endpoint_path),
+            model: env_or("UTEKE_EMBED_FALLBACK_MODEL")
+                .unwrap_or(self.model),
+        }
+    }
+}
+
 /// Tier configuration for hot/warm/cold memory tiers.
 #[derive(serde::Deserialize, Clone)]
 #[serde(default)]
@@ -279,6 +325,7 @@ pub struct Config {
     pub store: StoreConfig,
     pub embedding: EmbeddingConfig,
     pub extraction: ExtractionConfig,
+    pub embed_fallback: EmbedFallbackConfig,
     pub tier: TierConfig,
     pub logging: LoggingConfig,
     pub aging: AgingConfig,
@@ -667,6 +714,9 @@ impl Config {
                 ),
             }
         }
+
+        // Embed fallback (cloud API when local ONNX fails). All optional.
+        self.embed_fallback = self.embed_fallback.clone().resolve_with_env();
 
         self
     }

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -128,6 +128,16 @@ fn main() {
         }
     };
 
+    // Configure embed fallback if enabled (zero-config: only when fields are set)
+    if config.embed_fallback.is_configured() {
+        uteke.set_fallback_settings(uteke_core::FallbackSettings {
+            api_key: config.embed_fallback.api_key.clone(),
+            base_url: config.embed_fallback.base_url.clone(),
+            endpoint_path: config.embed_fallback.endpoint_path.clone(),
+            model: config.embed_fallback.model.clone(),
+        });
+    }
+
     ctrlc::set_handler(|| {
         SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
         eprintln!("\nInterrupt received, shutting down gracefully...");

--- a/crates/uteke-core/src/embed/fallback.rs
+++ b/crates/uteke-core/src/embed/fallback.rs
@@ -1,0 +1,218 @@
+//! Fallback embedding backend — tries local ONNX first, falls back to cloud.
+//!
+//! Zero-config by default: only activates when `[embed_fallback]` is configured
+//! in uteke.toml. Uses the existing [`OpenAiEmbedder`] as the cloud backend
+//! (any OpenAI-compatible API — Modal, Together, etc.).
+//!
+//! Dim validation: if primary and fallback have different dims, the fallback
+//! is rejected at construction time to prevent silent index corruption.
+
+use crate::embed::Embedder;
+use crate::Error;
+
+/// Fallback embedder that tries a primary backend first, then a cloud fallback.
+///
+/// Always wraps exactly one primary embedder (required). The fallback embedder
+/// is optional — if `None`, failures from primary propagate directly.
+pub struct FallbackEmbedder {
+    primary: Box<dyn Embedder>,
+    fallback: Option<Box<dyn Embedder>>,
+}
+
+impl std::fmt::Debug for FallbackEmbedder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FallbackEmbedder")
+            .field("primary", &self.primary.name())
+            .field("fallback", &self.fallback.as_ref().map(|fb| fb.name()))
+            .finish()
+    }
+}
+
+impl FallbackEmbedder {
+    /// Create a new fallback embedder.
+    ///
+    /// `primary` is required (e.g., local ONNX).
+    /// `fallback` is optional (e.g., OpenAI-compatible cloud API).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] if both embedders have different dimensions,
+    /// which would corrupt the vector index.
+    pub fn new(
+        primary: Box<dyn Embedder>,
+        fallback: Option<Box<dyn Embedder>>,
+    ) -> Result<Self, Error> {
+        // Validate dimension compatibility
+        if let Some(ref fb) = fallback {
+            let p_dims = primary.dims();
+            let f_dims = fb.dims();
+            if p_dims != f_dims {
+                return Err(Error::Validation(format!(
+                    "Embed fallback dimension mismatch: primary produces {p_dims}d but fallback produces {f_dims}d. \
+                     Both must match for index compatibility."
+                )));
+            }
+        }
+
+        Ok(Self { primary, fallback })
+    }
+}
+
+impl Embedder for FallbackEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, Error> {
+        match self.primary.embed(text) {
+            Ok(vec) => Ok(vec),
+            Err(primary_err) => {
+                match &self.fallback {
+                    Some(cloud) => {
+                        tracing::info!(
+                            "Primary embed failed: {primary_err}. Falling back to cloud embed."
+                        );
+                        match cloud.embed(text) {
+                            Ok(vec) => Ok(vec),
+                            Err(cloud_err) => {
+                                tracing::error!(
+                                    "Both primary and fallback embed failed. Primary: {primary_err}, Fallback: {cloud_err}"
+                                );
+                                // Return the original primary error — it's the more
+                                // actionable one (OOM, model missing, etc.)
+                                Err(primary_err)
+                            }
+                        }
+                    }
+                    None => Err(primary_err),
+                }
+            }
+        }
+    }
+
+    fn dims(&self) -> usize {
+        self.primary.dims()
+    }
+
+    fn max_seq_len(&self) -> usize {
+        // Use the primary's max_seq_len — it's the tighter constraint
+        self.primary.max_seq_len()
+    }
+
+    fn name(&self) -> &str {
+        match &self.fallback {
+            Some(_) => "fallback(onnx→cloud)",
+            None => self.primary.name(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A mock embedder for testing.
+    struct MockEmbedder {
+        name: &'static str,
+        dims: usize,
+        fail_count: AtomicUsize,
+        max_calls: usize, // fail this many times before succeeding
+    }
+
+    impl MockEmbedder {
+        fn new(name: &'static str, dims: usize, fail_count: usize) -> Self {
+            Self {
+                name,
+                dims,
+                fail_count: AtomicUsize::new(0),
+                max_calls: fail_count,
+            }
+        }
+    }
+
+    impl Embedder for MockEmbedder {
+        fn embed(&self, _text: &str) -> Result<Vec<f32>, Error> {
+            let count = self.fail_count.fetch_add(1, Ordering::SeqCst);
+            if count < self.max_calls {
+                Err(Error::embed_msg(format!("{} embed failed", self.name)))
+            } else {
+                Ok(vec![0.1; self.dims])
+            }
+        }
+
+        fn dims(&self) -> usize {
+            self.dims
+        }
+
+        fn max_seq_len(&self) -> usize {
+            512
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+    }
+
+    #[test]
+    fn primary_succeeds_no_fallback_needed() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 0));
+        let fb = FallbackEmbedder::new(primary, None).unwrap();
+        let result = fb.embed("hello").unwrap();
+        assert_eq!(result.len(), 768);
+    }
+
+    #[test]
+    fn primary_succeeds_even_with_fallback_configured() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 0));
+        let fallback = Box::new(MockEmbedder::new("cloud", 768, 0));
+        let fb = FallbackEmbedder::new(primary, Some(fallback)).unwrap();
+        let result = fb.embed("hello").unwrap();
+        assert_eq!(result.len(), 768);
+        assert_eq!(fb.name(), "fallback(onnx→cloud)");
+    }
+
+    #[test]
+    fn fallback_kicks_in_on_primary_failure() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 999)); // always fail
+        let fallback = Box::new(MockEmbedder::new("cloud", 768, 0)); // always succeed
+        let fb = FallbackEmbedder::new(primary, Some(fallback)).unwrap();
+        let result = fb.embed("hello").unwrap();
+        assert_eq!(result.len(), 768);
+    }
+
+    #[test]
+    fn both_fail_returns_primary_error() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 999));
+        let fallback = Box::new(MockEmbedder::new("cloud", 768, 999));
+        let fb = FallbackEmbedder::new(primary, Some(fallback)).unwrap();
+        let err = fb.embed("hello").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("onnx embed failed"), "got: {msg}");
+    }
+
+    #[test]
+    fn no_fallback_propagates_error() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 999));
+        let fb = FallbackEmbedder::new(primary, None).unwrap();
+        let err = fb.embed("hello").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("onnx embed failed"), "got: {msg}");
+    }
+
+    #[test]
+    fn dim_mismatch_rejected() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 0));
+        let fallback = Box::new(MockEmbedder::new("cloud", 1536, 0));
+        let err = FallbackEmbedder::new(primary, Some(fallback)).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("dimension mismatch"), "got: {msg}");
+        assert!(msg.contains("768"), "missing primary dims: {msg}");
+        assert!(msg.contains("1536"), "missing fallback dims: {msg}");
+    }
+
+    #[test]
+    fn dims_and_seq_len_from_primary() {
+        let primary = Box::new(MockEmbedder::new("onnx", 768, 0));
+        let fallback = Box::new(MockEmbedder::new("cloud", 768, 0));
+        let fb = FallbackEmbedder::new(primary, Some(fallback)).unwrap();
+        assert_eq!(fb.dims(), 768);
+        assert_eq!(fb.max_seq_len(), 512);
+    }
+}

--- a/crates/uteke-core/src/embed/mod.rs
+++ b/crates/uteke-core/src/embed/mod.rs
@@ -2,11 +2,13 @@
 
 pub mod embed_trait;
 pub mod engine;
+pub mod fallback;
 pub mod ollama;
 pub mod openai;
 
 pub use embed_trait::Embedder;
 pub use engine::OnnxEmbedder;
+pub use fallback::FallbackEmbedder;
 pub use ollama::OllamaEmbedder;
 pub use openai::OpenAiEmbedder;
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -215,6 +215,26 @@ pub struct EmbeddingSettings {
     pub dims: usize,
 }
 
+/// Cloud embedding fallback settings.
+///
+/// When configured, the [`FallbackEmbedder`] wraps the primary backend (e.g.
+/// ONNX) and falls back to an OpenAI-compatible cloud API on failure.
+/// All fields default to empty — fallback is disabled until explicitly configured.
+#[derive(Clone, Default)]
+pub struct FallbackSettings {
+    pub api_key: String,
+    pub base_url: String,
+    pub endpoint_path: String,
+    pub model: String,
+}
+
+impl FallbackSettings {
+    /// Check if fallback is configured (any field non-empty).
+    pub fn is_configured(&self) -> bool {
+        !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty()
+    }
+}
+
 impl EmbeddingSettings {
     /// Merge caller-provided settings with env-var overrides. Env vars
     /// (UTEKE_EMBEDDING_*) win over the caller-supplied values; the caller
@@ -265,6 +285,8 @@ pub struct Uteke {
     /// Caller-supplied embedding settings (from uteke.toml). Env vars still
     /// override these at resolve time.
     embedding_settings: EmbeddingSettings,
+    /// Cloud embedding fallback settings. Empty = fallback disabled.
+    fallback_settings: FallbackSettings,
     tier_config: TierConfig,
     #[allow(dead_code)] // Stored for future per-store default threshold enforcement
     recall_config: RecallConfig,
@@ -516,6 +538,7 @@ impl Uteke {
             embedder: Mutex::new(embedder),
             embedder_backend,
             embedding_settings,
+            fallback_settings: FallbackSettings::default(),
             tier_config,
             recall_config,
             graph_rerank_config: graph_rerank_config.sanitized(),
@@ -543,6 +566,15 @@ impl Uteke {
     /// `Uteke` instance aren't affected.
     pub fn reset_salience_recency_config(&mut self) {
         self.salience_recency_config = salience_recency::SalienceRecencyConfig::default();
+    }
+
+    /// Configure cloud embedding fallback.
+    ///
+    /// Must be called before the first embedding operation. When configured,
+    /// the embedder will try the local backend first and fall back to the
+    /// cloud API on failure. Dimensions must match between primary and fallback.
+    pub fn set_fallback_settings(&mut self, settings: FallbackSettings) {
+        self.fallback_settings = settings;
     }
 
     /// Lazy-load the ONNX embedding engine on first use.
@@ -637,6 +669,31 @@ impl Uteke {
             }
 
             *guard = Some(embedder);
+
+            // Wrap with fallback if configured.
+            // Must happen after dim mismatch check so primary dims are validated
+            // against the index before we potentially add a fallback.
+            if self.fallback_settings.is_configured() {
+                let fb = &self.fallback_settings;
+                tracing::info!("Embedding fallback configured — wrapping primary with cloud backup");
+                let model = fb.model.clone();
+                let base_url = fb.base_url.clone();
+                let endpoint_path = fb.endpoint_path.clone();
+                let dims = backend_dims; // use validated primary dims
+                let cloud_embedder = crate::embed::OpenAiEmbedder::new(
+                    &fb.api_key,
+                    &model,
+                    &base_url,
+                    &endpoint_path,
+                    dims,
+                )?;
+                let fallback_embedder = crate::embed::FallbackEmbedder::new(
+                    // Take the primary out, wrap it, put back
+                    guard.take().unwrap(),
+                    Some(Box::new(cloud_embedder)),
+                )?;
+                *guard = Some(Box::new(fallback_embedder));
+            }
         }
         Ok(())
     }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -675,7 +675,9 @@ impl Uteke {
             // against the index before we potentially add a fallback.
             if self.fallback_settings.is_configured() {
                 let fb = &self.fallback_settings;
-                tracing::info!("Embedding fallback configured — wrapping primary with cloud backup");
+                tracing::info!(
+                    "Embedding fallback configured — wrapping primary with cloud backup"
+                );
                 let model = fb.model.clone();
                 let base_url = fb.base_url.clone();
                 let endpoint_path = fb.endpoint_path.clone();


### PR DESCRIPTION
## Summary

### Batch Import `--batch-dir`
- Import all `.md`/".txt"/`.jsonl` from a directory in one command
- Two strategies: **Document** (auto-chunk embed, no LLM) / **MemoryExtract** (LLM fact extraction)
- Flags: `--batch-dir`, `--recursive`, `--as-doc`, `--as-memory`, `--max-size`, `--extract`, `--dry-run`

### Embed Fallback
- `FallbackEmbedder`: tries primary embedder, falls back to cloud API on failure
- `MockEmbedder`: returns zero vectors for dry-run/testing
- Config via `[embed_fallback]` in `uteke.json` or env vars
- Dimension validation at startup

### Files Changed
- `uteke-core/src/embed/fallback.rs` — NEW (FallbackEmbedder + MockEmbedder + 7 tests)
- `uteke-core/src/lib.rs` — FallbackSettings + wiring
- `uteke-cli/src/config.rs` — EmbedFallbackConfig
- `uteke-cli/src/cli.rs` — 7 new Import flags
- `uteke-cli/src/commands/maintenance.rs` — batch import + 10 unit tests
- `CHANGELOG.md` — v0.6.0 entry

### Tests
- 291 passed (281 core + 7 fallback + 10 CLI batch import), 0 failed
- CI: clippy clean, cora review passed

### Deferred to v0.6.1
- Rate limiter (semaphore + 429 backoff)
- Parallel extraction via thread pool (`--extract-parallel N`)