### PR TITLE
release: v0.6.7 → main

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Non-critical: project board sync should not block or create noise
+    continue-on-error: true
     steps:
       - name: Sync issue/PR to Project Board
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,20 +275,6 @@ jobs:
           chmod +x ../binaries/*
           ls -lh ../binaries/
 
-      - name: Download embedding model
-        run: |
-          mkdir -p models/onnx
-          curl -fSL --retry 3 --retry-delay 5 \
-            -o models/onnx/model_q4.onnx \
-            "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx"
-          curl -fSL --retry 3 --retry-delay 5 \
-            -o models/onnx/model_q4.onnx_data \
-            "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/onnx/model_q4.onnx_data"
-          curl -fSL --retry 3 --retry-delay 5 \
-            -o models/tokenizer.json \
-            "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX/resolve/main/tokenizer.json"
-          ls -lh models/onnx/ models/tokenizer.json
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
 
 ## [Unreleased]
 
+## [0.6.7] — 2026-07-06
+
+### Added
+- **Automatic memory-provider for pi, claude, cursor (#575, #577)** — `uteke init --agent <agent> --memory-provider` now mirrors the Hermes auto-recall experience for all agents. Pi gets a TypeScript extension hooking `before_agent_start` with slash commands. Claude and Cursor get enhanced rules with auto-recall instructions and MCP server config snippets.
+- **GET /room/memories endpoint + uteke_room_memories MCP tool (#569)** — Chronological room memory listing with optional author filter.
+
+### Fixed
+- **uteke-mcp JSON-RPC 2.0 spec compliance (#573, #576)** — Success responses no longer include `"error": null` (tagged enum replaces flat struct with Option fields). Notifications (requests with no `id`) no longer receive a response. Fixes Claude Code `✗ Failed to connect`.
+
+### Changed
+- **Slim Docker image** — Removed bundled embedding model (~208MB) from Docker build. Image size reduced from ~218MB to ~10MB. Model downloads lazily on first container start and persists in the named volume.
+
 ## [0.6.6] — 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "clap",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "dirs",
  "serde",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,7 @@ COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
 COPY --from=builder /build/uteke-mcp /usr/local/bin/uteke-mcp
 
-# Copy embedding model (pre-baked by CI)
-COPY models/ /data/models/embeddinggemma-q4
-
-# Copy entrypoint script (handles lazy model download)
+# Copy entrypoint script (handles lazy model download on first run)
 COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uteke stats
 > Listens on localhost only by default. See [Docker docs](docs/docker.md) for auth setup.
 
 ```bash
-# One-liner (model pre-baked in image)
+# One-liner (model downloads on first run, cached in volume)
 docker run -d --name uteke -p 127.0.0.1:8767:8767 -v uteke-data:/data \
   ghcr.io/codecoradev/uteke:latest
 

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -431,7 +431,7 @@ After meaningful decisions, discoveries, or progress: call `uteke_remember` with
         println!("  Rules include auto-recall + MCP config snippet.");
         println!();
         println!("  Add MCP server to .cursor/mcp.json:");
-        println!("    {\"mcpServers\":{\"uteke\":{\"command\":\"uteke-mcp\"}}}");
+        println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}");
     }
     Ok(())
 }

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -431,7 +431,7 @@ After meaningful decisions, discoveries, or progress: call `uteke_remember` with
         println!("  Rules include auto-recall + MCP config snippet.");
         println!();
         println!("  Add MCP server to .cursor/mcp.json:");
-        println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}");
+        println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}}");
     }
     Ok(())
 }

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -18,9 +18,27 @@ pub(crate) fn run_init_command(cli: &Cli) -> Result<(), String> {
 /// Dispatch init to the appropriate agent type.
 pub(crate) fn run_init(agent: &str, memory_provider: bool, json: bool) -> Result<(), String> {
     match agent {
-        "pi" => init_pi(json),
-        "claude" => init_claude(json),
-        "cursor" => init_cursor(json),
+        "pi" => {
+            if memory_provider {
+                init_pi_memory_provider(json)
+            } else {
+                init_pi(json)
+            }
+        }
+        "claude" => {
+            if memory_provider {
+                init_claude_memory_provider(json)
+            } else {
+                init_claude(json)
+            }
+        }
+        "cursor" => {
+            if memory_provider {
+                init_cursor_memory_provider(json)
+            } else {
+                init_cursor(json)
+            }
+        }
         "hermes" => {
             if memory_provider {
                 init_hermes_memory_provider(json)
@@ -200,6 +218,224 @@ fn init_cursor(json: bool) -> Result<(), String> {
     Ok(())
 }
 
+/// Initialize uteke memory-provider integration for Pi (#575).
+///
+/// Installs the pi TypeScript extension that hooks `before_agent_start` to
+/// automatically inject relevant memories into every agent turn — mirroring
+/// the Hermes memory-provider experience. No manual `uteke recall` needed.
+///
+/// Extension template lives in `extensions/pi-memory-provider/`.
+fn init_pi_memory_provider(json: bool) -> Result<(), String> {
+    let ext_dir = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|h| {
+            let mut p = std::path::PathBuf::from(h);
+            p.push(".pi");
+            p.push("agent");
+            p.push("extensions");
+            p.push("uteke-memory-provider");
+            p
+        })
+        .or_else(|| {
+            std::env::current_dir().ok().map(|d| {
+                d.join(".pi")
+                    .join("extensions")
+                    .join("uteke-memory-provider")
+            })
+        })
+        .ok_or_else(|| "Cannot determine pi extension install directory".to_string())?;
+
+    let installed_to_home = ext_dir.components().any(|c| c.as_os_str() == ".pi");
+
+    std::fs::create_dir_all(&ext_dir)
+        .map_err(|e| format!("Failed to create extension dir: {e}"))?;
+
+    // Templates embedded from extensions/pi-memory-provider/ at build time.
+    let index_ts = include_str!("../../../extensions/pi-memory-provider/index.ts");
+    let package_json = include_str!("../../../extensions/pi-memory-provider/package.json");
+
+    std::fs::write(ext_dir.join("index.ts"), index_ts)
+        .map_err(|e| format!("Failed to write index.ts: {e}"))?;
+    std::fs::write(ext_dir.join("package.json"), package_json)
+        .map_err(|e| format!("Failed to write package.json: {e}"))?;
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "pi",
+            "plugin": "memory-provider",
+            "directory": ext_dir.to_string_lossy(),
+            "files": ["index.ts", "package.json"],
+            "status": "installed",
+            "auto_registered": installed_to_home
+        });
+        println!("{obj}");
+    } else {
+        println!(
+            "✓ Pi memory-provider extension installed: {}/",
+            ext_dir.display()
+        );
+        if installed_to_home {
+            println!("  Location: ~/.pi/agent/extensions/uteke-memory-provider/");
+        } else {
+            println!("  Location: {}/", ext_dir.display());
+        }
+        println!("  Restart pi to activate — memories are auto-recalled every turn.");
+    }
+    Ok(())
+}
+
+/// Initialize uteke memory-provider integration for Claude Code (#575).
+///
+/// Claude Code has no lifecycle hooks, so the approach is:
+/// 1. Generate an enhanced UTEKE.md with stronger auto-recall rules
+/// 2. Wire the MCP server (uteke-mcp) config snippet for claude_desktop_config.json
+///
+/// The MCP server provides `uteke_recall`/`uteke_remember` as first-class tools,
+/// and the rules instruct Claude to recall at task start.
+fn init_claude_memory_provider(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let md_path = cwd.join("UTEKE.md");
+
+    // Enhanced rules that include MCP wiring instructions
+    let md_content = r#"# Uteke Memory Integration (Auto Mode)
+
+## MCP Server
+Your uteke MCP server provides these tools: `uteke_recall`, `uteke_remember`, `uteke_search`, `uteke_list`, `uteke_forget`, `uteke_stats`, `uteke_context`.
+
+## Auto-Recall Rule
+**At the start of every task**, before asking the user, run:
+```
+uteke_recall(query: "<task summary>", limit: 5)
+```
+Inject any relevant memories into your working context.
+
+## Store Proactively
+After each meaningful decision or discovery:
+```
+uteke_remember(content: "<fact>", tags: ["relevant", "tags"])
+```
+
+## Commands
+- `uteke remember "<text>" --tags <tags>` — Store a memory
+- `uteke recall "<query>" --limit <n>` — Semantic search
+- `uteke search "<keywords>"` — Keyword search
+- `uteke stats` — Statistics
+
+## MCP Config (add to claude_desktop_config.json or .claude.json)
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp",
+      "args": []
+    }
+  }
+}
+```
+"#;
+
+    std::fs::write(&md_path, md_content).map_err(|e| format!("Failed to write UTEKE.md: {e}"))?;
+
+    // Enhance CLAUDE.md with auto-recall reference
+    let claude_md = cwd.join("CLAUDE.md");
+    if claude_md.exists() {
+        let existing = std::fs::read_to_string(&claude_md)
+            .map_err(|e| format!("Failed to read CLAUDE.md: {e}"))?;
+        if !existing.contains("uteke_recall") {
+            let updated = format!(
+                "{existing}\n\n## Uteke Auto-Memory\n\nBefore every task, call `uteke_recall` with the task summary. See UTEKE.md for full integration.\n"
+            );
+            std::fs::write(&claude_md, updated)
+                .map_err(|e| format!("Failed to update CLAUDE.md: {e}"))?;
+        }
+    }
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "claude",
+            "plugin": "memory-provider",
+            "file": md_path.to_string_lossy(),
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!("✓ Claude memory-provider installed: {}", md_path.display());
+        println!("  UTEKE.md includes auto-recall rules + MCP config snippet.");
+        if claude_md.exists() {
+            println!("  Auto-recall reference added to CLAUDE.md");
+        }
+        println!();
+        println!("  Add MCP server to your Claude config:");
+        println!("    claude mcp add uteke -- uteke-mcp");
+    }
+    Ok(())
+}
+
+/// Initialize uteke memory-provider integration for Cursor (#575).
+///
+/// Cursor has no lifecycle hooks. Strategy:
+/// 1. Generate enhanced cursor rules (.cursor/rules/uteke.mdc) with auto-recall rules
+/// 2. Include MCP server config snippet
+fn init_cursor_memory_provider(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let rules_dir = cwd.join(".cursor").join("rules");
+    std::fs::create_dir_all(&rules_dir).map_err(|e| format!("Failed to create rules dir: {e}"))?;
+
+    let rules_content = r#"---
+description: Uteke auto-memory — recall before every task, store after decisions
+globs: 
+alwaysApply: true
+---
+
+# Uteke Memory (Auto Mode)
+
+## MCP Tools Available
+`uteke_recall`, `uteke_remember`, `uteke_search`, `uteke_list`, `uteke_forget`, `uteke_stats`, `uteke_context`
+
+## Auto-Recall Rule
+**Before starting any task**, call `uteke_recall` with the task summary as the query. Use the results to restore context from prior sessions.
+
+## Store Proactively
+After meaningful decisions, discoveries, or progress: call `uteke_remember` with relevant tags.
+
+## MCP Config (add to .cursor/mcp.json)
+```json
+{
+  "mcpServers": {
+    "uteke": {
+      "command": "uteke-mcp",
+      "args": []
+    }
+  }
+}
+```
+"#;
+
+    let rules_path = rules_dir.join("uteke.mdc");
+    std::fs::write(&rules_path, rules_content)
+        .map_err(|e| format!("Failed to write rules: {e}"))?;
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "cursor",
+            "plugin": "memory-provider",
+            "file": rules_path.to_string_lossy(),
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!(
+            "✓ Cursor memory-provider installed: {}",
+            rules_path.display()
+        );
+        println!("  Rules include auto-recall + MCP config snippet.");
+        println!();
+        println!("  Add MCP server to .cursor/mcp.json:");
+        println!("    {\"mcpServers\":{\"uteke\":{\"command\":\"uteke-mcp\"}}}");
+    }
+    Ok(())
+}
+
 /// Initialize uteke integration for Hermes (#384).
 /// Generates a uteke-tool plugin in the Hermes plugins directory.
 fn init_hermes(json: bool) -> Result<(), String> {
@@ -375,5 +611,32 @@ mod tests {
             PLUGIN_YAML.contains("on_pre_compress"),
             "manifest must declare the on_pre_compress hook"
         );
+    }
+
+    // Pi memory-provider template guards (#575).
+    const PI_INDEX_TS: &str = include_str!("../../../extensions/pi-memory-provider/index.ts");
+    const PI_PACKAGE_JSON: &str =
+        include_str!("../../../extensions/pi-memory-provider/package.json");
+
+    #[test]
+    fn pi_memory_provider_has_before_agent_start_hook() {
+        assert!(
+            PI_INDEX_TS.contains("before_agent_start"),
+            "pi extension must hook before_agent_start for auto-recall"
+        );
+        assert!(
+            PI_INDEX_TS.contains("recallMemories"),
+            "pi extension must have recallMemories function"
+        );
+        assert!(
+            PI_INDEX_TS.contains("uteke recall"),
+            "pi extension must invoke uteke recall CLI"
+        );
+    }
+
+    #[test]
+    fn pi_memory_provider_manifest_valid() {
+        assert!(PI_PACKAGE_JSON.contains("uteke-memory-provider"));
+        assert!(PI_PACKAGE_JSON.contains("Apache-2.0"));
     }
 }

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -8,13 +8,24 @@ use serde_json::Value;
 use uteke_core::Uteke;
 
 // ── JSON-RPC types ──────────────────────────────────────────────────────────
+//
+// Per JSON-RPC 2.0 spec:
+//   - "result" and "error" are mutually exclusive; omit the absent one.
+//   - Notifications (id is None/absent) MUST NOT receive a response.
 
 #[derive(Serialize)]
-pub struct JsonRpcResponse {
-    pub jsonrpc: &'static str,
-    pub id: Value,
-    pub result: Option<Value>,
-    pub error: Option<JsonRpcError>,
+#[serde(untagged)]
+pub enum JsonRpcResponse {
+    Success {
+        jsonrpc: &'static str,
+        id: Value,
+        result: Value,
+    },
+    Error {
+        jsonrpc: &'static str,
+        id: Value,
+        error: JsonRpcError,
+    },
 }
 
 #[derive(Serialize)]
@@ -51,44 +62,61 @@ struct ToolResult {
 /// Handle a single MCP JSON-RPC request (#381).
 ///
 /// This is the shared handler used by both the stdio binary and the
-/// HTTP endpoint. Returns a `JsonRpcResponse` ready for serialization.
-pub fn handle_jsonrpc(uteke: &Uteke, raw: &str) -> String {
+/// HTTP endpoint. Returns `Some(JsonRpcResponse)` for regular requests
+/// and `None` for notifications (which must not receive a response
+/// per JSON-RPC 2.0 §4.1).
+pub fn handle_jsonrpc(uteke: &Uteke, raw: &str) -> Option<String> {
     let req: JsonRpcRequest = match serde_json::from_str(raw) {
         Ok(r) => r,
         Err(e) => {
-            let resp = JsonRpcResponse {
+            let resp = JsonRpcResponse::Error {
                 jsonrpc: "2.0",
                 id: Value::Null,
-                result: None,
-                error: Some(JsonRpcError {
+                error: JsonRpcError {
                     code: -32700,
                     message: format!("Parse error: {e}"),
-                }),
+                },
             };
-            return serde_json::to_string(&resp).unwrap_or_default();
+            return Some(serde_json::to_string(&resp).unwrap_or_default());
         }
     };
 
-    let id = req.id.clone().unwrap_or(Value::Null);
+    let is_notification = req.id.is_none();
+    let id = req.id.unwrap_or(Value::Null);
 
     match handle_request(uteke, &req.method, req.params) {
-        Ok(result) => serde_json::to_string(&JsonRpcResponse {
-            jsonrpc: "2.0",
-            id,
-            result: Some(result),
-            error: None,
-        })
-        .unwrap_or_default(),
-        Err(msg) => serde_json::to_string(&JsonRpcResponse {
-            jsonrpc: "2.0",
-            id,
-            result: None,
-            error: Some(JsonRpcError {
-                code: -32603,
-                message: msg,
-            }),
-        })
-        .unwrap_or_default(),
+        Ok(result) => {
+            if is_notification {
+                // Notifications must not receive any response per JSON-RPC 2.0 §4.1.
+                None
+            } else {
+                Some(
+                    serde_json::to_string(&JsonRpcResponse::Success {
+                        jsonrpc: "2.0",
+                        id,
+                        result,
+                    })
+                    .unwrap_or_default(),
+                )
+            }
+        }
+        Err(msg) => {
+            if is_notification {
+                None
+            } else {
+                Some(
+                    serde_json::to_string(&JsonRpcResponse::Error {
+                        jsonrpc: "2.0",
+                        id,
+                        error: JsonRpcError {
+                            code: -32603,
+                            message: msg,
+                        },
+                    })
+                    .unwrap_or_default(),
+                )
+            }
+        }
     }
 }
 

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -128,6 +128,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_graph_add_edge(),
                 tool_graph_remove_edge(),
                 tool_room_recall(),
+                tool_room_memories(),
             ]
         })),
 
@@ -157,6 +158,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_graph_add_edge" => exec_graph_add_edge(uteke, &arguments)?,
                 "uteke_graph_remove_edge" => exec_graph_remove_edge(uteke, &arguments)?,
                 "uteke_room_recall" => exec_room_recall(uteke, &arguments)?,
+                "uteke_room_memories" => exec_room_memories(uteke, &arguments)?,
                 _ => return Err(format!("Unknown tool: {tool_name}")),
             };
 
@@ -401,6 +403,22 @@ fn tool_room_recall() -> Value {
                 "limit": { "type": "integer", "description": "Max results (default 5)", "default": 5 }
             },
             "required": ["room_id", "query"]
+        }
+    })
+}
+
+fn tool_room_memories() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_memories",
+        "description": "List all memories in a room chronologically (by joined_at). Cross-namespace: returns memories from all namespaces. Use this for full timeline listing without semantic ranking.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "author": { "type": "string", "description": "Optional author filter" },
+                "limit": { "type": "integer", "description": "Max results (default 100)", "default": 100 }
+            },
+            "required": ["room_id"]
         }
     })
 }
@@ -1005,6 +1023,41 @@ fn exec_room_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         .map(|sr| format!("[{:.2}] {}", sr.score, sr.memory.content))
         .collect();
 
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: lines.join("\n"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_memories(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let author = args["author"].as_str();
+    let limit = args["limit"].as_u64().unwrap_or(100) as usize;
+
+    let memories = uteke
+        .recall_room(room_id, author, limit)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if memories.is_empty() {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "No memories found in room.".to_string(),
+            }],
+            is_error: false,
+        });
+    }
+
+    let lines: Vec<String> = memories
+        .iter()
+        .map(|m| {
+            let created = m.created_at.format("%Y-%m-%d %H:%M");
+            format!("[{created} | {}] {}", m.namespace, m.content)
+        })
+        .collect();
     Ok(ToolResult {
         content: vec![McpContent::Text {
             r#type: "text".to_string(),

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -55,8 +55,10 @@ fn main() {
         }
 
         // Delegate to the shared handler (#381).
-        let response = uteke_mcp::handle_jsonrpc(&uteke, &line);
-        let _ = writeln!(stdout, "{response}");
-        let _ = stdout.flush();
+        // None = notification (no response per JSON-RPC 2.0 §4.1).
+        if let Some(response) = uteke_mcp::handle_jsonrpc(&uteke, &line) {
+            let _ = writeln!(stdout, "{response}");
+            let _ = stdout.flush();
+        }
     }
 }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -697,9 +697,44 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
-        // ── Room Recall (semantic) ────────────────────────────────────────
+        // ── Room Memories (chronological listing — GET /room/memories) ────
+        (Method::Get, p) if p == "/room/memories" || p.starts_with("/room/memories?") => {
+            let query_str = p.strip_prefix("/room/memories?");
+            let room_id = query_str.and_then(|q| parse_query_param(q, "room_id"));
+            let room_id = match room_id {
+                Some(id) => id,
+                None => {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Missing required parameter: room_id. Usage: GET /room/memories?room_id=<id>[&author=<author>&limit=<n>]",
+                    );
+                }
+            };
+            let limit = query_str
+                .and_then(|q| parse_query_param(q, "limit"))
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(100);
+            let author = query_str.and_then(|q| parse_query_param(q, "author"));
+            match uteke.recall_room(&room_id, author.as_deref(), limit) {
+                Ok(memories) => ctx.ok_response_for(req, &memories),
+                Err(e) => {
+                    error!("Internal error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
+            }
+        }
+
+        // ── Room Recall (semantic — requires non-empty query) ─────────────
         (Method::Post, "/room/recall") => match read_body::<RoomRecallRequest>(req.as_reader()) {
             Ok(req_data) => {
+                if req_data.query.trim().is_empty() {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Empty query is not allowed. Use GET /room/memories for chronological listing.",
+                    );
+                }
                 let min_score = req_data.min_score.unwrap_or(
                     ctx.recall_config
                         .as_ref()

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -916,16 +916,33 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             if let Err(e) = req.as_reader().take(MAX_MCP_BODY).read_to_string(&mut body) {
                 return ctx.error_response_for(req, 400, format!("Failed to read body: {e}"));
             }
-            let response = uteke_mcp::handle_jsonrpc(&uteke, &body);
-            tiny_http::Response::from_string(response)
-                .with_header(
-                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+            // None = notification (no response per JSON-RPC 2.0 §4.1) → 204 No Content
+            match uteke_mcp::handle_jsonrpc(&uteke, &body) {
+                Some(response) => tiny_http::Response::from_string(response)
+                    .with_header(
+                        tiny_http::Header::from_bytes(
+                            &b"Content-Type"[..],
+                            &b"application/json"[..],
+                        )
                         .unwrap(),
-                )
-                .with_header(
-                    tiny_http::Header::from_bytes(&b"MCP-Protocol-Version"[..], &b"2025-06-18"[..])
+                    )
+                    .with_header(
+                        tiny_http::Header::from_bytes(
+                            &b"MCP-Protocol-Version"[..],
+                            &b"2025-06-18"[..],
+                        )
                         .unwrap(),
-                )
+                    ),
+                None => tiny_http::Response::from_string("")
+                    .with_status_code(204)
+                    .with_header(
+                        tiny_http::Header::from_bytes(
+                            &b"MCP-Protocol-Version"[..],
+                            &b"2025-06-18"[..],
+                        )
+                        .unwrap(),
+                    ),
+            }
         }
 
         // ── Document: Create / Upsert ────────────────────────────────────

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -127,6 +127,7 @@ fn main() {
                 println!("  GET  /namespaces           → {{ namespaces }}");
                 println!("  POST /room/create          → {{ room_id, title, namespace }} → {{ created }}");
                 println!("  GET  /room/list            → [?namespace=] → [rooms]");
+                println!("  GET  /room/memories       → ?room_id=<id>[&author=&limit=] → chronological memories");
                 println!("  POST /room/recall          → {{ room_id, query }} → ranked memories");
                 println!("  POST /room/summary         → {{ room_id }} → {{ summary }}");
                 println!("  POST /room/document        → {{ room_id }} → {{ document }}");

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ verify_sha256() {
   fi
 }
 
-# Lazy download: only if model not pre-baked by CI
+# Lazy download: only if model not present in volume
 if [ ! -f "$MODEL_FILE" ]; then
   echo "Model not found, downloading embedding model (~208MB)..."
   mkdir -p "${MODEL_DIR}/onnx"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ title: Docker
 
 # Docker
 
-Uteke ships as a multi-arch Docker image with the embedding model pre-baked. No download needed on first run.
+Uteke ships as a lightweight multi-arch Docker image (~10MB). The embedding model (~208MB) downloads automatically on first run and is cached in the volume — subsequent updates are instant.
 
 ## Quick Start
 

--- a/extensions/pi-memory-provider/index.ts
+++ b/extensions/pi-memory-provider/index.ts
@@ -1,0 +1,186 @@
+/**
+ * Uteke Memory Provider Extension for Pi
+ *
+ * Automatic persistent memory integration — mirrors the Hermes memory-provider
+ * experience. Hooks `before_agent_start` to inject relevant memories into
+ * every agent turn without manual tool calls.
+ *
+ * Install:
+ *   Global:  ~/.pi/agent/extensions/uteke-memory-provider/index.ts
+ *   Project: .pi/extensions/uteke-memory-provider/index.ts
+ *
+ * Requires: `uteke` binary on PATH (same binary as the CLI).
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Config (reads from env, can be extended)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_NAMESPACE = "default";
+const RECALL_LIMIT = 6;
+const RECALL_MIN_SCORE = 0.45;
+const RECALL_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Subprocess helpers
+// ---------------------------------------------------------------------------
+
+function utekeBin(): string {
+	const envBin = process.env.UTEKE_BIN;
+	if (envBin) return envBin;
+	// pi extensions run as Node.js — use which-compatible lookup
+	try {
+		return execSync("which uteke", { encoding: "utf-8", timeout: 3000 }).trim();
+	} catch {
+		return "uteke";
+	}
+}
+
+function runUteke(args: string[], timeout = RECALL_TIMEOUT_MS): string {
+	const bin = utekeBin();
+	const env = { ...process.env };
+	// Allow pointing uteke at a different home directory
+	if (process.env.UTEKE_HOME) {
+		env.HOME = process.env.UTEKE_HOME;
+	}
+	try {
+		return execSync(`${bin} ${args.join(" ")}`, {
+			encoding: "utf-8",
+			timeout,
+			env,
+		});
+	} catch (err: any) {
+		return "";
+	}
+}
+
+function recallMemories(query: string): string[] {
+	const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
+	const limit = process.env.UTEKE_RECALL_LIMIT || String(RECALL_LIMIT);
+	const minScore = process.env.UTEKE_RECALL_MIN_SCORE || String(RECALL_MIN_SCORE);
+
+	const raw = runUteke([
+		"recall", `"${query}"`,
+		"--namespace", ns,
+		"--limit", limit,
+		"--min-score", minScore,
+		"--json",
+	]);
+
+	if (!raw.trim()) return [];
+
+	try {
+		const items = JSON.parse(raw);
+		const results: string[] = [];
+		for (const item of items) {
+			const mem = item.memory || item;
+			const content = mem.content || "";
+			if (content) {
+				results.push(content);
+			}
+		}
+		return results;
+	} catch {
+		return [];
+	}
+}
+
+function formatMemories(memories: string[]): string {
+	if (!memories.length) return "";
+	const lines = memories.map((m, i) => `${i + 1}. ${m}`).join("\n");
+	return (
+		"\n\n## Relevant Memories (uteke)\n\n" +
+		lines +
+		"\n\nUse `uteke remember` to store new facts, `uteke recall` to search more."
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+	let available = false;
+
+	// Check uteke availability on session start
+	pi.on("session_start", async (_event, ctx) => {
+		const out = runUteke(["stats"], 3000);
+		available = out.trim().length > 0;
+
+		if (available) {
+			ctx.ui.setStatus("uteke", "🧠 uteke: active");
+		} else {
+			ctx.ui.setStatus("uteke", "🧠 uteke: not found");
+		}
+	});
+
+	// Core hook: inject relevant memories before every agent turn
+	pi.on("before_agent_start", async (event) => {
+		if (!available) return;
+
+		const prompt = (event.prompt || "").trim();
+		if (!prompt || prompt.length < 3) return;
+
+		const memories = recallMemories(prompt);
+		if (!memories.length) return;
+
+		const injection = formatMemories(memories);
+
+		return {
+			systemPrompt: event.systemPrompt + injection,
+		};
+	});
+
+	// Slash commands for manual control
+	pi.registerCommand("uteke-recall", {
+		description: "Manually recall memories for a topic",
+		handler: async (args, _ctx) => {
+			const query = args.join(" ").trim();
+			if (!query) return "Usage: /uteke-recall <topic>";
+			const memories = recallMemories(query);
+			if (!memories.length) return "No relevant memories found.";
+			return formatMemories(memories);
+		},
+	});
+
+	pi.registerCommand("uteke-save", {
+		description: "Save a memory to uteke",
+		handler: async (args, _ctx) => {
+			const content = args.join(" ").trim();
+			if (!content) return "Usage: /uteke-save <content>";
+			runUteke(["remember", `"${content}"`], RECALL_TIMEOUT_MS);
+			return "✓ Memory saved.";
+		},
+	});
+
+	pi.registerCommand("uteke-stats", {
+		description: "Show uteke memory stats",
+		handler: async (_args, ctx) => {
+			const out = runUteke(["stats"], 5000);
+			available = out.trim().length > 0;
+			ctx.ui.setStatus("uteke", available ? "🧠 uteke: active" : "🧠 uteke: not found");
+			return out.trim() || "uteke: not available";
+		},
+	});
+
+	pi.registerCommand("uteke-on", {
+		description: "Enable automatic memory recall",
+		handler: async () => {
+			available = true;
+			return "✓ Automatic uteke recall enabled.";
+		},
+	});
+
+	pi.registerCommand("uteke-off", {
+		description: "Disable automatic memory recall",
+		handler: async () => {
+			available = false;
+			return "✓ Automatic uteke recall disabled.";
+		},
+	});
+}

--- a/extensions/pi-memory-provider/package.json
+++ b/extensions/pi-memory-provider/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uteke-memory-provider",
+  "version": "0.1.0",
+  "description": "Pi extension — automatic uteke memory recall injected into every turn",
+  "main": "index.ts",
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "keywords": ["pi-extension", "uteke", "memory", "memory-provider"],
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
## Release v0.6.7

Merge develop → main for v0.6.7 release.

After merge, tag `v0.6.7` on main to trigger release workflow (build, Docker, crates.io, GitHub Release).

### CHANGELOG

**Added:**
- Automatic memory-provider for pi/claude/cursor (#575, #577)
- GET /room/memories endpoint + uteke_room_memories MCP tool (#569)

**Fixed:**
- uteke-mcp JSON-RPC 2.0 spec compliance (#573, #576)

**Changed:**
- Slim Docker image (~218MB → ~10MB)