### PR TITLE
fix: add libgomp1 to Docker runtime + Docker Hub multi-push (v0.6.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        id: dockerhub
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Download Linux binaries from build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -285,7 +293,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ steps.dockerhub.outcome == 'success' && 'docker.io/codecoradev/uteke' || '' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+- **Docker image missing libgomp1** — `uteke-serve` failed with `libmvec.so.1` on Debian runtime. Added `libgomp1` to Dockerfile runtime dependencies.
+
+### Changed
+- **Docker Hub multi-push** — Release workflow now publishes to Docker Hub (`codecoradev/uteke`) in addition to GHCR, conditional on `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` org secrets. Falls back to GHCR-only when secrets are absent.
+
 ## [0.6.1] — 2026-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 curl && \
+    ca-certificates libssl3 libgomp1 curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user


### PR DESCRIPTION
## Summary

Fixes Docker image crash and adds Docker Hub publish support.

### Changes
- **Dockerfile**: Add `libgomp1` to runtime dependencies (fixes `libmvec.so.1` missing error)
- **release.yml**: Docker Hub login + conditional multi-push (GHCR + Docker Hub)
- Falls back to GHCR-only when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets not configured
- Version bump 0.6.1 → 0.6.2

### Files
| File | Change |
|------|--------|
| `Dockerfile` | +libgomp1 runtime dep |
| `.github/workflows/release.yml` | +Docker Hub login + conditional push |
| `CHANGELOG.md` | Unreleased section |
| `Cargo.toml` + `Cargo.lock` | v0.6.2 bump |

### Docker Hub Setup (optional)
Add org secrets to enable Docker Hub push:
```
DOCKERHUB_USERNAME = codecoradev
DOCKERHUB_TOKEN = dckr_pat_***
```
If not set, release publishes to GHCR only (no behavior change).