### PR TITLE
docs: update getting-started Hermes callout with 3 integration modes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,8 +200,10 @@ uteke import memories.jsonl
 uteke import notes.txt --extract
 ```
 
-> 💡 **Hermes users?** Install uteke as an automatic memory provider:
-> `uteke init --agent hermes --memory-provider`. See [Hermes integration](integrations/hermes.md).
+> 💡 **Hermes users?** Three integration modes available:
+> - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](integrations/hermes.md).
+> - **Mode B (memory-provider):** Full auto — `uteke init --agent hermes --memory-provider`. Automatic recall + LLM fact extraction.
+> - **Mode A (uteke-tool):** Manual — `uteke init --agent hermes`. Explicit `uteke(action="...")` calls with multi-agent room support.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Ported from closed #490. After merging #491 (Mode C docs), the getting-started Hermes callout still referenced only Mode B.

## Changes

- `getting-started.md`: Update Hermes callout to list all 3 integration modes (A, B, C) with brief descriptions and link to full docs.

## Related

- #491 (merged) — Mode C documentation
- #490 (closed) — original source of getting-started update