### PR TITLE
Release v0.6.1 — version bump, CHANGELOG, AGENT.md fix

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.0
+- **Version:** 0.6.1
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -89,7 +89,7 @@ crates/uteke-server/src/
 ### Schema Versioning
 
 - `schema_version` table with integer counter
-- Current: **v11** (document engine + knowledge graph + timeline + citations)
+- Current: **v12** (document engine + knowledge graph + timeline + citations + hierarchy)
 - Auto-migration on upgrade, zero data loss
 
 ---
@@ -157,19 +157,29 @@ feature branch → PR → develop (default branch)
 
 ### 5. Release Process
 
-**Prerequisite:** All v0.X.0 milestone issues closed, docs updated.
+**Prerequisite:** All milestone issues closed, docs updated.
+
+#### Release Branch Checklist
+
+When creating a release branch (`release/vX.Y.Z`), these changes MUST be in the branch:
+
+1. **Version bump** — `Cargo.toml` `[workspace.package].version` → new version
+2. **CHANGELOG.md** — move entries from `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD`, add empty `[Unreleased]`
+3. **AGENT.md** — update version string + any stale references (schema version, etc.)
+4. **README.md / README.id.md** — version badge if applicable
+
+#### Release Flow
 
 ```bash
-# 1. Update docs (CHANGELOG, README, cli-reference, roadmap, etc.)
-# 2. Bump version in Cargo.toml + inter-crate deps
-# 3. PR to develop, merge
-# 4. PR develop → main, merge
-# 5. Tag from main commit:
+# 1. Create release branch from develop with version bump + CHANGELOG + AGENT.md
+# 2. PR release/vX.Y.Z → develop, merge
+# 3. PR develop → main, merge
+# 4. Tag from main commit:
 git checkout main
 git pull origin main
 git tag vX.Y.Z -m "vX.Y.Z — Description"
 git push origin vX.Y.Z
-# 6. Release workflow auto-builds: binaries, crates.io, Docker, GitHub Release
+# 5. Release workflow auto-builds: binaries, crates.io, Docker, GitHub Release
 ```
 
 **Never tag without merging develop → main first.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.6.1] — 2026-06-30
+
 ### Fixed
 - **#500: Schema migration v11→v12 missing has_children column** — Partially-migrated databases (schema_version=12 but missing `has_children`) now get the column repaired on next open. `uteke repair` also fixes schema inconsistencies.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"


### PR DESCRIPTION
## Summary

Patch release preparation for v0.6.1 — version bump and documentation updates only. No code changes.

### Changes
- **Cargo.toml:** `workspace.package.version` 0.6.0 → 0.6.1
- **Cargo.lock:** sync all 4 crate versions to 0.6.1
- **CHANGELOG.md:** move entries from `[Unreleased]` → `[0.6.1] — 2026-06-30`, add empty `[Unreleased]`
- **AGENT.md:**
  - Version string 0.6.0 → 0.6.1
  - Schema version v11 → v12 (stale reference from v0.4.x era)
  - Add **Release Branch Checklist** to Release Process section — explicit steps for version bump + CHANGELOG + AGENT.md when creating release branches

### Includes
- #500 fix (schema migration repair)
- #501 fix (install.sh uteke-mcp)
- #503 docs (version strings, roadmap status)

### Next Steps After Merge
1. PR develop → main
2. Tag `v0.6.1` from main
3. Release workflow auto-publishes