### PR TITLE
docs: v0.6.5 remaining fixes — /recent, graph mutation, sidebar, version bump

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.4
+- **Version:** 0.6.5
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "chrono",
  "clap",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "dirs",
  "serde",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.4-green.svg" alt="v0.6.4" />
+  <img src="https://img.shields.io/badge/status-v0.6.5-green.svg" alt="v0.6.5" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.4-green.svg" alt="v0.6.4" />
+  <img src="https://img.shields.io/badge/status-v0.6.5-green.svg" alt="v0.6.5" />
 </p>
 
 <p align="center">

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
           { text: 'Relationship Graph', link: '/getting-started#relationship-graph' },
           { text: 'Benchmarks', link: '/getting-started#benchmarking' },
           { text: 'MCP Server', link: '/mcp' },
+          { text: 'Document Commands', link: '/cli-reference#document-commands' },
+          { text: 'Graph API', link: '/cli-reference#graph-api-408-542' },
         ],
       },
       {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.6.4**.
+Complete reference for all uteke commands. Version **0.6.5**.
 
 ## Global Flags
 
@@ -701,6 +701,10 @@ When `[server] enabled = true` is set in config, the CLI auto-routes commands th
 | POST | `/doc/search` | Hybrid/semantic/FTS document search (#440) |
 | POST | `/doc/move` | Move document to new parent (#438) |
 | DELETE | `/doc/delete?id=` | Delete document with cascade |
+| GET | `/recent` | Recent memories (supports `?namespace=`, `?limit=`, `?offset=`) (#528) |
+| GET | `/graph` | Graph visualization — nodes, edges, stats (#408) |
+| POST | `/graph/edge` | Create a typed edge between two memories (#542) |
+| DELETE | `/graph/edge` | Remove an edge by ID (#542) |
 | POST | `/mcp` | MCP JSON-RPC endpoint (#381) |
 
 ### MCP Server
@@ -817,15 +821,27 @@ uteke doc export           # markdown to stdout
 uteke doc export --json    # JSON to stdout
 ```
 
-## Graph API (#408)
+## Graph API (#408, #542)
 
-The server exposes a graph visualization endpoint:
+### Visualization
 
 ```bash
 # All nodes + edges + stats
 curl http://127.0.0.1:8767/graph
 
 # Response: { nodes: [...], edges: [...], stats: {...} }
+```
+
+### Mutation
+
+```bash
+# Create a typed edge
+curl -X POST http://127.0.0.1:8767/graph/edge \
+  -H "Content-Type: application/json" \
+  -d '{"from": "<uuid>", "to": "<uuid>", "edge_type": "references"}'
+
+# Delete an edge by ID
+curl -X DELETE "http://127.0.0.1:8767/graph/edge?id=<edge-uuid>"
 ```
 
 ## Server Authentication (#409)


### PR DESCRIPTION
## Changes

### 1. Document `GET /recent` endpoint (#528)
Added to HTTP Endpoints table in `cli-reference.md` with query params (`?namespace=`, `?limit=`, `?offset=`).

### 2. Graph mutation endpoints (#542) in HTTP table
- `GET /graph` — visualization
- `POST /graph/edge` — create edge
- `DELETE /graph/edge` — remove edge

Expanded Graph API section with mutation curl examples.

### 3. VitePress sidebar entries
Added **Document Commands** and **Graph API** entries pointing to anchors in `cli-reference.md`.

### 4. Version bump 0.6.4 → 0.6.5
- `Cargo.toml` (workspace.package)
- `README.md` + `README.id.md` (badge)
- `AGENT.md` (version field)
- `docs/cli-reference.md` (version string)

## Files changed
- `docs/cli-reference.md`
- `docs/.vitepress/config.ts`
- `Cargo.toml` + `Cargo.lock`
- `README.md`
- `README.id.md`
- `AGENT.md`