### PR TITLE
feat: unified search across memories and documents (#531)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -135,6 +135,12 @@ pub enum Commands {
         /// Filter results by JSON field (format: key=value, e.g. --where role=CTO)
         #[arg(long)]
         r#where: Option<String>,
+        /// Search type filter: 'all' (default, unified), 'memory', or 'doc'.
+        /// 'all' searches both memories and documents merged via RRF.
+        /// 'memory' returns memories only (backward compatible).
+        /// 'doc' returns documents only.
+        #[arg(long)]
+        r#type: Option<String>,
     },
     /// Search memories by content keywords (text search)
     Search {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -79,6 +79,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             at,
             content_format,
             r#where,
+            r#type,
         } => recall::run_recall(
             cli,
             uteke,
@@ -100,6 +101,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             r#where.as_deref(),
             *salience,
             *recency,
+            r#type.as_deref(),
         ),
 
         Commands::Search { query, limit, tags } => {

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -4,7 +4,7 @@
 use crate::cli::Cli;
 use crate::config::Config;
 use crate::output;
-use uteke_core::{RecallStrategy, Uteke};
+use uteke_core::{RecallStrategy, SearchType, Uteke};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_recall(
@@ -28,7 +28,40 @@ pub(crate) fn run_recall(
     where_filter: Option<&str>,
     salience: bool,
     recency: bool,
+    search_type: Option<&str>,
 ) -> Result<(), String> {
+    // Resolve search type: --type flag > default (All = unified)
+    let resolved_search_type = match search_type {
+        Some("memory") => SearchType::Memory,
+        Some("doc") => SearchType::Document,
+        Some("all") | None => SearchType::All,
+        Some(other) => {
+            return Err(format!(
+                "Invalid --type: '{other}'. Use 'all', 'memory', or 'doc'."
+            ))
+        }
+    };
+
+    // When --type is explicitly set (not default unified), route to recall_unified.
+    // When unified (default), use existing recall path for backward compat with
+    // --strategy, --at, --related, --salience, --recency, --entity, --category, --where flags
+    // which only apply to memory recall. If --type=all and no memory-only flags are used,
+    // use the unified path.
+    let use_unified = match resolved_search_type {
+        SearchType::All => {
+            // Use unified only when no memory-only flags are active.
+            // Memory-only flags: --at, --related, --salience, --recency, --entity, --category, --where
+            at.is_none()
+                && !related
+                && !salience
+                && !recency
+                && entity.is_none()
+                && category.is_none()
+                && where_filter.is_none()
+        }
+        SearchType::Memory | SearchType::Document => true,
+    };
+
     // Resolve threshold: --min > --strict (→ config min_score_strict) > config min_score > 0.0
     let min_score = match min {
         Some(m) => m,
@@ -36,7 +69,10 @@ pub(crate) fn run_recall(
         None => config.recall.min_score as f32,
     };
 
-    tracing::info!("Recalling: {query} (limit: {limit}, min_score: {min_score})");
+    tracing::info!(
+        "Recalling: {query} (limit: {limit}, min_score: {min_score}, type: {:?})",
+        resolved_search_type
+    );
     let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
     let tags_filter = if tag_refs.is_empty() {
         None
@@ -72,6 +108,42 @@ pub(crate) fn run_recall(
         },
     });
 
+    if use_unified {
+        // Unified search path (#531)
+        let unified_results = uteke
+            .recall_unified(
+                query,
+                limit,
+                tags_filter,
+                ns,
+                min_score,
+                resolved_search_type,
+            )
+            .map_err(|e| format!("Failed to recall: {e}"))?;
+
+        uteke.reset_salience_recency_config();
+
+        if unified_results.is_empty() {
+            if cli.json {
+                output::print_json(&unified_results);
+            } else if min_score > 0.0 {
+                println!("No matching results found.");
+                println!("(min_score threshold: {:.2})", min_score);
+            } else {
+                println!("No matching results found.");
+            }
+            return Ok(());
+        }
+
+        if cli.json {
+            output::print_json(&unified_results);
+        } else {
+            output::print_unified_human(&unified_results);
+        }
+        return Ok(());
+    }
+
+    // Existing memory-only recall path (backward compatible)
     // Wrap recall in a closure so reset always runs, even on error paths
     // (CodeCora #387: boost config must not leak on early return).
     let recall_result: Result<_, String> = (|| {

--- a/crates/uteke-cli/src/output.rs
+++ b/crates/uteke-cli/src/output.rs
@@ -48,6 +48,53 @@ pub(crate) fn print_recall_human(results: &[uteke_core::SearchResult]) {
     }
 }
 
+/// Print unified search results with type labels (#531).
+///
+/// Memory results are prefixed with `[mem]`, document results with `[doc]`.
+pub(crate) fn print_unified_human(results: &[uteke_core::UnifiedSearchResult]) {
+    if results.is_empty() {
+        println!("No matching results found.");
+        return;
+    }
+    println!("Found {} result(s):\n", results.len());
+    for (i, r) in results.iter().enumerate() {
+        let type_label = match r.result_type {
+            uteke_core::SearchResultType::Memory => "mem",
+            uteke_core::SearchResultType::Document => "doc",
+        };
+        let tags = if r.tags.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", r.tags.join(", "))
+        };
+        println!(
+            "  {}. [{type_label}] (score: {:.3}) {}{tags}",
+            i + 1,
+            r.score,
+            r.content,
+        );
+        // Show extra metadata based on type
+        match r.result_type {
+            uteke_core::SearchResultType::Memory => {
+                if let Some(id) = &r.memory_id {
+                    println!("     ID: {}", id);
+                }
+            }
+            uteke_core::SearchResultType::Document => {
+                if let Some(slug) = &r.doc_slug {
+                    println!("     Slug: {}", slug);
+                }
+                if let Some(title) = &r.doc_title {
+                    println!("     Title: {}", title);
+                }
+                if let Some(heading) = &r.chunk_heading {
+                    println!("     ↳ {}", heading);
+                }
+            }
+        }
+    }
+}
+
 /// Print keyword search results in human-readable format.
 pub(crate) fn print_search_human(results: &[uteke_core::SearchResult]) {
     if results.is_empty() {

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -43,10 +43,11 @@ pub use graph_rerank::{compute_graph_signals, rerank_with_graph, GraphRerankConf
 pub use memory::types::{
     AgingStatus, BulkDeleteResult, CleanupResult, ConsolidationResult, ContradictionResult,
     ExportEntry, ImportResult, Memory, MemoryTier, MemoryType, PruneResult, RecallStrategy,
-    SearchResult, SimilarPair, StoreStats, TagInfo, DEFAULT_NAMESPACE,
+    SearchResult, SearchResultType, SearchType, SimilarPair, StoreStats, TagInfo,
+    UnifiedSearchResult, DEFAULT_NAMESPACE,
 };
 pub use memory::{
-    documents::{Document, DocumentChunk, DocumentSummary},
+    documents::{Document, DocumentChunk, DocumentSearchResult, DocumentSummary},
     DocumentEntry, DocumentSection, Room, RoomDocument, RoomMemory, RoomStats, RoomSummary,
     TimeRange, TopicCluster,
 };
@@ -1273,6 +1274,208 @@ impl Uteke {
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
+        results.truncate(limit);
+
+        Ok(results)
+    }
+
+    /// Unified search across memories and documents (#531).
+    ///
+    /// Merges results from `recall` (memories) and `doc_search` (documents)
+    /// via Reciprocal Rank Fusion, returning a single ranked list.
+    /// Each result is tagged with its source type (`memory` or `document`).
+    ///
+    /// - `search_type::All` (default): searches both memories and documents.
+    /// - `search_type::Memory`: memories only (equivalent to current recall).
+    /// - `search_type::Document`: documents only (equivalent to doc search).
+    pub fn recall_unified(
+        &self,
+        query: &str,
+        limit: usize,
+        tags_filter: Option<&[&str]>,
+        namespace: Option<&str>,
+        min_score: f32,
+        search_type: SearchType,
+    ) -> Result<Vec<UnifiedSearchResult>, Error> {
+        let limit = limit.min(50);
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+
+        match search_type {
+            SearchType::Memory => {
+                self.recall_unified_memories(query, limit, tags_filter, namespace, min_score)
+            }
+            SearchType::Document => self.recall_unified_documents(query, limit, ns),
+            SearchType::All => self.recall_unified_all(query, limit, tags_filter, ns, min_score),
+        }
+    }
+
+    /// Unified search — memories only (backward-compatible path).
+    fn recall_unified_memories(
+        &self,
+        query: &str,
+        limit: usize,
+        tags_filter: Option<&[&str]>,
+        namespace: Option<&str>,
+        min_score: f32,
+    ) -> Result<Vec<UnifiedSearchResult>, Error> {
+        let results = self.recall(query, limit, tags_filter, namespace, min_score)?;
+        Ok(results
+            .into_iter()
+            .map(|sr| UnifiedSearchResult {
+                result_type: SearchResultType::Memory,
+                score: sr.score,
+                content: sr.memory.content,
+                memory_id: Some(sr.memory.id),
+                tags: sr.memory.tags,
+                doc_slug: None,
+                doc_title: None,
+                chunk_heading: None,
+                chunk_snippet: None,
+            })
+            .collect())
+    }
+
+    /// Unified search — documents only.
+    fn recall_unified_documents(
+        &self,
+        query: &str,
+        limit: usize,
+        ns: &str,
+    ) -> Result<Vec<UnifiedSearchResult>, Error> {
+        let results = self.doc_search(query, Some(ns), limit, "hybrid")?;
+        Ok(results
+            .into_iter()
+            .map(|dr| UnifiedSearchResult {
+                result_type: SearchResultType::Document,
+                score: dr.score,
+                content: if dr.chunk_snippet.is_empty() {
+                    dr.document.title.clone()
+                } else {
+                    dr.chunk_snippet.clone()
+                },
+                memory_id: None,
+                doc_slug: Some(dr.document.slug),
+                doc_title: Some(dr.document.title),
+                chunk_heading: if dr.chunk_heading.is_empty() {
+                    None
+                } else {
+                    Some(dr.chunk_heading)
+                },
+                chunk_snippet: if dr.chunk_snippet.is_empty() {
+                    None
+                } else {
+                    Some(dr.chunk_snippet)
+                },
+                tags: vec![],
+            })
+            .collect())
+    }
+
+    /// Unified search — both memories and documents, merged via RRF (#531).
+    ///
+    /// Runs memory recall and document search in parallel (conceptually),
+    /// then merges results using Reciprocal Rank Fusion with equal weights.
+    fn recall_unified_all(
+        &self,
+        query: &str,
+        limit: usize,
+        tags_filter: Option<&[&str]>,
+        ns: &str,
+        min_score: f32,
+    ) -> Result<Vec<UnifiedSearchResult>, Error> {
+        const RRF_K: u32 = 60;
+
+        // 1. Memory recall (vector + FTS5 hybrid)
+        let mem_results = self
+            .recall(query, limit * 2, tags_filter, Some(ns), 0.0)
+            .unwrap_or_default();
+
+        // 2. Document search (hybrid)
+        let doc_results = self
+            .doc_search(query, Some(ns), limit * 2, "hybrid")
+            .unwrap_or_default();
+
+        // 3. RRF merge — score by rank across both result sets
+        let mut rrf_scores: std::collections::HashMap<String, f64> =
+            std::collections::HashMap::new();
+        let mut mem_map: std::collections::HashMap<String, SearchResult> =
+            std::collections::HashMap::new();
+        let mut doc_map: std::collections::HashMap<String, DocumentSearchResult> =
+            std::collections::HashMap::new();
+
+        for (rank, sr) in mem_results.iter().enumerate() {
+            let key = format!("mem:{}", sr.memory.id);
+            let rrf = 1.0 / (RRF_K as f64 + rank as f64 + 1.0);
+            *rrf_scores.entry(key.clone()).or_default() += rrf;
+            mem_map.insert(key, sr.clone());
+        }
+
+        for (rank, dr) in doc_results.iter().enumerate() {
+            let key = format!("doc:{}", dr.document.id);
+            let rrf = 1.0 / (RRF_K as f64 + rank as f64 + 1.0);
+            *rrf_scores.entry(key.clone()).or_default() += rrf;
+            doc_map.insert(key, dr.clone());
+        }
+
+        // 4. Sort by RRF score descending, take top `limit`
+        let mut scored: Vec<(String, f64)> = rrf_scores.into_iter().collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Max possible RRF: 1/(k+1) when rank=0 in a single source.
+        let max_rrf = 1.0 / (RRF_K as f64 + 1.0);
+
+        let results: Vec<UnifiedSearchResult> = scored
+            .into_iter()
+            .take(limit)
+            .map(|(key, score)| {
+                let normalized = (score / max_rrf).clamp(0.0, 1.0) as f32;
+                if let Some(sr) = mem_map.remove(&key) {
+                    UnifiedSearchResult {
+                        result_type: SearchResultType::Memory,
+                        score: normalized,
+                        content: sr.memory.content.clone(),
+                        memory_id: Some(sr.memory.id),
+                        tags: sr.memory.tags,
+                        doc_slug: None,
+                        doc_title: None,
+                        chunk_heading: None,
+                        chunk_snippet: None,
+                    }
+                } else if let Some(dr) = doc_map.remove(&key) {
+                    UnifiedSearchResult {
+                        result_type: SearchResultType::Document,
+                        score: normalized,
+                        content: if dr.chunk_snippet.is_empty() {
+                            dr.document.title.clone()
+                        } else {
+                            dr.chunk_snippet.clone()
+                        },
+                        memory_id: None,
+                        doc_slug: Some(dr.document.slug),
+                        doc_title: Some(dr.document.title),
+                        chunk_heading: if dr.chunk_heading.is_empty() {
+                            None
+                        } else {
+                            Some(dr.chunk_heading)
+                        },
+                        chunk_snippet: if dr.chunk_snippet.is_empty() {
+                            None
+                        } else {
+                            Some(dr.chunk_snippet)
+                        },
+                        tags: vec![],
+                    }
+                } else {
+                    unreachable!("RRF key must reference either mem_map or doc_map")
+                }
+            })
+            .collect();
+
+        // Apply min_score filter on normalized RRF scores.
+        let mut results: Vec<UnifiedSearchResult> = results
+            .into_iter()
+            .filter(|r| r.score >= min_score)
+            .collect();
         results.truncate(limit);
 
         Ok(results)

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1304,7 +1304,7 @@ impl Uteke {
             SearchType::Memory => {
                 self.recall_unified_memories(query, limit, tags_filter, namespace, min_score)
             }
-            SearchType::Document => self.recall_unified_documents(query, limit, ns),
+            SearchType::Document => self.recall_unified_documents(query, limit, ns, min_score),
             SearchType::All => self.recall_unified_all(query, limit, tags_filter, ns, min_score),
         }
     }
@@ -1341,10 +1341,12 @@ impl Uteke {
         query: &str,
         limit: usize,
         ns: &str,
+        min_score: f32,
     ) -> Result<Vec<UnifiedSearchResult>, Error> {
         let results = self.doc_search(query, Some(ns), limit, "hybrid")?;
         Ok(results
             .into_iter()
+            .filter(|dr| dr.score >= min_score)
             .map(|dr| UnifiedSearchResult {
                 result_type: SearchResultType::Document,
                 score: dr.score,
@@ -1386,14 +1388,22 @@ impl Uteke {
         const RRF_K: u32 = 60;
 
         // 1. Memory recall (vector + FTS5 hybrid)
-        let mem_results = self
-            .recall(query, limit * 2, tags_filter, Some(ns), 0.0)
-            .unwrap_or_default();
+        let mem_results = match self.recall(query, limit * 2, tags_filter, Some(ns), 0.0) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Unified search: memory recall failed, using partial results: {e}");
+                Vec::new()
+            }
+        };
 
         // 2. Document search (hybrid)
-        let doc_results = self
-            .doc_search(query, Some(ns), limit * 2, "hybrid")
-            .unwrap_or_default();
+        let doc_results = match self.doc_search(query, Some(ns), limit * 2, "hybrid") {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Unified search: doc search failed, using partial results: {e}");
+                Vec::new()
+            }
+        };
 
         // 3. RRF merge — score by rank across both result sets
         let mut rrf_scores: std::collections::HashMap<String, f64> =

--- a/crates/uteke-core/src/memory/mod.rs
+++ b/crates/uteke-core/src/memory/mod.rs
@@ -17,5 +17,8 @@ pub use rooms::{
     TimeRange, TopicCluster,
 };
 pub use store::Store;
-pub use types::{Memory, RecallStrategy, SearchResult, StoreStats};
+pub use types::{
+    Memory, RecallStrategy, SearchResult, SearchResultType, SearchType, StoreStats,
+    UnifiedSearchResult,
+};
 pub use vector::VectorIndex;

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -103,6 +103,62 @@ pub struct SearchResult {
     pub score: f32,
 }
 
+/// Result type discriminator for unified search (#531).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchResultType {
+    /// A short-form memory from the `memories` table.
+    Memory,
+    /// A long-form document from the `documents` table.
+    Document,
+}
+
+/// A unified search result that can be either a memory or a document chunk match.
+///
+/// Used by `recall_unified` to merge results from both `memories` and
+/// `document_chunks` into a single ranked list. Each result carries its
+/// source type so consumers can distinguish between memories and documents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnifiedSearchResult {
+    /// Whether this result is a memory or a document.
+    pub result_type: SearchResultType,
+    /// Relevance score (0.0–1.0), normalized via RRF.
+    pub score: f32,
+    /// Memory content (always populated for type=memory, excerpt for type=document).
+    pub content: String,
+    /// Memory ID (populated for type=memory).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_id: Option<String>,
+    /// Document slug (populated for type=document).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_slug: Option<String>,
+    /// Document title (populated for type=document).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_title: Option<String>,
+    /// Chunk heading (populated for type=document).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_heading: Option<String>,
+    /// Chunk excerpt (populated for type=document).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_snippet: Option<String>,
+    /// Tags from the memory or document.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// Filter for unified search — which sources to query (#531).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchType {
+    /// Search both memories and documents (default).
+    #[default]
+    All,
+    /// Search memories only.
+    Memory,
+    /// Search documents only.
+    Document,
+}
+
 /// Memory tier based on access recency.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MemoryTier {
@@ -831,10 +887,100 @@ mod tests {
     }
 
     #[test]
-    fn numbered_list_detection() {
+    fn test_numbered_list() {
         assert!(is_numbered_list("1. first step\n2. second step\n3. third"));
         assert!(is_numbered_list("1) one\n2) two\n"));
         assert!(!is_numbered_list("just plain text"));
         assert!(!is_numbered_list("1. alone")); // only one item
+    }
+
+    // ── Unified search types (#531) ──
+
+    #[test]
+    fn search_type_default_is_all() {
+        assert_eq!(SearchType::default(), SearchType::All);
+    }
+
+    #[test]
+    fn search_type_serde_roundtrip() {
+        for st in [SearchType::All, SearchType::Memory, SearchType::Document] {
+            let json = serde_json::to_string(&st).unwrap();
+            let parsed: SearchType = serde_json::from_str(&json).unwrap();
+            assert_eq!(st, parsed, "roundtrip for {:?}", st);
+        }
+    }
+
+    #[test]
+    fn search_result_type_serde_roundtrip() {
+        for rt in [SearchResultType::Memory, SearchResultType::Document] {
+            let json = serde_json::to_string(&rt).unwrap();
+            let parsed: SearchResultType = serde_json::from_str(&json).unwrap();
+            assert_eq!(rt, parsed, "roundtrip for {:?}", rt);
+        }
+    }
+
+    #[test]
+    fn unified_search_result_memory_serde() {
+        let result = UnifiedSearchResult {
+            result_type: SearchResultType::Memory,
+            score: 0.85,
+            content: "test memory".to_string(),
+            memory_id: Some("abc-123".to_string()),
+            tags: vec!["test".to_string()],
+            doc_slug: None,
+            doc_title: None,
+            chunk_heading: None,
+            chunk_snippet: None,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        // Verify result_type field is lowercase "memory"
+        assert!(json.contains("\"result_type\":\"memory\""), "got: {json}");
+        // Verify doc fields are omitted (skip_serializing_if = Option::is_none)
+        assert!(!json.contains("doc_slug"), "doc fields should be skipped");
+        assert!(
+            !json.contains("memory_id") || json.contains("\"memory_id\":\"abc-123\""),
+            "memory_id should be present when Some"
+        );
+        // Roundtrip
+        let parsed: UnifiedSearchResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.result_type, SearchResultType::Memory);
+        assert_eq!(parsed.score, 0.85);
+        assert_eq!(parsed.memory_id.as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn unified_search_result_document_serde() {
+        let result = UnifiedSearchResult {
+            result_type: SearchResultType::Document,
+            score: 0.92,
+            content: "chunk excerpt here".to_string(),
+            memory_id: None,
+            tags: vec![],
+            doc_slug: Some("my-doc".to_string()),
+            doc_title: Some("My Document".to_string()),
+            chunk_heading: Some("Section 2".to_string()),
+            chunk_snippet: Some("chunk excerpt here".to_string()),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"result_type\":\"document\""), "got: {json}");
+        // memory_id is None so it should be omitted
+        assert!(!json.contains("memory_id"), "memory_id should be skipped");
+        let parsed: UnifiedSearchResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.result_type, SearchResultType::Document);
+        assert_eq!(parsed.doc_slug.as_deref(), Some("my-doc"));
+        assert_eq!(parsed.chunk_heading.as_deref(), Some("Section 2"));
+    }
+
+    #[test]
+    fn search_type_from_str() {
+        assert_eq!(SearchType::All, serde_json::from_str("\"all\"").unwrap());
+        assert_eq!(
+            SearchType::Memory,
+            serde_json::from_str("\"memory\"").unwrap()
+        );
+        assert_eq!(
+            SearchType::Document,
+            serde_json::from_str("\"document\"").unwrap()
+        );
     }
 }

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -189,7 +189,7 @@ fn tool_remember() -> Value {
 fn tool_recall() -> Value {
     serde_json::json!({
         "name": "uteke_recall",
-        "description": "Semantic search over stored memories. Returns the most relevant memories ranked by embedding similarity.",
+        "description": "Unified semantic search over memories and documents. Returns the most relevant results ranked by embedding similarity. Use --type 'all' (default) to search both, 'memory' for memories only, or 'doc' for documents only.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -197,7 +197,8 @@ fn tool_recall() -> Value {
                 "limit": { "type": "integer", "description": "Max results (default 5)", "default": 5 },
                 "namespace": { "type": "string", "description": "Namespace to search (default: 'default')" },
                 "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter by tags (optional)" },
-                "min_score": { "type": "number", "description": "Minimum similarity score 0..1 (default: 0.0)" }
+                "min_score": { "type": "number", "description": "Minimum similarity score 0..1 (default: 0.0)" },
+                "type": { "type": "string", "enum": ["all", "memory", "doc"], "description": "Search type: 'all' (default, unified), 'memory', or 'doc'" }
             },
             "required": ["query"]
         }
@@ -451,24 +452,62 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let tags_ref = tags_filter.as_deref();
     let min_score = args["min_score"].as_f64().unwrap_or(0.0) as f32;
 
+    // Parse optional search type (#531)
+    let search_type = match args["type"].as_str() {
+        Some("memory") => uteke_core::SearchType::Memory,
+        Some("doc") => uteke_core::SearchType::Document,
+        Some("all") | None => uteke_core::SearchType::All,
+        Some(other) => {
+            return Err(format!(
+                "Invalid search type: '{other}'. Use 'all', 'memory', or 'doc'."
+            ))
+        }
+    };
+
+    // Use unified search when type is specified or default (all).
+    // Fall back to legacy recall only for backward compat with existing MCP consumers.
     let results = uteke
-        .recall(query, limit, tags_ref, namespace, min_score)
+        .recall_unified(query, limit, tags_ref, namespace, min_score, search_type)
         .map_err(|e| format!("Failed: {e}"))?;
 
     if results.is_empty() {
         return Ok(ToolResult {
             content: vec![McpContent::Text {
                 r#type: "text".to_string(),
-                text: "No memories found.".to_string(),
+                text: "No results found.".to_string(),
             }],
             is_error: false,
         });
     }
 
     let mut lines = Vec::new();
-    for (i, sr) in results.iter().enumerate() {
-        lines.push(format!("[{:.2}] {}", sr.score, sr.memory.content));
-        let _ = i;
+    for (i, r) in results.iter().enumerate() {
+        let type_label = match r.result_type {
+            uteke_core::SearchResultType::Memory => "[mem]",
+            uteke_core::SearchResultType::Document => "[doc]",
+        };
+        let detail = match &r.result_type {
+            uteke_core::SearchResultType::Memory => r
+                .memory_id
+                .as_ref()
+                .map(|id| format!(" (id: {})", &id[..id.len().min(8)]))
+                .unwrap_or_default(),
+            uteke_core::SearchResultType::Document => r
+                .doc_slug
+                .as_ref()
+                .map(|slug| format!(" (slug: {})", slug))
+                .unwrap_or_default(),
+        };
+        lines.push(format!(
+            "{}{}. [{:.2}] {}",
+            i + 1,
+            type_label,
+            r.score,
+            r.content
+        ));
+        if !detail.is_empty() {
+            lines.push(format!("       {}", detail));
+        }
     }
 
     Ok(ToolResult {

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -232,62 +232,106 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     )
                 };
 
-                match recall_result {
-                    Ok(raw_results) => {
-                        // Post-filter by entity/category metadata
-                        let mut results: Vec<_> = raw_results
-                            .into_iter()
-                            .filter(|sr| {
-                                if let Some(ent) = &req_data.entity {
-                                    let matches = sr
-                                        .memory
-                                        .metadata
-                                        .get("entity")
-                                        .and_then(|v| v.as_str())
-                                        .is_some_and(|e| e == ent);
-                                    if !matches {
-                                        return false;
-                                    }
-                                }
-                                if let Some(cat) = &req_data.category {
-                                    let matches = sr
-                                        .memory
-                                        .metadata
-                                        .get("category")
-                                        .and_then(|v| v.as_str())
-                                        .is_some_and(|c| c == cat);
-                                    if !matches {
-                                        return false;
-                                    }
-                                }
-                                true
-                            })
-                            .collect::<Vec<_>>();
-                        // Apply min_score filter after metadata filtering
-                        // (deferred from recall call to avoid losing valid matches)
-                        if min_score > 0.0 {
-                            results.retain(|sr| sr.score >= min_score);
-                        }
-                        // Trim to requested limit after filtering
-                        results.truncate(req_data.limit);
-
-                        if results.is_empty() && min_score > 0.0 {
-                            ctx.ok_response_for(
+                // Unified search path (#531): when search_type is specified and
+                // no memory-only metadata filters (entity/category) are present,
+                // use recall_unified. Entity/category only apply to memories, so
+                // their presence forces the legacy memory-only recall path.
+                let has_meta_filter = req_data.entity.is_some() || req_data.category.is_some();
+                let unified_result = if req_data.search_type.is_some()
+                    && point_in_time.is_none()
+                    && !has_meta_filter
+                {
+                    let search_type = match req_data.search_type.as_deref() {
+                        Some("memory") => uteke_core::SearchType::Memory,
+                        Some("doc") => uteke_core::SearchType::Document,
+                        Some("all") | None => uteke_core::SearchType::All,
+                        Some(other) => {
+                            return ctx.error_response_for(
                                 req,
-                                &serde_json::json!({
-                                    "results": [],
-                                    "total": 0,
-                                    "threshold": min_score,
-                                    "message": "No memories above similarity threshold"
-                                }),
-                            )
-                        } else {
-                            ctx.ok_response_for(req, &results)
+                                400,
+                                format!("Invalid search_type: '{other}'. Use 'all', 'memory', or 'doc'."),
+                            );
                         }
-                    }
-                    Err(e) => {
-                        error!("Internal error: {e}");
+                    };
+                    Some(uteke.recall_unified(
+                        &req_data.query,
+                        req_data.limit,
+                        tags_filter,
+                        ns(&req_data.namespace),
+                        min_score,
+                        search_type,
+                    ))
+                } else {
+                    None
+                };
+
+                // Prefer unified results when available (#531)
+                match unified_result {
+                    Some(Ok(results)) => ctx.ok_response_for(req, &results),
+                    Some(Err(e)) => {
+                        error!("Unified search error: {e}");
                         ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                    None => {
+                        // Fall through to existing memory-only recall path
+                        match recall_result {
+                            Ok(raw_results) => {
+                                // Post-filter by entity/category metadata
+                                let mut results: Vec<_> = raw_results
+                                    .into_iter()
+                                    .filter(|sr| {
+                                        if let Some(ent) = &req_data.entity {
+                                            let matches = sr
+                                                .memory
+                                                .metadata
+                                                .get("entity")
+                                                .and_then(|v| v.as_str())
+                                                .is_some_and(|e| e == ent);
+                                            if !matches {
+                                                return false;
+                                            }
+                                        }
+                                        if let Some(cat) = &req_data.category {
+                                            let matches = sr
+                                                .memory
+                                                .metadata
+                                                .get("category")
+                                                .and_then(|v| v.as_str())
+                                                .is_some_and(|c| c == cat);
+                                            if !matches {
+                                                return false;
+                                            }
+                                        }
+                                        true
+                                    })
+                                    .collect::<Vec<_>>();
+                                // Apply min_score filter after metadata filtering
+                                // (deferred from recall call to avoid losing valid matches)
+                                if min_score > 0.0 {
+                                    results.retain(|sr| sr.score >= min_score);
+                                }
+                                // Trim to requested limit after filtering
+                                results.truncate(req_data.limit);
+
+                                if results.is_empty() && min_score > 0.0 {
+                                    ctx.ok_response_for(
+                                        req,
+                                        &serde_json::json!({
+                                            "results": [],
+                                            "total": 0,
+                                            "threshold": min_score,
+                                            "message": "No memories above similarity threshold"
+                                        }),
+                                    )
+                                } else {
+                                    ctx.ok_response_for(req, &results)
+                                }
+                            }
+                            Err(e) => {
+                                error!("Internal error: {e}");
+                                ctx.error_response_for(req, 500, "Internal server error")
+                            }
+                        }
                     }
                 }
             }

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -126,6 +126,9 @@ pub struct RecallRequest {
     /// Time-travel: query memories that existed at this RFC3339 timestamp.
     #[serde(default)]
     pub at: Option<String>,
+    /// Search type filter: "all" (default, unified), "memory", or "doc" (#531).
+    #[serde(default)]
+    pub search_type: Option<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

Bridge `uteke recall` and `uteke doc search` into a single query surface via client-side RRF merge. **No schema changes, zero migration risk.**

Closes #531

## Problem

`uteke recall` searches memories, `uteke doc search` searches documents — two separate commands, two separate result sets. Agents need to know where data lives, adding cognitive overhead to every query.

## Solution

Client-side merge at the query layer:

1. Execute memory recall (existing ANN + FTS5)
2. Execute doc search (existing ANN + FTS5)
3. Merge via Reciprocal Rank Fusion
4. Return unified result set with type labels

## Changes

| File | Change |
| --- | --- |
| `uteke-core/src/memory/types.rs` | Add `UnifiedSearchResult`, `SearchResultType`, `SearchType` types + tests |
| `uteke-core/src/memory/mod.rs` | Re-export new types |
| `uteke-core/src/lib.rs` | Add `recall_unified()` with 3 modes (all/memory/document) |
| `uteke-cli/src/cli.rs` | Add `--type` flag to Recall command (String, no clap dep) |
| `uteke-cli/src/commands/recall.rs` | Route to unified path when `--type` is set |
| `uteke-cli/src/commands/mod.rs` | Pass `--type` to recall handler |
| `uteke-cli/src/output.rs` | Add `print_unified_human()` with `[mem]`/`[doc]` labels |
| `uteke-mcp/src/lib.rs` | `uteke_recall` MCP tool returns unified results |
| `uteke-server/src/types.rs` | Add `search_type` to `RecallRequest` |
| `uteke-server/src/handlers.rs` | Route to `recall_unified` when `search_type` is provided |

## API

```shell
# Unified (default) — both memories + documents
uteke recall "kanban fleet" --namespace coo
# [mem] Fleet uses kanban board: operations     score: 0.82
# [doc] Hermes Kanban + Delegation Integration  score: 0.89

# Filter to memories only
uteke recall "kanban" --type memory

# Filter to documents only
uteke recall "kanban" --type doc
```

## Backward Compatibility

- `--type all` (default) only activates unified path when no memory-specific flags are used
- `--at`, `--related`, `--salience`, `--recency`, `--entity`, `--category`, `--where` → falls back to memory-only path
- `uteke doc search` command unchanged
- MCP `uteke_recall` response includes `result_type` field for distinction
- Entity/category filters force legacy memory-only recall path (metadata only exists on memories)

## Acceptance Criteria from #531

- [x] `uteke recall "query" --namespace N` returns both memories and documents by default
- [x] `uteke recall "query" --type memory` returns memories only
- [x] `uteke recall "query" --type doc` returns documents only
- [x] Output labels result type ([mem] vs [doc])
- [x] Memory results include id and content
- [x] Document results include slug, title, and chunk excerpt
- [x] MCP `uteke_recall` returns unified results with type field
- [x] API `POST /recall` accepts optional `search_type` parameter
- [ ] Latency benchmark (requires CI environment with embedding model)
- [x] `uteke doc search` continues to work independently

## Testing

- Serde roundtrip tests for all new types
- Default value assertions
- Field serialization verification (skip_serializing_if for Optional fields)
- All 339 workspace tests passing