### PR TITLE
feat(init): add --memory-provider mode for pi, claude, cursor

### DIFF
--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -431,7 +431,7 @@ After meaningful decisions, discoveries, or progress: call `uteke_remember` with
         println!("  Rules include auto-recall + MCP config snippet.");
         println!();
         println!("  Add MCP server to .cursor/mcp.json:");
-        println!("    {\"mcpServers\":{\"uteke\":{\"command\":\"uteke-mcp\"}}}");
+        println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}");
     }
     Ok(())
 }

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -431,7 +431,7 @@ After meaningful decisions, discoveries, or progress: call `uteke_remember` with
         println!("  Rules include auto-recall + MCP config snippet.");
         println!();
         println!("  Add MCP server to .cursor/mcp.json:");
-        println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}");
+        println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}}");
     }
     Ok(())
 }

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -18,9 +18,27 @@ pub(crate) fn run_init_command(cli: &Cli) -> Result<(), String> {
 /// Dispatch init to the appropriate agent type.
 pub(crate) fn run_init(agent: &str, memory_provider: bool, json: bool) -> Result<(), String> {
     match agent {
-        "pi" => init_pi(json),
-        "claude" => init_claude(json),
-        "cursor" => init_cursor(json),
+        "pi" => {
+            if memory_provider {
+                init_pi_memory_provider(json)
+            } else {
+                init_pi(json)
+            }
+        }
+        "claude" => {
+            if memory_provider {
+                init_claude_memory_provider(json)
+            } else {
+                init_claude(json)
+            }
+        }
+        "cursor" => {
+            if memory_provider {
+                init_cursor_memory_provider(json)
+            } else {
+                init_cursor(json)
+            }
+        }
         "hermes" => {
             if memory_provider {
                 init_hermes_memory_provider(json)
@@ -200,6 +218,224 @@ fn init_cursor(json: bool) -> Result<(), String> {
     Ok(())
 }
 
+/// Initialize uteke memory-provider integration for Pi (#575).
+///
+/// Installs the pi TypeScript extension that hooks `before_agent_start` to
+/// automatically inject relevant memories into every agent turn — mirroring
+/// the Hermes memory-provider experience. No manual `uteke recall` needed.
+///
+/// Extension template lives in `extensions/pi-memory-provider/`.
+fn init_pi_memory_provider(json: bool) -> Result<(), String> {
+    let ext_dir = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|h| {
+            let mut p = std::path::PathBuf::from(h);
+            p.push(".pi");
+            p.push("agent");
+            p.push("extensions");
+            p.push("uteke-memory-provider");
+            p
+        })
+        .or_else(|| {
+            std::env::current_dir().ok().map(|d| {
+                d.join(".pi")
+                    .join("extensions")
+                    .join("uteke-memory-provider")
+            })
+        })
+        .ok_or_else(|| "Cannot determine pi extension install directory".to_string())?;
+
+    let installed_to_home = ext_dir.components().any(|c| c.as_os_str() == ".pi");
+
+    std::fs::create_dir_all(&ext_dir)
+        .map_err(|e| format!("Failed to create extension dir: {e}"))?;
+
+    // Templates embedded from extensions/pi-memory-provider/ at build time.
+    let index_ts = include_str!("../../../extensions/pi-memory-provider/index.ts");
+    let package_json = include_str!("../../../extensions/pi-memory-provider/package.json");
+
+    std::fs::write(ext_dir.join("index.ts"), index_ts)
+        .map_err(|e| format!("Failed to write index.ts: {e}"))?;
+    std::fs::write(ext_dir.join("package.json"), package_json)
+        .map_err(|e| format!("Failed to write package.json: {e}"))?;
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "pi",
+            "plugin": "memory-provider",
+            "directory": ext_dir.to_string_lossy(),
+            "files": ["index.ts", "package.json"],
+            "status": "installed",
+            "auto_registered": installed_to_home
+        });
+        println!("{obj}");
+    } else {
+        println!(
+            "✓ Pi memory-provider extension installed: {}/",
+            ext_dir.display()
+        );
+        if installed_to_home {
+            println!("  Location: ~/.pi/agent/extensions/uteke-memory-provider/");
+        } else {
+            println!("  Location: {}/", ext_dir.display());
+        }
+        println!("  Restart pi to activate — memories are auto-recalled every turn.");
+    }
+    Ok(())
+}
+
+/// Initialize uteke memory-provider integration for Claude Code (#575).
+///
+/// Claude Code has no lifecycle hooks, so the approach is:
+/// 1. Generate an enhanced UTEKE.md with stronger auto-recall rules
+/// 2. Wire the MCP server (uteke-mcp) config snippet for claude_desktop_config.json
+///
+/// The MCP server provides `uteke_recall`/`uteke_remember` as first-class tools,
+/// and the rules instruct Claude to recall at task start.
+fn init_claude_memory_provider(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let md_path = cwd.join("UTEKE.md");
+
+    // Enhanced rules that include MCP wiring instructions
+    let md_content = r#"# Uteke Memory Integration (Auto Mode)
+
+## MCP Server
+Your uteke MCP server provides these tools: `uteke_recall`, `uteke_remember`, `uteke_search`, `uteke_list`, `uteke_forget`, `uteke_stats`, `uteke_context`.
+
+## Auto-Recall Rule
+**At the start of every task**, before asking the user, run:
+```
+uteke_recall(query: "<task summary>", limit: 5)
+```
+Inject any relevant memories into your working context.
+
+## Store Proactively
+After each meaningful decision or discovery:
+```
+uteke_remember(content: "<fact>", tags: ["relevant", "tags"])
+```
+
+## Commands
+- `uteke remember "<text>" --tags <tags>` — Store a memory
+- `uteke recall "<query>" --limit <n>` — Semantic search
+- `uteke search "<keywords>"` — Keyword search
+- `uteke stats` — Statistics
+
+## MCP Config (add to claude_desktop_config.json or .claude.json)
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp",
+      "args": []
+    }
+  }
+}
+```
+"#;
+
+    std::fs::write(&md_path, md_content).map_err(|e| format!("Failed to write UTEKE.md: {e}"))?;
+
+    // Enhance CLAUDE.md with auto-recall reference
+    let claude_md = cwd.join("CLAUDE.md");
+    if claude_md.exists() {
+        let existing = std::fs::read_to_string(&claude_md)
+            .map_err(|e| format!("Failed to read CLAUDE.md: {e}"))?;
+        if !existing.contains("uteke_recall") {
+            let updated = format!(
+                "{existing}\n\n## Uteke Auto-Memory\n\nBefore every task, call `uteke_recall` with the task summary. See UTEKE.md for full integration.\n"
+            );
+            std::fs::write(&claude_md, updated)
+                .map_err(|e| format!("Failed to update CLAUDE.md: {e}"))?;
+        }
+    }
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "claude",
+            "plugin": "memory-provider",
+            "file": md_path.to_string_lossy(),
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!("✓ Claude memory-provider installed: {}", md_path.display());
+        println!("  UTEKE.md includes auto-recall rules + MCP config snippet.");
+        if claude_md.exists() {
+            println!("  Auto-recall reference added to CLAUDE.md");
+        }
+        println!();
+        println!("  Add MCP server to your Claude config:");
+        println!("    claude mcp add uteke -- uteke-mcp");
+    }
+    Ok(())
+}
+
+/// Initialize uteke memory-provider integration for Cursor (#575).
+///
+/// Cursor has no lifecycle hooks. Strategy:
+/// 1. Generate enhanced cursor rules (.cursor/rules/uteke.mdc) with auto-recall rules
+/// 2. Include MCP server config snippet
+fn init_cursor_memory_provider(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let rules_dir = cwd.join(".cursor").join("rules");
+    std::fs::create_dir_all(&rules_dir).map_err(|e| format!("Failed to create rules dir: {e}"))?;
+
+    let rules_content = r#"---
+description: Uteke auto-memory — recall before every task, store after decisions
+globs: 
+alwaysApply: true
+---
+
+# Uteke Memory (Auto Mode)
+
+## MCP Tools Available
+`uteke_recall`, `uteke_remember`, `uteke_search`, `uteke_list`, `uteke_forget`, `uteke_stats`, `uteke_context`
+
+## Auto-Recall Rule
+**Before starting any task**, call `uteke_recall` with the task summary as the query. Use the results to restore context from prior sessions.
+
+## Store Proactively
+After meaningful decisions, discoveries, or progress: call `uteke_remember` with relevant tags.
+
+## MCP Config (add to .cursor/mcp.json)
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp",
+      "args": []
+    }
+  }
+}
+```
+"#;
+
+    let rules_path = rules_dir.join("uteke.mdc");
+    std::fs::write(&rules_path, rules_content)
+        .map_err(|e| format!("Failed to write rules: {e}"))?;
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "cursor",
+            "plugin": "memory-provider",
+            "file": rules_path.to_string_lossy(),
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!(
+            "✓ Cursor memory-provider installed: {}",
+            rules_path.display()
+        );
+        println!("  Rules include auto-recall + MCP config snippet.");
+        println!();
+        println!("  Add MCP server to .cursor/mcp.json:");
+        println!("    {\"mcpServers\":{\"uteke\":{\"command\":\"uteke-mcp\"}}}");
+    }
+    Ok(())
+}
+
 /// Initialize uteke integration for Hermes (#384).
 /// Generates a uteke-tool plugin in the Hermes plugins directory.
 fn init_hermes(json: bool) -> Result<(), String> {
@@ -375,5 +611,32 @@ mod tests {
             PLUGIN_YAML.contains("on_pre_compress"),
             "manifest must declare the on_pre_compress hook"
         );
+    }
+
+    // Pi memory-provider template guards (#575).
+    const PI_INDEX_TS: &str = include_str!("../../../extensions/pi-memory-provider/index.ts");
+    const PI_PACKAGE_JSON: &str =
+        include_str!("../../../extensions/pi-memory-provider/package.json");
+
+    #[test]
+    fn pi_memory_provider_has_before_agent_start_hook() {
+        assert!(
+            PI_INDEX_TS.contains("before_agent_start"),
+            "pi extension must hook before_agent_start for auto-recall"
+        );
+        assert!(
+            PI_INDEX_TS.contains("recallMemories"),
+            "pi extension must have recallMemories function"
+        );
+        assert!(
+            PI_INDEX_TS.contains("uteke recall"),
+            "pi extension must invoke uteke recall CLI"
+        );
+    }
+
+    #[test]
+    fn pi_memory_provider_manifest_valid() {
+        assert!(PI_PACKAGE_JSON.contains("uteke-memory-provider"));
+        assert!(PI_PACKAGE_JSON.contains("Apache-2.0"));
     }
 }

--- a/extensions/pi-memory-provider/index.ts
+++ b/extensions/pi-memory-provider/index.ts
@@ -1,0 +1,186 @@
+/**
+ * Uteke Memory Provider Extension for Pi
+ *
+ * Automatic persistent memory integration — mirrors the Hermes memory-provider
+ * experience. Hooks `before_agent_start` to inject relevant memories into
+ * every agent turn without manual tool calls.
+ *
+ * Install:
+ *   Global:  ~/.pi/agent/extensions/uteke-memory-provider/index.ts
+ *   Project: .pi/extensions/uteke-memory-provider/index.ts
+ *
+ * Requires: `uteke` binary on PATH (same binary as the CLI).
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Config (reads from env, can be extended)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_NAMESPACE = "default";
+const RECALL_LIMIT = 6;
+const RECALL_MIN_SCORE = 0.45;
+const RECALL_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Subprocess helpers
+// ---------------------------------------------------------------------------
+
+function utekeBin(): string {
+	const envBin = process.env.UTEKE_BIN;
+	if (envBin) return envBin;
+	// pi extensions run as Node.js — use which-compatible lookup
+	try {
+		return execSync("which uteke", { encoding: "utf-8", timeout: 3000 }).trim();
+	} catch {
+		return "uteke";
+	}
+}
+
+function runUteke(args: string[], timeout = RECALL_TIMEOUT_MS): string {
+	const bin = utekeBin();
+	const env = { ...process.env };
+	// Allow pointing uteke at a different home directory
+	if (process.env.UTEKE_HOME) {
+		env.HOME = process.env.UTEKE_HOME;
+	}
+	try {
+		return execSync(`${bin} ${args.join(" ")}`, {
+			encoding: "utf-8",
+			timeout,
+			env,
+		});
+	} catch (err: any) {
+		return "";
+	}
+}
+
+function recallMemories(query: string): string[] {
+	const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
+	const limit = process.env.UTEKE_RECALL_LIMIT || String(RECALL_LIMIT);
+	const minScore = process.env.UTEKE_RECALL_MIN_SCORE || String(RECALL_MIN_SCORE);
+
+	const raw = runUteke([
+		"recall", `"${query}"`,
+		"--namespace", ns,
+		"--limit", limit,
+		"--min-score", minScore,
+		"--json",
+	]);
+
+	if (!raw.trim()) return [];
+
+	try {
+		const items = JSON.parse(raw);
+		const results: string[] = [];
+		for (const item of items) {
+			const mem = item.memory || item;
+			const content = mem.content || "";
+			if (content) {
+				results.push(content);
+			}
+		}
+		return results;
+	} catch {
+		return [];
+	}
+}
+
+function formatMemories(memories: string[]): string {
+	if (!memories.length) return "";
+	const lines = memories.map((m, i) => `${i + 1}. ${m}`).join("\n");
+	return (
+		"\n\n## Relevant Memories (uteke)\n\n" +
+		lines +
+		"\n\nUse `uteke remember` to store new facts, `uteke recall` to search more."
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+	let available = false;
+
+	// Check uteke availability on session start
+	pi.on("session_start", async (_event, ctx) => {
+		const out = runUteke(["stats"], 3000);
+		available = out.trim().length > 0;
+
+		if (available) {
+			ctx.ui.setStatus("uteke", "🧠 uteke: active");
+		} else {
+			ctx.ui.setStatus("uteke", "🧠 uteke: not found");
+		}
+	});
+
+	// Core hook: inject relevant memories before every agent turn
+	pi.on("before_agent_start", async (event) => {
+		if (!available) return;
+
+		const prompt = (event.prompt || "").trim();
+		if (!prompt || prompt.length < 3) return;
+
+		const memories = recallMemories(prompt);
+		if (!memories.length) return;
+
+		const injection = formatMemories(memories);
+
+		return {
+			systemPrompt: event.systemPrompt + injection,
+		};
+	});
+
+	// Slash commands for manual control
+	pi.registerCommand("uteke-recall", {
+		description: "Manually recall memories for a topic",
+		handler: async (args, _ctx) => {
+			const query = args.join(" ").trim();
+			if (!query) return "Usage: /uteke-recall <topic>";
+			const memories = recallMemories(query);
+			if (!memories.length) return "No relevant memories found.";
+			return formatMemories(memories);
+		},
+	});
+
+	pi.registerCommand("uteke-save", {
+		description: "Save a memory to uteke",
+		handler: async (args, _ctx) => {
+			const content = args.join(" ").trim();
+			if (!content) return "Usage: /uteke-save <content>";
+			runUteke(["remember", `"${content}"`], RECALL_TIMEOUT_MS);
+			return "✓ Memory saved.";
+		},
+	});
+
+	pi.registerCommand("uteke-stats", {
+		description: "Show uteke memory stats",
+		handler: async (_args, ctx) => {
+			const out = runUteke(["stats"], 5000);
+			available = out.trim().length > 0;
+			ctx.ui.setStatus("uteke", available ? "🧠 uteke: active" : "🧠 uteke: not found");
+			return out.trim() || "uteke: not available";
+		},
+	});
+
+	pi.registerCommand("uteke-on", {
+		description: "Enable automatic memory recall",
+		handler: async () => {
+			available = true;
+			return "✓ Automatic uteke recall enabled.";
+		},
+	});
+
+	pi.registerCommand("uteke-off", {
+		description: "Disable automatic memory recall",
+		handler: async () => {
+			available = false;
+			return "✓ Automatic uteke recall disabled.";
+		},
+	});
+}

--- a/extensions/pi-memory-provider/package.json
+++ b/extensions/pi-memory-provider/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uteke-memory-provider",
+  "version": "0.1.0",
+  "description": "Pi extension — automatic uteke memory recall injected into every turn",
+  "main": "index.ts",
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "keywords": ["pi-extension", "uteke", "memory", "memory-provider"],
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
## Summary

Closes #575 — automatic memory-provider for non-Hermes agents.

### Problem

`uteke init --agent hermes --memory-provider` gives automatic recall injection. But `pi`, `claude`, and `cursor` only install manual instructions — users must remember to call `uteke recall`/ `uteke remember` themselves.

### Changes

| Agent | Mode | What's installed |
|-------|------|-----------------|
| **pi** | `--memory-provider` | TypeScript extension at `~/.pi/agent/extensions/uteke-memory-provider/` — hooks `before_agent_start` to auto-inject relevant memories every turn. Includes slash commands: `/uteke-recall`, `/uteke-save`, `/uteke-stats`, `/uteke-on`, `/uteke-off`. |
| **claude** | `--memory-provider` | Enhanced `UTEKE.md` with auto-recall rules + MCP server config snippet. Updates `CLAUDE.md` with auto-recall reference. |
| **cursor** | `--memory-provider` | Enhanced `.cursor/rules/uteke.mdc` with auto-recall rules + MCP config snippet (alwaysApply: true). |

### New files

```
extensions/pi-memory-provider/
├── index.ts       # Pi TypeScript extension
└── package.json   # Manifest
```

### Modified files

- `crates/uteke-cli/src/init.rs` — updated `run_init()` dispatch + added `init_pi_memory_provider()`, `init_claude_memory_provider()`, `init_cursor_memory_provider()`. Added compile-time template guard tests.

### Usage

```bash
uteke init --agent pi --memory-provider
uteke init --agent claude --memory-provider
uteke init --agent cursor --memory-provider
```

Without `--memory-provider`, behavior is unchanged (manual instructions only).

### Test plan
- [x] `cargo fmt --all -- --check` passes
- [ ] CI: check, fmt, clippy, test, build
- [ ] Template guard tests: pi extension has `before_agent_start` hook