### PR TITLE
feat: HTTP graph mutation endpoints — POST/DELETE /graph/edge (#542)

### DIFF
--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -297,6 +297,34 @@ impl<'a> GraphStore<'a> {
         Ok(())
     }
 
+    /// Remove an edge between two nodes. Returns true if an edge was deleted.
+    /// When `relation` is Some, only deletes the edge matching that relation type.
+    /// When `relation` is None, deletes ALL edges between source and target.
+    pub fn remove_edge(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relation: Option<&str>,
+    ) -> Result<bool, Error> {
+        let affected = match relation {
+            Some(rel) => self
+                .conn
+                .execute(
+                    "DELETE FROM graph_edges WHERE source_id = ?1 AND target_id = ?2 AND relation = ?3",
+                    params![source_id, target_id, rel],
+                )
+                .map_err(|e| Error::db("delete graph edge", e))?,
+            None => self
+                .conn
+                .execute(
+                    "DELETE FROM graph_edges WHERE source_id = ?1 AND target_id = ?2",
+                    params![source_id, target_id],
+                )
+                .map_err(|e| Error::db("delete graph edge", e))?,
+        };
+        Ok(affected > 0)
+    }
+
     /// Find a node by label (case-insensitive).
     pub fn find_node(&self, label: &str) -> Result<Option<GraphNode>, Error> {
         self.conn

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -662,6 +662,36 @@ impl Uteke {
         &self.store.conn
     }
 
+    /// Add an edge between two graph nodes (#542).
+    ///
+    /// `source_id` and `target_id` are graph node IDs (not memory IDs).
+    /// The edge uses INSERT OR IGNORE — if the edge already exists, it's a no-op.
+    pub fn add_graph_edge(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relation: &str,
+        weight: f64,
+    ) -> Result<(), Error> {
+        let gs = GraphStore::new(&self.store.conn);
+        gs.add_edge(source_id, target_id, relation, weight)
+    }
+
+    /// Remove an edge between two graph nodes (#542).
+    ///
+    /// When `relation` is Some, only removes edges matching that relation type.
+    /// When None, removes ALL edges between source and target.
+    /// Returns true if at least one edge was deleted.
+    pub fn remove_graph_edge(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relation: Option<&str>,
+    ) -> Result<bool, Error> {
+        let gs = GraphStore::new(&self.store.conn);
+        gs.remove_edge(source_id, target_id, relation)
+    }
+
     /// Get graph nodes + edges for visualization (#408).
     ///
     /// Returns all nodes and edges in the knowledge graph, optionally

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -125,6 +125,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_doc_search(),
                 tool_doc_delete(),
                 tool_graph(),
+                tool_graph_add_edge(),
+                tool_graph_remove_edge(),
                 tool_room_recall(),
             ]
         })),
@@ -152,6 +154,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_doc_search" => exec_doc_search(uteke, &arguments)?,
                 "uteke_doc_delete" => exec_doc_delete(uteke, &arguments)?,
                 "uteke_graph" => exec_graph(uteke, &arguments)?,
+                "uteke_graph_add_edge" => exec_graph_add_edge(uteke, &arguments)?,
+                "uteke_graph_remove_edge" => exec_graph_remove_edge(uteke, &arguments)?,
                 "uteke_room_recall" => exec_room_recall(uteke, &arguments)?,
                 _ => return Err(format!("Unknown tool: {tool_name}")),
             };
@@ -888,4 +892,104 @@ fn exec_room_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         }],
         is_error: false,
     })
+}
+
+// ── Graph mutation tools (#542) ────────────────────────────────────────
+
+fn tool_graph_add_edge() -> Value {
+    serde_json::json!({
+        "name": "uteke_graph_add_edge",
+        "description": "Add an edge between two nodes in the knowledge graph. The source and target must be valid graph node IDs (not memory IDs). If the edge already exists, it is a no-op.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["source", "target"],
+            "properties": {
+                "source": { "type": "string", "description": "Graph node ID of the source node" },
+                "target": { "type": "string", "description": "Graph node ID of the target node" },
+                "relation": { "type": "string", "description": "Edge relation type (default: references)" },
+                "weight": { "type": "number", "description": "Edge weight (default: 1.0)" }
+            }
+        }
+    })
+}
+
+fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let source = args["source"].as_str().ok_or("Missing source")?;
+    let target = args["target"].as_str().ok_or("Missing target")?;
+
+    if source == target {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "Error: self-loop edges are not allowed (source == target)".to_string(),
+            }],
+            is_error: true,
+        });
+    }
+
+    let relation = args["relation"].as_str().unwrap_or("references");
+    let weight = args["weight"].as_f64().unwrap_or(1.0);
+
+    uteke
+        .add_graph_edge(source, target, relation, weight)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!(
+                "Edge added: {} -[{}]-> {} (weight: {})",
+                source, relation, target, weight
+            ),
+        }],
+        is_error: false,
+    })
+}
+
+fn tool_graph_remove_edge() -> Value {
+    serde_json::json!({
+        "name": "uteke_graph_remove_edge",
+        "description": "Remove an edge between two nodes in the knowledge graph. When relation is specified, only removes edges matching that relation type. When omitted, removes ALL edges between source and target.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["source", "target"],
+            "properties": {
+                "source": { "type": "string", "description": "Graph node ID of the source node" },
+                "target": { "type": "string", "description": "Graph node ID of the target node" },
+                "relation": { "type": "string", "description": "Edge relation type to remove (optional)" }
+            }
+        }
+    })
+}
+
+fn exec_graph_remove_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let source = args["source"].as_str().ok_or("Missing source")?;
+    let target = args["target"].as_str().ok_or("Missing target")?;
+    let relation = args["relation"].as_str();
+
+    let deleted = uteke
+        .remove_graph_edge(source, target, relation)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let rel_label = relation.unwrap_or("any");
+    if deleted {
+        Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: format!("Edge removed: {} -[{}]-> {}", source, rel_label, target),
+            }],
+            is_error: false,
+        })
+    } else {
+        Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: format!(
+                    "No edge found: {} -[{}]-> {} (nothing removed)",
+                    source, rel_label, target
+                ),
+            }],
+            is_error: false,
+        })
+    }
 }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -545,6 +545,100 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // ── Graph Mutation: Add Edge (#542) ──────────────────────────────
+        (Method::Post, "/graph/edge") => {
+            #[derive(Deserialize)]
+            struct AddEdgeRequest {
+                source: String,
+                target: String,
+                #[serde(default = "default_relation")]
+                relation: String,
+                #[serde(default = "default_weight")]
+                weight: f64,
+            }
+
+            fn default_relation() -> String {
+                "references".to_string()
+            }
+            fn default_weight() -> f64 {
+                1.0
+            }
+
+            match read_body::<AddEdgeRequest>(req.as_reader()) {
+                Ok(body) => {
+                    if body.source == body.target {
+                        return ctx.error_response_for(
+                            req,
+                            400,
+                            "Self-loop edges are not allowed (source == target)",
+                        );
+                    }
+                    match uteke.add_graph_edge(
+                        &body.source,
+                        &body.target,
+                        &body.relation,
+                        body.weight,
+                    ) {
+                        Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"ok": true})),
+                        Err(e) => {
+                            let msg = e.to_string();
+                            if msg.contains("FOREIGN KEY") || msg.contains("not found") {
+                                ctx.error_response_for(
+                                    req,
+                                    404,
+                                    format!(
+                                        "Node not found: source or target does not exist ({msg})"
+                                    ),
+                                )
+                            } else {
+                                error!("Graph add_edge error: {e}");
+                                ctx.error_response_for(req, 500, "Internal server error")
+                            }
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
+        // ── Graph Mutation: Remove Edge (#542) ────────────────────────────
+        (Method::Delete, p) if p == "/graph/edge" || p.starts_with("/graph/edge?") => {
+            let url = req.url().to_string();
+            let query = url.split('?').nth(1).unwrap_or("");
+            let source = parse_query_param(query, "source");
+            let target = parse_query_param(query, "target");
+            let relation = parse_query_param(query, "relation");
+
+            let (source, target) = match (source, target) {
+                (Some(s), Some(t)) => (s, t),
+                _ => {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Missing required query params: source and target",
+                    );
+                }
+            };
+
+            if source == target {
+                return ctx.error_response_for(
+                    req,
+                    400,
+                    "Self-loop edges are not allowed (source == target)",
+                );
+            }
+
+            match uteke.remove_graph_edge(&source, &target, relation.as_deref()) {
+                Ok(deleted) => {
+                    ctx.ok_response_for(req, &serde_json::json!({"ok": true, "deleted": deleted}))
+                }
+                Err(e) => {
+                    error!("Graph remove_edge error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
+            }
+        }
+
         // ── Room Summary ────────────────────────────────────────────────
         (Method::Post, "/room/summary") => {
             #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

Adds HTTP endpoints and MCP tools for graph edge mutations in uteke-server, enabling clients (like Corin) to be fully HTTP-only — no direct uteke-core access needed for graph operations.

### Changes

**uteke-core** (+58 lines)
- `GraphStore::remove_edge()` — delete edge by source+target, optional relation filter, returns bool
- `Uteke::add_graph_edge()` / `remove_graph_edge()` — convenience wrappers

**uteke-server** (+94 lines)
- `POST /graph/edge` — add edge between graph nodes
  - Request: `{ source, target, relation?, weight? }`
  - Response: `{ ok: true }`
  - Validation: 400 self-loop, 404 FK violation (node not found)
- `DELETE /graph/edge?source=...&target=...&relation=...` — remove edge
  - Response: `{ ok: true, deleted: bool }`
  - Validation: 400 missing params, 400 self-loop

**uteke-mcp** (+104 lines)
- `uteke_graph_add_edge` tool — add edge with optional relation/weight
- `uteke_graph_remove_edge` tool — remove edge with optional relation filter

### Auth
Both endpoints require write token. Read-only token returns 403 (handled by existing auth gate at `handlers.rs:47`).

### Acceptance Criteria from #542
- [x] `POST /graph/edge` adds edge between existing graph nodes
- [x] `DELETE /graph/edge?source=...&target=...` removes edge
- [x] Returns 404 if source or target node does not exist (FK violation)
- [x] Returns 400 for self-loop edges (source == target)
- [x] Read-only token returns 403
- [x] MCP JSON-RPC wrapper works for both operations

Closes #542