### PR TITLE
release: v0.6.4 — develop → main (version bump + docs validated)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.1
+- **Version:** 0.6.4
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -164,9 +164,10 @@ feature branch → PR → develop (default branch)
 When creating a release branch (`release/vX.Y.Z`), these changes MUST be in the branch:
 
 1. **Version bump** — `Cargo.toml` `[workspace.package].version` → new version
-2. **CHANGELOG.md** — move entries from `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD`, add empty `[Unreleased]`
-3. **AGENT.md** — update version string + any stale references (schema version, etc.)
-4. **README.md / README.id.md** — version badge if applicable
+2. **Inter-crate version pins** — every `crates/*/Cargo.toml` that references workspace crates must match the new version
+3. **CHANGELOG.md** — move entries from `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD`, add empty `[Unreleased]`
+4. **AGENT.md** — update version string + any stale references (schema version, etc.)
+5. **README.md / README.id.md** — version badge if applicable
 
 #### Release Flow
 
@@ -373,6 +374,17 @@ v0.0.14 release failed 3 times because:
 3. **Windows build failure blocked GitHub Release** — release job depended on both `build-release` AND `publish-crates`, so one platform failure blocked everything.
 
 **Fix:** Run `cargo publish --dry-run --allow-dirty` locally before tagging. Decouple publish from release.
+
+### Version Bump Is Mandatory Before Every Release
+
+v0.6.4 tag was pushed without bumping `workspace.package.version` from 0.6.3 → 0.6.4. `cargo publish` rejected it: "crate uteke-core@0.6.3 already exists on crates.io index". The release workflow reported success (misleading) but no crate was actually published.
+
+**Rule:** Before pushing any `v*` tag, verify ALL these are updated:
+1. `Cargo.toml` `[workspace.package].version` → new version
+2. Every inter-crate dependency version matches (e.g. `uteke-cli` depends on `uteke-core = "0.6.x"`)
+3. `CHANGELOG.md` date set to release date
+4. `AGENT.md` version string updated
+5. Run `cargo publish --dry-run --allow-dirty -p <crate>` to verify publish works
 
 ### Re-tagging Is Destructive and Confusing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.4] — Unreleased
+## [0.6.4] — 2026-07-03
 
 ### Added
 - **Gate ONNX behind `onnx` feature (#533, #534)** — `ort` and transitive `numkong` are now optional, gated behind `default-features = false`. Consumers that don't need ONNX/embedding can opt out entirely, resolving CI build failures on Ubuntu 22.04 (AVX-512) and macOS Intel (no prebuilt).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.3-green.svg" alt="v0.6.3" />
+  <img src="https://img.shields.io/badge/status-v0.6.4-green.svg" alt="v0.6.4" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.3-green.svg" alt="v0.6.3" />
+  <img src="https://img.shields.io/badge/status-v0.6.4-green.svg" alt="v0.6.4" />
 </p>
 
 <p align="center">

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.6.0**.
+Complete reference for all uteke commands. Version **0.6.4**.
 
 ## Global Flags
 
@@ -61,7 +61,7 @@ uteke remember "User prefers dark mode" --tags pref --namespace my-agent
 
 ## uteke recall
 
-Hybrid search combining vector similarity with FTS5 full-text search, ranked by Reciprocal Rank Fusion (RRF). Hot memories (accessed within 7 days) get a score boost.
+Unified search combining vector similarity with FTS5 full-text search, ranked by Reciprocal Rank Fusion (RRF). Searches **both memories and documents** by default (unified mode). Hot memories (accessed within 7 days) get a score boost.
 
 ```bash
 uteke recall "What framework does the API use?"
@@ -69,10 +69,15 @@ uteke recall "deployment" --limit 10
 uteke recall "database config" --namespace hermes --json
 uteke recall "server" --entity staging-server --json
 uteke recall "config" --category infrastructure --limit 5
+# Search documents only
+uteke recall "API architecture" --type doc
+# Search memories only (backward compatible)
+uteke recall "deployment" --type memory
 ```
 
 | Flag | Description |
 |------|-------------|
+| `--type <type>` | Search scope: `all` (default — memories + documents, unified via RRF), `memory` (memories only), `doc` (documents only) |
 | `--limit <n>` | Max results (default: 5) |
 | `--entity <name>` | Filter results to a specific entity |
 | `--category <cat>` | Filter results to a specific category |
@@ -830,7 +835,7 @@ Dual-role API token model:
 | Flag / Env | Role | Access |
 |------------|------|--------|
 | `--auth-token` / `UTEKE_AUTH_TOKEN` | Admin | All endpoints (GET, POST, DELETE) |
-| `--read-only-token` / `UTEKE_READ_ONLY_TOKEN` | ReadOnly | GET endpoints only (403 on writes) |
+| `--read-only-token` / `UTEKE_READ_ONLY_TOKEN` | ReadOnly | All read endpoints (GET + POST search/list/graph). 403 on writes. |
 
 ```bash
 # Start with dual tokens


### PR DESCRIPTION
## v0.6.4 Release

### Pre-release checklist ✅
- [x] Version bump: Cargo.toml 0.6.3 → 0.6.4
- [x] CHANGELOG.md updated with all changes
- [x] AGENT.md version + release checklist updated
- [x] README.md + README.id.md badges → v0.6.4
- [x] docs/cli-reference.md: version, unified search, read-only token
- [x] Docs audited against all commits since v0.6.3

### Key changes
- ONNX feature gate (ort/numkong optional via default-features=false)
- Unified search (recall returns memories + documents)
- Cross-namespace list/recent
- Read-only token on POST read endpoints
- Server module refactor