### PR TITLE
fix: allow read-only token on read POST endpoints (#524)

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -44,9 +44,27 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         AuthResult::Disabled
     };
 
-    // Enforce read-only restriction (#409): ReadOnly tokens can only use GET.
+    // Enforce read-only restriction (#409, #524):
+    // ReadOnly tokens can use GET endpoints + read-only POST endpoints.
+    // Write operations (POST /remember, POST /forget, etc.) are blocked.
     if let AuthResult::Authenticated(ApiRole::ReadOnly) = auth_role {
-        if method != Method::Get {
+        // POST endpoints that are reads (semantic search, list, stats).
+        // Exact match to avoid prefix-based bypass (e.g. /recallfoo).
+        let read_only_post_paths = [
+            "/list",
+            "/recall",
+            "/search",
+            "/stats",
+            "/room/recall",
+            "/room/summary",
+            "/room/document",
+            "/room/stats",
+            "/doc/get",
+            "/doc/list",
+            "/doc/search",
+        ];
+        let is_read = method == Method::Get || read_only_post_paths.iter().any(|ep| path == *ep);
+        if !is_read {
             return ctx.error_response_for(
                 req,
                 403,


### PR DESCRIPTION
## Problem
Read-only token blocks **all** POST endpoints with 403, including reads like `POST /recall`, `POST /list`, `POST /search`. Clients (e.g. CorIn desktop) that query memories via these endpoints get empty data with a read-only token.

Fixes #524.

## Root Cause
The read-only middleware used a blanket `method != Method::Get` check (line 49), blocking **all** non-GET requests regardless of whether they are reads or writes.

## Fix
Replace blanket HTTP method check with per-endpoint allowlist based on **operation semantics**:

| POST Path | Operation | ReadOnly? |
|-----------|-----------|-----------|
| `/recall`, `/search`, `/list`, `/stats` | Read queries | ✅ Allow |
| `/room/recall`, `/room/summary`, `/room/document`, `/room/stats` | Room reads | ✅ Allow |
| `/doc/get`, `/doc/list`, `/doc/search` | Document reads | ✅ Allow |
| `/remember`, `/forget`, `/room/create`, `/room/delete`, `/doc/create`, `/doc/move`, `/doc/delete`, `/context`, `/dream`, `/mcp` | Writes | ❌ Block |

All GET endpoints remain unchanged (already allowed).

### Security note
- **Exact path match only** (`path == *ep`) to prevent prefix-based bypass (Cora flagged this).
- MCP endpoint (`/mcp`) still blocked for read-only — it can perform writes via `uteke_remember` tool.

## Files
- `crates/uteke-server/src/handlers.rs` — replace blanket check with allowlist