### PR TITLE
fix(core): add room tables to SCHEMA constant for fresh DB

### DIFF
--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -130,6 +130,27 @@ CREATE TABLE IF NOT EXISTS document_chunks (
 );
 CREATE INDEX IF NOT EXISTS idx_doc_chunks_doc ON document_chunks(document_id);
 CREATE INDEX IF NOT EXISTS idx_doc_chunks_heading ON document_chunks(heading);
+
+-- v3: Room-based collaborative memory tables.
+CREATE TABLE IF NOT EXISTS rooms (
+    id TEXT PRIMARY KEY,
+    title TEXT,
+    namespace TEXT NOT NULL DEFAULT 'default',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rooms_namespace ON rooms(namespace);
+
+CREATE TABLE IF NOT EXISTS room_memories (
+    room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    author TEXT NOT NULL DEFAULT 'unknown',
+    role TEXT NOT NULL DEFAULT 'participant',
+    joined_at TEXT NOT NULL,
+    PRIMARY KEY (room_id, memory_id)
+);
+CREATE INDEX IF NOT EXISTS idx_room_memories_room ON room_memories(room_id);
+CREATE INDEX IF NOT EXISTS idx_room_memories_author ON room_memories(author);
 "#;
 
 /// Indexes that depend on migration-added columns.


### PR DESCRIPTION
## Summary

Fresh databases were missing rooms and room_memories tables because the CREATE TABLE statements were only in the migration (v2→v3), not in the SCHEMA constant.

## Problem

- SCHEMA constant at store.rs lacked room tables
- Fresh DB init skipped migration → no room tables created
- uteke room create/list/stats would fail on fresh installs

## Fix

Add CREATE TABLE IF NOT EXISTS for both tables to the SCHEMA constant, matching migration v2→v3 columns exactly:

- rooms: id, title, namespace, created_at, updated_at
- room_memories: room_id, memory_id, author, role, joined_at

## Test

- Fresh DB (rm -rf + uteke-serve): both tables created with correct columns
- POST /room/create: works
- GET /room/list: returns room with updated_at
- Existing DB (migration path): unchanged (IF NOT EXISTS)
- cargo build: clean
- cargo fmt: clean

## Files Changed

crates/uteke-core/src/memory/store.rs  (+21 lines)