### PR TITLE
chore: release v0.6.7 prep — changelog, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
 
 ## [Unreleased]
 
+## [0.6.7] — 2026-07-06
+
+### Added
+- **Automatic memory-provider for pi, claude, cursor (#575, #577)** — `uteke init --agent <agent> --memory-provider` now mirrors the Hermes auto-recall experience for all agents. Pi gets a TypeScript extension hooking `before_agent_start` with slash commands. Claude and Cursor get enhanced rules with auto-recall instructions and MCP server config snippets.
+- **GET /room/memories endpoint + uteke_room_memories MCP tool (#569)** — Chronological room memory listing with optional author filter.
+
+### Fixed
+- **uteke-mcp JSON-RPC 2.0 spec compliance (#573, #576)** — Success responses no longer include `"error": null` (tagged enum replaces flat struct with Option fields). Notifications (requests with no `id`) no longer receive a response. Fixes Claude Code `✗ Failed to connect`.
+
+### Changed
+- **Slim Docker image** — Removed bundled embedding model (~208MB) from Docker build. Image size reduced from ~218MB to ~10MB. Model downloads lazily on first container start and persists in the named volume.
+
 ## [0.6.6] — 2026-07-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"


### PR DESCRIPTION
## Summary

Release preparation for **v0.6.7**.

### Changes
- Bump version `0.6.6` → `0.6.7` in `Cargo.toml`
- Add CHANGELOG entry for v0.6.7 (Added / Fixed / Changed)

### Contents
| Section | Items |
|---------|-------|
| Added | Automatic memory-provider for pi/claude/cursor (#575, #577), GET /room/memories endpoint (#569) |
| Fixed | uteke-mcp JSON-RPC 2.0 spec compliance (#573, #576) |
| Changed | Slim Docker image (~218MB → ~10MB) |

Merge → develop, then PR develop → main, then tag `v0.6.7`.