### PR TITLE
chore: v0.6.5 pre-release — CHANGELOG, README, MCP fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
 
 ## [Unreleased]
 
+### Added
+- **HTTP graph mutation endpoints (#542)** — `POST /graph/edge` creates a new typed edge between two memories; `DELETE /graph/edge` removes an edge by its ID. Enables programmatic graph editing without the CLI.
+
+### Fixed
+- **Cross-process file lock (#543)** — usearch index is now protected by a file lock to prevent race conditions when multiple uteke processes access the same database concurrently.
+- **FTS5 initialization on every startup (#544)** — FTS5 virtual table and triggers are now re-created on every startup, not just during schema migration. Fixes missing FTS5 after partial upgrades.
+- **Room list `--namespace` filter returns empty array (#545)** — namespace filtering now correctly matches room namespaces instead of returning no results.
+- **Room recall `--query` returns empty results (#546)** — semantic search within rooms now returns correct results; the query embedding was being silently discarded.
+- **Room document missing sections for note/insight/reference/event types (#547)** — document sections for non-core memory types (note, insight, reference, event) are now generated correctly in room documents.
+- **documents_fts migration repair (#549)** — FTS5 virtual table is rebuilt if missing or corrupted during migration, preventing `no such table: documents_fts` errors.
+- **Document delete by slug (#550)** — `uteke doc delete` now correctly resolves documents by slug (not just UUID), matching the behavior of `get` and `list`.
+
 ## [0.6.3] — 2026-07-01
 
 ### Fixed

--- a/README.id.md
+++ b/README.id.md
@@ -92,7 +92,7 @@ AI agent melupakan semua hal antar sesi. Uteke memberikan mereka memori persiste
 - 🔌 **MCP Server** — JSON-RPC via stdio + Streamable HTTP transport
 - 📝 **Document Engine** — Wiki/knowledge base dengan `uteke doc create/get/list` + auto-chunking
 - 🤖 **Cosine Auto-Linking** — Otomatis membuat edge `similar_to` antar memory terkait
-- 🌐 **Graph API** — Endpoint `GET /graph` mengembalikan nodes + edges JSON untuk visualisasi
+- 🌐 **Graph API** — `GET /graph` mengembalikan nodes + edges JSON; `POST /graph/edge` dan `DELETE /graph/edge` untuk mutasi
 - 🔑 **View-Only API Keys** — Token read-only untuk akses GET saja ke server
 - 📄 **Markdown Chunker** — Membagi dokumen berdasarkan heading, respect code block dan token limit
 - 📥 **Import/Export** — Backup dan restore berbasis JSONL

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 - 📝 **Document Engine** — Wiki/knowledge base with `uteke doc create/get/list` and auto-chunking
 
 - 🤖 **Cosine Auto-Linking** — Automatically creates `similar_to` edges between related memories
-- 🌐 **Graph API** — `GET /graph` endpoint returns nodes + edges JSON for visualization
+- 🌐 **Graph API** — `GET /graph` returns nodes + edges JSON; `POST /graph/edge` and `DELETE /graph/edge` for mutation
 - 🔑 **View-Only API Keys** — Read-only tokens for safe GET-only access to the server
 - 📄 **Markdown Chunker** — Splits documents by headings, respects code blocks and token limits
 

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -666,13 +666,14 @@ fn exec_doc_create(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let content = args["content"].as_str().ok_or("Missing 'content'")?;
     let title = args["title"].as_str().unwrap_or("");
     let namespace = args["namespace"].as_str();
+    let parent = args["parent"].as_str();
     let tags: Vec<&str> = args["tags"]
         .as_array()
         .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
 
     let id = uteke
-        .doc_upsert(slug, title, content, &tags, namespace)
+        .doc_upsert_with_parent(slug, title, content, &tags, namespace, parent)
         .map_err(|e| format!("Failed: {e}"))?;
 
     Ok(ToolResult {


### PR DESCRIPTION
## Pre-release housekeeping for v0.6.5

### CHANGELOG
- Populate [Unreleased] with all 8 merged issues (#542-#550)

### README
- Add POST/DELETE /graph/edge mutation endpoints to Graph API bullet (both EN and ID)

### MCP Fix
- Fix uteke_doc_create executor to pass parent param to doc_upsert_with_parent (schema declared it but executor was ignoring it)

### Validation
Part of pre-release validation (release-validation skill).