### PR TITLE
fix: room document missing sections for note/insight/reference/event types (#547)

### DIFF
--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -699,6 +699,9 @@ impl super::Store {
             heading: &'static str,
             icon: &'static str,
         }
+        // Known type sections — memories matching these keys get their own
+        // dedicated section (#547: previously only 5 types were mapped,
+        // causing note/insight/reference/event memories to vanish silently).
         let type_sections = [
             TypeSection {
                 key: "decision",
@@ -725,7 +728,26 @@ impl super::Store {
                 heading: "Context & Discussion",
                 icon: "💬",
             },
+            TypeSection {
+                key: "insight",
+                heading: "Insights",
+                icon: "💡",
+            },
+            TypeSection {
+                key: "reference",
+                heading: "References",
+                icon: "📎",
+            },
+            TypeSection {
+                key: "event",
+                heading: "Events",
+                icon: "📅",
+            },
         ];
+
+        // Collect which memory IDs have been assigned to a typed section,
+        // so we can put the remainder into a catch-all "Notes" section (#547).
+        let mut assigned: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for ts in &type_sections {
             let mut matching: Vec<&crate::memory::types::Memory> = memories
@@ -734,6 +756,9 @@ impl super::Store {
                 .collect();
             if matching.is_empty() {
                 continue;
+            }
+            for m in &matching {
+                assigned.insert(m.id.clone());
             }
             // Sort by importance desc, fallback recency
             matching.sort_by(|a, b| {
@@ -754,6 +779,29 @@ impl super::Store {
             sections.push(DocumentSection {
                 heading: ts.heading.to_string(),
                 icon: ts.icon.to_string(),
+                entries,
+            });
+        }
+
+        // Catch-all: any memory not yet assigned (e.g. "note" type, the
+        // default fallback from MemoryType::infer_from_content) lands here.
+        let unassigned: Vec<&crate::memory::types::Memory> = memories
+            .iter()
+            .filter(|m| !m.pinned && !assigned.contains(&m.id))
+            .collect();
+        if !unassigned.is_empty() {
+            let entries: Vec<DocumentEntry> = unassigned
+                .into_iter()
+                .map(|m| DocumentEntry {
+                    content: m.content.clone(),
+                    author: author_map.get(&m.id).cloned().unwrap_or_default(),
+                    tags: m.tags.clone(),
+                    created_at: fmt_time(&m.created_at.to_rfc3339()),
+                })
+                .collect();
+            sections.push(DocumentSection {
+                heading: "Notes & General".to_string(),
+                icon: "📝".to_string(),
                 entries,
             });
         }


### PR DESCRIPTION
## Closes
- #547 — room document (CLI) returns empty sections — works via uteke-serve

## Root Cause

`room_document()` only mapped **5 memory types** to document sections:

| Key | Section |
|-----|---------|
| decision | Decisions |
| fact | Research &amp; Facts |
| procedure | Procedures |
| preference | Preferences |
| context | Context &amp; Discussion |

But `MemoryType::infer_from_content()` produces **9 types**. The remaining 4 types (**note**, **insight**, **reference**, **event**) had no matching section — their memories vanished silently from the document.

Since `note` is the **default fallback** type (when content doesn't match any pattern), rooms with generic content like "Technical review needed" or "Budget approved" would all infer as `note` and no section matched — resulting in `sections: []`.

## Fix

1. **Added dedicated sections** for `insight`, `reference`, and `event` types
2. **Added catch-all "Notes &amp; General" section** that captures any memory not yet assigned to a typed section — covers the `note` type and any future types
3. Section ordering: Pinned, Decisions, Facts, Procedures, Preferences, Context, Insights, References, Events, Notes &amp; General
