### PR TITLE
Add dedicated MCP docs page with remote/VPS/domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,23 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 - 📎 **Citations** — Source attribution on every memory (URL, file, user, import)
 - 🔌 **MCP Server** — JSON-RPC over stdio + Streamable HTTP transport
 - 📝 **Document Engine** — Wiki/knowledge base with `uteke doc create/get/list` and auto-chunking
+
 - 🤖 **Cosine Auto-Linking** — Automatically creates `similar_to` edges between related memories
 - 🌐 **Graph API** — `GET /graph` endpoint returns nodes + edges JSON for visualization
 - 🔑 **View-Only API Keys** — Read-only tokens for safe GET-only access to the server
 - 📄 **Markdown Chunker** — Splits documents by headings, respects code blocks and token limits
+
+<details>
+<summary>🔌 MCP Server — configure with Claude Code, Cursor, Hermes</summary>
+
+```jsonc
+// .mcp.json (Claude Code, Cursor)
+{ "mcpServers": { "uteke": { "command": "uteke-mcp" } } }
+```
+
+See [MCP docs](/mcp) for Claude Desktop, Hermes, and HTTP transport.
+</details>
+
 
 📖 [Full documentation](docs/getting-started.md) · [CLI reference](docs/cli-reference.md) · [Configuration](docs/configuration.md)
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           { text: 'Smart Decay', link: '/getting-started#memory-importance-pinning' },
           { text: 'Relationship Graph', link: '/getting-started#relationship-graph' },
           { text: 'Benchmarks', link: '/getting-started#benchmarking' },
+          { text: 'MCP Server', link: '/mcp' },
         ],
       },
       {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,6 +200,25 @@ uteke import memories.jsonl
 uteke import notes.txt --extract
 ```
 
+## MCP Integration
+
+Add uteke as an MCP server to your AI coding agent in seconds:
+
+**Claude Code** — add to `.mcp.json`:
+
+```json
+{ "mcpServers": { "uteke": { "command": "uteke-mcp" } } }
+```
+
+**With HTTP** (requires `uteke-serve`):
+
+```json
+{ "mcpServers": { "uteke": { "url": "http://127.0.0.1:8767/mcp" } } }
+```
+
+See [MCP Server](/mcp) for all supported clients and tools.
+
+
 > 💡 **Hermes users?** Three integration modes available:
 > - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](integrations/hermes.md).
 > - **Mode B (memory-provider):** Full auto — `uteke init --agent hermes --memory-provider`. Automatic recall + LLM fact extraction.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,253 @@
+---
+title: MCP Server
+---
+# MCP Server (Model Context Protocol)
+
+Expose uteke memories as tools to AI coding agents — Claude Code, Claude Desktop, Cursor, Copilot, and any MCP-compatible client.
+
+## Quick Start
+
+### Option A: Stdio Transport (recommended for local agents)
+
+No daemon needed — uteke-mcp communicates over stdin/stdout:
+
+```jsonc
+// Claude Code — .mcp.json or ~/.claude/settings.json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp"
+    }
+  }
+}
+```
+
+### Option B: HTTP Transport (for remote/shared access)
+
+Requires `uteke-serve` running. Uses Streamable HTTP transport:
+
+```jsonc
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "http://127.0.0.1:8767/mcp"
+    }
+  }
+}
+```
+
+## Client Configuration
+
+### Claude Code
+
+Create or edit `.mcp.json` in your project root, or `~/.claude/settings.json` for global access:
+
+```jsonc
+// Stdio (recommended)
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp"
+    }
+  }
+}
+```
+
+```jsonc
+// HTTP (requires uteke-serve)
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "http://127.0.0.1:8767/mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Create or edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```jsonc
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+Create or edit `.cursor/mcp.json` in your project root:
+
+```jsonc
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp"
+    }
+  }
+}
+```
+
+### Hermes
+
+Register uteke as an MCP server with the Hermes native client:
+
+```bash
+# Stdio transport
+hermes mcp add uteke --command uteke-mcp
+
+# HTTP transport (requires uteke-serve running)
+hermes mcp add uteke --url http://127.0.0.1:8767/mcp
+```
+
+## Available Tools
+
+Both transports expose the same 15 tools (MCP protocol version `2025-06-18`):
+
+| Tool | Description |
+|------|-------------|
+| `uteke_remember` | Store a memory (supports type, room, author, tags) |
+| `uteke_recall` | Semantic search (supports tags filter, min_score) |
+| `uteke_search` | Text search with optional tag filter |
+| `uteke_list` | List memories (supports pagination via offset) |
+| `uteke_forget` | Delete a memory |
+| `uteke_stats` | Memory store statistics |
+| `uteke_context` | AI-optimized context output for prompts |
+| `uteke_dream` | One-command maintenance pipeline (lint → backlinks → dedup → orphans) |
+| `uteke_doc_create` | Create a document (wiki/knowledge base entry) |
+| `uteke_doc_get` | Retrieve a document by ID |
+| `uteke_doc_list` | List all documents |
+| `uteke_doc_search` | Search documents |
+| `uteke_doc_delete` | Delete a document |
+| `uteke_graph` | Get nodes + edges JSON for visualization |
+| `uteke_room_recall` | Semantic recall within a room |
+
+## Transport Comparison
+
+| | Stdio | HTTP |
+|---|---|---|
+| Binary | `uteke-mcp` | `uteke-serve` |
+| Daemon needed | No | Yes |
+| Remote access | No | Yes |
+| Protocol | JSON-RPC over stdin/stdout | Streamable HTTP (POST `/mcp`) |
+| Best for | Local agents, single machine | Shared/team, remote access |
+
+> **Tip:** HTTP transport is recommended when `uteke-serve` is already running — it avoids subprocess overhead and works across machines. Stdio transport is simpler for local, single-agent setups where no daemon is desired.
+
+## Remote Access (VPS / Server / Domain)
+
+### Connect from a local agent to a remote uteke-serve
+
+When `uteke-serve` runs on a VPS or remote server, your local MCP client connects over HTTP:
+
+```bash
+# On the server — start uteke-serve with auth enabled
+UTEKE_AUTH_TOKEN=your-secret uteke-serve --host 0.0.0.0 --port 8767
+```
+
+> **Note:** In production, use environment variables for tokens — never commit secrets to config files. Some clients support env var substitution (e.g., `$UTEKE_AUTH_TOKEN`).
+
+```jsonc
+// Claude Code — .mcp.json
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "https://uteke.yourdomain.com/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret"
+      }
+    }
+  }
+}
+```
+
+```jsonc
+// Claude Desktop
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "https://uteke.yourdomain.com/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret"
+      }
+    }
+  }
+}
+```
+
+```jsonc
+// Cursor
+{
+  "mcpServers": {
+    "uteke": {
+      "url": "https://uteke.yourdomain.com/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret"
+      }
+    }
+  }
+}
+```
+
+### Docker on a VPS
+
+```bash
+docker run -d --name uteke \
+  -p 8767:8767 \
+  -e UTEKE_AUTH_TOKEN=your-secret \
+  -v uteke-data:/data \
+  ghcr.io/codecoradev/uteke:latest
+```
+
+Point your MCP client at `http://YOUR_VPS_IP:8767/mcp` (or use a domain with TLS — see below).
+
+### Domain + TLS (Recommended for Production)
+
+For HTTPS with a domain, use a reverse proxy (Caddy, Nginx, or Cloudflare Tunnel) in front of uteke-serve:
+
+```bash
+# uteke-serve still on localhost — the proxy handles TLS
+UTEKE_AUTH_TOKEN=your-secret uteke-serve --host 127.0.0.1 --port 8767
+```
+
+See [TLS & Reverse Proxy](/tls) for full setup guides (Caddy, Nginx, Cloudflare Tunnel).
+
+### Important: Network Security
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `--host` | `127.0.0.1` (local) or `0.0.0.0` (remote) | Bind to localhost unless you need remote access |
+| `UTEKE_AUTH_TOKEN` | Set a strong token | **Required** for remote access — without it, anyone can read/write your memories |
+| TLS | Use reverse proxy + HTTPS | Encrypts traffic in transit — **strongly recommended** for remote setups |
+| Firewall | Allow only port 8767/tcp | Restrict access at the network level |
+
+## Namespace Isolation
+
+The MCP server uses the `default` namespace by default. Each agent can use its own isolated namespace by passing a `namespace` argument to any tool call. Memories in one namespace are never visible to another.
+
+This is the MCP equivalent of the CLI's `--namespace` flag — see [Multi-Agent Isolation](/getting-started#multi-agent-isolation) for details.
+
+## Docker
+
+When running uteke in Docker, both transports are available:
+
+- **HTTP:** Start the container normally — the MCP endpoint is at `http://localhost:8767/mcp` via port mapping.
+- **Stdio:** Use `--entrypoint uteke-mcp` to run the MCP binary directly inside the container.
+
+See [Docker guide — MCP](/docker#mcp-model-context-protocol) for full Docker-specific configuration and examples.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `uteke-mcp: command not found` | Run `install.sh` or `cargo install -p uteke-mcp` to install the binary |
+| `Permission denied` | `chmod +x $(which uteke-mcp)` or ensure the binary is on your `PATH` |
+| `Connection refused` (HTTP) | Ensure `uteke-serve` is running: `uteke-serve` |
+| Client can't see tools | Verify the MCP config JSON is valid and the client has been restarted |
+| Slow first query | The embedding model (~188MB) downloads on first use — subsequent calls are ~30ms |
+
+See also: [Architecture — MCP Transport](/architecture#mcp-transport-381)


### PR DESCRIPTION
## Summary

Dedicated MCP documentation page + sidebar + getting-started quickstart + README update.

### New
- **docs/mcp.md** — Comprehensive MCP docs page:
  - Quick Start (stdio + HTTP)
  - Client Configuration: Claude Code, Claude Desktop, Cursor, Hermes
  - All 15 MCP tools table
  - Transport Comparison (stdio vs HTTP)
  - **Remote Access (VPS / Server / Domain)** — full setup with auth headers
  - Docker on VPS
  - Domain + TLS via reverse proxy
  - Network Security table
  - Namespace Isolation
  - Docker section + link to docker.md
  - Troubleshooting

### Updated
- **docs/.vitepress/config.ts** — Added MCP Server to Features sidebar
- **docs/getting-started.md** — Added MCP Integration quickstart section
- **README.md** — Added collapsible MCP config example + fixed link to VitePress format

### No Rust code changes — docs only.