### PR TITLE
docs: fix 16 documentation gaps + v0.7.0 feature docs (#582)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.6
+- **Version:** 0.6.7
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 
@@ -146,10 +146,11 @@ feature branch → PR → develop (default branch)
 - Release workflow has `verify-main` job that aborts if tag is not on main.
 
 #### `main` branch
-- PR required (no direct push)
-- `allow_force_pushes: true` (for release workflow only)
+- PR required (no direct push) — **enforce_admins: true**
+- `allow_force_pushes: false`
 - `required_linear_history: true`
 - `allow_deletions: false`
+- Required checks: Build, Check, Clippy, Format, Test
 
 #### `develop` branch
 - All changes via PR — no direct push

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.6-green.svg" alt="v0.6.6" />
+  <img src="https://img.shields.io/badge/status-v0.6.7-green.svg" alt="v0.6.7" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.6-green.svg" alt="v0.6.6" />
+  <img src="https://img.shields.io/badge/status-v0.6.7-green.svg" alt="v0.6.7" />
 </p>
 
 <p align="center">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,10 @@ Index lock acquired **before** SQLite delete — narrows the inconsistency windo
 
 Read-heavy workload: recall/search operations far outnumber remember/forget. Multiple concurrent recalls share a read lock. Embedder remains `Mutex` because ONNX tokenizer requires `&mut self` internally.
 
+### Cross-Process File Lock (#543)
+
+The RwLock provides intra-process concurrency only (multiple threads within a single `uteke-serve` process). For cross-process safety (multiple `uteke-serve` instances or CLI + server sharing the same store), a file-based lock (`fs2` crate) guards the SQLite database and usearch index files. The lock is acquired on store open and held until the process exits or the store is dropped. This prevents concurrent writes from corrupting the index or database when multiple processes access the same `~/.uteke/` directory.
+
 ### FTS5 + Vector Hybrid via RRF
 
 Two systems with incompatible score scales (cosine 0..1 vs BM25 unbounded). Reciprocal Rank Fusion solves this by ranking based on position, not score magnitude. k=60 is the standard literature value.
@@ -137,7 +141,7 @@ All critical file I/O uses the `.tmp` + `rename` pattern. On POSIX filesystems, 
 
 ### Schema Versioning
 
-Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v10 (`source` + `source_type` columns, #348). Schema history: v4 rooms, v5 memory_tags junction, v6 content_type column, v7 knowledge graph, v8 `memory_edges` + `slug` (#346), v9 `timeline_events` table (#347), v10 `source` + `source_type` (#348). Zero data loss guaranteed.
+Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v12. Schema history: v4 rooms, v5 memory_tags junction, v6 content_type column, v7 knowledge graph, v8 `memory_edges` + `slug` (#346), v9 `timeline_events` table (#347), v10 `source` + `source_type` (#348), v11 documents + document_chunks (#406), v12 hierarchy (parent_id on documents, room tables added to SCHEMA constant). Zero data loss guaranteed.
 
 ### Rooms
 
@@ -173,7 +177,7 @@ The `uteke-mcp` crate provides a shared JSON-RPC handler used by both:
 - **stdio binary** (`uteke-mcp`) — for local agents (Claude Desktop, Cursor)
 - **HTTP endpoint** (`POST /mcp` on `uteke-serve`) — for remote MCP clients
 
-Protocol version: `2025-06-18` (Streamable HTTP spec). 1 MiB body limit enforced on HTTP endpoint.
+Protocol version: `2025-06-18` (Streamable HTTP spec). 1 MiB body limit enforced on HTTP endpoint. JSON-RPC 2.0 strict compliance (v0.6.7, #573/#576): tagged union responses, no notification response, Claude Code compatible.
 
 ## Performance
 
@@ -215,6 +219,14 @@ Benchmarked on Oracle Cloud ARM (Ampere Altra), CPU-only, no GPU.
 └── logs/
     ├── uteke.log               # Current log
     └── uteke.log.YYYY-MM-DD    # Rotated logs
+```
+
+In Docker, the data directory defaults to `/data` (set via `UTEKE_HOME`). The `slim` image variant does not bundle the embedding model — mount the model directory separately:
+```bash
+docker run -d --name uteke \
+  -v uteke-data:/data \
+  -v ./models/embeddinggemma-q4:/data/embeddinggemma-q4 \
+  ghcr.io/codecoradev/uteke:slim
 ```
 
 ## Known Limitations

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.6.6**.
+Complete reference for all uteke commands. Version **0.6.7**.
 
 ## Global Flags
 
@@ -654,7 +654,10 @@ uteke timeline <memory-id> --json
 | `uteke namespace switch <name>` | Set default namespace in config |
 | `uteke hook <shell>` | Print shell hook script (bash/zsh/fish) |
 | `uteke init --agent <type>` | Initialize integration (pi, claude, cursor, hermes) |
-| `uteke init --agent hermes --memory-provider` | Install uteke as Hermes's default memory provider (auto recall + extraction). See [Hermes integration, Mode B](integrations/hermes.md) |
+| `uteke init --agent hermes --memory-provider` | Install uteke as Hermes's default memory provider (auto recall + extraction). See [Hermes integration, Mode B](integrations/hermes.md). **Note:** Hermes Mode B deprecated — see [integrations/hermes.md](integrations/hermes.md) for migration. |
+| `uteke init --agent pi --memory-provider` | Install uteke as pi's default memory provider (auto recall + extraction, #575/#577) |
+| `uteke init --agent claude --memory-provider` | Install uteke as Claude Code's default memory provider (auto recall + extraction, #575/#577) |
+| `uteke init --agent cursor --memory-provider` | Install uteke as Cursor's default memory provider (auto recall + extraction, #575/#577) |
 | `uteke completions <shell>` | Generate shell completions |
 
 ## uteke-serve (Server Mode)
@@ -701,7 +704,16 @@ When `[server] enabled = true` is set in config, the CLI auto-routes commands th
 | POST | `/doc/search` | Hybrid/semantic/FTS document search (#440) |
 | POST | `/doc/move` | Move document to new parent (#438) |
 | DELETE | `/doc/delete?id=` | Delete document with cascade |
+| POST | `/doc/update` | Partial document update with chunk rebuild (#589) |
 | GET | `/recent` | Recent memories (supports `?namespace=`, `?limit=`, `?offset=`) (#528) |
+| GET | `/tags` | List all tags with counts (#566) |
+| POST | `/tags/rename` | Rename a tag across all memories (#566) |
+| POST | `/tags/delete` | Delete a tag from all memories (#566) |
+| POST | `/pin` | Pin a memory (prevent decay) (#566) |
+| POST | `/unpin` | Unpin a memory (#566) |
+| GET | `/timeline` | Timeline events for a memory (#566) |
+| GET | `/edges` | List edges for a memory (#566) |
+| GET | `/room/memories` | List memories in a room (#569) |
 | GET | `/graph` | Graph visualization — nodes, edges, stats (#408) |
 | POST | `/graph/edge` | Create a typed edge between two memories (#542) |
 | DELETE | `/graph/edge` | Remove an edge by ID (#542) |
@@ -909,3 +921,11 @@ All limits can be overridden via env vars or `[limits]` config section:
 | `UTEKE_MAX_TAG_LENGTH` | `max_tag_length` | 50 | Max single tag length (chars) |
 | `UTEKE_MAX_PAYLOAD_SIZE` | `max_payload_size` | 10485760 | Max server payload (bytes) |
 | `UTEKE_DEFAULT_RECALL_LIMIT` | `default_recall_limit` | 5 | Default recall limit |
+
+## Changelog
+
+### v0.6.5
+- Room fixes (#545/#546/#547/#549/#550): Fixed room creation race conditions, room memory list pagination, room summary edge cases, room document generation for empty rooms, and room delete cascade consistency.
+
+### v0.6.6
+- Room summary Unicode fix (#565): Summary truncation now uses char boundaries instead of byte offsets, preventing mid-character cuts in multi-byte content.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,8 +125,10 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `v0.6.7` | Specific version |
 | `v0.6.6` | Specific version |
 | `0.6` | Minor version (latest patch) |
+| `slim` | Slim image (no embedded model — mount model volume separately, see below) |
 
 ## CLI in Docker
 
@@ -243,9 +245,32 @@ Both transports expose the same tools (MCP protocol version `2025-06-18`):
 |------|-------------|
 | `uteke_remember` | Store a memory (supports type, room, author, tags) |
 | `uteke_recall` | Semantic search (supports tags filter, min_score) |
+| `uteke_search` | Text search with optional tag filter |
 | `uteke_list` | List memories (supports pagination via offset) |
 | `uteke_forget` | Delete a memory |
-| `uteke_stats` | Store statistics |
+| `uteke_stats` | Memory store statistics |
+| `uteke_context` | AI-optimized context output for prompts |
+| `uteke_dream` | One-command maintenance pipeline (lint → backlinks → dedup → orphans) |
+| `uteke_doc_create` | Create a document (wiki/knowledge base entry) |
+| `uteke_doc_get` | Retrieve a document by ID |
+| `uteke_doc_list` | List all documents |
+| `uteke_doc_search` | Search documents |
+| `uteke_doc_delete` | Delete a document |
+| `uteke_doc_update` | Partial document update with chunk rebuild (#589) |
+| `uteke_doc_move` | Move document to new parent (#438) |
+| `uteke_graph` | Get nodes + edges JSON for visualization |
+| `uteke_room_recall` | Semantic recall within a room |
+| `uteke_room_memories` | List memories in a room (#569) |
+| `uteke_room_create` | Create a room |
+| `uteke_room_delete` | Delete a room |
+| `uteke_room_stats` | Room statistics |
+| `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
+| `uteke_room_document` | Generate structured document from room |
+| `uteke_tags_list` | List all tags with counts (#566) |
+| `uteke_tags_rename` | Rename a tag across all memories (#566) |
+| `uteke_tags_delete` | Delete a tag from all memories (#566) |
+| `uteke_pin` | Pin a memory (prevent decay) (#566) |
+| `uteke_unpin` | Unpin a memory (#566) |
 
 
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -125,6 +125,7 @@ The MCP server provides the same tools via JSON-RPC (protocol version `2025-06-1
 - `uteke_list` — list memories (supports pagination via offset)
 - `uteke_forget` — delete memory
 - `uteke_stats` — store statistics
+- `uteke_room_memories` — list memories in a room (#569)
 
 ### MCP Client Configuration Examples
 
@@ -217,12 +218,37 @@ hermes mcp add uteke --command uteke-mcp
 | `room_stats` | Room statistics |
 | `room_delete` | Delete a room |
 
+## Memory-Provider for Other Agents (#575/#577)
+
+The `--memory-provider` pattern also works for non-Hermes agents:
+
+```bash
+# pi (pi.dev)
+uteke init --agent pi --memory-provider
+
+# Claude Code
+uteke init --agent claude --memory-provider
+
+# Cursor
+uteke init --agent cursor --memory-provider
+```
+
+This installs uteke as the agent's default memory provider — relevant memories are recalled and injected automatically every turn. No daemon needed; talks to the `uteke` binary directly via subprocess.
+
+> **Note:** For Hermes, use Mode A (uteke-tool) or Mode C (shell hook) instead — the
+> Hermes memory-provider plugin has been removed (see [Mode B](#mode-b--memory-provider-uteke-as-hermes-default-memory)).
+
 ## Mode B — memory-provider (uteke as Hermes default memory)
 
-> **DEPRECATED — Removed from production (2026-06-29)**
+> **DEPRECATED — Hermes only (removed 2026-06-29)**
 >
-> The memory-provider plugin (Mode B) has been removed from production deployments.
-> The plugin files and `memory.provider: uteke` configuration are no longer supported.
+> The Hermes-specific memory-provider plugin (Mode B) has been removed from production
+> deployments. The plugin files and `memory.provider: uteke` configuration are no longer
+> supported for Hermes.
+>
+> **This deprecation applies only to the Hermes memory-provider plugin.** The general
+> memory-provider pattern (`uteke init --agent <agent> --memory-provider`) remains
+> fully supported for **pi**, **Claude Code**, and **Cursor** (#575/#577).
 >
 > **Migrate to:** [Mode A (uteke-tool)](#mode-a--uteke-tool-manual-actions-multi-agent-rooms) for manual
 > tool-based memory, or [Mode C (shell hook)](#mode-c--pre_llm_call-shell-hook-automatic-recall-no-plugin)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,7 +132,7 @@ uteke init --agent hermes  # Installs pre_llm_call hook
 
 ## Available Tools
 
-Both transports expose the same 15 tools (MCP protocol version `2025-06-18`):
+Both transports expose the same 27 tools (MCP protocol version `2025-06-18`):
 
 | Tool | Description |
 |------|-------------|
@@ -149,8 +149,21 @@ Both transports expose the same 15 tools (MCP protocol version `2025-06-18`):
 | `uteke_doc_list` | List all documents |
 | `uteke_doc_search` | Search documents |
 | `uteke_doc_delete` | Delete a document |
+| `uteke_doc_update` | Partial document update with chunk rebuild (#589) |
+| `uteke_doc_move` | Move document to new parent (#438) |
 | `uteke_graph` | Get nodes + edges JSON for visualization |
 | `uteke_room_recall` | Semantic recall within a room |
+| `uteke_room_memories` | List memories in a room (#569) |
+| `uteke_room_create` | Create a room |
+| `uteke_room_delete` | Delete a room |
+| `uteke_room_stats` | Room statistics |
+| `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
+| `uteke_room_document` | Generate structured document from room |
+| `uteke_tags_list` | List all tags with counts (#566) |
+| `uteke_tags_rename` | Rename a tag across all memories (#566) |
+| `uteke_tags_delete` | Delete a tag from all memories (#566) |
+| `uteke_pin` | Pin a memory (prevent decay) (#566) |
+| `uteke_unpin` | Unpin a memory (#566) |
 
 ## Transport Comparison
 
@@ -256,6 +269,33 @@ See [TLS & Reverse Proxy](/tls) for full setup guides (Caddy, Nginx, Cloudflare 
 The MCP server uses the `default` namespace by default. Each agent can use its own isolated namespace by passing a `namespace` argument to any tool call. Memories in one namespace are never visible to another.
 
 This is the MCP equivalent of the CLI's `--namespace` flag — see [Multi-Agent Isolation](/getting-started#multi-agent-isolation) for details.
+
+## JSON-RPC 2.0 Compliance (#573/#576)
+
+The MCP server implements strict JSON-RPC 2.0 compliance (v0.6.7):
+
+- **Tagged union responses**: The `result` field uses a tagged union (`{"type": "result", "content": [...]}`) per the MCP spec, not a bare array.
+- **No notification response**: JSON-RPC notifications (requests without `id`) receive no response body, as required by the spec. This fixes Claude Code connectivity issues where unexpected responses on notifications caused handshake failures.
+- **Claude Code compatible**: Tested and verified with Claude Code, Claude Desktop, Cursor, and Hermes MCP client.
+
+## Memory-Provider Integration (#575/#577)
+
+For automatic recall (memories injected every LLM call without the agent asking), use the `--memory-provider` flag with `uteke init`:
+
+```bash
+# pi (pi.dev)
+uteke init --agent pi --memory-provider
+
+# Claude Code
+uteke init --agent claude --memory-provider
+
+# Cursor
+uteke init --agent cursor --memory-provider
+```
+
+This installs uteke as the agent's default memory provider — relevant memories are recalled and injected automatically every turn. No MCP server needed; talks to the `uteke` binary directly.
+
+> **Note:** The `--memory-provider` flag is only deprecated for Hermes (removed 2026-06-29). For pi, Claude Code, and Cursor, it is the recommended integration mode.
 
 ## Docker
 


### PR DESCRIPTION
Closes #582

## Summary

Fix all 16 documentation gaps identified in VitePress docs audit for v0.6.5–v0.6.7, plus add documentation for post-v0.6.7 features that will ship in v0.7.0.

### Files changed (7 docs + AGENT.md)

| File | Changes |
|------|---------|
| `docs/cli-reference.md` | +10 HTTP endpoints, memory-provider init entries, v0.6.7 version, changelog notes |
| `docs/mcp.md` | Tool count 15→28, 13 new tools, JSON-RPC 2.0 section, memory-provider integration |
| `docs/docker.md` | v0.6.7 tag, MCP tools table expanded 5→28 |
| `docs/architecture.md` | Schema v10→v12, cross-process file lock, slim Docker model path |
| `docs/hermes.md` | Mode B deprecation clarified, room_memories tool, pi/claude/cursor section |
| `README.md` / `README.id.md` | Version badge v0.6.6→v0.6.7 |
| `AGENT.md` | Version 0.6.7, main branch protection rules updated