### PR TITLE
Release v0.6.1 — schema fix, uteke-mcp install, doc updates

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -6,8 +6,8 @@
 
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
-- **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.3.2
+- **Repo:** `codecoradev/uteke` (remote GitHub), local clone
+- **Version:** 0.6.0
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Fixed
+- **#500: Schema migration v11→v12 missing has_children column** — Partially-migrated databases (schema_version=12 but missing `has_children`) now get the column repaired on next open. `uteke repair` also fixes schema inconsistencies.
+
+### Changed
+- **#501: install.sh now installs uteke-mcp** — All three binaries (uteke, uteke-serve, uteke-mcp) are now installed via the quick-install script.
+
+### Docs
+- Updated version strings to 0.6.0 in cli-reference.md, roadmap.md, AGENT.md.
+
 ## [0.6.0] — 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -103,8 +103,11 @@ impl crate::Uteke {
         })
     }
 
-    /// Repair: rebuild usearch index from SQLite.
+    /// Repair: rebuild usearch index from SQLite + fix schema inconsistencies.
     pub fn repair(&self) -> Result<RepairReport, Error> {
+        // Fix partially-migrated schema (e.g. missing has_children column, #500).
+        self.store.ensure_schema_consistency()?;
+
         let before_db = self.store.count(None)?;
         let before_index = {
             let index = self

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -127,6 +127,44 @@ impl super::Store {
             }
         }
 
+        // Post-migration consistency checks: repair partially-migrated databases
+        // where a migration stamped the version but failed partway through (#500).
+        self.ensure_documents_has_children()?;
+
+        Ok(())
+    }
+
+    /// Ensure the `has_children` column exists on the `documents` table.
+    ///
+    /// Schema v12 migration (`migrate_v11_to_v12`) adds this column, but a
+    /// partially-migrated DB may have schema_version=12 without the column.
+    /// This check runs after every `ensure_schema_version()` call (including on
+    /// open) so the column is repaired on next access.
+    fn ensure_documents_has_children(&self) -> Result<(), Error> {
+        // Only relevant for schema v12+ databases.
+        let version = self.schema_version().unwrap_or(0);
+        if version < 12 {
+            return Ok(());
+        }
+        if !self.column_exists_in("documents", "has_children") {
+            tracing::warn!(
+                "documents.has_children column missing on schema v{version} DB — repairing (#500)"
+            );
+            self.conn
+                .execute(
+                    "ALTER TABLE documents ADD COLUMN has_children INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )
+                .map_err(|e| Error::db("repair has_children column (#500)", e))?;
+        }
+        Ok(())
+    }
+
+    /// Ensure all expected columns exist for the current schema version.
+    ///
+    /// Called by `uteke repair` to fix partially-migrated databases.
+    pub fn ensure_schema_consistency(&self) -> Result<(), Error> {
+        self.ensure_documents_has_children()?;
         Ok(())
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.3.2**.
+Complete reference for all uteke commands. Version **0.6.0**.
 
 ## Global Flags
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,6 +204,8 @@ uteke import notes.txt --extract
 > - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](integrations/hermes.md).
 > - **Mode B (memory-provider):** Full auto — `uteke init --agent hermes --memory-provider`. Automatic recall + LLM fact extraction.
 > - **Mode A (uteke-tool):** Manual — `uteke init --agent hermes`. Explicit `uteke(action="...")` calls with multi-agent room support.
+>
+> The install script installs all three binaries (`uteke`, `uteke-serve`, `uteke-mcp`) so MCP integration is available immediately.
 
 ## Troubleshooting
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ Demand-gated — we build what people actually use. Track progress on [GitHub Is
 - Public `store()` accessor for downstream crates `✓ Done`
 - rusqlite 0.31 → 0.40 upgrade `✓ Done`
 
-## v0.6.0 — Batch Import & Embed Fallback `:soon:`
+## v0.6.0 — Batch Import & Embed Fallback `✓ Released 2026-06-30`
 
 - Batch directory import (`--batch-dir`) `✓ Done`
   - Auto-detection: `.md` → document, `.txt`/`.jsonl` → memory extraction

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ set -e
 REPO="codecoradev/uteke"
 BINARY_NAME="uteke"
 SERVER_BINARY_NAME="uteke-serve"
+MCP_BINARY_NAME="uteke-mcp"
 INSTALL_DIR="${UTEKE_INSTALL_DIR:-$HOME/.local/bin}"
 
 # Colors
@@ -140,10 +141,16 @@ install() {
     if [ -f "${TEMP_DIR}/${SERVER_BINARY_NAME}" ]; then
         mv "${TEMP_DIR}/${SERVER_BINARY_NAME}" "${INSTALL_DIR}/"
     fi
+    if [ -f "${TEMP_DIR}/${MCP_BINARY_NAME}" ]; then
+        mv "${TEMP_DIR}/${MCP_BINARY_NAME}" "${INSTALL_DIR}/"
+    fi
 
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
     if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
         chmod +x "${INSTALL_DIR}/${SERVER_BINARY_NAME}"
+    fi
+    if [ -f "${INSTALL_DIR}/${MCP_BINARY_NAME}" ]; then
+        chmod +x "${INSTALL_DIR}/${MCP_BINARY_NAME}"
     fi
 
     # Cleanup
@@ -152,6 +159,9 @@ install() {
     info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
     if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
         info "Successfully installed ${SERVER_BINARY_NAME} to ${INSTALL_DIR}/${SERVER_BINARY_NAME}"
+    fi
+    if [ -f "${INSTALL_DIR}/${MCP_BINARY_NAME}" ]; then
+        info "Successfully installed ${MCP_BINARY_NAME} to ${INSTALL_DIR}/${MCP_BINARY_NAME}"
     fi
 }
 


### PR DESCRIPTION
## Summary

Patch release fixing 3 issues found during comprehensive feature testing of v0.5.x/v0.6.x.

### Fixes
- **#500:** Schema migration v11→v12 — `has_children` column added on every DB open for partially-migrated databases. `uteke repair` now also fixes schema inconsistencies.
- **#501:** `install.sh` now installs all 3 binaries (uteke, uteke-serve, uteke-mcp). Updated getting-started docs.

### Docs
- **#503:** Updated version strings to 0.6.0 in cli-reference.md, roadmap.md, AGENT.md.
- Roadmap v0.6.0 status: ` :soon: ` → ` ✓ Released 2026-06-30 `

### Chore
- Sync Cargo.lock version to 0.6.0

### Closed as false positive
- **#499:** Server auth bypass — auth works correctly, `/health` is intentionally exempt for load balancers
- **#502:** GET /room/list — endpoint already exists (implemented in v0.2.1 #395)

## Commits
`b061126` chore: sync Cargo.lock versions to 0.6.0
`97460f3` docs: update version strings to 0.6.0, fix roadmap status (#503)
`f597025` fix: install uteke-mcp binary via install.sh (#501)
`547b039` fix: ensure has_children column exists for schema v12+ (#500)

## Test Plan
- [ ] CI green (clippy + tests)
- [ ] Manual: fresh install via install.sh verifies all 3 binaries
- [ ] Manual: `uteke repair` on partially-migrated DB fixes `has_children`
- [ ] Manual: doc version strings correct across all files