### PR TITLE
Merge develop → main for v0.6.1 release

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.0
+- **Version:** 0.6.1
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -89,7 +89,7 @@ crates/uteke-server/src/
 ### Schema Versioning
 
 - `schema_version` table with integer counter
-- Current: **v11** (document engine + knowledge graph + timeline + citations)
+- Current: **v12** (document engine + knowledge graph + timeline + citations + hierarchy)
 - Auto-migration on upgrade, zero data loss
 
 ---
@@ -157,19 +157,29 @@ feature branch → PR → develop (default branch)
 
 ### 5. Release Process
 
-**Prerequisite:** All v0.X.0 milestone issues closed, docs updated.
+**Prerequisite:** All milestone issues closed, docs updated.
+
+#### Release Branch Checklist
+
+When creating a release branch (`release/vX.Y.Z`), these changes MUST be in the branch:
+
+1. **Version bump** — `Cargo.toml` `[workspace.package].version` → new version
+2. **CHANGELOG.md** — move entries from `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD`, add empty `[Unreleased]`
+3. **AGENT.md** — update version string + any stale references (schema version, etc.)
+4. **README.md / README.id.md** — version badge if applicable
+
+#### Release Flow
 
 ```bash
-# 1. Update docs (CHANGELOG, README, cli-reference, roadmap, etc.)
-# 2. Bump version in Cargo.toml + inter-crate deps
-# 3. PR to develop, merge
-# 4. PR develop → main, merge
-# 5. Tag from main commit:
+# 1. Create release branch from develop with version bump + CHANGELOG + AGENT.md
+# 2. PR release/vX.Y.Z → develop, merge
+# 3. PR develop → main, merge
+# 4. Tag from main commit:
 git checkout main
 git pull origin main
 git tag vX.Y.Z -m "vX.Y.Z — Description"
 git push origin vX.Y.Z
-# 6. Release workflow auto-builds: binaries, crates.io, Docker, GitHub Release
+# 5. Release workflow auto-builds: binaries, crates.io, Docker, GitHub Release
 ```
 
 **Never tag without merging develop → main first.**

--- a/AGENT.md
+++ b/AGENT.md
@@ -6,8 +6,8 @@
 
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
-- **Repo:** `codecoradev/uteke` (remote GitHub), local at `/Users/mis-puragroup/development/riset-ai/uteke`
-- **Version:** 0.3.2
+- **Repo:** `codecoradev/uteke` (remote GitHub), local clone
+- **Version:** 0.6.0
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.6.1] — 2026-06-30
+
 ### Fixed
 - **#500: Schema migration v11→v12 missing has_children column** — Partially-migrated databases (schema_version=12 but missing `has_children`) now get the column repaired on next open. `uteke repair` also fixes schema inconsistencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Fixed
+- **#500: Schema migration v11→v12 missing has_children column** — Partially-migrated databases (schema_version=12 but missing `has_children`) now get the column repaired on next open. `uteke repair` also fixes schema inconsistencies.
+
+### Changed
+- **#501: install.sh now installs uteke-mcp** — All three binaries (uteke, uteke-serve, uteke-mcp) are now installed via the quick-install script.
+
+### Docs
+- Updated version strings to 0.6.0 in cli-reference.md, roadmap.md, AGENT.md.
+
 ## [0.6.0] — 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -103,8 +103,11 @@ impl crate::Uteke {
         })
     }
 
-    /// Repair: rebuild usearch index from SQLite.
+    /// Repair: rebuild usearch index from SQLite + fix schema inconsistencies.
     pub fn repair(&self) -> Result<RepairReport, Error> {
+        // Fix partially-migrated schema (e.g. missing has_children column, #500).
+        self.store.ensure_schema_consistency()?;
+
         let before_db = self.store.count(None)?;
         let before_index = {
             let index = self

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -127,6 +127,44 @@ impl super::Store {
             }
         }
 
+        // Post-migration consistency checks: repair partially-migrated databases
+        // where a migration stamped the version but failed partway through (#500).
+        self.ensure_documents_has_children()?;
+
+        Ok(())
+    }
+
+    /// Ensure the `has_children` column exists on the `documents` table.
+    ///
+    /// Schema v12 migration (`migrate_v11_to_v12`) adds this column, but a
+    /// partially-migrated DB may have schema_version=12 without the column.
+    /// This check runs after every `ensure_schema_version()` call (including on
+    /// open) so the column is repaired on next access.
+    fn ensure_documents_has_children(&self) -> Result<(), Error> {
+        // Only relevant for schema v12+ databases.
+        let version = self.schema_version().unwrap_or(0);
+        if version < 12 {
+            return Ok(());
+        }
+        if !self.column_exists_in("documents", "has_children") {
+            tracing::warn!(
+                "documents.has_children column missing on schema v{version} DB — repairing (#500)"
+            );
+            self.conn
+                .execute(
+                    "ALTER TABLE documents ADD COLUMN has_children INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )
+                .map_err(|e| Error::db("repair has_children column (#500)", e))?;
+        }
+        Ok(())
+    }
+
+    /// Ensure all expected columns exist for the current schema version.
+    ///
+    /// Called by `uteke repair` to fix partially-migrated databases.
+    pub fn ensure_schema_consistency(&self) -> Result<(), Error> {
+        self.ensure_documents_has_children()?;
         Ok(())
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.3.2**.
+Complete reference for all uteke commands. Version **0.6.0**.
 
 ## Global Flags
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,6 +204,8 @@ uteke import notes.txt --extract
 > - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](integrations/hermes.md).
 > - **Mode B (memory-provider):** Full auto — `uteke init --agent hermes --memory-provider`. Automatic recall + LLM fact extraction.
 > - **Mode A (uteke-tool):** Manual — `uteke init --agent hermes`. Explicit `uteke(action="...")` calls with multi-agent room support.
+>
+> The install script installs all three binaries (`uteke`, `uteke-serve`, `uteke-mcp`) so MCP integration is available immediately.
 
 ## Troubleshooting
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ Demand-gated — we build what people actually use. Track progress on [GitHub Is
 - Public `store()` accessor for downstream crates `✓ Done`
 - rusqlite 0.31 → 0.40 upgrade `✓ Done`
 
-## v0.6.0 — Batch Import & Embed Fallback `:soon:`
+## v0.6.0 — Batch Import & Embed Fallback `✓ Released 2026-06-30`
 
 - Batch directory import (`--batch-dir`) `✓ Done`
   - Auto-detection: `.md` → document, `.txt`/`.jsonl` → memory extraction

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ set -e
 REPO="codecoradev/uteke"
 BINARY_NAME="uteke"
 SERVER_BINARY_NAME="uteke-serve"
+MCP_BINARY_NAME="uteke-mcp"
 INSTALL_DIR="${UTEKE_INSTALL_DIR:-$HOME/.local/bin}"
 
 # Colors
@@ -140,10 +141,16 @@ install() {
     if [ -f "${TEMP_DIR}/${SERVER_BINARY_NAME}" ]; then
         mv "${TEMP_DIR}/${SERVER_BINARY_NAME}" "${INSTALL_DIR}/"
     fi
+    if [ -f "${TEMP_DIR}/${MCP_BINARY_NAME}" ]; then
+        mv "${TEMP_DIR}/${MCP_BINARY_NAME}" "${INSTALL_DIR}/"
+    fi
 
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
     if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
         chmod +x "${INSTALL_DIR}/${SERVER_BINARY_NAME}"
+    fi
+    if [ -f "${INSTALL_DIR}/${MCP_BINARY_NAME}" ]; then
+        chmod +x "${INSTALL_DIR}/${MCP_BINARY_NAME}"
     fi
 
     # Cleanup
@@ -152,6 +159,9 @@ install() {
     info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
     if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
         info "Successfully installed ${SERVER_BINARY_NAME} to ${INSTALL_DIR}/${SERVER_BINARY_NAME}"
+    fi
+    if [ -f "${INSTALL_DIR}/${MCP_BINARY_NAME}" ]; then
+        info "Successfully installed ${MCP_BINARY_NAME} to ${INSTALL_DIR}/${MCP_BINARY_NAME}"
     fi
 }
 


### PR DESCRIPTION
## Summary

Sync develop to main for v0.6.1 patch release.

### Includes
- PR #504: #500 schema fix, #501 install.sh uteke-mcp, #503 doc updates
- PR #506: version bump 0.6.0 → 0.6.1, CHANGELOG, AGENT.md fix (schema v12, release checklist)

### After Merge
1. Tag `v0.6.1` from main HEAD
2. Release workflow auto-publishes binaries + crates.io + Docker + GitHub Release