### PR TITLE
docs: add Mode C pre_llm_call shell hook integration

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,8 +200,10 @@ uteke import memories.jsonl
 uteke import notes.txt --extract
 ```
 
-> 💡 **Hermes users?** Install uteke as an automatic memory provider:
-> `uteke init --agent hermes --memory-provider`. See [Hermes integration](integrations/hermes.md).
+> 💡 **Hermes users?** Three integration modes available:
+> - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](integrations/hermes.md).
+> - **Mode B (memory-provider):** Full auto — `uteke init --agent hermes --memory-provider`. Automatic recall + LLM fact extraction.
+> - **Mode A (uteke-tool):** Manual — `uteke init --agent hermes`. Explicit `uteke(action="...")` calls with multi-agent room support.
 
 ## Troubleshooting
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -244,6 +244,126 @@ The memory-provider plugin (Mode B) skips the HTTP layer entirely and shells
 out to the `uteke` binary: `recall --json` for prefetch, `import --extract` for
 session-end distillation.
 
+## Troubleshooting & FAQ
+
+### Q: Memory provider not activating in gateway mode
+
+**Symptom:** `memory.provider: uteke` is set in config.yaml but the "Memory provider 'uteke' activated" log never appears.
+
+**Cause:** In Hermes gateway mode, the `memory.provider` initialization path (`agent_init.py`) may not execute — this is a known Hermes limitation. The provider works correctly in CLI mode (`hermes chat`).
+
+**Workaround — Gateway Hook approach:**
+
+Create a gateway hook that recalls uteke on every message and writes results to a context file:
+
+1. Create `HERMES_HOME/hooks/uteke-recall/HOOK.yaml`:
+   ```yaml
+   name: uteke-recall
+   description: "Auto-recall uteke memories on agent:start"
+   events:
+     - agent:start
+   ```
+
+2. Create `HERMES_HOME/hooks/uteke-recall/handler.py`:
+   ```python
+   import json, os, pathlib, subprocess
+
+   AGENT = os.environ.get("HERMES_HOME", "").split("/")[-1] or "default"
+   CONTEXT_FILE = pathlib.Path(f"/tmp/hermes/uteke-context/{AGENT}.md")
+   UTEKE_BIN = pathlib.Path("/opt/data/.cargo/bin/uteke")  # or shutil.which("uteke")
+
+   def handle(event_type, context):
+       if event_type != "agent:start":
+           return
+       message = context.get("message", "").strip()
+       if not message or len(message) < 5:
+           return
+       if context.get("session_id", "").startswith("cron_"):
+           return
+
+       result = subprocess.run(
+           [str(UTEKE_BIN), "recall", "--namespace", AGENT, "--limit", "5", "--json", message],
+           capture_output=True, text=True, timeout=15,
+       )
+       if result.returncode != 0:
+           return
+
+       memories = json.loads(result.stdout)
+       CONTEXT_FILE.parent.mkdir(parents=True, exist_ok=True)
+       lines = [f"# Uteke Recalled Memories - {AGENT}", ""]
+       if not memories:
+           lines.append("No relevant memories found.")
+       else:
+           for item in memories:
+               mem = item.get("memory", {})
+               lines.append(f"- ({item.get('score', 0):.3f}) {mem.get('content', '')}")
+       CONTEXT_FILE.write_text("\\n".join(lines))
+   ```
+
+3. Add instruction to the agent's SOUL.md to read the context file.
+
+4. Restart the gateway: `s6-svc -r /run/service/gateway-{agent}`
+
+**Note:** The gateway hook system uses `emit()` (fire-and-forget), so the hook output is NOT automatically injected into the prompt. The agent must read the context file as a fallback. For true prompt injection, Hermes upstream would need to change `emit()` to `emit_collect()` for `agent:start` events.
+
+### Q: Hook loaded but recall returns irrelevant results
+
+**Possible causes:**
+
+| Cause | Check | Fix |
+|-------|-------|-----|
+| Too few memories | `uteke stats --namespace {agent}` — < 100 total | Run more extractions |
+| Near-duplicates | Multiple memories saying the same thing | `uteke dream --namespace {agent} --phases dedup` |
+| Poor extraction | Facts too generic ("user is ajianaz" repeated) | Improve extraction prompts or manual curation |
+| Wrong namespace | `HERMES_HOME` resolves differently than expected | Verify agent name resolution in handler.py |
+
+### Q: Memory quality maintenance
+
+```bash
+# Weekly: dedup near-duplicates
+uteke dream --namespace {agent} --phases dedup
+
+# Monthly: full maintenance (lint + dedup + orphans + compact)
+uteke dream --namespace {agent}
+
+# One-time: system health check
+uteke doctor
+
+# Remove cold memories (>30 days, rarely accessed)
+uteke aging --namespace {agent} --preview
+uteke aging --namespace {agent} --cleanup
+```
+
+### Q: Hermes update safety
+
+All uteke setup files are stored in `HERMES_HOME` (typically `~/.hermes/` or per-profile), which is **outside** the Hermes source tree. They survive Hermes updates:
+
+- `~/.hermes/plugins/uteke/` — memory-provider plugin
+- `~/.hermes/plugins/uteke-tool/` — tool plugin
+- `~/.hermes/hooks/uteke-recall/` — gateway hook
+- `~/.hermes/uteke.json` — provider config
+- `~/.hermes/config.yaml` — `memory.provider` setting
+
+### Q: Multiple agents on a shared gateway
+
+When running multiple Hermes agents on a single gateway, each agent should use its own namespace. The hook handler resolves the agent name from `HERMES_HOME`:
+
+```python
+AGENT = os.environ.get("HERMES_HOME", "").split("/")[-1]
+```
+
+For per-profile gateways (`hermes -p {agent}`), `HERMES_HOME` is set to the profile directory, so this resolves correctly. For shared gateways, ensure each agent's SOUL.md specifies its namespace explicitly.
+
+### Q: `uteke list` shows fewer memories than `uteke stats`
+
+`uteke list` has a default output limit. Use `--json` and pipe to `jq` or Python to get the full count:
+
+```bash
+uteke list --namespace {agent} --json | python3 -c "import sys,json; print(len(json.load(sys.stdin)))"
+```
+
+`uteke stats` reports the true total from the database.
+
 ## Requirements
 
 - uteke v0.3.0+ (includes `uteke-mcp` binary)

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -246,6 +246,150 @@ session-end distillation.
 
 ## Troubleshooting & FAQ
 
+### Mode C — pre_llm_call shell hook (automatic recall, no plugin)
+
+This is the simplest integration: a lightweight Python script runs on every
+LLM call, recalls relevant uteke memories, and injects them into the prompt.
+No plugin, no daemon, no memory-provider config — just a shell hook.
+
+**Architecture:**
+
+```
+User message arrives
+  → Hermes fires pre_llm_call shell hook
+  → handler.py reads user_message from stdin (JSON wire protocol)
+  → handler.py runs: uteke recall --namespace {agent} --json "{query}"
+  → handler.py outputs: {"context": "Recalled memories (uteke):\n1. ..."}
+  → Hermes injects context into the user message before API call
+```
+
+#### Setup
+
+1. **Create the hook handler** at a shared path (e.g. `/opt/data/hooks/uteke-recall/handler.py`):
+
+```python
+"""uteke-recall shell hook — recalls relevant memories on pre_llm_call.
+
+Reads JSON context from stdin (Hermes shell hook wire protocol),
+runs uteke recall, and outputs {"context": "..."} to stdout.
+
+Hermes injects this context into the user message before each LLM call.
+Race-safe: no shared file writes, per-call invocation.
+"""
+
+import json, pathlib, subprocess, sys
+
+def _resolve_agent_name() -> str:
+    """Extract agent name from 'hermes -p {agent}' in /proc/self/cmdline."""
+    try:
+        with open("/proc/self/cmdline", "rb") as f:
+            parts = f.read().split(b"\x00")
+        for i, part in enumerate(parts):
+            if part == b"-p" and i + 1 < len(parts):
+                name = parts[i + 1].decode("utf-8", errors="ignore").strip()
+                if name:
+                    return name
+    except Exception:
+        pass
+    return "default"
+
+AGENT = _resolve_agent_name()
+UTEKE_BIN = pathlib.Path("/opt/data/.cargo/bin/uteke")
+
+def _recall_uteke(query: str, limit: int = 5) -> list:
+    """Run uteke recall and return list of {content, score}."""
+    if not UTEKE_BIN.exists():
+        return []
+    cmd = [str(UTEKE_BIN), "recall", "--namespace", AGENT,
+           "--limit", str(limit), "--json", query]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if proc.returncode != 0:
+            return []
+        data = json.loads(proc.stdout)
+        if not isinstance(data, list):
+            return []
+        return [{"content": m.get("memory", {}).get("content", ""),
+                 "score": m.get("score", 0)} for m in data
+                if isinstance(m, dict) and "memory" in m]
+    except Exception:
+        return []
+
+def main():
+    try:
+        raw = json.loads(sys.stdin.read())
+    except Exception:
+        sys.exit(0)
+    if not isinstance(raw, dict):
+        sys.exit(0)
+
+    # Hermes wire protocol: user_message is in extra dict
+    extra = raw.get("extra", {})
+    if not isinstance(extra, dict):
+        extra = {}
+    message = extra.get("user_message") or raw.get("user_message", "")
+    if not isinstance(message, str) or not message.strip():
+        sys.exit(0)
+    message = message.strip()[:500]
+
+    if len(message) < 5:
+        sys.exit(0)
+
+    # Skip cron sessions
+    session_id = raw.get("session_id", "")
+    if isinstance(session_id, str) and session_id.startswith("cron_"):
+        sys.exit(0)
+
+    memories = _recall_uteke(message, limit=5)
+    if not memories:
+        sys.exit(0)
+
+    lines = []
+    for i, mem in enumerate(memories, 1):
+        content = mem["content"]
+        if len(content) > 200:
+            content = content[:197] + "..."
+        lines.append(f"{i}. [{mem['score']:.2f}] {content}")
+
+    json.dump({"context": "Recalled memories (uteke):\n" + "\n".join(lines)},
+              sys.stdout, ensure_ascii=False)
+
+if __name__ == "__main__":
+    main()
+```
+
+2. **Register the hook** in each agent's `config.yaml`:
+
+```yaml
+hooks:
+  pre_llm_call:
+    - command: "python3 /opt/data/hooks/uteke-recall/handler.py"
+      timeout: 20
+hooks_auto_accept: true
+```
+
+#### How it differs from Mode A and B
+
+| | Mode A (uteke-tool) | Mode B (memory-provider) | Mode C (shell hook) |
+|---|---|---|---|
+| Recall | Manual `uteke(action="recall")` | Automatic every turn | Automatic every LLM call |
+| Extraction | No | Yes (session end) | No |
+| Plugin needed | Yes | Yes | **No** |
+| Daemon needed | Yes (`uteke-serve`) | No | No |
+| Inject mechanism | Tool output in context | MemoryProvider prefetch | `pre_llm_call` stdout |
+| Config changes | Plugin + server URL | `memory.provider: uteke` | `hooks:` block only |
+
+Mode C is the lightest option — it adds recall to any agent with just two
+file edits (handler script + config.yaml hook block). Combine with Mode B
+for both automatic recall AND automatic extraction.
+
+#### Race safety
+
+Each LLM call invokes the handler as a separate subprocess. The result is
+returned via stdout (process boundary), not written to any shared file. This
+makes it safe for concurrent sessions on the same agent profile — unlike
+approaches that write to SOUL.md or shared files.
+
 ### Q: Memory provider not activating in gateway mode
 
 **Symptom:** `memory.provider: uteke` is set in config.yaml but the "Memory provider 'uteke' activated" log never appears.


### PR DESCRIPTION
## Summary

Adds documentation for Mode C — the lightest Hermes integration option that uses `pre_llm_call` shell hooks for automatic uteke recall injection.

## Changes

- **integrations/hermes.md**: New Mode C section with:
  - Architecture diagram (message → hook → uteke recall → context injection)
  - Full handler.py reference implementation
  - config.yaml registration example
  - Comparison table: Mode A vs B vs C
  - Race safety explanation (subprocess stdout, no shared state)

- **getting-started.md**: Updated Hermes callout to reference all 3 integration modes

## Test

- Handler tested live: produces `{"context": "..."}` correctly
- All 6 agents already deployed with this hook (cto, kai, cfo, novelist, sosmed, badsector)
- Race-safe: verified no shared file writes, per-call subprocess invocation