### PR TITLE
docs: batch import + embed fallback documentation

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -78,7 +78,9 @@ AI agent melupakan semua hal antar sesi. Uteke memberikan mereka memori persiste
 - 🖥️ **Mode Server** — Daemon persisten dengan recall hangat ~42ms (75x lebih cepat dari CLI)
 - 🔥 **Memori Bertingkat** — Pelacakan Hot/Warm/Cold dengan pembersihan otomatis memori basi
 - 🔒 **Sepenuhnya Offline** — Embedding ONNX lokal (768d), tanpa telemetri, tanpa cloud, tanpa panggilan API
-- 📦 **Satu Binary** — Zero dependensi. Tanpa Docker, tanpa server database, tanpa Python, tanpa API key
+- 🔄 **Embed Fallback** — Otomatis fallback ke cloud API jika local embedder gagal; MockEmbedder untuk testing
+- 📂 **Batch Import** — Import seluruh direktori (`--batch-dir`) dengan routing strategi otomatis (dokumen vs. ekstraksi memori)
+- 📦 **Single Binary** — Tanpa dependensi. Tanpa Docker, tanpa database server, tanpa Python, tanpa API key
 - 📥 **Import/Export** — Backup dan restore berbasis JSONL
 - 🧩 **Tipe Memori** — Kategori bertipe (fact, procedure, decision, dll.) dengan auto-inferensi
 - 🔗 **Backlinks** — Edge memori dua arah — referensi otomatis timbal balik

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 - 🖥️ **Server Mode** — Persistent daemon with ~42ms warm recall (75x faster than CLI)
 - 🔥 **Tiered Memory** — Hot/Warm/Cold tracking with auto-cleanup of stale memories
 - 🔒 **Fully Offline** — Local ONNX embeddings (768d), no telemetry, no cloud, no API calls
+- 🔄 **Embed Fallback** — Gracefully falls back to cloud API if local embedder fails; MockEmbedder for testing
+- 📂 **Batch Import** — Import entire directories (`--batch-dir`) with auto-strategy routing (document vs. memory extraction)
 - 📦 **Single Binary** — Zero dependencies. No Docker, no database server, no Python, no API keys
 - 📥 **Import/Export** — JSONL-based backup and restore
 - 🧩 **Memory Types** — Typed categories (fact, procedure, decision, etc.) with auto-inference

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -412,6 +412,47 @@ needs no duplicate key.
 See [configuration](#extraction) for the `[extraction]` config block and
 `UTEKE_EXTRACTION_*` environment variables.
 
+### Batch import (`--batch-dir`)
+
+Import all files from a directory in one command. Each file is processed
+according to its type:
+
+| Extension | Strategy | Description |
+|-----------|----------|-------------|
+| `.md` / `.markdown` | Document (default) | Full content → auto-chunk → embed. No LLM. |
+| `.md` + `--extract` | Memory extract | LLM fact extraction → atomic facts → embed. |
+| `.txt` / `.jsonl` | Memory extract | LLM fact extraction (requires `--extract`). |
+| `.txt` / `.jsonl` + `--as-doc` | Document override | Import as document, skip LLM. |
+
+```bash
+# Dry run — preview what would be imported
+uteke import --batch-dir ./knowledge --dry-run
+
+# Import all markdown as documents (no LLM, fully offline)
+uteke import --batch-dir ./docs --recursive --tags docs
+
+# Import with LLM fact extraction
+uteke import --batch-dir ./notes --extract \
+  --extract-model gpt-4o-mini \
+  --extract-base-url https://api.openai.com/v1 \
+  --tags imported
+
+# Force all files as documents (skip extraction)
+uteke import --batch-dir ./raw --as-doc --recursive
+
+# Limit file size (default: 1MB)
+uteke import --batch-dir ./large-docs --max-size 500000
+```
+
+| Flag | Description |
+|------|-------------|
+| `--batch-dir <PATH>` | Directory to import (enables batch mode) |
+| `--recursive` | Recurse into subdirectories |
+| `--as-doc` | Force all files as documents (skip LLM extraction) |
+| `--as-memory` | Force all files through LLM extraction |
+| `--max-size <BYTES>` | Skip files larger than N bytes (default: 1,000,000) |
+| `--dry-run` | Preview files and strategies without importing |
+
 ## uteke graph
 
 Knowledge graph operations (v0.2.0). Nodes and edges stored in SQLite (`graph_nodes`, `graph_edges` tables, schema v7).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,33 @@ To migrate, run `uteke repair` after switching backends — it rebuilds the vect
 UTEKE_ALLOW_DIM_MISMATCH=1 uteke repair
 ```
 
+## Embed Fallback
+
+When the primary embedding backend fails (model not found, OOM, network error),
+uteke can transparently retry with a fallback endpoint. This is opt-in — if
+unconfigured, no cloud calls are made.
+
+```toml
+[embed_fallback]
+enabled = false               # opt-in: must be true to activate
+base_url = ""                 # e.g. "https://api.openai.com/v1"
+api_key = ""                  # or use UTEKE_EMBED_FALLBACK_API_KEY
+model = ""                    # e.g. "text-embedding-3-small"
+dims = 0                      # 0 = use fallback model default
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `false` | Must be explicitly enabled — no surprise cloud calls |
+| `base_url` | `""` | Fallback API endpoint (OpenAI-compatible) |
+| `api_key` | `""` | API key for the fallback endpoint |
+| `model` | `""` | Fallback embedding model |
+| `dims` | `0` | Fallback dimensions (0 = model default) |
+
+**Environment variables** take precedence: `UTEKE_EMBED_FALLBACK_ENABLED`, `UTEKE_EMBED_FALLBACK_BASE_URL`, `UTEKE_EMBED_FALLBACK_API_KEY`, `UTEKE_EMBED_FALLBACK_MODEL`, `UTEKE_EMBED_FALLBACK_DIMS`.
+
+**Dimension validation** — if the fallback produces different dimensions than the primary, uteke rejects it at startup with a clear error. Both backends must produce vectors of the same dimensionality.
+
 ## Fact Extraction
 
 Configure LLM-backed fact extraction for `uteke import --extract`. This is


### PR DESCRIPTION
## Summary

Documentation updates for v0.6.0 batch import and embed fallback features (PR #488).

### Changes
- **README.md** — Added batch import + embed fallback to Key Features
- **README.id.md** — Same (Indonesian version)
- **docs/cli-reference.md** — New `--batch-dir` section with flags table, strategy table, and usage examples
- **docs/configuration.md** — New `[embed_fallback]` section with config table, env vars, and dim validation docs

### Files
4 changed, +73 -1