### PR TITLE
fix: documents_fts migration repair + doc delete by slug (#549, #550)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1007,27 +1007,30 @@ impl Uteke {
     /// Cascades to children and chunks. Returns (deleted, subtree_size).
     /// Also removes chunk embeddings from usearch index.
     pub fn doc_delete(&self, id: &str, namespace: Option<&str>) -> Result<(bool, usize), Error> {
-        // Collect all document IDs in the subtree before deletion.
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+
+        // Resolve slug to ID FIRST, before any other operations.
+        // Accepts both UUID and slug (consistent with doc_get) (#550).
+        let resolved_id = match self.store.get_document(id)? {
+            Some(d) => d.id,
+            None => {
+                self.store
+                    .get_document_by_slug(id, ns)?
+                    .ok_or_else(|| Error::validation(format!("document not found: {id}")))?
+                    .id
+            }
+        };
+
+        // Collect all document IDs in the subtree before deletion.
         let subtree = self
             .store
-            .list_descendants(id, ns, None, 10000)
+            .list_descendants(&resolved_id, ns, None, 10000)
             .unwrap_or_default();
-
-        // Get the main document ID too.
-        let main_id = match self.store.get_document(id)? {
-            Some(d) => d.id,
-            None => self
-                .store
-                .get_document_by_slug(id, ns)?
-                .map(|d| d.id)
-                .unwrap_or_default(),
-        };
 
         let all_ids: Vec<String> = subtree
             .iter()
             .map(|d| d.id.clone())
-            .chain(std::iter::once(main_id.clone()))
+            .chain(std::iter::once(resolved_id.clone()))
             .collect();
 
         // Get chunk IDs to remove from usearch.
@@ -1036,7 +1039,7 @@ impl Uteke {
             .delete_chunks_for_documents(&all_ids)
             .unwrap_or_default();
 
-        let (deleted, subtree_size) = self.store.delete_document(id)?;
+        let (deleted, subtree_size) = self.store.delete_document(&resolved_id)?;
 
         // Remove chunk entries from usearch index.
         if !chunk_ids.is_empty() {

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -130,6 +130,7 @@ impl super::Store {
         // Post-migration consistency checks: repair partially-migrated databases
         // where a migration stamped the version but failed partway through (#500).
         self.ensure_documents_has_children()?;
+        self.ensure_documents_fts()?;
 
         Ok(())
     }
@@ -157,6 +158,61 @@ impl super::Store {
                 )
                 .map_err(|e| Error::db("repair has_children column (#500)", e))?;
         }
+        Ok(())
+    }
+
+    /// Ensure the `documents_fts` FTS5 virtual table exists and is populated (#549).
+    ///
+    /// Schema v12 migration creates this table with best-effort (`let _ = execute(...)`)
+    /// which means a silent failure leaves the table absent. Existing documents are never
+    /// backfilled. This check runs after every `ensure_schema_version()` call so the
+    /// table is created and populated on next access.
+    fn ensure_documents_fts(&self) -> Result<(), Error> {
+        // Only relevant for schema v12+ databases.
+        let version = self.schema_version().unwrap_or(0);
+        if version < 12 {
+            return Ok(());
+        }
+
+        // Check if the FTS table already exists.
+        let exists: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='documents_fts')",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("check documents_fts exists (#549)", e))?;
+
+        if !exists {
+            tracing::warn!(
+                "documents_fts table missing on schema v{} DB — creating (#549)",
+                version
+            );
+            // Create FTS5 table.
+            self.conn
+                .execute_batch(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content='documents', content_rowid='rowid')",
+                )
+                .map_err(|e| Error::db("create documents_fts (#549)", e))?;
+
+            // Create sync triggers.
+            self.conn.execute_batch(
+                "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN                  INSERT INTO documents_fts(rowid, title, slug) VALUES (new.rowid, new.title, new.slug); END;                  CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN                  UPDATE documents_fts SET title = new.title, slug = new.slug WHERE rowid = new.rowid; END;                  CREATE TRIGGER IF NOT EXISTS documents_fts_delete AFTER DELETE ON documents BEGIN                  DELETE FROM documents_fts WHERE rowid = old.rowid; END;",
+            ).map_err(|e| Error::db("create documents_fts triggers (#549)", e))?;
+
+            // Backfill existing documents into FTS index.
+            self.conn
+                .execute_batch(
+                    "INSERT INTO documents_fts(rowid, title, slug)                      SELECT rowid, title, slug FROM documents",
+                )
+                .map_err(|e| Error::db("backfill documents_fts (#549)", e))?;
+
+            tracing::info!(
+                "documents_fts table created and backfilled from existing documents (#549)"
+            );
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fixes #549 and #550 — two bugs in the document engine.

### #549: `documents_fts` table missing — FTS5 search fails for document chunks

**Root cause:** Schema v12 migration creates the `documents_fts` FTS5 virtual table with **best-effort** execution (`let _ = self.conn.execute(sql, []);`). If the creation failed silently, the table is absent and existing documents are never backfilled. Every `uteke recall` / `uteke doc search` logs a noisy warning.

**Fix:** Add `ensure_documents_fts()` consistency check (same pattern as `ensure_documents_has_children()` from #500):
- Runs after every `ensure_schema_version()` call (including on store open)
- Checks if `documents_fts` exists via `sqlite_master`
- If missing: creates FTS5 table, sync triggers, and backfills existing documents
- Also exposed via `ensure_schema_consistency()` for `uteke repair`

### #550: `uteke doc delete <SLUG>` fails — only works with document ID

**Root cause:** `doc_delete()` resolved the slug to an ID (`main_id`) for chunk cleanup, but passed the **original slug** to `delete_document(id)` which queries `WHERE id = ?1`. Slug never matches a UUID.

**Fix:** Resolve slug to `resolved_id` FIRST, then use it consistently for descendants, chunk cleanup, and the actual delete.

## Test Results

- `cargo check`: clean
- `cargo fmt --check`: clean
- `cargo test`: 284 passed, 4 pre-existing failures (dream tests — ONNX backend)
- All `schema` and `document` tests: passed

## Files Changed

- `crates/uteke-core/src/memory/schema.rs`: +56 (ensure_documents_fts)
- `crates/uteke-core/src/lib.rs`: +17/-14 (doc_delete slug fix)

Closes #549, Closes #550