### PR TITLE
docs: fix CHANGELOG ordering — add v0.6.5, reorder descending, complete links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,3 @@
-## [0.6.4] — 2026-07-03
-
-### Added
-- **Gate ONNX behind `onnx` feature (#533, #534)** — `ort` and transitive `numkong` are now optional, gated behind `default-features = false`. Consumers that don't need ONNX/embedding can opt out entirely, resolving CI build failures on Ubuntu 22.04 (AVX-512) and macOS Intel (no prebuilt).
-- **Unified search across memories and documents (#531)** — single search endpoint returns results from both memories and documents.
-- **`/namespaces?with_counts=true` + `/recent` endpoints (#527, #528)** — namespace listing with per-namespace memory counts; recent memories across all namespaces.
-- **Cross-namespace `/list` and `/list_at_time` (#526)** — calling `/list` without namespace returns results from all namespaces.
-
-### Changed
-- **Split uteke-server monolith into modules (#514)** — refactored single-file server into modular structure for maintainability.
-
-### Fixed
-- **Read-only token on POST read endpoints (#524)** — read-only tokens now work on POST-based read endpoints (search, list, graph, etc).
-- **SQLite count column type** — use `u32` instead of `usize` (no `FromSql` impl for `usize`).
-- **`Option<String>` to `Option<&str>`** — fixed `list()` call parameter type.
-- **CodeCora alerts** — min_score in document path + improved error logging.
-
 ## [Unreleased]
 
 ## [0.6.7] — 2026-07-06
@@ -32,8 +15,15 @@
 ## [0.6.6] — 2026-07-05
 
 ### Added
-- **HTTP graph mutation endpoints (#542)** — `POST /graph/edge` creates a new typed edge between two memories; `DELETE /graph/edge` removes an edge by its ID. Enables programmatic graph editing without the CLI.
 - **Tags, pin, timeline, and edges HTTP endpoints (#566)** — 7 new REST endpoints: `GET /tags`, `POST /tags/rename`, `POST /tags/delete`, `POST /pin`, `POST /unpin`, `GET /timeline`, `GET /edges`. Enables full tag management, memory pinning, audit timeline, and graph edge queries via HTTP.
+
+### Fixed
+- **Room summary panic on multi-byte Unicode (#565)** — `room_summary()` panicked on Unicode chars (≤, ≥, etc.) because of byte-index slicing. Replaced with char-based truncation (`chars().take(N).collect()`).
+
+## [0.6.5] — 2026-07-05
+
+### Added
+- **HTTP graph mutation endpoints (#542)** — `POST /graph/edge` creates a new typed edge between two memories; `DELETE /graph/edge` removes an edge by its ID. Enables programmatic graph editing without the CLI.
 
 ### Fixed
 - **Cross-process file lock (#543)** — usearch index is now protected by a file lock to prevent race conditions when multiple uteke processes access the same database concurrently.
@@ -43,11 +33,27 @@
 - **Room document missing sections for note/insight/reference/event types (#547)** — document sections for non-core memory types (note, insight, reference, event) are now generated correctly in room documents.
 - **documents_fts migration repair (#549)** — FTS5 virtual table is rebuilt if missing or corrupted during migration, preventing `no such table: documents_fts` errors.
 - **Document delete by slug (#550)** — `uteke doc delete` now correctly resolves documents by slug (not just UUID), matching the behavior of `get` and `list`.
-- **Room summary panic on multi-byte Unicode (#565)** — `room_summary()` panicked on Unicode chars (≤, ≥, etc.) because of byte-index slicing. Replaced with char-based truncation (`chars().take(N).collect()`).
 
 ### Docs
 - **HTTP API documentation for `/recent` and graph mutation endpoints** — `GET /recent` (with query params), `GET /graph`, `POST /graph/edge`, `DELETE /graph/edge` added to HTTP Endpoints table. Graph API section expanded with mutation curl examples.
 - **VitePress sidebar entries** — added Document Commands and Graph API links to docs sidebar.
+
+## [0.6.4] — 2026-07-03
+
+### Added
+- **Gate ONNX behind `onnx` feature (#533, #534)** — `ort` and transitive `numkong` are now optional, gated behind `default-features = false`. Consumers that don't need ONNX/embedding can opt out entirely, resolving CI build failures on Ubuntu 22.04 (AVX-512) and macOS Intel (no prebuilt).
+- **Unified search across memories and documents (#531)** — single search endpoint returns results from both memories and documents.
+- **`/namespaces?with_counts=true` + `/recent` endpoints (#527, #528)** — namespace listing with per-namespace memory counts; recent memories across all namespaces.
+- **Cross-namespace `/list` and `/list_at_time` (#526)** — calling `/list` without namespace returns results from all namespaces.
+
+### Changed
+- **Split uteke-server monolith into modules (#514)** — refactored single-file server into modular structure for maintainability.
+
+### Fixed
+- **Read-only token on POST read endpoints (#524)** — read-only tokens now work on POST-based read endpoints (search, list, graph, etc).
+- **SQLite count column type** — use `u32` instead of `usize` (no `FromSql` impl for `usize`).
+- **`Option<String>` to `Option<&str>`** — fixed `list()` call parameter type.
+- **CodeCora alerts** — min_score in document path + improved error logging.
 
 ## [0.6.3] — 2026-07-01
 
@@ -1127,8 +1133,31 @@
 - **Binary name:** `uteke`
 - **Minimum Rust version:** 1.75+
 
+[Unreleased]: https://github.com/codecoradev/uteke/compare/v0.6.7...HEAD
+[0.6.7]: https://github.com/codecoradev/uteke/releases/tag/v0.6.7
+[0.6.6]: https://github.com/codecoradev/uteke/releases/tag/v0.6.6
+[0.6.5]: https://github.com/codecoradev/uteke/releases/tag/v0.6.5
+[0.6.4]: https://github.com/codecoradev/uteke/releases/tag/v0.6.4
+[0.6.3]: https://github.com/codecoradev/uteke/releases/tag/v0.6.3
+[0.6.2]: https://github.com/codecoradev/uteke/releases/tag/v0.6.2
+[0.6.1]: https://github.com/codecoradev/uteke/releases/tag/v0.6.1
+[0.6.0]: https://github.com/codecoradev/uteke/releases/tag/v0.6.0
+[0.5.0]: https://github.com/codecoradev/uteke/releases/tag/v0.5.0
+[0.4.3]: https://github.com/codecoradev/uteke/releases/tag/v0.4.3
+[0.4.2]: https://github.com/codecoradev/uteke/releases/tag/v0.4.2
+[0.4.1]: https://github.com/codecoradev/uteke/releases/tag/v0.4.1
+[0.4.0]: https://github.com/codecoradev/uteke/releases/tag/v0.4.0
+[0.3.2]: https://github.com/codecoradev/uteke/releases/tag/v0.3.2
+[0.3.1]: https://github.com/codecoradev/uteke/releases/tag/v0.3.1
+[0.3.0]: https://github.com/codecoradev/uteke/releases/tag/v0.3.0
+[0.2.1]: https://github.com/codecoradev/uteke/releases/tag/v0.2.1
+[0.2.0]: https://github.com/codecoradev/uteke/releases/tag/v0.2.0
+[0.1.0]: https://github.com/codecoradev/uteke/releases/tag/v0.1.0
+[0.0.15]: https://github.com/codecoradev/uteke/releases/tag/v0.0.15
+[0.0.14]: https://github.com/codecoradev/uteke/releases/tag/v0.0.14
 [0.0.13]: https://github.com/codecoradev/uteke/releases/tag/v0.0.13
 [0.0.12]: https://github.com/codecoradev/uteke/releases/tag/v0.0.12
+[0.0.11]: https://github.com/codecoradev/uteke/releases/tag/v0.0.11
 [0.0.10]: https://github.com/codecoradev/uteke/releases/tag/v0.0.10
 [0.0.9]: https://github.com/codecoradev/uteke/releases/tag/v0.0.9
 [0.0.8]: https://github.com/codecoradev/uteke/releases/tag/v0.0.8


### PR DESCRIPTION
## Summary
- Fix CHANGELOG ordering: `[Unreleased]` → v0.6.7 → v0.6.6 → v0.6.5 → v0.6.4 → ... (newest at top)
- Add missing `v0.6.5` section with its actual entries (graph mutation, file lock, FTS5, room fixes)
- Split entries that were incorrectly assigned to v0.6.6 back to their correct versions
- Complete all version links at bottom (was missing v0.1.0–v0.6.7)

## Problem
CHANGELOG had version ordering chaos: v0.6.4 at the top, `[Unreleased]` buried mid-file, v0.6.6 entries mixed with v0.6.5 items, and v0.6.5 had no section at all despite having a git tag.
