### PR TITLE
deps: update crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Update `crossbeam-epoch` from 0.9.18 to 0.9.20 to fix RUSTSEC-2026-0204.

## Advisory

- **ID:** RUSTSEC-2026-0204
- **Title:** Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
- **Date:** 2026-07-06
- **Fix:** Upgrade to >=0.9.20

## Dependency Path

```
uteke-core → tokenizers → rayon → rayon-core → crossbeam-deque → crossbeam-epoch
```

## Changes

- `Cargo.lock` only (+2/-2 lines)
- No code changes — API compatible

## Note

Local build requires `libssl-dev` (unrelated to this change). CI has the dependency and will verify.