### PR TITLE
fix: add GET /room/memories endpoint + tighten POST /room/recall

### DIFF
--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -128,6 +128,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_graph_add_edge(),
                 tool_graph_remove_edge(),
                 tool_room_recall(),
+                tool_room_memories(),
             ]
         })),
 
@@ -157,6 +158,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_graph_add_edge" => exec_graph_add_edge(uteke, &arguments)?,
                 "uteke_graph_remove_edge" => exec_graph_remove_edge(uteke, &arguments)?,
                 "uteke_room_recall" => exec_room_recall(uteke, &arguments)?,
+                "uteke_room_memories" => exec_room_memories(uteke, &arguments)?,
                 _ => return Err(format!("Unknown tool: {tool_name}")),
             };
 
@@ -401,6 +403,22 @@ fn tool_room_recall() -> Value {
                 "limit": { "type": "integer", "description": "Max results (default 5)", "default": 5 }
             },
             "required": ["room_id", "query"]
+        }
+    })
+}
+
+fn tool_room_memories() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_memories",
+        "description": "List all memories in a room chronologically (by joined_at). Cross-namespace: returns memories from all namespaces. Use this for full timeline listing without semantic ranking.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "author": { "type": "string", "description": "Optional author filter" },
+                "limit": { "type": "integer", "description": "Max results (default 100)", "default": 100 }
+            },
+            "required": ["room_id"]
         }
     })
 }
@@ -1005,6 +1023,41 @@ fn exec_room_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         .map(|sr| format!("[{:.2}] {}", sr.score, sr.memory.content))
         .collect();
 
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: lines.join("\n"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_memories(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let author = args["author"].as_str();
+    let limit = args["limit"].as_u64().unwrap_or(100) as usize;
+
+    let memories = uteke
+        .recall_room(room_id, author, limit)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if memories.is_empty() {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "No memories found in room.".to_string(),
+            }],
+            is_error: false,
+        });
+    }
+
+    let lines: Vec<String> = memories
+        .iter()
+        .map(|m| {
+            let created = m.created_at.format("%Y-%m-%d %H:%M");
+            format!("[{created} | {}] {}", m.namespace, m.content)
+        })
+        .collect();
     Ok(ToolResult {
         content: vec![McpContent::Text {
             r#type: "text".to_string(),

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -697,9 +697,44 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
-        // ── Room Recall (semantic) ────────────────────────────────────────
+        // ── Room Memories (chronological listing — GET /room/memories) ────
+        (Method::Get, p) if p == "/room/memories" || p.starts_with("/room/memories?") => {
+            let query_str = p.strip_prefix("/room/memories?");
+            let room_id = query_str.and_then(|q| parse_query_param(q, "room_id"));
+            let room_id = match room_id {
+                Some(id) => id,
+                None => {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Missing required parameter: room_id. Usage: GET /room/memories?room_id=<id>[&author=<author>&limit=<n>]",
+                    );
+                }
+            };
+            let limit = query_str
+                .and_then(|q| parse_query_param(q, "limit"))
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(100);
+            let author = query_str.and_then(|q| parse_query_param(q, "author"));
+            match uteke.recall_room(&room_id, author.as_deref(), limit) {
+                Ok(memories) => ctx.ok_response_for(req, &memories),
+                Err(e) => {
+                    error!("Internal error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
+            }
+        }
+
+        // ── Room Recall (semantic — requires non-empty query) ─────────────
         (Method::Post, "/room/recall") => match read_body::<RoomRecallRequest>(req.as_reader()) {
             Ok(req_data) => {
+                if req_data.query.trim().is_empty() {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Empty query is not allowed. Use GET /room/memories for chronological listing.",
+                    );
+                }
                 let min_score = req_data.min_score.unwrap_or(
                     ctx.recall_config
                         .as_ref()

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -127,6 +127,7 @@ fn main() {
                 println!("  GET  /namespaces           → {{ namespaces }}");
                 println!("  POST /room/create          → {{ room_id, title, namespace }} → {{ created }}");
                 println!("  GET  /room/list            → [?namespace=] → [rooms]");
+                println!("  GET  /room/memories       → ?room_id=<id>[&author=&limit=] → chronological memories");
                 println!("  POST /room/recall          → {{ room_id, query }} → ranked memories");
                 println!("  POST /room/summary         → {{ room_id }} → {{ summary }}");
                 println!("  POST /room/document        → {{ room_id }} → {{ document }}");


### PR DESCRIPTION
Closes #569

## Summary

**Bug:**  had no chronological fallback — sending an empty query returned zero results silently instead of listing all room memories in order.

**Fix (Option B from issue):**

### 1. New endpoint: 
- Chronological listing of all room memories, wrapping existing  core function
- Pure HTTP wiring — zero new core code
- Query params:  (required),  (optional),  (default 100)
- Returns 400 with usage hint if  missing
- Cross-namespace (same as existing room endpoints)

### 2. Tightened 
- Rejects empty/whitespace-only query with HTTP 400
- Error message points to  as the correct endpoint for chronological listing

### 3. New MCP tool: 
- Chronological room memory listing via MCP
- Output format: `[YYYY-MM-DD HH:MM | namespace] content`
- Same params:  (required),  (optional),  (default 100)

## Changes
- `uteke-server/src/handlers.rs` — GET /room/memories route + empty query guard on POST /room/recall
- `uteke-server/src/main.rs` — Help output updated
- `uteke-mcp/src/lib.rs` — uteke_room_memories tool definition + executor

## Test plan
- [ ] `GET /room/memories?room_id=test` returns chronological memories
- [ ] `GET /room/memories` returns 400 with usage message
- [ ] `POST /room/recall { room_id: "x", query: "" }` returns 400
- [ ] `POST /room/recall { room_id: "x", query: "valid query" }` still works
- [ ] MCP `uteke_room_memories` tool lists memories chronologically