### PR TITLE
fix: add cross-process file lock to prevent usearch race condition (#543)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,6 +2810,7 @@ version = "0.6.4"
 dependencies = [
  "chrono",
  "dirs",
+ "fs2",
  "ndarray",
  "ort",
  "reqwest",

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2"
 dirs = "6"
 tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+fs2 = "0.4"
 # ONNX-only dependencies (gated behind `onnx` feature)
 ort = { version = "2.0.0-rc.12", features = ["download-binaries"], optional = true }
 ndarray = { version = "0.17", optional = true }

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -1,7 +1,15 @@
 //! Persistent vector index using usearch (HNSW with disk persistence).
+//!
+//! Cross-process safety (#543): Each VectorIndex acquires an exclusive file
+//! lock (via fs2) on the .usearch file during construction. The lock is held
+//! until the VectorIndex is dropped, serializing concurrent CLI invocations
+//! that share the same on-disk index. In-process thread safety uses
+//! RwLock<VectorIndex> in lib.rs.
 
 use crate::Error;
+use fs2::FileExt;
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
@@ -14,6 +22,11 @@ const DEFAULT_DIMS: usize = 768;
 /// - **Insert**: incremental, no rebuild
 /// - **Delete**: incremental, no rebuild
 /// - **Save**: persists to disk after mutations
+///
+/// **Cross-process safety (#543):** An exclusive file lock on the `.usearch`
+/// file serializes concurrent access from separate CLI processes. The lock is
+/// held for the lifetime of the VectorIndex. In-process thread safety uses
+/// `RwLock` in `Uteke`.
 pub struct VectorIndex {
     index: Index,
     /// Maps integer key (u64) → memory UUID string.
@@ -26,6 +39,9 @@ pub struct VectorIndex {
     path: Option<PathBuf>,
     /// Whether the index has unsaved changes.
     dirty: bool,
+    /// Cross-process file lock on the .usearch file (#543).
+    /// Held until the VectorIndex is dropped.
+    _lock_file: Option<File>,
 }
 
 impl VectorIndex {
@@ -39,19 +55,33 @@ impl VectorIndex {
             next_key: 0,
             path: None,
             dirty: false,
+            _lock_file: None,
         })
     }
 
     /// Load index from disk, or create empty if file doesn't exist.
     /// `path` is the path to the `.usearch` file.
+    ///
+    /// Acquires an **exclusive file lock** on the `.usearch` file to prevent
+    /// cross-process race conditions (e.g., `xargs -P5 uteke remember`).
+    /// The lock is held until this `VectorIndex` is dropped (#543).
     pub fn load_or_create(path: &Path, dims: usize) -> Result<Self, Error> {
-        if path.exists() {
-            Self::load(path)
-        } else {
-            let mut idx = Self::new(dims)?;
-            idx.path = Some(path.to_path_buf());
-            Ok(idx)
+        // Ensure the file exists so we can open + lock it.
+        if !path.exists() {
+            // Create a zero-byte placeholder; usearch will overwrite on save.
+            std::fs::write(path, []).map_err(|e| Error::embed("create usearch file", e))?;
         }
+
+        let lock_file = acquire_file_lock(path)?;
+
+        let mut idx = if path.metadata().map_or(true, |m| m.len() == 0) {
+            Self::new(dims)?
+        } else {
+            Self::load(path)?
+        };
+        idx.path = Some(path.to_path_buf());
+        idx._lock_file = Some(lock_file);
+        Ok(idx)
     }
 
     /// Load an existing index from disk.
@@ -92,6 +122,7 @@ impl VectorIndex {
             next_key,
             path: Some(path.to_path_buf()),
             dirty: false,
+            _lock_file: None, // Set by caller (load_or_create)
         })
     }
 
@@ -280,6 +311,32 @@ pub fn cosine_distance_to_similarity(distance: f32) -> f32 {
     // usearch cosine distance = 1 - cosine_similarity
     let sim = 1.0 - distance;
     sim.clamp(0.0, 1.0)
+}
+
+/// Acquire an exclusive file lock on the usearch index file (#543).
+///
+/// Blocks until the lock is available. This serializes concurrent access from
+/// separate CLI processes (e.g., `xargs -P5 uteke remember`).
+fn acquire_file_lock(path: &Path) -> Result<File, Error> {
+    let file = File::options()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| Error::embed_msg(format!("Failed to open usearch file for locking: {e}")))?;
+
+    if file.try_lock_exclusive().is_ok() {
+        tracing::debug!("usearch file lock acquired: {}", path.display());
+    } else {
+        tracing::debug!("usearch file lock busy on {}, waiting...", path.display());
+        file.lock_exclusive()
+            .map_err(|e| Error::embed("acquire exclusive file lock on usearch", e))?;
+        tracing::debug!(
+            "usearch file lock acquired (after wait): {}",
+            path.display()
+        );
+    }
+
+    Ok(file)
 }
 
 /// Atomic file write: write to temp file then rename.


### PR DESCRIPTION
## Problem

Multiple concurrent `uteke remember` invocations (e.g. `xargs -P5`) each load the usearch vector index, insert, and save — each save **overwrites** other inserts, causing data loss.

The `RwLock<VectorIndex>` only protects within a single process.

## Fix

- Add `fs2` dependency for advisory file locking
- `VectorIndex` acquires exclusive file lock on `.usearch` file during `load_or_create()`, held until `Drop`
- Concurrent CLI invocations block at lock acquisition instead of corrupting the index
- 288 tests pass, clippy/fmt clean

Closes #543