### PR TITLE
docs: sync CHANGELOG v0.6.0 date to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-30
+
 ### Added
 - **Batch import (`--batch-dir`)** — import all `.md`/`.markdown`/`.txt`/`.jsonl` files from a
   directory in one command. Two strategies: **Document** (`.md` → auto-chunk →


### PR DESCRIPTION
Sync develop (CHANGELOG v0.6.0 date fix) → main.