### PR TITLE
fix: upgrade Dockerfile to debian:trixie-slim for libmvec.so.1 (v0.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## [Unreleased]
 
+## [0.6.3] — 2026-07-01
+
+### Fixed
+- **Docker ARM64 libmvec.so.1 missing** — ARM64 binaries built on `ubuntu-24.04-arm` (glibc 2.39) require `libmvec.so.1` (ARM SVE math library), which doesn't exist in Debian Bookworm (glibc 2.36). Upgraded Dockerfile base image to `debian:trixie-slim` (glibc 2.41) and added `libstdc++6` runtime dependency. Also removes incorrect `libgomp1` from v0.6.2.
+
 ## [0.6.2] — 2026-07-01
 
 ### Fixed
-- **Docker image missing libgomp1** — `uteke-serve` failed with `libmvec.so.1` on Debian runtime. Added `libgomp1` to Dockerfile runtime dependencies.
+- **Docker image missing libgomp1** — `uteke-serve` failed with `libmvec.so.1` on Debian runtime. Added `libgomp1` to Dockerfile runtime dependencies. (Incorrect fix — see v0.6.3)
 
 ### Changed
 - **Docker Hub multi-push** — Release workflow now publishes to Docker Hub (`codecoradev/uteke`) in addition to GHCR, conditional on `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` org secrets. Falls back to GHCR-only when secrets are absent.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Builder ────────────────────────────────────────────────────
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 
 ARG TARGETARCH
 ARG VERSION=v0.6.0
@@ -25,10 +25,10 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     chmod +x uteke uteke-serve uteke-mcp
 
 # ── Stage 2: Runtime ────────────────────────────────────────────────────
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libgomp1 curl && \
+    ca-certificates libssl3 libstdc++6 curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:trixie-slim AS builder
 
 ARG TARGETARCH
-ARG VERSION=v0.6.0
+ARG VERSION=v0.6.3
 
 LABEL version=${VERSION}
 LABEL org.opencontainers.image.version=${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libstdc++6 curl && \
+    ca-certificates libssl3t64 libstdc++6 curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.2-green.svg" alt="v0.6.2" />
+  <img src="https://img.shields.io/badge/status-v0.6.3-green.svg" alt="v0.6.3" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.2-green.svg" alt="v0.6.2" />
+  <img src="https://img.shields.io/badge/status-v0.6.3-green.svg" alt="v0.6.3" />
 </p>
 
 <p align="center">

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,7 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.6.2` | Specific version |
+| `v0.6.3` | Specific version |
 | `0.6` | Minor version (latest patch) |
 
 ## CLI in Docker


### PR DESCRIPTION
## Root Cause
ARM64 binaries built on `ubuntu-24.04-arm` (glibc 2.39) link `libmvec.so.1` (ARM SVE math vector extension library). Debian Bookworm's glibc 2.36 does **not** include this library. The v0.6.2 fix (`libgomp1`) was incorrect — `libmvec.so.1` is from `libc6`, not `libgomp1`.

## Fix
Upgrade Dockerfile base image from `debian:bookworm-slim` (glibc 2.36) to `debian:trixie-slim` (glibc 2.41, stable since Jun 2025). Also adds `libstdc++6` (required in slim images) and removes incorrect `libgomp1`.

| Library | Provided By | Bookworm | Trixie |
|---------|------------|----------|--------|
| `libmvec.so.1` | `libc6` (glibc ≥2.38) | ❌ | ✅ |
| `libstdc++.so.6` | `libstdc++6` | In slim? | In slim |
| `libssl3` | `libssl3` | ✅ | ✅ |

## Files
- `Dockerfile` — bookworm-slim → trixie-slim, libgomp1 → libstdc++6
- `Cargo.toml` + `Cargo.lock` — v0.6.3
- `CHANGELOG.md` — v0.6.3 entry
- `README.md` / `README.id.md` — version badge
- `docs/docker.md` — tag example