### PR TITLE
feat(#527,#528): /namespaces?with_counts=true + GET /recent endpoint

### DIFF
--- a/crates/uteke-core/src/memory/tags.rs
+++ b/crates/uteke-core/src/memory/tags.rs
@@ -372,10 +372,7 @@ impl super::Store {
 
         let rows = stmt
             .query_map([], |row: &rusqlite::Row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, usize>(1)?,
-                ))
+                Ok((row.get::<_, String>(0)?, row.get::<_, usize>(1)?))
             })
             .map_err(|e| Error::db("database operation", e))?;
 

--- a/crates/uteke-core/src/memory/tags.rs
+++ b/crates/uteke-core/src/memory/tags.rs
@@ -372,7 +372,7 @@ impl super::Store {
 
         let rows = stmt
             .query_map([], |row: &rusqlite::Row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, usize>(1)?))
+                Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)? as usize))
             })
             .map_err(|e| Error::db("database operation", e))?;
 

--- a/crates/uteke-core/src/memory/tags.rs
+++ b/crates/uteke-core/src/memory/tags.rs
@@ -354,4 +354,35 @@ impl super::Store {
         }
         Ok(namespaces)
     }
+
+    /// List namespaces with memory counts.
+    ///
+    /// Returns `[(namespace, count)]` — e.g. `[("default", 432), ("cto", 28)]`.
+    /// Used by `/namespaces?with_counts=true` endpoint (#527).
+    pub fn list_namespaces_with_counts(&self) -> Result<Vec<(String, usize)>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT namespace, COUNT(*) as cnt \
+                 FROM memories \
+                 GROUP BY namespace \
+                 ORDER BY namespace",
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+
+        let rows = stmt
+            .query_map([], |row: &rusqlite::Row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, usize>(1)?,
+                ))
+            })
+            .map_err(|e| Error::db("database operation", e))?;
+
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row.map_err(|e| Error::db("database operation", e))?);
+        }
+        Ok(result)
+    }
 }

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -927,6 +927,13 @@ impl crate::Uteke {
         self.store.list_namespaces()
     }
 
+    /// List all namespaces with memory counts (#527).
+    ///
+    /// Returns `[(namespace, count)]` — e.g. `[("default", 432), ("cto", 28)]`.
+    pub fn list_namespaces_with_counts(&self) -> Result<Vec<(String, usize)>, Error> {
+        self.store.list_namespaces_with_counts()
+    }
+
     /// List all tags with their usage counts.
     pub fn tags_with_counts(&self, namespace: Option<&str>) -> Result<Vec<TagInfo>, Error> {
         self.store.tags_with_counts(namespace)

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -438,11 +438,54 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Namespaces ──────────────────────────────────────────────────
-        (Method::Get, "/namespaces") => match uteke.list_namespaces() {
-            Ok(namespaces) => ctx.ok_response_for(req, &namespaces),
-            Err(e) => {
-                error!("Internal error: {e}");
-                ctx.error_response_for(req, 500, "Internal server error")
+        (Method::Get, p) if p == "/namespaces" || p.starts_with("/namespaces?") => {
+            let with_counts = path.contains("with_counts=true");
+            if with_counts {
+                match uteke.list_namespaces_with_counts() {
+                    Ok(counts) => {
+                        #[derive(serde::Serialize)]
+                        struct NamespaceCount {
+                            name: String,
+                            count: usize,
+                        }
+                        let result: Vec<NamespaceCount> = counts
+                            .into_iter()
+                            .map(|(name, count)| NamespaceCount { name, count })
+                            .collect();
+                        ctx.ok_response_for(req, &result)
+                    }
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            } else {
+                match uteke.list_namespaces() {
+                    Ok(namespaces) => ctx.ok_response_for(req, &namespaces),
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            }
+        }
+
+        // ── Recent (#528) ──────────────────────────────────────────────
+        (Method::Get, p) if p == "/recent" || p.starts_with("/recent?") => {
+            let ns = parse_query_namespace(&path);
+            let query = path.split('?').nth(1).unwrap_or("");
+            let limit = parse_query_param(query, "limit")
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(20);
+            let offset = parse_query_param(query, "offset")
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0);
+            match uteke.list(None, limit, offset, ns) {
+                Ok(memories) => ctx.ok_response_for(req, &memories),
+                Err(e) => {
+                    error!("Internal error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
             }
         },
 

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -487,7 +487,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     ctx.error_response_for(req, 500, "Internal server error")
                 }
             }
-        },
+        }
 
         // ── Graph Visualization (#408) ───────────────────────────────────
         (Method::Get, p) if p == "/graph" || p.starts_with("/graph?") => {

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -480,7 +480,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             let offset = parse_query_param(query, "offset")
                 .and_then(|v| v.parse::<usize>().ok())
                 .unwrap_or(0);
-            match uteke.list(None, limit, offset, ns) {
+            match uteke.list(None, limit, offset, ns.as_deref()) {
                 Ok(memories) => ctx.ok_response_for(req, &memories),
                 Err(e) => {
                     error!("Internal error: {e}");


### PR DESCRIPTION
Fixes #527, Fixes #528

## #527 — GET /namespaces?with_counts=true

### Problem
No lightweight way to get per-namespace memory counts. Clients must fetch full memory arrays (limit:500) per namespace just to count them.

### Solution
Enrich existing `/namespaces` endpoint with optional query param:

\`\`\`
GET /namespaces              → ["default", "cto", "kai"]
GET /namespaces?with_counts=true → [{"name":"default","count":432},{"name":"cto","count":28}]
\`\`\`

Core: new `list_namespaces_with_counts()` in `tags.rs` + `operations.rs`.

## #528 — GET /recent

### Problem  
No endpoint for recent memories across all namespaces. Dashboard clients fan out N requests.

### Solution
\`\`\`
GET /recent?limit=20&offset=0&namespace=cto
\`\`\`

Thin GET wrapper over `list()` — leverages the cross-namespace fix from #526.
- Default: all namespaces, limit 20
- Optional: namespace filter, offset for pagination

## Files changed
- `crates/uteke-core/src/memory/tags.rs` — `list_namespaces_with_counts()`
- `crates/uteke-core/src/operations.rs` — expose new method
- `crates/uteke-server/src/handlers.rs` — enriched `/namespaces` + new `/recent`

## Depends on
- #526 (cross-namespace list fix) — merged first for `/recent` to work correctly