### PR TITLE
feat: gate ONNX dependencies behind 'onnx' feature

### DIFF
--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.6.0" }
+uteke-core = { path = "../uteke-core", version = "0.6.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["memory", "ai", "embedding", "vector-search", "semantic"]
 categories = ["science", "data-structures"]
 readme = "../../README.md"
 
+[features]
+default = ["onnx"]
+onnx = ["dep:ort", "dep:ndarray", "dep:tokenizers", "dep:sha2"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -18,13 +22,14 @@ usearch = "2"
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 thiserror = "2"
-ort = { version = "2.0.0-rc.12", features = ["download-binaries"] }
-ndarray = "0.17"
-tokenizers = "0.23"
 dirs = "6"
 tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
-sha2 = "0.11"
+# ONNX-only dependencies (gated behind `onnx` feature)
+ort = { version = "2.0.0-rc.12", features = ["download-binaries"], optional = true }
+ndarray = { version = "0.17", optional = true }
+tokenizers = { version = "0.23", optional = true }
+sha2 = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/uteke-core/src/embed/embed_trait.rs
+++ b/crates/uteke-core/src/embed/embed_trait.rs
@@ -1,7 +1,10 @@
 //! Embedder trait — abstraction over embedding backends.
 //!
 //! Implementations:
-//! - [`OnnxEmbedder`](crate::embed::OnnxEmbedder) — local ONNX EmbeddingGemma (default)
+//! - [`OnnxEmbedder`](crate::embed::OnnxEmbedder) — local ONNX EmbeddingGemma (default) *(requires `onnx` feature)*
+//! - [`OllamaEmbedder`](crate::embed::OllamaEmbedder) — Ollama API
+//! - [`OpenAiEmbedder`](crate::embed::OpenAiEmbedder) — OpenAI API
+//! - [`FallbackEmbedder`](crate::embed::FallbackEmbedder) — passthrough (no-op, zero vectors)
 //!
 //! Future backends (OpenAI, Ollama, etc.) implement this trait without
 //! touching recall/remember code.

--- a/crates/uteke-core/src/embed/mod.rs
+++ b/crates/uteke-core/src/embed/mod.rs
@@ -1,18 +1,21 @@
 //! Embedding engine components.
 
 pub mod embed_trait;
+#[cfg(feature = "onnx")]
 pub mod engine;
 pub mod fallback;
 pub mod ollama;
 pub mod openai;
 
 pub use embed_trait::Embedder;
+#[cfg(feature = "onnx")]
 pub use engine::OnnxEmbedder;
 pub use fallback::FallbackEmbedder;
 pub use ollama::OllamaEmbedder;
 pub use openai::OpenAiEmbedder;
 
 /// Backward-compat alias — old code referencing `EmbeddingEngine` continues to work.
+#[cfg(feature = "onnx")]
 #[allow(dead_code)]
 pub type EmbeddingEngine = OnnxEmbedder;
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -57,7 +57,9 @@ pub use salience_recency::{
 };
 pub use timeline::{TimelineEvent, TimelineEventType};
 
-pub use embed::{Embedder, OnnxEmbedder};
+pub use embed::Embedder;
+#[cfg(feature = "onnx")]
+pub use embed::OnnxEmbedder;
 pub use error::{format_bytes, Error};
 pub use types::{DoctorCheck, DoctorReport, DoctorStatus, RepairReport, VerifyReport};
 
@@ -415,6 +417,7 @@ impl Uteke {
         let dims = match embedder.as_ref() {
             Some(e) => e.dims(),
             None => match embedder_backend.as_str() {
+                #[cfg(feature = "onnx")]
                 "onnx" | "" | "custom" => crate::embed::OnnxEmbedder::dims(),
                 "openai" => {
                     // User-configurable via uteke.toml or UTEKE_EMBEDDING_DIMS.
@@ -519,6 +522,7 @@ impl Uteke {
             tracing::debug!(backend = %self.embedder_backend, "Lazy-initializing embedding backend");
             let backend = self.embedder_backend.as_str();
             let embedder: Box<dyn crate::embed::Embedder> = match backend {
+                #[cfg(feature = "onnx")]
                 "onnx" | "" => Box::new(crate::embed::OnnxEmbedder::new()?),
                 "custom" => {
                     return Err(Error::generic(

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.6.0" }
+uteke-core = { path = "../uteke-core", version = "0.6.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.6.0" }
+uteke-core = { path = "../uteke-core", version = "0.6.0", features = ["onnx"] }
 uteke-mcp = { path = "../uteke-mcp", version = "0.6.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

Add optional `onnx` feature (default enabled) to `uteke-core` that gates `ort`, `ndarray`, `tokenizers`, and `sha2`. External consumers (e.g. CorIn) can use `default-features = false` to skip ONNX compilation while still accessing SQLite, usearch, and remote embedders (Ollama, OpenAI).

Closes #533
Closes #534

## Changes

| File | Change |
|------|--------|
| `uteke-core/Cargo.toml` | Add `[features]` with `default = ["onnx"]`, gate `ort`/`ndarray`/`tokenizers`/`sha2` as optional |
| `uteke-core/src/embed/mod.rs` | Gate `engine` module + `OnnxEmbedder` re-export behind `#[cfg(feature = "onnx")]` |
| `uteke-core/src/embed/embed_trait.rs` | Expand doc with all embedder implementations |
| `uteke-core/src/lib.rs` | Gate `OnnxEmbedder` re-export + lazy-init/dims calls behind cfg |
| `uteke-cli/Cargo.toml` | Explicit `features = ["onnx"]` |
| `uteke-server/Cargo.toml` | Explicit `features = ["onnx"]` |
| `uteke-mcp/Cargo.toml` | Explicit `features = ["onnx"]` |

## Verification

- ✅ `cargo check --workspace` — pass
- ✅ `cargo check -p uteke-core --no-default-features` — pass (feature gate works)
- ✅ `cargo fmt --all -- --check` — pass
- ✅ `cargo clippy --workspace --all-targets` — pass
- ✅ `cargo test --workspace` — 339 passed, 13 ignored

## Backward Compatibility

100% — default features unchanged. All existing uteke binaries continue to use ONNX embedding.

## Impact on CorIn

CorIn can now depend on `uteke-core` with `default-features = false`:

```toml
uteke-core = { git = "...", branch = "develop", default-features = false }
```

This skips `ort` + `numkong` compilation issues on x86_64-darwin (#534) and ubuntu-22.04 (#533).