### PR TITLE
release: sync develop → main for v0.6.5

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.4
+- **Version:** 0.6.5
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
 
 ## [Unreleased]
 
+### Added
+- **HTTP graph mutation endpoints (#542)** — `POST /graph/edge` creates a new typed edge between two memories; `DELETE /graph/edge` removes an edge by its ID. Enables programmatic graph editing without the CLI.
+
+### Fixed
+- **Cross-process file lock (#543)** — usearch index is now protected by a file lock to prevent race conditions when multiple uteke processes access the same database concurrently.
+- **FTS5 initialization on every startup (#544)** — FTS5 virtual table and triggers are now re-created on every startup, not just during schema migration. Fixes missing FTS5 after partial upgrades.
+- **Room list `--namespace` filter returns empty array (#545)** — namespace filtering now correctly matches room namespaces instead of returning no results.
+- **Room recall `--query` returns empty results (#546)** — semantic search within rooms now returns correct results; the query embedding was being silently discarded.
+- **Room document missing sections for note/insight/reference/event types (#547)** — document sections for non-core memory types (note, insight, reference, event) are now generated correctly in room documents.
+- **documents_fts migration repair (#549)** — FTS5 virtual table is rebuilt if missing or corrupted during migration, preventing `no such table: documents_fts` errors.
+- **Document delete by slug (#550)** — `uteke doc delete` now correctly resolves documents by slug (not just UUID), matching the behavior of `get` and `list`.
+
 ## [0.6.3] — 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 - **documents_fts migration repair (#549)** — FTS5 virtual table is rebuilt if missing or corrupted during migration, preventing `no such table: documents_fts` errors.
 - **Document delete by slug (#550)** — `uteke doc delete` now correctly resolves documents by slug (not just UUID), matching the behavior of `get` and `list`.
 
+### Docs
+- **HTTP API documentation for `/recent` and graph mutation endpoints** — `GET /recent` (with query params), `GET /graph`, `POST /graph/edge`, `DELETE /graph/edge` added to HTTP Endpoints table. Graph API section expanded with mutation curl examples.
+- **VitePress sidebar entries** — added Document Commands and Graph API links to docs sidebar.
+- **Version bump 0.6.4 → 0.6.5** — all version strings synchronized across Cargo.toml, README.md, README.id.md, AGENT.md, and cli-reference.md.
+
 ## [0.6.3] — 2026-07-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,6 +2810,7 @@ version = "0.6.4"
 dependencies = [
  "chrono",
  "dirs",
+ "fs2",
  "ndarray",
  "ort",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "clap",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dirs",
  "serde",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "chrono",
  "clap",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "dirs",
  "serde",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -92,7 +92,7 @@ AI agent melupakan semua hal antar sesi. Uteke memberikan mereka memori persiste
 - 🔌 **MCP Server** — JSON-RPC via stdio + Streamable HTTP transport
 - 📝 **Document Engine** — Wiki/knowledge base dengan `uteke doc create/get/list` + auto-chunking
 - 🤖 **Cosine Auto-Linking** — Otomatis membuat edge `similar_to` antar memory terkait
-- 🌐 **Graph API** — Endpoint `GET /graph` mengembalikan nodes + edges JSON untuk visualisasi
+- 🌐 **Graph API** — `GET /graph` mengembalikan nodes + edges JSON; `POST /graph/edge` dan `DELETE /graph/edge` untuk mutasi
 - 🔑 **View-Only API Keys** — Token read-only untuk akses GET saja ke server
 - 📄 **Markdown Chunker** — Membagi dokumen berdasarkan heading, respect code block dan token limit
 - 📥 **Import/Export** — Backup dan restore berbasis JSONL

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.4-green.svg" alt="v0.6.4" />
+  <img src="https://img.shields.io/badge/status-v0.6.5-green.svg" alt="v0.6.5" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.4-green.svg" alt="v0.6.4" />
+  <img src="https://img.shields.io/badge/status-v0.6.5-green.svg" alt="v0.6.5" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 - 📝 **Document Engine** — Wiki/knowledge base with `uteke doc create/get/list` and auto-chunking
 
 - 🤖 **Cosine Auto-Linking** — Automatically creates `similar_to` edges between related memories
-- 🌐 **Graph API** — `GET /graph` endpoint returns nodes + edges JSON for visualization
+- 🌐 **Graph API** — `GET /graph` returns nodes + edges JSON; `POST /graph/edge` and `DELETE /graph/edge` for mutation
 - 🔑 **View-Only API Keys** — Read-only tokens for safe GET-only access to the server
 - 📄 **Markdown Chunker** — Splits documents by headings, respects code blocks and token limits
 

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2"
 dirs = "6"
 tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+fs2 = "0.4"
 # ONNX-only dependencies (gated behind `onnx` feature)
 ort = { version = "2.0.0-rc.12", features = ["download-binaries"], optional = true }
 ndarray = { version = "0.17", optional = true }

--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -297,6 +297,19 @@ impl<'a> GraphStore<'a> {
         Ok(())
     }
 
+    /// Remove an edge between two nodes by source and target IDs.
+    /// Returns true if an edge was removed, false if none existed.
+    pub fn remove_edge(&self, source_id: &str, target_id: &str) -> Result<bool, Error> {
+        let affected = self
+            .conn
+            .execute(
+                "DELETE FROM graph_edges WHERE source_id = ?1 AND target_id = ?2",
+                params![source_id, target_id],
+            )
+            .map_err(|e| Error::db("remove graph edge", e))?;
+        Ok(affected > 0)
+    }
+
     /// Find a node by label (case-insensitive).
     pub fn find_node(&self, label: &str) -> Result<Option<GraphNode>, Error> {
         self.conn
@@ -799,6 +812,30 @@ mod tests {
         assert_eq!(triples.len(), 1);
         assert_eq!(triples[0].source.label, "Alice");
         assert_eq!(triples[0].target.label, "ProjectX");
+    }
+
+    #[test]
+    fn test_remove_edge() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        g.add_edge(&alice, &bob, "knows", 1.0).unwrap();
+        assert_eq!(g.all_edges().unwrap().len(), 1);
+
+        let removed = g.remove_edge(&alice, &bob).unwrap();
+        assert!(removed);
+        assert_eq!(g.all_edges().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_remove_edge_nonexistent() {
+        let conn = setup();
+        let g = GraphStore::new(&conn);
+        let alice = g.upsert_node("Alice", None, None).unwrap();
+        let bob = g.upsert_node("Bob", None, None).unwrap();
+        let removed = g.remove_edge(&alice, &bob).unwrap();
+        assert!(!removed);
     }
 
     #[test]

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1007,27 +1007,30 @@ impl Uteke {
     /// Cascades to children and chunks. Returns (deleted, subtree_size).
     /// Also removes chunk embeddings from usearch index.
     pub fn doc_delete(&self, id: &str, namespace: Option<&str>) -> Result<(bool, usize), Error> {
-        // Collect all document IDs in the subtree before deletion.
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+
+        // Resolve slug to ID FIRST, before any other operations.
+        // Accepts both UUID and slug (consistent with doc_get) (#550).
+        let resolved_id = match self.store.get_document(id)? {
+            Some(d) => d.id,
+            None => {
+                self.store
+                    .get_document_by_slug(id, ns)?
+                    .ok_or_else(|| Error::validation(format!("document not found: {id}")))?
+                    .id
+            }
+        };
+
+        // Collect all document IDs in the subtree before deletion.
         let subtree = self
             .store
-            .list_descendants(id, ns, None, 10000)
+            .list_descendants(&resolved_id, ns, None, 10000)
             .unwrap_or_default();
-
-        // Get the main document ID too.
-        let main_id = match self.store.get_document(id)? {
-            Some(d) => d.id,
-            None => self
-                .store
-                .get_document_by_slug(id, ns)?
-                .map(|d| d.id)
-                .unwrap_or_default(),
-        };
 
         let all_ids: Vec<String> = subtree
             .iter()
             .map(|d| d.id.clone())
-            .chain(std::iter::once(main_id.clone()))
+            .chain(std::iter::once(resolved_id.clone()))
             .collect();
 
         // Get chunk IDs to remove from usearch.
@@ -1036,7 +1039,7 @@ impl Uteke {
             .delete_chunks_for_documents(&all_ids)
             .unwrap_or_default();
 
-        let (deleted, subtree_size) = self.store.delete_document(id)?;
+        let (deleted, subtree_size) = self.store.delete_document(&resolved_id)?;
 
         // Remove chunk entries from usearch index.
         if !chunk_ids.is_empty() {

--- a/crates/uteke-core/src/memory/fts5.rs
+++ b/crates/uteke-core/src/memory/fts5.rs
@@ -379,8 +379,7 @@ mod tests {
     #[test]
     fn test_fts5_exists() {
         let store = Store::open(":memory:").unwrap();
-        assert!(!store.fts5_exists().unwrap());
-        store.init_fts5().unwrap();
+        // FTS5 is now auto-initialized on open (#544).
         assert!(store.fts5_exists().unwrap());
     }
 }

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -699,6 +699,9 @@ impl super::Store {
             heading: &'static str,
             icon: &'static str,
         }
+        // Known type sections — memories matching these keys get their own
+        // dedicated section (#547: previously only 5 types were mapped,
+        // causing note/insight/reference/event memories to vanish silently).
         let type_sections = [
             TypeSection {
                 key: "decision",
@@ -725,7 +728,26 @@ impl super::Store {
                 heading: "Context & Discussion",
                 icon: "💬",
             },
+            TypeSection {
+                key: "insight",
+                heading: "Insights",
+                icon: "💡",
+            },
+            TypeSection {
+                key: "reference",
+                heading: "References",
+                icon: "📎",
+            },
+            TypeSection {
+                key: "event",
+                heading: "Events",
+                icon: "📅",
+            },
         ];
+
+        // Collect which memory IDs have been assigned to a typed section,
+        // so we can put the remainder into a catch-all "Notes" section (#547).
+        let mut assigned: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for ts in &type_sections {
             let mut matching: Vec<&crate::memory::types::Memory> = memories
@@ -734,6 +756,9 @@ impl super::Store {
                 .collect();
             if matching.is_empty() {
                 continue;
+            }
+            for m in &matching {
+                assigned.insert(m.id.clone());
             }
             // Sort by importance desc, fallback recency
             matching.sort_by(|a, b| {
@@ -754,6 +779,29 @@ impl super::Store {
             sections.push(DocumentSection {
                 heading: ts.heading.to_string(),
                 icon: ts.icon.to_string(),
+                entries,
+            });
+        }
+
+        // Catch-all: any memory not yet assigned (e.g. "note" type, the
+        // default fallback from MemoryType::infer_from_content) lands here.
+        let unassigned: Vec<&crate::memory::types::Memory> = memories
+            .iter()
+            .filter(|m| !m.pinned && !assigned.contains(&m.id))
+            .collect();
+        if !unassigned.is_empty() {
+            let entries: Vec<DocumentEntry> = unassigned
+                .into_iter()
+                .map(|m| DocumentEntry {
+                    content: m.content.clone(),
+                    author: author_map.get(&m.id).cloned().unwrap_or_default(),
+                    tags: m.tags.clone(),
+                    created_at: fmt_time(&m.created_at.to_rfc3339()),
+                })
+                .collect();
+            sections.push(DocumentSection {
+                heading: "Notes & General".to_string(),
+                icon: "📝".to_string(),
                 entries,
             });
         }

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -138,18 +138,19 @@ impl super::Store {
             .map_err(|e| Error::db("get room", e))
     }
 
-    /// List rooms that a namespace has participated in.
+    /// List rooms, optionally filtered by namespace.
     pub fn list_rooms(&self, namespace: Option<&str>) -> Result<Vec<Room>, Error> {
         // Rooms are cross-namespace collaboration spaces (#392).
         // By default, list ALL rooms across all namespaces.
-        // When a namespace is provided, filter to that namespace only.
+        // When a namespace is provided, filter to rooms whose namespace
+        // column matches. No JOIN needed — the namespace column lives
+        // on the rooms table itself (#545).
         let sql = match namespace {
             Some(_) => {
-                "SELECT DISTINCT r.id, r.title, r.namespace, r.created_at, r.updated_at \
-                 FROM rooms r \
-                 INNER JOIN room_memories rm ON r.id = rm.room_id \
-                 WHERE r.namespace = ?1 \
-                 ORDER BY r.updated_at DESC"
+                "SELECT id, title, namespace, created_at, updated_at \
+                 FROM rooms \
+                 WHERE namespace = ?1 \
+                 ORDER BY updated_at DESC"
             }
             None => {
                 "SELECT id, title, namespace, created_at, updated_at FROM rooms \

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -130,6 +130,7 @@ impl super::Store {
         // Post-migration consistency checks: repair partially-migrated databases
         // where a migration stamped the version but failed partway through (#500).
         self.ensure_documents_has_children()?;
+        self.ensure_documents_fts()?;
 
         Ok(())
     }
@@ -157,6 +158,61 @@ impl super::Store {
                 )
                 .map_err(|e| Error::db("repair has_children column (#500)", e))?;
         }
+        Ok(())
+    }
+
+    /// Ensure the `documents_fts` FTS5 virtual table exists and is populated (#549).
+    ///
+    /// Schema v12 migration creates this table with best-effort (`let _ = execute(...)`)
+    /// which means a silent failure leaves the table absent. Existing documents are never
+    /// backfilled. This check runs after every `ensure_schema_version()` call so the
+    /// table is created and populated on next access.
+    fn ensure_documents_fts(&self) -> Result<(), Error> {
+        // Only relevant for schema v12+ databases.
+        let version = self.schema_version().unwrap_or(0);
+        if version < 12 {
+            return Ok(());
+        }
+
+        // Check if the FTS table already exists.
+        let exists: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='documents_fts')",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("check documents_fts exists (#549)", e))?;
+
+        if !exists {
+            tracing::warn!(
+                "documents_fts table missing on schema v{} DB — creating (#549)",
+                version
+            );
+            // Create FTS5 table.
+            self.conn
+                .execute_batch(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content='documents', content_rowid='rowid')",
+                )
+                .map_err(|e| Error::db("create documents_fts (#549)", e))?;
+
+            // Create sync triggers.
+            self.conn.execute_batch(
+                "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN                  INSERT INTO documents_fts(rowid, title, slug) VALUES (new.rowid, new.title, new.slug); END;                  CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN                  UPDATE documents_fts SET title = new.title, slug = new.slug WHERE rowid = new.rowid; END;                  CREATE TRIGGER IF NOT EXISTS documents_fts_delete AFTER DELETE ON documents BEGIN                  DELETE FROM documents_fts WHERE rowid = old.rowid; END;",
+            ).map_err(|e| Error::db("create documents_fts triggers (#549)", e))?;
+
+            // Backfill existing documents into FTS index.
+            self.conn
+                .execute_batch(
+                    "INSERT INTO documents_fts(rowid, title, slug)                      SELECT rowid, title, slug FROM documents",
+                )
+                .map_err(|e| Error::db("backfill documents_fts (#549)", e))?;
+
+            tracing::info!(
+                "documents_fts table created and backfilled from existing documents (#549)"
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -132,6 +132,29 @@ impl super::Store {
         self.ensure_documents_has_children()?;
         self.ensure_documents_fts()?;
 
+        // Ensure FTS5 virtual table and sync triggers exist (#544).
+        //
+        // Fresh databases skip all migrations (version is stamped directly at
+        // CURRENT_SCHEMA_VERSION), so migrate_v1_to_v2() — which calls init_fts5()
+        // — never runs. Existing databases at the correct version also skip
+        // migrations. In both cases FTS5 may be missing even though memories
+        // exist, causing FTS5 recall to return empty results.
+        //
+        // init_fts5() is idempotent (CREATE IF NOT EXISTS / TRIGGER IF NOT EXISTS),
+        // so it's safe to call on every open.
+        if !self.fts5_exists()? {
+            tracing::info!("FTS5 virtual table missing — initializing (#544)");
+            self.init_fts5()?;
+            let count: i64 = self
+                .conn
+                .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
+                .unwrap_or(0);
+            if count > 0 {
+                tracing::info!("Rebuilding FTS5 index for {count} existing memories");
+                self.rebuild_fts5()?;
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -1,7 +1,15 @@
 //! Persistent vector index using usearch (HNSW with disk persistence).
+//!
+//! Cross-process safety (#543): Each VectorIndex acquires an exclusive file
+//! lock (via fs2) on the .usearch file during construction. The lock is held
+//! until the VectorIndex is dropped, serializing concurrent CLI invocations
+//! that share the same on-disk index. In-process thread safety uses
+//! RwLock<VectorIndex> in lib.rs.
 
 use crate::Error;
+use fs2::FileExt;
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
@@ -14,6 +22,11 @@ const DEFAULT_DIMS: usize = 768;
 /// - **Insert**: incremental, no rebuild
 /// - **Delete**: incremental, no rebuild
 /// - **Save**: persists to disk after mutations
+///
+/// **Cross-process safety (#543):** An exclusive file lock on the `.usearch`
+/// file serializes concurrent access from separate CLI processes. The lock is
+/// held for the lifetime of the VectorIndex. In-process thread safety uses
+/// `RwLock` in `Uteke`.
 pub struct VectorIndex {
     index: Index,
     /// Maps integer key (u64) → memory UUID string.
@@ -26,6 +39,9 @@ pub struct VectorIndex {
     path: Option<PathBuf>,
     /// Whether the index has unsaved changes.
     dirty: bool,
+    /// Cross-process file lock on the .usearch file (#543).
+    /// Held until the VectorIndex is dropped.
+    _lock_file: Option<File>,
 }
 
 impl VectorIndex {
@@ -39,19 +55,33 @@ impl VectorIndex {
             next_key: 0,
             path: None,
             dirty: false,
+            _lock_file: None,
         })
     }
 
     /// Load index from disk, or create empty if file doesn't exist.
     /// `path` is the path to the `.usearch` file.
+    ///
+    /// Acquires an **exclusive file lock** on the `.usearch` file to prevent
+    /// cross-process race conditions (e.g., `xargs -P5 uteke remember`).
+    /// The lock is held until this `VectorIndex` is dropped (#543).
     pub fn load_or_create(path: &Path, dims: usize) -> Result<Self, Error> {
-        if path.exists() {
-            Self::load(path)
-        } else {
-            let mut idx = Self::new(dims)?;
-            idx.path = Some(path.to_path_buf());
-            Ok(idx)
+        // Ensure the file exists so we can open + lock it.
+        if !path.exists() {
+            // Create a zero-byte placeholder; usearch will overwrite on save.
+            std::fs::write(path, []).map_err(|e| Error::embed("create usearch file", e))?;
         }
+
+        let lock_file = acquire_file_lock(path)?;
+
+        let mut idx = if path.metadata().map_or(true, |m| m.len() == 0) {
+            Self::new(dims)?
+        } else {
+            Self::load(path)?
+        };
+        idx.path = Some(path.to_path_buf());
+        idx._lock_file = Some(lock_file);
+        Ok(idx)
     }
 
     /// Load an existing index from disk.
@@ -92,6 +122,7 @@ impl VectorIndex {
             next_key,
             path: Some(path.to_path_buf()),
             dirty: false,
+            _lock_file: None, // Set by caller (load_or_create)
         })
     }
 
@@ -280,6 +311,32 @@ pub fn cosine_distance_to_similarity(distance: f32) -> f32 {
     // usearch cosine distance = 1 - cosine_similarity
     let sim = 1.0 - distance;
     sim.clamp(0.0, 1.0)
+}
+
+/// Acquire an exclusive file lock on the usearch index file (#543).
+///
+/// Blocks until the lock is available. This serializes concurrent access from
+/// separate CLI processes (e.g., `xargs -P5 uteke remember`).
+fn acquire_file_lock(path: &Path) -> Result<File, Error> {
+    let file = File::options()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| Error::embed_msg(format!("Failed to open usearch file for locking: {e}")))?;
+
+    if file.try_lock_exclusive().is_ok() {
+        tracing::debug!("usearch file lock acquired: {}", path.display());
+    } else {
+        tracing::debug!("usearch file lock busy on {}, waiting...", path.display());
+        file.lock_exclusive()
+            .map_err(|e| Error::embed("acquire exclusive file lock on usearch", e))?;
+        tracing::debug!(
+            "usearch file lock acquired (after wait): {}",
+            path.display()
+        );
+    }
+
+    Ok(file)
 }
 
 /// Atomic file write: write to temp file then rename.

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -89,11 +89,9 @@ impl crate::Uteke {
         }
         let id_set: std::collections::HashSet<String> = room_ids.into_iter().collect();
 
-        // 2. Over-fetch via hybrid recall (no namespace filter — rooms are cross-ns)
-        // Cap at 200 to prevent unbounded searches for large rooms.
+        // 2. Over-fetch via hybrid recall (no namespace filter — rooms are cross-ns).
+        // Cap at 200 to prevent unbounded searches for large rooms (#546).
         let fetch_limit = (limit * 5).min(200).max(limit);
-        // If room has fewer memories than fetch_limit, only fetch that many.
-        let fetch_limit = fetch_limit.min(id_set.len());
         let results = self.recall_hybrid(
             query,
             fetch_limit,

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -125,6 +125,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_doc_search(),
                 tool_doc_delete(),
                 tool_graph(),
+                tool_graph_add_edge(),
+                tool_graph_remove_edge(),
                 tool_room_recall(),
             ]
         })),
@@ -152,6 +154,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_doc_search" => exec_doc_search(uteke, &arguments)?,
                 "uteke_doc_delete" => exec_doc_delete(uteke, &arguments)?,
                 "uteke_graph" => exec_graph(uteke, &arguments)?,
+                "uteke_graph_add_edge" => exec_graph_add_edge(uteke, &arguments)?,
+                "uteke_graph_remove_edge" => exec_graph_remove_edge(uteke, &arguments)?,
                 "uteke_room_recall" => exec_room_recall(uteke, &arguments)?,
                 _ => return Err(format!("Unknown tool: {tool_name}")),
             };
@@ -397,6 +401,38 @@ fn tool_room_recall() -> Value {
                 "limit": { "type": "integer", "description": "Max results (default 5)", "default": 5 }
             },
             "required": ["room_id", "query"]
+        }
+    })
+}
+
+fn tool_graph_add_edge() -> Value {
+    serde_json::json!({
+        "name": "uteke_graph_add_edge",
+        "description": "Add an edge between two memories in the knowledge graph. Both memories must exist. Self-loops are rejected.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source": { "type": "string", "description": "Source memory ID" },
+                "target": { "type": "string", "description": "Target memory ID" },
+                "edge_type": { "type": "string", "description": "Edge relation type (default: 'related')" },
+                "weight": { "type": "number", "description": "Edge weight (default: 1.0)" }
+            },
+            "required": ["source", "target"]
+        }
+    })
+}
+
+fn tool_graph_remove_edge() -> Value {
+    serde_json::json!({
+        "name": "uteke_graph_remove_edge",
+        "description": "Remove an edge between two memories in the knowledge graph.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source": { "type": "string", "description": "Source memory ID" },
+                "target": { "type": "string", "description": "Target memory ID" }
+            },
+            "required": ["source", "target"]
         }
     })
 }
@@ -787,6 +823,93 @@ fn exec_graph(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         }],
         is_error: false,
     })
+}
+
+fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let source = args["source"].as_str().ok_or("Missing 'source'")?;
+    let target = args["target"].as_str().ok_or("Missing 'target'")?;
+    let edge_type = args["edge_type"].as_str().unwrap_or("related");
+    let weight = args["weight"].as_f64().unwrap_or(1.0);
+
+    if source == target {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "Error: self-loop edges are not allowed (source == target)".to_string(),
+            }],
+            is_error: true,
+        });
+    }
+
+    // Validate both memories exist
+    match uteke.get_by_id(source) {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Ok(ToolResult {
+                content: vec![McpContent::Text {
+                    r#type: "text".to_string(),
+                    text: format!("Error: source memory not found: {source}"),
+                }],
+                is_error: true,
+            });
+        }
+        Err(e) => return Err(format!("Failed: {e}")),
+    }
+    match uteke.get_by_id(target) {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Ok(ToolResult {
+                content: vec![McpContent::Text {
+                    r#type: "text".to_string(),
+                    text: format!("Error: target memory not found: {target}"),
+                }],
+                is_error: true,
+            });
+        }
+        Err(e) => return Err(format!("Failed: {e}")),
+    }
+
+    let conn = uteke.graph_store();
+    let gs = uteke_core::graph::GraphStore::new(conn);
+    gs.add_edge(source, target, edge_type, weight)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("✓ Added edge: {source} -[{edge_type}]-> {target}"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_graph_remove_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let source = args["source"].as_str().ok_or("Missing 'source'")?;
+    let target = args["target"].as_str().ok_or("Missing 'target'")?;
+
+    let conn = uteke.graph_store();
+    let gs = uteke_core::graph::GraphStore::new(conn);
+    let removed = gs
+        .remove_edge(source, target)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if removed {
+        Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: format!("✓ Removed edge: {source} -> {target}"),
+            }],
+            is_error: false,
+        })
+    } else {
+        Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: format!("Edge not found: {source} -> {target}"),
+            }],
+            is_error: true,
+        })
+    }
 }
 
 fn exec_context(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -666,13 +666,14 @@ fn exec_doc_create(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let content = args["content"].as_str().ok_or("Missing 'content'")?;
     let title = args["title"].as_str().unwrap_or("");
     let namespace = args["namespace"].as_str();
+    let parent = args["parent"].as_str();
     let tags: Vec<&str> = args["tags"]
         .as_array()
         .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
 
     let id = uteke
-        .doc_upsert(slug, title, content, &tags, namespace)
+        .doc_upsert_with_parent(slug, title, content, &tags, namespace, parent)
         .map_err(|e| format!("Failed: {e}"))?;
 
     Ok(ToolResult {

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -545,6 +545,95 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // ── Graph Mutation: Add Edge (#542) ──────────────────────────────
+        (Method::Post, "/graph/edge") => match read_body::<GraphEdgeRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                // Reject self-loops
+                if req_data.source == req_data.target {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Self-loop edges are not allowed (source == target)",
+                    );
+                }
+
+                // Validate both nodes exist as memories (issue #542 acceptance criteria)
+                match uteke.get_by_id(&req_data.source) {
+                    Ok(Some(_)) => {}
+                    Ok(None) => {
+                        return ctx.error_response_for(
+                            req,
+                            404,
+                            format!("Source memory not found: {}", req_data.source),
+                        );
+                    }
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        return ctx.error_response_for(req, 500, "Internal server error");
+                    }
+                }
+                match uteke.get_by_id(&req_data.target) {
+                    Ok(Some(_)) => {}
+                    Ok(None) => {
+                        return ctx.error_response_for(
+                            req,
+                            404,
+                            format!("Target memory not found: {}", req_data.target),
+                        );
+                    }
+                    Err(e) => {
+                        error!("Internal error: {e}");
+                        return ctx.error_response_for(req, 500, "Internal server error");
+                    }
+                }
+
+                let conn = uteke.graph_store();
+                let gs = uteke_core::graph::GraphStore::new(conn);
+                let relation = req_data.edge_type.as_deref().unwrap_or("related");
+                let weight = req_data.weight.unwrap_or(1.0);
+
+                match gs.add_edge(&req_data.source, &req_data.target, relation, weight) {
+                    Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"ok": true})),
+                    Err(e) => {
+                        error!("Graph add_edge error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Graph Mutation: Remove Edge (#542) ────────────────────────────
+        (Method::Delete, p) if p == "/graph/edge" || p.starts_with("/graph/edge?") => {
+            let query = p.split('?').nth(1).unwrap_or("");
+            let source = parse_query_param(query, "source");
+            let target = parse_query_param(query, "target");
+
+            match (&source, &target) {
+                (Some(src), Some(tgt)) => {
+                    let conn = uteke.graph_store();
+                    let gs = uteke_core::graph::GraphStore::new(conn);
+                    match gs.remove_edge(src, tgt) {
+                        Ok(true) => ctx.ok_response_for(req, &serde_json::json!({"ok": true})),
+                        Ok(false) => ctx.error_response_for(
+                            req,
+                            404,
+                            format!("Edge not found: {src} -> {tgt}"),
+                        ),
+                        Err(e) => {
+                            error!("Graph remove_edge error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                }
+                _ => ctx.error_response_for(
+                    req,
+                    400,
+                    "Provide both ?source=...&target=... query parameters",
+                ),
+            }
+        }
+
         // ── Room Summary ────────────────────────────────────────────────
         (Method::Post, "/room/summary") => {
             #[derive(Deserialize)]

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -283,3 +283,15 @@ pub const STRICT_THRESHOLD: f32 = 0.5;
 /// Default minimum score for server recall.
 /// Used as fallback when [recall] min_score is not configured.
 pub const DEFAULT_MIN_SCORE: f32 = 0.0;
+
+// ── Graph Types ────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct GraphEdgeRequest {
+    pub source: String,
+    pub target: String,
+    #[serde(default)]
+    pub edge_type: Option<String>,
+    #[serde(default)]
+    pub weight: Option<f64>,
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
           { text: 'Relationship Graph', link: '/getting-started#relationship-graph' },
           { text: 'Benchmarks', link: '/getting-started#benchmarking' },
           { text: 'MCP Server', link: '/mcp' },
+          { text: 'Document Commands', link: '/cli-reference#document-commands' },
+          { text: 'Graph API', link: '/cli-reference#graph-api-408-542' },
         ],
       },
       {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.6.4**.
+Complete reference for all uteke commands. Version **0.6.5**.
 
 ## Global Flags
 
@@ -701,6 +701,10 @@ When `[server] enabled = true` is set in config, the CLI auto-routes commands th
 | POST | `/doc/search` | Hybrid/semantic/FTS document search (#440) |
 | POST | `/doc/move` | Move document to new parent (#438) |
 | DELETE | `/doc/delete?id=` | Delete document with cascade |
+| GET | `/recent` | Recent memories (supports `?namespace=`, `?limit=`, `?offset=`) (#528) |
+| GET | `/graph` | Graph visualization — nodes, edges, stats (#408) |
+| POST | `/graph/edge` | Create a typed edge between two memories (#542) |
+| DELETE | `/graph/edge` | Remove an edge by ID (#542) |
 | POST | `/mcp` | MCP JSON-RPC endpoint (#381) |
 
 ### MCP Server
@@ -817,15 +821,27 @@ uteke doc export           # markdown to stdout
 uteke doc export --json    # JSON to stdout
 ```
 
-## Graph API (#408)
+## Graph API (#408, #542)
 
-The server exposes a graph visualization endpoint:
+### Visualization
 
 ```bash
 # All nodes + edges + stats
 curl http://127.0.0.1:8767/graph
 
 # Response: { nodes: [...], edges: [...], stats: {...} }
+```
+
+### Mutation
+
+```bash
+# Create a typed edge
+curl -X POST http://127.0.0.1:8767/graph/edge \
+  -H "Content-Type: application/json" \
+  -d '{"from": "<uuid>", "to": "<uuid>", "edge_type": "references"}'
+
+# Delete an edge by ID
+curl -X DELETE "http://127.0.0.1:8767/graph/edge?id=<edge-uuid>"
 ```
 
 ## Server Authentication (#409)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,7 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.6.3` | Specific version |
+| `v0.6.5` | Specific version |
 | `0.6` | Minor version (latest patch) |
 
 ## CLI in Docker


### PR DESCRIPTION
## Release v0.6.5 — develop → main

Sync all changes from develop to main for v0.6.5 release.

After merge: tag `v0.6.5` on main to trigger release workflow (Docker + GitHub Release).

### Changes included (v0.6.4 → v0.6.5)
See CHANGELOG `[Unreleased]` section for full details.

**Summary:**
- 1 new feature (graph mutation endpoints)
- 8 bug fixes (#543–#550)
- 3 documentation improvements