### PR TITLE
Add uteke-mcp to Docker image + MCP docs gaps (#505)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,13 +79,14 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build release binaries
-        run: cargo build --release --target ${{ matrix.target }} -p uteke-cli -p uteke-server
+        run: cargo build --release --target ${{ matrix.target }} -p uteke-cli -p uteke-server -p uteke-mcp
 
       - name: Strip binaries (Unix)
         if: runner.os != 'Windows'
         run: |
           strip target/${{ matrix.target }}/release/uteke || true
           strip target/${{ matrix.target }}/release/uteke-serve || true
+          strip target/${{ matrix.target }}/release/uteke-mcp || true
 
       - name: Extract version
         id: version
@@ -98,8 +99,9 @@ jobs:
           mkdir -p release
           cp target/${{ matrix.target }}/release/uteke release/uteke
           cp target/${{ matrix.target }}/release/uteke-serve release/uteke-serve
+          cp target/${{ matrix.target }}/release/uteke-mcp release/uteke-mcp
           cd release
-          tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke uteke-serve
+          tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke uteke-serve uteke-mcp
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -108,8 +110,9 @@ jobs:
           mkdir release
           cp target/${{ matrix.target }}/release/uteke.exe release/uteke.exe
           cp target/${{ matrix.target }}/release/uteke-serve.exe release/uteke-serve.exe
+          cp target/${{ matrix.target }}/release/uteke-mcp.exe release/uteke-mcp.exe
           cd release
-          7z a "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke.exe uteke-serve.exe
+          7z a "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke.exe uteke-serve.exe uteke-mcp.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -190,7 +193,7 @@ jobs:
           echo "" >> release-notes.md
           cat changelog-body.md >> release-notes.md
           echo "" >> release-notes.md
-          printf '### 📦 Binaries\n\nEach archive contains **two binaries**:\n- `uteke` — CLI tool\n- `uteke-serve` — HTTP server daemon\n\n' >> release-notes.md
+          printf '### 📦 Binaries\n\nEach archive contains **three binaries**:\n- `uteke` — CLI tool\n- `uteke-serve` — HTTP server daemon\n- `uteke-mcp` — MCP server (stdio + HTTP)\n\n' >> release-notes.md
           printf '| Platform | File |\n|----------|------|\n' >> release-notes.md
           printf '| Linux (x86_64) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
           printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
@@ -256,9 +259,11 @@ jobs:
           tar xzf "$AMD64" -C ../binaries
           mv ../binaries/uteke ../binaries/uteke-amd64
           mv ../binaries/uteke-serve ../binaries/uteke-serve-amd64
+          mv ../binaries/uteke-mcp ../binaries/uteke-mcp-amd64
           tar xzf "$ARM64" -C ../binaries
           mv ../binaries/uteke ../binaries/uteke-arm64
           mv ../binaries/uteke-serve ../binaries/uteke-serve-arm64
+          mv ../binaries/uteke-mcp ../binaries/uteke-mcp-arm64
           chmod +x ../binaries/*
           ls -lh ../binaries/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ WORKDIR /build
 # Copy CI-downloaded binaries (preferred).
 COPY binaries/ ./
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      mv uteke-arm64 uteke && mv uteke-serve-arm64 uteke-serve && \
-      rm -f uteke-amd64 uteke-serve-amd64; \
+      mv uteke-arm64 uteke && mv uteke-serve-arm64 uteke-serve && mv uteke-mcp-arm64 uteke-mcp && \
+      rm -f uteke-amd64 uteke-serve-amd64 uteke-mcp-amd64; \
     else \
-      mv uteke-amd64 uteke && mv uteke-serve-amd64 uteke-serve && \
-      rm -f uteke-arm64 uteke-serve-arm64; \
+      mv uteke-amd64 uteke && mv uteke-serve-amd64 uteke-serve && mv uteke-mcp-amd64 uteke-mcp && \
+      rm -f uteke-arm64 uteke-serve-arm64 uteke-mcp-arm64; \
     fi && \
-    chmod +x uteke uteke-serve
+    chmod +x uteke uteke-serve uteke-mcp
 
 # ── Stage 2: Runtime ────────────────────────────────────────────────────
 FROM debian:bookworm-slim
@@ -38,6 +38,7 @@ RUN groupadd --system --gid 1000 uteke && \
 # Copy binaries
 COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
+COPY --from=builder /build/uteke-mcp /usr/local/bin/uteke-mcp
 
 # Copy embedding model (pre-baked by CI)
 COPY models/ /data/models/embeddinggemma-q4

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -148,4 +148,92 @@ healthcheck:
 
 ## Behind a Reverse Proxy
 
+## MCP (Model Context Protocol)
+
+The Docker image includes the `uteke-mcp` binary for MCP-based AI agent integration.
+
+### HTTP Transport (via uteke-serve)
+
+HTTP transport is available through `uteke-serve` at the `/mcp` endpoint. Start the container normally and point your MCP client at the server:
+
+```bash
+# Start uteke with MCP endpoint enabled (default)
+docker run -d --name uteke \
+  -p 127.0.0.1:8767:8767 \
+  -v uteke-data:/data \
+  ghcr.io/codecoradev/uteke:latest
+
+# The MCP endpoint is available at:
+# http://localhost:8767/mcp (Streamable HTTP transport)
+```
+
+Example client configurations:
+
+```jsonc
+// Claude Desktop — claude_desktop_config.json
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "http://localhost:8767/mcp"
+    }
+  }
+}
+```
+
+```jsonc
+// Cursor — .cursor/mcp.json
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "http://localhost:8767/mcp"
+    }
+  }
+}
+```
+
+> **Note**: When running uteke in Docker and the MCP client on the host, `localhost` works because of the port mapping. For remote setups, replace `localhost` with the server's hostname or IP and configure `UTEKE_AUTH_TOKEN`.
+
+### Stdio Transport (via uteke-mcp)
+
+The `uteke-mcp` binary in the container provides stdio transport for clients that require subprocess-based MCP. Use `--entrypoint` to run it:
+
+```bash
+docker run --rm -v uteke-data:/data \
+  --entrypoint uteke-mcp \
+  -i ghcr.io/codecoradev/uteke:latest
+```
+
+For Claude Desktop or Cursor with stdio transport:
+
+```jsonc
+// Claude Desktop — claude_desktop_config.json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "uteke-data:/data",
+        "--entrypoint", "uteke-mcp",
+        "ghcr.io/codecoradev/uteke:latest"
+      ]
+    }
+  }
+}
+```
+
+### Available MCP Tools
+
+Both transports expose the same tools (MCP protocol version `2025-06-18`):
+
+| Tool | Description |
+|------|-------------|
+| `uteke_remember` | Store a memory (supports type, room, author, tags) |
+| `uteke_recall` | Semantic search (supports tags filter, min_score) |
+| `uteke_list` | List memories (supports pagination via offset) |
+| `uteke_forget` | Delete a memory |
+| `uteke_stats` | Store statistics |
+
+
+
 See [TLS & Reverse Proxy](/tls) for Caddy, Nginx, and Cloudflare Tunnel setup.

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -126,6 +126,79 @@ The MCP server provides the same tools via JSON-RPC (protocol version `2025-06-1
 - `uteke_forget` — delete memory
 - `uteke_stats` — store statistics
 
+### MCP Client Configuration Examples
+
+#### Claude Desktop (stdio transport)
+
+Create or edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp"
+    }
+  }
+}
+```
+
+#### Claude Desktop (HTTP transport)
+
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "http://127.0.0.1:8767/mcp"
+    }
+  }
+}
+```
+
+#### Cursor
+
+Create or edit `.cursor/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp"
+    }
+  }
+}
+```
+
+Or with HTTP transport:
+
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "http://127.0.0.1:8767/mcp"
+    }
+  }
+}
+```
+
+#### Hermes Native MCP Client (HTTP transport)
+
+```bash
+# Register with Hermes using HTTP transport (requires uteke-serve running)
+hermes mcp add uteke --url http://127.0.0.1:8767/mcp
+```
+
+Or with stdio transport:
+
+```bash
+# Register with Hermes using stdio transport
+hermes mcp add uteke --command uteke-mcp
+```
+
+> **Tip:** HTTP transport is recommended when `uteke-serve` is already running — it avoids
+> subprocess overhead and works across machines. Stdio transport is simpler for local,
+> single-agent setups where no daemon is desired.
+
 ## Available Actions
 
 | Action | Description |
@@ -144,7 +217,19 @@ The MCP server provides the same tools via JSON-RPC (protocol version `2025-06-1
 | `room_stats` | Room statistics |
 | `room_delete` | Delete a room |
 
-## Mode B — memory-provider (uteke as Hermes's default memory)
+## Mode B — memory-provider (uteke as Hermes default memory)
+
+> **DEPRECATED — Removed from production (2026-06-29)**
+>
+> The memory-provider plugin (Mode B) has been removed from production deployments.
+> The plugin files and `memory.provider: uteke` configuration are no longer supported.
+>
+> **Migrate to:** [Mode A (uteke-tool)](#mode-a--uteke-tool-manual-actions-multi-agent-rooms) for manual
+> tool-based memory, or [Mode C (shell hook)](#mode-c--pre_llm_call-shell-hook-automatic-recall-no-plugin)
+> for automatic recall. For MCP-based integration, use the [MCP Server](#mcp-server-alternative) with
+> [client configuration examples](#mcp-client-configuration-examples).
+>
+> The documentation below is kept for historical reference only.
 
 This mode makes uteke Hermes's long-term memory backend. There are no manual
 `uteke(...)` calls: relevant memories are recalled and injected into the prompt


### PR DESCRIPTION
## Summary

Closes #505 — documentation + CI/Docker config changes only. No Rust code changes.

### Changes

#### 1. uteke-mcp in release pipeline + Docker (HIGH)
- **release.yml:** Added `-p uteke-mcp` to cargo build, strip, packaging (Unix + Windows), Docker binary extraction
- **Dockerfile:** Added uteke-mcp binary copy, rename logic (arm64/amd64), and runtime copy
- Release notes updated: "two binaries" → "three binaries"

#### 2. MCP section in docker.md (HIGH)
- HTTP transport via uteke-serve `/mcp` endpoint
- Stdio transport via uteke-mcp with `--entrypoint`
- Claude Desktop + Cursor config examples for both transports
- MCP tools table

#### 3. Mode B deprecated in hermes.md (MEDIUM)
- Added deprecation warning (removed from production 2026-06-29)
- Migration path: Mode A or Mode C
- Kept historical docs with clear deprecation marker

#### 4. MCP client config examples in hermes.md (MEDIUM)
- Claude Desktop (stdio + HTTP)
- Cursor (stdio + HTTP)
- Hermes native MCP client (stdio + HTTP)
- Transport selection tip