### PR TITLE
docs: add Docker Hub registry, update version badges to v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.6.2] — 2026-07-01
+
 ### Fixed
 - **Docker image missing libgomp1** — `uteke-serve` failed with `libmvec.so.1` on Debian runtime. Added `libgomp1` to Dockerfile runtime dependencies.
 

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.0-green.svg" alt="v0.6.0" />
+  <img src="https://img.shields.io/badge/status-v0.6.2-green.svg" alt="v0.6.2" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.0-green.svg" alt="v0.6.0" />
+  <img src="https://img.shields.io/badge/status-v0.6.2-green.svg" alt="v0.6.2" />
 </p>
 
 <p align="center">
@@ -49,6 +49,10 @@ uteke stats
 # One-liner (model pre-baked in image)
 docker run -d --name uteke -p 127.0.0.1:8767:8767 -v uteke-data:/data \
   ghcr.io/codecoradev/uteke:latest
+
+# Or from Docker Hub
+docker run -d --name uteke -p 127.0.0.1:8767:8767 -v uteke-data:/data \
+  codecoradev/uteke:latest
 
 # Or docker compose
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 # Uteke Docker Compose — default: localhost only, no auth
+# Images available: ghcr.io/codecoradev/uteke:latest (GHCR) or codecoradev/uteke:latest (Docker Hub)
 # For network access, uncomment UTEKE_AUTH_TOKEN below.
 services:
   uteke:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,11 +11,17 @@ Uteke ships as a multi-arch Docker image with the embedding model pre-baked. No 
 > ⚠️ **Security**: The default config listens on `127.0.0.1` (localhost only). For network access, set `UTEKE_AUTH_TOKEN` (see [Authentication](#with-authentication)).
 
 ```bash
-# Pull and run
+# Pull and run (GHCR)
 docker run -d --name uteke \
   -p 127.0.0.1:8767:8767 \
   -v uteke-data:/data \
   ghcr.io/codecoradev/uteke:latest
+
+# Or pull from Docker Hub
+docker run -d --name uteke \
+  -p 127.0.0.1:8767:8767 \
+  -v uteke-data:/data \
+  codecoradev/uteke:latest
 
 # Verify it's running
 curl http://localhost:8767/health
@@ -107,13 +113,20 @@ Images are built for:
 
 Docker automatically pulls the correct architecture.
 
+## Image Registries
+
+| Registry | Image |
+|----------|-------|
+| **GitHub Container Registry** | `ghcr.io/codecoradev/uteke:latest` |
+| **Docker Hub** | `codecoradev/uteke:latest` |
+
 ## Image Tags
 
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.2.0` | Specific version |
-| `0.2` | Minor version (latest patch) |
+| `v0.6.2` | Specific version |
+| `0.6` | Minor version (latest patch) |
 
 ## CLI in Docker
 


### PR DESCRIPTION
## Summary
Docs update for v0.6.2 release.

### Changes
- **docs/docker.md**: Add Image Registries table (GHCR + Docker Hub), Docker Hub quick start example, fix outdated tag examples (v0.2 → v0.6.2)
- **README.md / README.id.md**: Version badge v0.6.0 → v0.6.2, add Docker Hub docker run example
- **docker-compose.yml**: Add registry comment
- **CHANGELOG.md**: Finalize v0.6.2 section with date

### Files
| File | Change |
|------|--------|
| `docs/docker.md` | +Image Registries table, +Docker Hub examples |
| `README.md` | Version badge + Docker Hub |
| `README.id.md` | Version badge |
| `docker-compose.yml` | Registry comment |
| `CHANGELOG.md` | v0.6.2 finalized |