### PR TITLE
fix(rooms): use char-based truncation to prevent panic on multi-byte Unicode (#564)

### DIFF
--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -475,11 +475,13 @@ impl super::Store {
                     .iter()
                     .take(3)
                     .map(|m| {
-                        let s = m.content.clone();
-                        if s.len() > 100 {
-                            format!("{}...", &s[..97])
+                        let content = m.content.clone();
+                        // Use char count, not byte index, to avoid panic on multi-byte Unicode
+                        if content.chars().count() > 100 {
+                            let truncated: String = content.chars().take(97).collect();
+                            format!("{}...", truncated)
                         } else {
-                            s
+                            content
                         }
                     })
                     .collect();
@@ -584,11 +586,13 @@ impl super::Store {
             .iter()
             .take(5)
             .map(|m| {
-                let s = m.content.clone();
-                if s.len() > 120 {
-                    format!("{}...", &s[..117])
+                let content = m.content.clone();
+                // Use char count, not byte index, to avoid panic on multi-byte Unicode
+                if content.chars().count() > 120 {
+                    let truncated: String = content.chars().take(117).collect();
+                    format!("{}...", truncated)
                 } else {
-                    s
+                    content
                 }
             })
             .collect();
@@ -599,11 +603,13 @@ impl super::Store {
             .filter(|m| m.pinned)
             .take(5)
             .map(|m| {
-                let s = m.content.clone();
-                if s.len() > 120 {
-                    format!("{}...", &s[..117])
+                let content = m.content.clone();
+                // Use char count, not byte index, to avoid panic on multi-byte Unicode
+                if content.chars().count() > 120 {
+                    let truncated: String = content.chars().take(117).collect();
+                    format!("{}...", truncated)
                 } else {
-                    s
+                    content
                 }
             })
             .collect();


### PR DESCRIPTION
## Summary

Fixes #564 — `uteke room summary` panics on multi-byte Unicode characters.

## Root Cause

`room_summary()` used byte-index slicing (`&s[..97]`, `&s[..117]`) to truncate memory content. Rust strings are UTF-8, so multi-byte chars (≤, ≥, etc.) take 2-3 bytes. Slicing at a fixed byte index can land mid-character, causing `index out of bounds` panic at `rooms.rs:479:48`.

## Fix

- Replace `s.len()` → `s.chars().count()` for length checks
- Replace `&s[..N]` → `s.chars().take(N).collect()` for safe truncation
- Fixed 3 occurrences: `top_memories`, `recent_decisions`, `pinned` highlights

## Verification

- `cargo check -p uteke-core` ✅
- `cargo fmt --all -- --check` ✅  
- `cargo clippy -p uteke-core --all-targets -- -D warnings` ✅
- No remaining byte-index slicing patterns in rooms.rs