### PR TITLE
feat: add  CLI command for partial document updates (#589)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -489,6 +489,26 @@ pub enum DocCommands {
         #[arg(long, default_value = "hybrid")]
         mode: String,
     },
+    /// Partially update a document — only provided fields are changed (#589)
+    Update {
+        /// Document slug or ID
+        id_or_slug: String,
+        /// New title (optional — no chunk rebuild)
+        #[arg(long)]
+        title: Option<String>,
+        /// New content (triggers chunk rebuild)
+        #[arg(long)]
+        content: Option<String>,
+        /// Read new content from file (use - for stdin; triggers chunk rebuild)
+        #[arg(long)]
+        file: Option<String>,
+        /// Replace tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+        /// Replace metadata (JSON string)
+        #[arg(long)]
+        metadata: Option<String>,
+    },
     /// Delete a document by ID (cascades to children, #438)
     Delete {
         /// Document ID

--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -306,6 +306,104 @@ pub(crate) fn run(
             }
         }
 
+        DocCommands::Update {
+            id_or_slug,
+            title,
+            content,
+            file,
+            tags,
+            metadata,
+        } => {
+            // At least one field must be provided.
+            if title.is_none()
+                && content.is_none()
+                && file.is_none()
+                && tags.is_empty()
+                && metadata.is_none()
+            {
+                return Err(
+                    "Provide at least one field to update: --title, --content, --file, --tags, --metadata"
+                        .into(),
+                );
+            }
+
+            // Resolve content: --content, --file, or stdin.
+            let doc_content = if let Some(c) = content {
+                Some(c.clone())
+            } else if let Some(f) = file {
+                let text = if f == "-" {
+                    use std::io::Read;
+                    let mut buf = String::new();
+                    std::io::stdin()
+                        .read_to_string(&mut buf)
+                        .map_err(|e| format!("Failed to read stdin: {e}"))?;
+                    buf
+                } else {
+                    std::fs::read_to_string(f).map_err(|e| format!("Failed to read file: {e}"))?
+                };
+                Some(text)
+            } else {
+                None
+            };
+
+            // Parse metadata JSON if provided.
+            let meta_value: Option<serde_json::Value> = match metadata {
+                Some(ref json_str) => Some(
+                    serde_json::from_str(json_str)
+                        .map_err(|e| format!("Invalid metadata JSON: {e}"))?,
+                ),
+                None => None,
+            };
+
+            let title_ref = title.as_deref();
+            let content_ref = doc_content.as_deref();
+            let tag_refs: Option<&[String]> = if tags.is_empty() {
+                None
+            } else {
+                Some(tags.as_slice())
+            };
+            let meta_ref = meta_value.as_ref();
+
+            let updated = uteke
+                .doc_update(id_or_slug, ns, title_ref, content_ref, tag_refs, meta_ref)
+                .map_err(|e| format!("Failed to update document: {e}"))?;
+
+            match updated {
+                Some(d) => {
+                    let mut changed = Vec::new();
+                    if title.is_some() {
+                        changed.push("title");
+                    }
+                    if content.is_some() || file.is_some() {
+                        changed.push("content");
+                    }
+                    if !tags.is_empty() {
+                        changed.push("tags");
+                    }
+                    if metadata.is_some() {
+                        changed.push("metadata");
+                    }
+
+                    if cli.json {
+                        println!(
+                            r#"{{"slug": "{}", "title": "{}", "version": {}, "updated_fields": {}}}"#,
+                            d.slug,
+                            d.title,
+                            d.version,
+                            serde_json::to_string(&changed).unwrap_or_default()
+                        );
+                    } else {
+                        println!("✓ Document '{id_or_slug}' updated (v{})", d.version);
+                        println!("  Title: {}", d.title);
+                        println!("  Fields: {}", changed.join(", "));
+                    }
+                }
+                None => {
+                    return Err(format!("Document '{id_or_slug}' not found"));
+                }
+            }
+        }
+
         DocCommands::Delete { id } => {
             let (deleted, subtree_size) = uteke
                 .doc_delete(id, ns)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -794,6 +794,40 @@ uteke doc search "API reference" --mode fts --limit 5
 | `--mode <mode>` | `hybrid` (default), `semantic`, or `fts` |
 | `--limit <n>` | Max results (default: 5) |
 
+### `uteke doc update`
+
+Partially update a document — only provided fields are changed (#589). Content changes trigger chunk rebuild; metadata-only or title-only updates skip it.
+
+```bash
+# Update title only (no chunk rebuild)
+uteke doc update architecture --title "New Architecture Guide"
+
+# Update content from file (triggers chunk rebuild)
+uteke doc update architecture --file updated-guide.md
+
+# Update content from stdin
+echo "# New content" | uteke doc update architecture --file -
+
+# Replace tags
+uteke doc update architecture --tags wiki,tech,v2
+
+# Replace metadata
+uteke doc update architecture --metadata '{"draft": false, "reviewer": "CTO"}'
+
+# Multiple fields at once
+uteke doc update architecture --title "Final Guide" --tags wiki,published
+```
+
+| Flag | Description |
+|------|-------------|
+| `--title <title>` | New title (no chunk rebuild) |
+| `--content <text>` | New content (triggers chunk rebuild) |
+| `--file <path>` | Read new content from file (`-` for stdin; triggers chunk rebuild) |
+| `--tags <tags>` | Replace tags (comma-separated) |
+| `--metadata <json>` | Replace metadata (JSON string) |
+
+At least one field is required. Omitted fields are left unchanged.
+
 ### `uteke doc move`
 
 Move a document to a new parent or root (#438).


### PR DESCRIPTION
## Summary

Add dedicated `uteke doc update` CLI command for partial document updates, complementing the existing `doc create` (which performs full content replacement via upsert).

## Problem

- `uteke doc create` can overwrite documents by slug, but performs **full content replacement** — not a partial update
- HTTP `POST /doc/update` (added in PR #583) supports partial updates (title only, tags only, metadata only) with smart chunk rebuild only when content changes
- CLI had no dedicated `uteke doc update` command — users had to use the HTTP API directly

## Changes

### `crates/uteke-cli/src/cli.rs`
- Add `DocCommands::Update` variant with flags: `--title`, `--content`, `--file`, `--tags`, `--metadata`

### `crates/uteke-cli/src/commands/doc.rs`
- Add `DocCommands::Update` match arm calling `uteke.doc_update()` directly
- Validates at least one field is provided
- Content resolution: `--content` > `--file` > stdin (`--file -`)
- Metadata parsed from JSON string
- Human-readable + JSON output modes

### `docs/cli-reference.md`
- Document `uteke doc update` with usage examples and flag table

## Verification

- `cargo check -p uteke-cli` ✅
- `cargo clippy -p uteke-cli --all-targets` ✅ (no issues)
- `cargo fmt --all -- --check` ✅

Closes #589