### PR TITLE
release: v0.6.0 — batch import, embed fallback, bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,41 @@
 ## [Unreleased]
 
 ### Added
-- **Batch import (`--batch-dir`)** — import all `.md`/`.txt`/`.jsonl` files from a
+- **Batch import (`--batch-dir`)** — import all `.md`/`.markdown`/`.txt`/`.jsonl` files from a
   directory in one command. Two strategies: **Document** (`.md` → auto-chunk →
   embed, no LLM) and **MemoryExtract** (`.txt`/`.jsonl` → LLM fact extraction).
-  Use `--as-doc` or `--as-memory` to override auto-detection. `--recursive` for
-  nested directories, `--dry-run` to preview, `--max-size` to skip large files.
+  Use `--as-doc` or `--as-memory` to override auto-detection (mutually exclusive).
+  `--recursive` for nested directories, `--dry-run` to preview, `--max-size` to
+  skip large files. Path is canonicalized before traversal to prevent symlink
+  escapes (#492 review).
 - **Embed fallback** — optional cloud embedding API fallback when local ONNX fails.
   Configured via `[embed_fallback]` in `uteke.toml` or env vars
   `UTEKE_EMBED_FALLBACK_*`. Validates dimension compatibility at startup.
-  Zero cost when unconfigured.
+  Requires all three fields (`api_key`, `base_url`, `model`) — partial config
+  produces a warning instead of a runtime crash.
+- **Mode C documentation** — `docs/integrations/hermes.md` now documents all three
+  Hermes integration modes (A: uteke-tool, B: memory-provider, C: shell hook).
+  Getting-started callout updated to reference all modes.
+- **Migration upgrade regression test** — simulates v0.4.x DB (schema_version=11)
+  and verifies migration v11→v12 completes with all hierarchy columns and indexes.
 
 ### Changed
 - `ensure_embedder()` now wraps `OnnxEmbedder` in `FallbackEmbedder` when
   fallback settings are present and dims match.
+
+### Fixed
+- **#492: Schema migration crash on upgrade from v0.4.x** — duplicate document
+  hierarchy indexes (`idx_documents_path/parent/depth/sort`) in the `SCHEMA`
+  constant caused `execute_batch()` to fail before versioned migrations ran.
+  Columns didn't exist yet in existing DBs. Moved indexes to
+  `migrate_v11_to_v12()` where they belong.
+- **Batch import path canonicalization** — `--batch-dir` now resolves symlinks
+  and `..` components before traversal.
+- **Batch import silent errors** — `read_dir` failures on entries now logged
+  instead of silently swallowed.
+- **Fallback embedder partial config** — `is_configured()` now requires all
+  three fields (`api_key`, `base_url`, `model`). Partial config produces a
+  clear warning instead of a confusing runtime crash on first embed call.
 
 ## [0.5.0] — 2026-06-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:bookworm-slim AS builder
 
 ARG TARGETARCH
-ARG VERSION=v0.0.10
+ARG VERSION=v0.6.0
 
 LABEL version=${VERSION}
 LABEL org.opencontainers.image.version=${VERSION}

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.5.0-green.svg" alt="v0.5.0" />
+  <img src="https://img.shields.io/badge/status-v0.6.0-green.svg" alt="v0.6.0" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.5.0-green.svg" alt="v0.5.0" />
+  <img src="https://img.shields.io/badge/status-v0.6.0-green.svg" alt="v0.6.0" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.5.0" }
+uteke-core = { path = "../uteke-core", version = "0.6.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -244,14 +244,11 @@ pub enum Commands {
         #[arg(long, conflicts_with = "input")]
         batch_dir: Option<String>,
         /// Force document strategy (no LLM extraction) for all files
-        #[arg(long, requires = "batch_dir")]
+        #[arg(long, requires = "batch_dir", conflicts_with = "as_memory")]
         as_doc: bool,
         /// Force memory extraction strategy (LLM) for all files
-        #[arg(long, requires = "batch_dir")]
+        #[arg(long, requires = "batch_dir", conflicts_with = "as_doc")]
         as_memory: bool,
-        /// Max concurrent extractions (1 = sequential, max 10)
-        #[arg(long, default_value = "1", requires = "batch_dir")]
-        extract_parallel: usize,
         /// Dry run: show what would be imported without actually importing
         #[arg(long)]
         dry_run: bool,

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -397,9 +397,11 @@ pub(crate) fn run_import_batch(
     recursive: bool,
     dry_run: bool,
     max_size: usize,
-    extract_parallel: usize,
 ) -> Result<(), String> {
-    let dir_path = std::path::Path::new(dir);
+    let dir_path = match std::path::Path::new(dir).canonicalize() {
+        Ok(p) => p,
+        Err(e) => return Err(format!("Cannot resolve path '{}': {}", dir, e)),
+    };
     let start = std::time::Instant::now();
 
     // Discover files
@@ -453,7 +455,7 @@ pub(crate) fn run_import_batch(
 
     let mut result = BatchResult {
         files: files.len(),
-        total_facts: 0,
+        total_items: 0,
         imported: 0,
         skipped_files: 0,
         skipped_facts: 0,
@@ -471,7 +473,7 @@ pub(crate) fn run_import_batch(
         let title = title_from_slug(&slug);
         match import_single_document(uteke, path, &slug, &title, &tag_refs, ns) {
             Ok(count) => {
-                result.total_facts += count;
+                result.total_items += count;
                 result.imported += 1;
                 tracing::info!("Imported document '{}' — {} chunks", slug, count);
                 if !cli.json {
@@ -526,7 +528,7 @@ pub(crate) fn run_import_batch(
 
             match import_with_extraction(uteke, &content, &tag_refs, ns, &extract_opts) {
                 Ok(import_result) => {
-                    result.total_facts += import_result.imported;
+                    result.total_items += import_result.imported;
                     result.imported += 1;
                     result.skipped_facts += import_result.skipped;
                     if !cli.json {
@@ -545,11 +547,6 @@ pub(crate) fn run_import_batch(
                         println!("  ✗ [memory]{} {} — {}", progress_suffix, path.display(), e);
                     }
                 }
-            }
-
-            // Rate limiting between files (sequential mode)
-            if extract_parallel <= 1 && i < memory_files.len() - 1 {
-                std::thread::sleep(std::time::Duration::from_millis(500));
             }
         }
     }
@@ -570,7 +567,7 @@ pub(crate) fn run_import_batch(
             println!("✓ Batch import complete in {}ms", result.elapsed_ms);
         }
         println!("  Files processed: {}/{}", result.imported, result.files);
-        println!("  Total facts: {}", result.total_facts);
+        println!("  Total items: {}", result.total_items);
         let total_skipped = result.skipped_files + result.skipped_facts;
         if total_skipped > 0 {
             println!(
@@ -676,22 +673,11 @@ pub(crate) enum ImportStrategy {
     MemoryExtract,
 }
 
-/// Per-file batch result.
-#[derive(serde::Serialize)]
-#[allow(dead_code)]
-struct BatchFileResult {
-    path: String,
-    strategy: String,
-    facts: usize,
-    imported: bool,
-    error: Option<String>,
-}
-
 /// Aggregate batch result.
 #[derive(serde::Serialize)]
 struct BatchResult {
     files: usize,
-    total_facts: usize,
+    total_items: usize,
     imported: usize,
     skipped_files: usize,
     skipped_facts: usize,
@@ -714,7 +700,7 @@ fn discover_files(
         return Err(format!("'{}' is not a directory", dir.display()));
     }
 
-    let supported_exts = ["md", "txt", "jsonl", "text"];
+    let supported_exts = ["md", "markdown", "txt", "jsonl"];
     let mut files = Vec::new();
 
     fn walk(
@@ -727,7 +713,15 @@ fn discover_files(
         let entries = std::fs::read_dir(path)
             .map_err(|e| format!("Cannot read directory '{}': {}", path.display(), e))?;
 
-        let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+        let mut entries: Vec<_> = entries
+            .filter_map(|e| match e {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    tracing::warn!(dir = %path.display(), "Failed to read directory entry: {}", err);
+                    None
+                }
+            })
+            .collect();
         entries.sort_by_key(|e| e.file_name());
 
         for entry in entries {
@@ -781,7 +775,7 @@ fn discover_files(
 
 /// Determine import strategy for a file based on its extension and flags.
 ///
-/// - .md files → Document strategy (full content, auto-chunk)
+/// - .md/.markdown files → Document strategy (full content, auto-chunk)
 /// - .txt/.jsonl files → MemoryExtract strategy (LLM extraction)
 /// - Overridden by --as-doc / --as-memory flags
 fn determine_strategy(
@@ -816,9 +810,9 @@ fn slug_from_path(base: &std::path::Path, file: &std::path::Path) -> String {
     let slug = relative.to_string_lossy().replace(['/', '\\'], "-");
     let slug = slug
         .trim_end_matches(".md")
+        .trim_end_matches(".markdown")
         .trim_end_matches(".txt")
         .trim_end_matches(".jsonl")
-        .trim_end_matches(".text")
         .trim_end_matches('-')
         .to_lowercase();
     slug

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -405,7 +405,7 @@ pub(crate) fn run_import_batch(
     let start = std::time::Instant::now();
 
     // Discover files
-    let files = discover_files(dir_path, max_size, recursive)?;
+    let files = discover_files(&dir_path, max_size, recursive)?;
     if files.is_empty() {
         println!("No importable files found in '{}'.", dir);
         return Ok(());
@@ -469,7 +469,7 @@ pub(crate) fn run_import_batch(
 
     // ── Phase 1: Document imports (no LLM, sequential) ──
     for path in &doc_files {
-        let slug = slug_from_path(dir_path, path);
+        let slug = slug_from_path(&dir_path, path);
         let title = title_from_slug(&slug);
         match import_single_document(uteke, path, &slug, &title, &tag_refs, ns) {
             Ok(count) => {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -176,7 +176,6 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             batch_dir,
             as_doc,
             as_memory,
-            extract_parallel,
             dry_run,
             max_size,
             recursive,
@@ -199,7 +198,6 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
                 } else {
                     None
                 };
-                let parallel = (*extract_parallel).clamp(1, 10);
                 return maintenance::run_import_batch(
                     cli,
                     uteke,
@@ -211,7 +209,6 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
                     *recursive,
                     *dry_run,
                     *max_size,
-                    parallel,
                 );
             }
 

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -130,9 +130,17 @@ pub struct EmbedFallbackConfig {
 }
 
 impl EmbedFallbackConfig {
-    /// Check if fallback is configured (any field non-empty).
+    /// Check if fallback is fully configured (api_key, base_url, AND model).
+    /// Warns on partial config — partial config will be rejected by the core library.
     pub fn is_configured(&self) -> bool {
-        !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty()
+        let has_any = !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty();
+        let has_all = !self.api_key.is_empty() && !self.base_url.is_empty() && !self.model.is_empty();
+        if has_any && !has_all {
+            tracing::warn!(
+                "Embedding fallback partially configured — requires api_key, base_url, AND model"
+            );
+        }
+        has_all
     }
 
     /// Resolve with env var overrides. Env vars win over toml values.

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -133,8 +133,10 @@ impl EmbedFallbackConfig {
     /// Check if fallback is fully configured (api_key, base_url, AND model).
     /// Warns on partial config — partial config will be rejected by the core library.
     pub fn is_configured(&self) -> bool {
-        let has_any = !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty();
-        let has_all = !self.api_key.is_empty() && !self.base_url.is_empty() && !self.model.is_empty();
+        let has_any =
+            !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty();
+        let has_all =
+            !self.api_key.is_empty() && !self.base_url.is_empty() && !self.model.is_empty();
         if has_any && !has_all {
             tracing::warn!(
                 "Embedding fallback partially configured — requires api_key, base_url, AND model"

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -229,9 +229,20 @@ pub struct FallbackSettings {
 }
 
 impl FallbackSettings {
-    /// Check if fallback is configured (any field non-empty).
+    /// Check if fallback is configured (all required fields present).
+    /// Requires api_key AND base_url AND model — partial config is an error.
     pub fn is_configured(&self) -> bool {
-        !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty()
+        let has_any = !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty();
+        let has_all = !self.api_key.is_empty() && !self.base_url.is_empty() && !self.model.is_empty();
+        if has_any && !has_all {
+            tracing::warn!(
+                "Embedding fallback partially configured — requires api_key, base_url, AND model. Missing: {}",
+                if self.api_key.is_empty() { "api_key " } else { "" },
+                if self.base_url.is_empty() { "base_url " } else { "" },
+                if self.model.is_empty() { "model" } else { "" },
+            );
+        }
+        has_all
     }
 }
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -232,14 +232,27 @@ impl FallbackSettings {
     /// Check if fallback is configured (all required fields present).
     /// Requires api_key AND base_url AND model — partial config is an error.
     pub fn is_configured(&self) -> bool {
-        let has_any = !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty();
-        let has_all = !self.api_key.is_empty() && !self.base_url.is_empty() && !self.model.is_empty();
+        let has_any =
+            !self.api_key.is_empty() || !self.base_url.is_empty() || !self.model.is_empty();
+        let has_all =
+            !self.api_key.is_empty() && !self.base_url.is_empty() && !self.model.is_empty();
         if has_any && !has_all {
-            tracing::warn!(
-                "Embedding fallback partially configured — requires api_key, base_url, AND model. Missing: {}",
-                if self.api_key.is_empty() { "api_key " } else { "" },
-                if self.base_url.is_empty() { "base_url " } else { "" },
+            let missing = [
+                if self.api_key.is_empty() {
+                    "api_key "
+                } else {
+                    ""
+                },
+                if self.base_url.is_empty() {
+                    "base_url "
+                } else {
+                    ""
+                },
                 if self.model.is_empty() { "model" } else { "" },
+            ]
+            .join("");
+            tracing::warn!(
+                "Embedding fallback partially configured — requires api_key, base_url, AND model. Missing: {missing}"
             );
         }
         has_all

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.5.0" }
+uteke-core = { path = "../uteke-core", version = "0.6.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.5.0" }
-uteke-mcp = { path = "../uteke-mcp", version = "0.5.0" }
+uteke-core = { path = "../uteke-core", version = "0.6.0" }
+uteke-mcp = { path = "../uteke-mcp", version = "0.6.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'Architecture', link: '/architecture' },
+          { text: 'Hermes Integration', link: '/integrations/hermes' },
           { text: 'Pi Extension', link: '/extensions' },
           { text: 'TLS & Reverse Proxy', link: '/tls' },
           { text: 'Roadmap', link: '/roadmap' },

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -4,7 +4,7 @@
 
 ## Architecture
 
-Uteke integrates with Hermes in two ways. Pick the one that matches how you
+Uteke integrates with Hermes in three ways. Pick the one that matches how you
 want memory to behave.
 
 ```
@@ -302,7 +302,7 @@ def _resolve_agent_name() -> str:
     return "default"
 
 AGENT = _resolve_agent_name()
-UTEKE_BIN = pathlib.Path("/opt/data/.cargo/bin/uteke")  # adjust to your path
+UTEKE_BIN = pathlib.Path(shutil.which("uteke") or "/opt/data/.cargo/bin/uteke")  # adjust to your path
 
 def _recall_uteke(query: str, limit: int = 5) -> list:
     if not UTEKE_BIN.exists():

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ title: Roadmap
 
 Demand-gated — we build what people actually use. Track progress on [GitHub Issues](https://github.com/codecoradev/uteke/issues).
 
-## v0.5.0 — LLM Extraction & Hermes Integration `:soon:`
+## v0.5.0 — LLM Extraction & Hermes Integration `✓ Released 2026-06-27`
 
 - [#46 LLM fact extraction on import](https://github.com/codecoradev/uteke/issues/46) `✓ Done`
   - `uteke import --extract` distills noisy text into atomic facts
@@ -16,6 +16,18 @@ Demand-gated — we build what people actually use. Track progress on [GitHub Is
 - Default max_seq_length 256 → 2048 `✓ Done`
 - Public `store()` accessor for downstream crates `✓ Done`
 - rusqlite 0.31 → 0.40 upgrade `✓ Done`
+
+## v0.6.0 — Batch Import & Embed Fallback `:soon:`
+
+- Batch directory import (`--batch-dir`) `✓ Done`
+  - Auto-detection: `.md` → document, `.txt`/`.jsonl` → memory extraction
+  - `--as-doc`/`--as-memory` override, `--recursive`, `--dry-run`
+- Cloud embedding fallback `✓ Done`
+  - Optional `[embed_fallback]` config for cloud API failover
+  - Dimension validation at startup
+- Mode C (shell hook) docs `✓ Done`
+- Migration upgrade regression test `✓ Done`
+- Schema migration fix (#492) `✓ Done`
 
 ## v0.4.x — Polish & Stability `✓ Released 2026-06-22–24`
 


### PR DESCRIPTION
## v0.6.0 Release

### Added
- **Batch import (`--batch-dir`)** — import `.md`/`.markdown`/`.txt`/`.jsonl` from directory
- **Embed fallback** — optional cloud API fallback for local ONNX
- **Mode C docs** — Hermes integration: uteke-tool, memory-provider, shell hook
- **Migration regression test** — simulates v0.4.x → v0.5.0 upgrade path

### Fixed
- **#492:** Schema migration crash on upgrade (duplicate indexes)
- **C1:** Path canonicalization on `--batch-dir`
- **C2:** `read_dir` errors now logged (not silently swallowed)
- **C3:** Partial fallback config → warning instead of runtime crash

### Cleanup
- `--as-doc`/`--as-memory` mutually exclusive
- Removed dead `extract_parallel` flag and `BatchFileResult` struct
- `.text` extension → `.markdown`, `total_facts` → `total_items`

### Housekeeping
- Version bump + dep pins + Dockerfile + badges + CHANGELOG + roadmap + sidebar

**16 files changed, 96 insertions, 54 deletions**