### PR TITLE
fix(mcp): JSON-RPC 2.0 spec compliance — omit error field & skip notification acks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "clap",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "dirs",
  "serde",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -8,13 +8,24 @@ use serde_json::Value;
 use uteke_core::Uteke;
 
 // ── JSON-RPC types ──────────────────────────────────────────────────────────
+//
+// Per JSON-RPC 2.0 spec:
+//   - "result" and "error" are mutually exclusive; omit the absent one.
+//   - Notifications (id is None/absent) MUST NOT receive a response.
 
 #[derive(Serialize)]
-pub struct JsonRpcResponse {
-    pub jsonrpc: &'static str,
-    pub id: Value,
-    pub result: Option<Value>,
-    pub error: Option<JsonRpcError>,
+#[serde(untagged)]
+pub enum JsonRpcResponse {
+    Success {
+        jsonrpc: &'static str,
+        id: Value,
+        result: Value,
+    },
+    Error {
+        jsonrpc: &'static str,
+        id: Value,
+        error: JsonRpcError,
+    },
 }
 
 #[derive(Serialize)]
@@ -51,44 +62,61 @@ struct ToolResult {
 /// Handle a single MCP JSON-RPC request (#381).
 ///
 /// This is the shared handler used by both the stdio binary and the
-/// HTTP endpoint. Returns a `JsonRpcResponse` ready for serialization.
-pub fn handle_jsonrpc(uteke: &Uteke, raw: &str) -> String {
+/// HTTP endpoint. Returns `Some(JsonRpcResponse)` for regular requests
+/// and `None` for notifications (which must not receive a response
+/// per JSON-RPC 2.0 §4.1).
+pub fn handle_jsonrpc(uteke: &Uteke, raw: &str) -> Option<String> {
     let req: JsonRpcRequest = match serde_json::from_str(raw) {
         Ok(r) => r,
         Err(e) => {
-            let resp = JsonRpcResponse {
+            let resp = JsonRpcResponse::Error {
                 jsonrpc: "2.0",
                 id: Value::Null,
-                result: None,
-                error: Some(JsonRpcError {
+                error: JsonRpcError {
                     code: -32700,
                     message: format!("Parse error: {e}"),
-                }),
+                },
             };
-            return serde_json::to_string(&resp).unwrap_or_default();
+            return Some(serde_json::to_string(&resp).unwrap_or_default());
         }
     };
 
-    let id = req.id.clone().unwrap_or(Value::Null);
+    let is_notification = req.id.is_none();
+    let id = req.id.unwrap_or(Value::Null);
 
     match handle_request(uteke, &req.method, req.params) {
-        Ok(result) => serde_json::to_string(&JsonRpcResponse {
-            jsonrpc: "2.0",
-            id,
-            result: Some(result),
-            error: None,
-        })
-        .unwrap_or_default(),
-        Err(msg) => serde_json::to_string(&JsonRpcResponse {
-            jsonrpc: "2.0",
-            id,
-            result: None,
-            error: Some(JsonRpcError {
-                code: -32603,
-                message: msg,
-            }),
-        })
-        .unwrap_or_default(),
+        Ok(result) => {
+            if is_notification {
+                // Notifications must not receive any response per JSON-RPC 2.0 §4.1.
+                None
+            } else {
+                Some(
+                    serde_json::to_string(&JsonRpcResponse::Success {
+                        jsonrpc: "2.0",
+                        id,
+                        result,
+                    })
+                    .unwrap_or_default(),
+                )
+            }
+        }
+        Err(msg) => {
+            if is_notification {
+                None
+            } else {
+                Some(
+                    serde_json::to_string(&JsonRpcResponse::Error {
+                        jsonrpc: "2.0",
+                        id,
+                        error: JsonRpcError {
+                            code: -32603,
+                            message: msg,
+                        },
+                    })
+                    .unwrap_or_default(),
+                )
+            }
+        }
     }
 }
 

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -55,8 +55,10 @@ fn main() {
         }
 
         // Delegate to the shared handler (#381).
-        let response = uteke_mcp::handle_jsonrpc(&uteke, &line);
-        let _ = writeln!(stdout, "{response}");
-        let _ = stdout.flush();
+        // None = notification (no response per JSON-RPC 2.0 §4.1).
+        if let Some(response) = uteke_mcp::handle_jsonrpc(&uteke, &line) {
+            let _ = writeln!(stdout, "{response}");
+            let _ = stdout.flush();
+        }
     }
 }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -916,16 +916,33 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             if let Err(e) = req.as_reader().take(MAX_MCP_BODY).read_to_string(&mut body) {
                 return ctx.error_response_for(req, 400, format!("Failed to read body: {e}"));
             }
-            let response = uteke_mcp::handle_jsonrpc(&uteke, &body);
-            tiny_http::Response::from_string(response)
-                .with_header(
-                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+            // None = notification (no response per JSON-RPC 2.0 §4.1) → 204 No Content
+            match uteke_mcp::handle_jsonrpc(&uteke, &body) {
+                Some(response) => tiny_http::Response::from_string(response)
+                    .with_header(
+                        tiny_http::Header::from_bytes(
+                            &b"Content-Type"[..],
+                            &b"application/json"[..],
+                        )
                         .unwrap(),
-                )
-                .with_header(
-                    tiny_http::Header::from_bytes(&b"MCP-Protocol-Version"[..], &b"2025-06-18"[..])
+                    )
+                    .with_header(
+                        tiny_http::Header::from_bytes(
+                            &b"MCP-Protocol-Version"[..],
+                            &b"2025-06-18"[..],
+                        )
                         .unwrap(),
-                )
+                    ),
+                None => tiny_http::Response::from_string("")
+                    .with_status_code(204)
+                    .with_header(
+                        tiny_http::Header::from_bytes(
+                            &b"MCP-Protocol-Version"[..],
+                            &b"2025-06-18"[..],
+                        )
+                        .unwrap(),
+                    ),
+            }
         }
 
         // ── Document: Create / Upsert ────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #573 — `uteke-mcp` emits non-spec-compliant JSON-RPC, causing Claude Code to refuse connection.

### Changes

| File | What |
|------|------|
| `crates/uteke-mcp/src/lib.rs` | Changed `JsonRpcResponse` from flat struct with `Option` fields to **tagged enum** (Success/Error). `handle_jsonrpc` returns `Option<String>` — `None` for notifications (per §4.1). |
| `crates/uteke-mcp/src/main.rs` | Skips stdout write when handler returns `None` (notification). |
| `crates/uteke-server/src/handlers.rs` | Returns **204 No Content** for notifications on HTTP endpoint. Also fixed pre-existing formatting. |

### What was broken

1. **Success responses** included `"error": null` → violates JSON-RPC 2.0 §5.1 (result/error mutually exclusive)
2. **Notifications** received an ack response `{"id":null,...}` → violates JSON-RPC 2.0 §4.1 (no response to notifications)

### What's fixed

**Before (2.0K output, Claude Code rejects):**
```json
{"jsonrpc":"2.0","id":1,"result":{...},"error":null}
{"jsonrpc":"2.0","id":null,"result":null,"error":null}
```

**After (spec-compliant, Claude Code accepts):**
```json
{"jsonrpc":"2.0","id":1,"result":{...}}
(no second line — notification gets no response)
```

### Test plan

- [x] `cargo fmt --all -- --check` passes locally
- [ ] CI: check, fmt, clippy, test, build (depends on ubuntu-latest OpenSSL)
- [ ] Manual: `printf '...' | uteke-mcp` no longer emits notification acks