### PR TITLE
docs: CHANGELOG Docs section + docker.md version ref for v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 - **documents_fts migration repair (#549)** — FTS5 virtual table is rebuilt if missing or corrupted during migration, preventing `no such table: documents_fts` errors.
 - **Document delete by slug (#550)** — `uteke doc delete` now correctly resolves documents by slug (not just UUID), matching the behavior of `get` and `list`.
 
+### Docs
+- **HTTP API documentation for `/recent` and graph mutation endpoints** — `GET /recent` (with query params), `GET /graph`, `POST /graph/edge`, `DELETE /graph/edge` added to HTTP Endpoints table. Graph API section expanded with mutation curl examples.
+- **VitePress sidebar entries** — added Document Commands and Graph API links to docs sidebar.
+- **Version bump 0.6.4 → 0.6.5** — all version strings synchronized across Cargo.toml, README.md, README.id.md, AGENT.md, and cli-reference.md.
+
 ## [0.6.3] — 2026-07-01
 
 ### Fixed

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,7 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.6.3` | Specific version |
+| `v0.6.5` | Specific version |
 | `0.6` | Minor version (latest patch) |
 
 ## CLI in Docker


### PR DESCRIPTION
## Changes
- Add `### Docs` section in CHANGELOG `[Unreleased]` documenting PR #561 doc fixes (HTTP API docs, sidebar entries, version bump)
- Update `docs/docker.md` example version tag `v0.6.3` → `v0.6.5`