### PR TITLE
feat: POST /doc/update endpoint — partial document update with chunk rebuild

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -950,7 +950,7 @@ impl Uteke {
         };
 
         // If content was changed, rebuild chunks.
-        if content.is_some() {
+        if let Some(content_text) = content {
             let old_chunk_ids = self
                 .store
                 .delete_chunks_for_documents(std::slice::from_ref(&doc_id))?;
@@ -963,7 +963,7 @@ impl Uteke {
             let embedder = embedder.as_ref().expect("embedder ensured above");
 
             let max_chars = embedder.max_seq_len().saturating_mul(4).max(1024);
-            let chunks = crate::chunker::chunk_markdown(content.unwrap(), max_chars);
+            let chunks = crate::chunker::chunk_markdown(content_text, max_chars);
 
             let mut index = self
                 .index

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -917,6 +917,101 @@ impl Uteke {
         self.store.get_document(id_or_slug)
     }
 
+    /// Partially update a document — only provided fields are changed.
+    ///
+    /// Content changes trigger chunk rebuild (old chunks deleted, new ones
+    /// embedded and indexed). Version is always incremented.
+    /// Returns the updated document, or `None` if not found.
+    pub fn doc_update(
+        &self,
+        id_or_slug: &str,
+        namespace: Option<&str>,
+        title: Option<&str>,
+        content: Option<&str>,
+        tags: Option<&[String]>,
+        metadata: Option<&serde_json::Value>,
+    ) -> Result<Option<Document>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        // Resolve document.
+        let doc = match self.doc_get(id_or_slug, namespace)? {
+            Some(d) => d,
+            None => return Ok(None),
+        };
+        let doc_id = doc.id.clone();
+
+        // Partial update in SQLite.
+        let updated = self
+            .store
+            .update_document(&doc_id, title, content, tags, metadata)?;
+
+        let updated = match updated {
+            Some(d) => d,
+            None => return Ok(None),
+        };
+
+        // If content was changed, rebuild chunks.
+        if content.is_some() {
+            let old_chunk_ids = self
+                .store
+                .delete_chunks_for_documents(std::slice::from_ref(&doc_id))?;
+
+            self.ensure_embedder()?;
+            let embedder = self
+                .embedder
+                .lock()
+                .map_err(|_| Error::lock("embedder lock during document update"))?;
+            let embedder = embedder.as_ref().expect("embedder ensured above");
+
+            let max_chars = embedder.max_seq_len().saturating_mul(4).max(1024);
+            let chunks = crate::chunker::chunk_markdown(content.unwrap(), max_chars);
+
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during doc update"))?;
+
+            for old_id in &old_chunk_ids {
+                let key = format!("chunk:{}", old_id);
+                index.remove(&key);
+            }
+
+            for (i, chunk) in chunks.iter().enumerate() {
+                let chunk_id = uuid::Uuid::new_v4().to_string();
+                let embedding = embedder.embed(&chunk.content)?;
+
+                self.store.insert_document_chunk(
+                    &DocumentChunk {
+                        id: chunk_id.clone(),
+                        document_id: doc_id.clone(),
+                        chunk_index: i as i64,
+                        heading: chunk.heading.clone(),
+                        content: chunk.content.clone(),
+                        char_start: chunk.char_start as i64,
+                        char_end: chunk.char_end as i64,
+                        tags: updated.tags.clone(),
+                    },
+                    &embedding,
+                )?;
+
+                let index_key = format!("chunk:{}", chunk_id);
+                if let Err(e) = index.insert(&index_key, &embedding) {
+                    tracing::warn!(
+                        "Failed to insert chunk {} into index during update: {}",
+                        chunk_id,
+                        e
+                    );
+                }
+            }
+
+            if let Err(e) = index.save() {
+                tracing::warn!("Failed to persist index after doc update: {}", e);
+            }
+        }
+
+        tracing::info!("Document '{id_or_slug}' updated in namespace '{ns}'");
+        Ok(Some(updated))
+    }
+
     /// List documents in a namespace.
     pub fn doc_list(
         &self,

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -272,14 +272,6 @@ impl super::Store {
         };
 
         let new_title = title.unwrap_or(&existing.title);
-        let new_tags = match tags {
-            Some(t) => serde_json::to_string(t).unwrap_or_else(|_| "[]".into()),
-            None => serde_json::to_string(&existing.tags).unwrap_or_else(|_| "[]".into()),
-        };
-        let new_meta = match metadata {
-            Some(m) => m.to_string(),
-            None => existing.metadata.to_string(),
-        };
         let new_version = existing.version + 1;
         let now = chrono::Utc::now().to_rfc3339();
 

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -253,6 +253,97 @@ impl super::Store {
         Ok(doc_id)
     }
 
+    /// Partially update a document — only provided fields are changed.
+    ///
+    /// Returns the updated document (full). Returns `None` if not found.
+    /// Version is always incremented. Chunks are NOT rebuilt here
+    /// (caller must handle re-chunking if content changed).
+    pub fn update_document(
+        &self,
+        id: &str,
+        title: Option<&str>,
+        content: Option<&str>,
+        tags: Option<&[String]>,
+        metadata: Option<&serde_json::Value>,
+    ) -> Result<Option<Document>, Error> {
+        let existing = match self.get_document(id)? {
+            Some(doc) => doc,
+            None => return Ok(None),
+        };
+
+        let new_title = title.unwrap_or(&existing.title);
+        let new_tags = match tags {
+            Some(t) => serde_json::to_string(t).unwrap_or_else(|_| "[]".into()),
+            None => serde_json::to_string(&existing.tags).unwrap_or_else(|_| "[]".into()),
+        };
+        let new_meta = match metadata {
+            Some(m) => m.to_string(),
+            None => existing.metadata.to_string(),
+        };
+        let new_version = existing.version + 1;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Build SET clause dynamically — only update columns that changed.
+        let set_title = title.is_some();
+        let set_content = content.is_some();
+        let set_tags = tags.is_some();
+        let set_meta = metadata.is_some();
+
+        // Always update version and updated_at.
+        let mut set_clauses = vec!["version = ?1".to_string(), "updated_at = ?2".to_string()];
+        let mut param_idx = 3usize;
+
+        if set_title {
+            set_clauses.push(format!("title = ?{param_idx}"));
+            param_idx += 1;
+        }
+        if set_content {
+            set_clauses.push(format!("content = ?{param_idx}"));
+            param_idx += 1;
+        }
+        if set_tags {
+            set_clauses.push(format!("tags = ?{param_idx}"));
+            param_idx += 1;
+        }
+        if set_meta {
+            set_clauses.push(format!("metadata = ?{param_idx}"));
+            param_idx += 1;
+        }
+
+        let set_sql = set_clauses.join(", ");
+        let sql = format!("UPDATE documents SET {set_sql} WHERE id = ?{param_idx}");
+
+        // Build params dynamically.
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> =
+            vec![Box::new(new_version), Box::new(now)];
+        if set_title {
+            param_values.push(Box::new(new_title.to_string()));
+        }
+        if let Some(c) = content {
+            param_values.push(Box::new(c.to_string()));
+        }
+        if let Some(t) = tags {
+            param_values.push(Box::new(
+                serde_json::to_string(t).unwrap_or_else(|_| "[]".into()),
+            ));
+        }
+        if let Some(m) = metadata {
+            param_values.push(Box::new(m.to_string()));
+        }
+        // WHERE id = ?
+        param_values.push(Box::new(id.to_string()));
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|v| v.as_ref()).collect();
+
+        self.conn
+            .execute(&sql, param_refs.as_slice())
+            .map_err(|e| Error::db("update document (partial)", e))?;
+
+        // Fetch and return the updated document.
+        self.get_document(id)
+    }
+
     /// Insert a document chunk with embedding (#406).
     pub fn insert_document_chunk(
         &self,

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -1003,6 +1003,39 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             Err(e) => ctx.error_response_for(req, 400, e),
         },
 
+        // ── Document: Update (partial) ────────────────────────────────
+        (Method::Post, "/doc/update") => match read_body::<DocUpdateRequest>(req.as_reader()) {
+            Ok(req_data) => match resolve_doc_id_update(&req_data) {
+                Ok(id_or_slug) => {
+                    let title = req_data.title.as_deref();
+                    let content = req_data.content.as_deref();
+                    let tags = req_data.tags.as_deref();
+                    let metadata = req_data.metadata.as_ref();
+                    match uteke.doc_update(
+                        id_or_slug,
+                        ns(&req_data.namespace),
+                        title,
+                        content,
+                        tags,
+                        metadata,
+                    ) {
+                        Ok(Some(doc)) => ctx.ok_response_for(req, &doc),
+                        Ok(None) => ctx.error_response_for(
+                            req,
+                            404,
+                            format!("document not found: {id_or_slug}"),
+                        ),
+                        Err(e) => {
+                            error!("doc update error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            },
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
         // ── Document: List ─────────────────────────────────────────────
         (Method::Post, "/doc/list") => match read_body::<DocListParams>(req.as_reader()) {
             Ok(params) => {

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -61,6 +61,22 @@ pub struct DocMoveRequest {
     pub namespace: Option<String>,
 }
 
+#[derive(Deserialize)]
+pub struct DocUpdateRequest {
+    pub id: Option<String>,
+    pub slug: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
 pub fn default_search_mode() -> String {
     "hybrid".to_string()
 }
@@ -76,6 +92,14 @@ pub fn resolve_doc_id(req: &DocGetRequest) -> Result<&str, &'static str> {
 }
 
 pub fn resolve_doc_id_move(req: &DocMoveRequest) -> Result<&str, &'static str> {
+    match (&req.id, &req.slug) {
+        (Some(id), _) => Ok(id),
+        (_, Some(slug)) => Ok(slug),
+        _ => Err("provide either 'id' or 'slug'"),
+    }
+}
+
+pub fn resolve_doc_id_update(req: &DocUpdateRequest) -> Result<&str, &'static str> {
     match (&req.id, &req.slug) {
         (Some(id), _) => Ok(id),
         (_, Some(slug)) => Ok(slug),


### PR DESCRIPTION
## Summary

Add `POST /doc/update` endpoint to uteke-serve — partial document update with automatic chunk rebuild on content changes.

Follow-up to Corin #139. Enables the DocumentsView.svelte Save button for editing existing documents.

## API

```
POST /doc/update
{
  "id": "uuid" | "slug": "slug-name",
  "title": "New Title",
  "content": "# Updated markdown",
  "tags": ["tag1", "tag2"],
  "metadata": { ... },
  "namespace": "default"
}
-> Full Document (version incremented)
-> 404 if not found
```

## Behavior

| Field Changed | What Happens |
|---|---|
| title only | Title updated, no chunk rebuild |
| content | Content updated, old chunks deleted, new chunks embedded and indexed |
| tags | Tags updated, no chunk rebuild |
| metadata | Metadata updated, no chunk rebuild |
| Multiple fields | All updated atomically in single transaction |
| version | Always incremented (implicit) |
| updated_at | Always set to now (implicit) |

## Changes

| File | What | LOC |
|------|------|-----|
| documents.rs | update_document() - dynamic SET clause, only provided fields | +91 |
| lib.rs | doc_update() - resolve doc, partial update, chunk rebuild if content changed | +95 |
| types.rs | DocUpdateRequest struct + resolve_doc_id_update helper | +24 |
| handlers.rs | POST /doc/update route with 404 handling | +33 |

## Verification

- cargo fmt --all -- --check pass
- cargo clippy -p uteke-core -p uteke-server zero errors zero warnings
- cargo check zero compiler errors from our crates
- Full build verified by CI

## Cross-repo Dependency

Corin needs this merged first, then wire doc_update in uteke_client.rs + commands.rs + ipc.ts + DocumentsView.svelte (Corin #139)
