### PR TITLE
fix: room list namespace filter + room recall query empty results (#545, #546)

### DIFF
--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -138,18 +138,19 @@ impl super::Store {
             .map_err(|e| Error::db("get room", e))
     }
 
-    /// List rooms that a namespace has participated in.
+    /// List rooms, optionally filtered by namespace.
     pub fn list_rooms(&self, namespace: Option<&str>) -> Result<Vec<Room>, Error> {
         // Rooms are cross-namespace collaboration spaces (#392).
         // By default, list ALL rooms across all namespaces.
-        // When a namespace is provided, filter to that namespace only.
+        // When a namespace is provided, filter to rooms whose namespace
+        // column matches. No JOIN needed — the namespace column lives
+        // on the rooms table itself (#545).
         let sql = match namespace {
             Some(_) => {
-                "SELECT DISTINCT r.id, r.title, r.namespace, r.created_at, r.updated_at \
-                 FROM rooms r \
-                 INNER JOIN room_memories rm ON r.id = rm.room_id \
-                 WHERE r.namespace = ?1 \
-                 ORDER BY r.updated_at DESC"
+                "SELECT id, title, namespace, created_at, updated_at \
+                 FROM rooms \
+                 WHERE namespace = ?1 \
+                 ORDER BY updated_at DESC"
             }
             None => {
                 "SELECT id, title, namespace, created_at, updated_at FROM rooms \

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -89,11 +89,9 @@ impl crate::Uteke {
         }
         let id_set: std::collections::HashSet<String> = room_ids.into_iter().collect();
 
-        // 2. Over-fetch via hybrid recall (no namespace filter — rooms are cross-ns)
-        // Cap at 200 to prevent unbounded searches for large rooms.
+        // 2. Over-fetch via hybrid recall (no namespace filter — rooms are cross-ns).
+        // Cap at 200 to prevent unbounded searches for large rooms (#546).
         let fetch_limit = (limit * 5).min(200).max(limit);
-        // If room has fewer memories than fetch_limit, only fetch that many.
-        let fetch_limit = fetch_limit.min(id_set.len());
         let results = self.recall_hybrid(
             query,
             fetch_limit,


### PR DESCRIPTION
## Closes
- #545 — room list --namespace filter returns empty array despite rooms existing
- #546 — room recall --query (semantic search within room) returns empty results

## #545 — Root Cause

`list_rooms()` used `INNER JOIN room_memories` to filter by namespace. The namespace column lives directly on the `rooms` table — no JOIN needed. The JOIN returned empty results when a room had no linked memories yet, causing the filter to miss valid rooms.

**Fix:** Replaced JOIN query with simple `SELECT ... FROM rooms WHERE namespace = ?1`.

## #546 — Root Cause

`room_recall_query()` capped `fetch_limit` to `min(fetch_limit, id_set.len())`. When a room had fewer linked memory IDs than the fetch batch size, the limit was reduced — meaning rooms with 0-1 linked IDs got 0 results from vector search. The chronological path worked because it doesn't depend on vector recall.

**Fix:** Removed the `fetch_limit.min(id_set.len())` cap. Fetch limit is now `(limit * 5).min(200).max(limit)` as originally intended.
