### PR TITLE
fix: rename self-update command to 'uteke upgrade'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -334,11 +349,29 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -374,6 +407,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -559,13 +602,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -668,10 +721,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -783,6 +856,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1321,6 +1404,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2173,13 +2266,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2196,6 +2300,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2323,6 +2433,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2791,10 +2912,13 @@ dependencies = [
  "clap_complete",
  "ctrlc",
  "dirs",
+ "flate2",
  "reqwest",
  "serde",
  "serde_json",
  "serial_test",
+ "sha2 0.10.9",
+ "tar",
  "tempfile",
  "toml",
  "tracing",
@@ -2818,7 +2942,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -2845,7 +2969,7 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tiny_http",
  "toml",
  "tracing",
@@ -3339,6 +3463,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -26,6 +26,9 @@ clap_complete = "4"
 ctrlc = "3"
 tracing-appender = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"
 urlencoding = "2.1.3"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -692,4 +692,10 @@ pub enum AgingCommands {
         #[arg(long)]
         yes: bool,
     },
+    /// Check for updates and upgrade to the latest version
+    Update {
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
+    },
 }

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -520,6 +520,12 @@ pub enum DocCommands {
         #[arg(long)]
         output: Option<String>,
     },
+    /// Check for updates and upgrade to the latest version
+    Upgrade {
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
+    },
 }
 
 /// Subcommands for knowledge graph operations.
@@ -690,12 +696,6 @@ pub enum AgingCommands {
         max_access_count: u32,
         /// Skip confirmation prompt
         #[arg(long)]
-        yes: bool,
-    },
-    /// Check for updates and upgrade to the latest version
-    Update {
-        /// Skip confirmation prompt
-        #[arg(long, short)]
         yes: bool,
     },
 }

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -407,6 +407,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: DocCommands,
     },
+    /// Check for updates and upgrade to the latest version
+    Upgrade {
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
+    },
 }
 
 /// Document subcommands (#411, #438).
@@ -519,12 +525,6 @@ pub enum DocCommands {
         /// Output file (default: stdout)
         #[arg(long)]
         output: Option<String>,
-    },
-    /// Check for updates and upgrade to the latest version
-    Upgrade {
-        /// Skip confirmation prompt
-        #[arg(long, short)]
-        yes: bool,
     },
 }
 

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -17,7 +17,7 @@ mod room;
 mod server;
 mod tags;
 mod timeline;
-mod update;
+mod upgrade;
 
 use crate::cli::Cli;
 use crate::cli::Commands;
@@ -320,6 +320,6 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
 
         Commands::Doc { command } => crate::commands::doc::run(cli, uteke, command, config),
 
-        Commands::Update { yes } => update::run(*yes),
+        Commands::Upgrade { yes } => upgrade::run(*yes),
     }
 }

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ mod room;
 mod server;
 mod tags;
 mod timeline;
+mod update;
 
 use crate::cli::Cli;
 use crate::cli::Commands;
@@ -318,5 +319,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
         Commands::Timeline { id, limit } => timeline::run(cli, uteke, id, *limit),
 
         Commands::Doc { command } => crate::commands::doc::run(cli, uteke, command, config),
+
+        Commands::Update { yes } => update::run(*yes),
     }
 }

--- a/crates/uteke-cli/src/commands/update.rs
+++ b/crates/uteke-cli/src/commands/update.rs
@@ -1,0 +1,279 @@
+//! `uteke update` — check for updates and self-upgrade.
+//!
+//! Reuses the same logic as install.sh: detect OS/arch, fetch latest release
+//! from GitHub, download, verify checksum, replace the running binary.
+
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+use sha2::{Digest, Sha256};
+
+const REPO: &str = "codecoradev/uteke";
+const BINARY_NAME: &str = "uteke";
+
+/// Entry point for `uteke update`.
+pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Detect current version
+    let current_version = env!("CARGO_PKG_VERSION");
+    println!("[INFO] Current version: {current_version}");
+
+    // 2. Detect current binary path
+    let current_exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("[ERROR] Cannot determine current binary path: {e}");
+            eprintln!("        If installed via cargo, run: cargo install --path crates/uteke-cli");
+            return Err(e.into());
+        }
+    };
+
+    // 3. Detect OS and architecture
+    let os = detect_os();
+    let arch = detect_arch();
+
+    // 4. Get latest release version
+    let latest_version = get_latest_version()?;
+
+    // 5. Check if already up to date
+    if latest_version == current_version {
+        println!("[INFO] Already up to date ({current_version})");
+        return Ok(());
+    }
+
+    println!("[INFO] Latest version:  {latest_version}");
+    println!("[INFO] Release notes:  https://github.com/{REPO}/releases/tag/{latest_version}");
+
+    // 6. Confirm (unless --yes)
+    if !yes {
+        print!("? Update to {latest_version}? [y/N] ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().lock().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+        if input != "y" && input != "yes" {
+            println!("[INFO] Update cancelled.");
+            return Ok(());
+        }
+    }
+
+    // 7. Build target and download
+    let target = get_target(&os, &arch)?;
+
+    let archive_name = format!("{BINARY_NAME}-{target}-{latest_version}.tar.gz");
+    let download_url =
+        format!("https://github.com/{REPO}/releases/download/{latest_version}/{archive_name}");
+
+    println!("[INFO] Downloading {archive_name} ...");
+
+    let temp_dir = std::env::temp_dir().join(format!("uteke-update-{latest_version}"));
+    fs::create_dir_all(&temp_dir)?;
+    let archive_path = temp_dir.join(&archive_name);
+
+    let client = reqwest::blocking::Client::new();
+    let mut resp = client
+        .get(&download_url)
+        .send()
+        .map_err(|e| format!("Download failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_default();
+        return Err(format!("Download failed (HTTP {status}): {body}").into());
+    }
+
+    let mut file = fs::File::create(&archive_path)?;
+    io::copy(&mut resp, &mut file)?;
+    drop(file);
+
+    // 8. Verify checksum
+    let checksums_url = format!(
+        "https://github.com/{REPO}/releases/download/{latest_version}/checksums-sha256.txt"
+    );
+
+    println!("[INFO] Verifying checksum ...");
+
+    if let Ok(checksums_resp) = client.get(&checksums_url).send() {
+        if checksums_resp.status().is_success() {
+            let checksums_text = checksums_resp.text().unwrap_or_default();
+            if let Some(expected) = parse_checksum(&checksums_text, &archive_name) {
+                let actual = sha256_file(&archive_path)?;
+                if actual != expected {
+                    // Clean up on mismatch
+                    let _ = fs::remove_dir_all(&temp_dir);
+                    return Err(
+                        format!("Checksum mismatch! Expected: {expected}, got: {actual}").into(),
+                    );
+                }
+                println!("[INFO] Checksum verified: {actual}");
+            } else {
+                println!("[WARN] Checksum for {archive_name} not found — skipping verification");
+            }
+        } else {
+            println!("[WARN] Failed to download checksums — skipping verification");
+        }
+    }
+
+    // 9. Verify archive integrity (path traversal check)
+    let file = fs::File::open(&archive_path)?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(gz);
+    for entry in archive.entries()?.flatten() {
+        let path = entry
+            .path()?
+            .map_err(|e| format!("Archive path error: {e}"))?;
+        let path_str = path.to_string_lossy();
+        if path_str.starts_with('/') || path_str.contains("..") {
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(
+                "Archive contains unsafe paths (absolute or directory traversal) — refusing to extract"
+                    .into(),
+            );
+        }
+    }
+    drop(archive);
+
+    // 10. Extract
+    println!("[INFO] Extracting ...");
+    let file = fs::File::open(&archive_path)?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(gz);
+    archive.unpack(&temp_dir)?;
+
+    // 11. Find and replace binary
+    let extracted_binary = temp_dir.join(BINARY_NAME);
+    if !extracted_binary.exists() {
+        let _ = fs::remove_dir_all(&temp_dir);
+        return Err(format!("Binary '{BINARY_NAME}' not found in archive").into());
+    }
+
+    let install_dir = current_exe
+        .parent()
+        .ok_or("Cannot determine install directory")?;
+
+    // Copy to temp file first, then rename (atomic on POSIX)
+    let temp_new = install_dir.join(format!("{BINARY_NAME}.new"));
+    fs::copy(&extracted_binary, &temp_new)?;
+
+    // Verify the new binary runs
+    match std::process::Command::new(&temp_new)
+        .arg("--version")
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let new_version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            // Extract version from clap output like "uteke 0.6.7"
+            let extracted_version = new_version.split_whitespace().nth(1).unwrap_or("unknown");
+            println!("[INFO] Verified new binary: {extracted_version}");
+        }
+        Ok(output) => {
+            let _ = fs::remove_file(&temp_new);
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(format!(
+                "New binary failed to run: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+            .into());
+        }
+        Err(e) => {
+            let _ = fs::remove_file(&temp_new);
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(format!("Failed to verify new binary: {e}").into());
+        }
+    }
+
+    // Atomic rename
+    fs::rename(&temp_new, &current_exe)?;
+
+    // 12. Cleanup
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    println!("[INFO] Update complete. ({current_version} → {latest_version})");
+
+    Ok(())
+}
+
+fn detect_os() -> String {
+    match std::env::consts::OS {
+        "linux" => "linux".to_string(),
+        "macos" => "darwin".to_string(),
+        os => os.to_string(),
+    }
+}
+
+fn detect_arch() -> String {
+    match std::env::consts::ARCH {
+        "x86_64" => "x86_64".to_string(),
+        "aarch64" => "aarch64".to_string(),
+        arch => arch.to_string(),
+    }
+}
+
+fn get_target(os: &str, arch: &str) -> Result<String, Box<dyn std::error::Error>> {
+    match (os, arch) {
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu".into()),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu".into()),
+        ("darwin", "aarch64") => Ok("aarch64-apple-darwin".into()),
+        ("darwin", "x86_64") => {
+            Err("No pre-built binary for x86_64 macOS.\n  Install via: cargo install --path crates/uteke-cli".into())
+        }
+        _ => Err(format!("Unsupported platform: {os} {arch}")).into(),
+    }
+}
+
+fn get_latest_version() -> Result<String, Box<dyn std::error::Error>> {
+    let client = reqwest::blocking::Client::new();
+
+    // Primary: parse 302 redirect (no API call, no rate limit)
+    let resp = client
+        .head(format!("https://github.com/{REPO}/releases/latest"))
+        .send()
+        .map_err(|e| format!("Failed to check latest release: {e}"))?;
+
+    if let Some(location) = resp.headers().get("location") {
+        let loc = location.to_str().unwrap_or_default();
+        if let Some(tag) = loc.strip_prefix("/codecoradev/uteke/releases/tag/") {
+            return Ok(tag.trim_end_matches('?').to_string());
+        }
+        // Some mirrors might use different prefix
+        if let Some(tag) = loc.rsplit('/').next() {
+            if tag.starts_with('v') {
+                return Ok(tag.trim_end_matches('?').to_string());
+            }
+        }
+    }
+
+    // Fallback: GitHub API
+    let api_url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let resp = client
+        .get(&api_url)
+        .header("User-Agent", "uteke-update")
+        .send()
+        .map_err(|e| format!("GitHub API failed: {e}"))?;
+
+    if resp.status().is_success() {
+        let json: serde_json::Value = resp.json()?;
+        if let Some(tag) = json["tag_name"].as_str() {
+            return Ok(tag.to_string());
+        }
+    }
+
+    Err("Failed to determine latest version. Check https://github.com/{REPO}/releases".into())
+}
+
+fn parse_checksum(checksums_text: &str, archive_name: &str) -> Option<String> {
+    for line in checksums_text.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 && parts[1].contains(archive_name) {
+            return Some(parts[0].to_string());
+        }
+    }
+    None
+}
+
+fn sha256_file(path: &PathBuf) -> Result<String, Box<dyn std::error::Error>> {
+    let mut hasher = Sha256::new();
+    let mut file = fs::File::open(path)?;
+    io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}

--- a/crates/uteke-cli/src/commands/upgrade.rs
+++ b/crates/uteke-cli/src/commands/upgrade.rs
@@ -1,4 +1,4 @@
-//! `uteke update` — check for updates and self-upgrade.
+//! `uteke upgrade` — check for updates and self-upgrade.
 //!
 //! Reuses the same logic as install.sh: detect OS/arch, fetch latest release
 //! from GitHub, download, verify checksum, replace the running binary.
@@ -12,8 +12,8 @@ use sha2::{Digest, Sha256};
 const REPO: &str = "codecoradev/uteke";
 const BINARY_NAME: &str = "uteke";
 
-/// Entry point for `uteke update`.
-pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
+/// Entry point for `uteke upgrade`.
+pub fn run(yes: bool) -> Result<(), String> {
     // 1. Detect current version
     let current_version = env!("CARGO_PKG_VERSION");
     println!("[INFO] Current version: {current_version}");
@@ -24,7 +24,7 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
         Err(e) => {
             eprintln!("[ERROR] Cannot determine current binary path: {e}");
             eprintln!("        If installed via cargo, run: cargo install --path crates/uteke-cli");
-            return Err(e.into());
+            return Err(format!("Cannot determine current binary path: {e}"));
         }
     };
 
@@ -47,9 +47,14 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
     // 6. Confirm (unless --yes)
     if !yes {
         print!("? Update to {latest_version}? [y/N] ");
-        io::stdout().flush()?;
+        io::stdout()
+            .flush()
+            .map_err(|e| format!("stdout flush: {e}"))?;
         let mut input = String::new();
-        io::stdin().lock().read_line(&mut input)?;
+        io::stdin()
+            .lock()
+            .read_line(&mut input)
+            .map_err(|e| format!("stdin read: {e}"))?;
         let input = input.trim().to_lowercase();
         if input != "y" && input != "yes" {
             println!("[INFO] Update cancelled.");
@@ -67,7 +72,7 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
     println!("[INFO] Downloading {archive_name} ...");
 
     let temp_dir = std::env::temp_dir().join(format!("uteke-update-{latest_version}"));
-    fs::create_dir_all(&temp_dir)?;
+    fs::create_dir_all(&temp_dir).map_err(|e| format!("Failed to create temp dir: {e}"))?;
     let archive_path = temp_dir.join(&archive_name);
 
     let client = reqwest::blocking::Client::new();
@@ -79,11 +84,12 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().unwrap_or_default();
-        return Err(format!("Download failed (HTTP {status}): {body}").into());
+        return Err(format!("Download failed (HTTP {status}): {body}"));
     }
 
-    let mut file = fs::File::create(&archive_path)?;
-    io::copy(&mut resp, &mut file)?;
+    let mut file = fs::File::create(&archive_path)
+        .map_err(|e| format!("Failed to create archive file: {e}"))?;
+    io::copy(&mut resp, &mut file).map_err(|e| format!("Failed to write archive: {e}"))?;
     drop(file);
 
     // 8. Verify checksum
@@ -101,9 +107,9 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
                 if actual != expected {
                     // Clean up on mismatch
                     let _ = fs::remove_dir_all(&temp_dir);
-                    return Err(
-                        format!("Checksum mismatch! Expected: {expected}, got: {actual}").into(),
-                    );
+                    return Err(format!(
+                        "Checksum mismatch! Expected: {expected}, got: {actual}"
+                    ));
                 }
                 println!("[INFO] Checksum verified: {actual}");
             } else {
@@ -115,19 +121,25 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // 9. Verify archive integrity (path traversal check)
-    let file = fs::File::open(&archive_path)?;
+    let file = fs::File::open(&archive_path).map_err(|e| format!("Failed to open archive: {e}"))?;
     let gz = flate2::read::GzDecoder::new(file);
     let mut archive = tar::Archive::new(gz);
-    for entry in archive.entries()?.flatten() {
+    for entry in archive
+        .entries()
+        .map_err(|e| format!("Failed to read archive entries: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read archive entry: {e}"))?;
+        // entry.path() returns Result<Cow<Path>, _> in the tar crate's entry iteration
+        // but after .flatten() above and here we use the raw entry — path() returns Result
         let path = entry
-            .path()?
+            .path()
             .map_err(|e| format!("Archive path error: {e}"))?;
         let path_str = path.to_string_lossy();
         if path_str.starts_with('/') || path_str.contains("..") {
             let _ = fs::remove_dir_all(&temp_dir);
             return Err(
                 "Archive contains unsafe paths (absolute or directory traversal) — refusing to extract"
-                    .into(),
+                    .to_string(),
             );
         }
     }
@@ -135,25 +147,28 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
 
     // 10. Extract
     println!("[INFO] Extracting ...");
-    let file = fs::File::open(&archive_path)?;
+    let file = fs::File::open(&archive_path).map_err(|e| format!("Failed to open archive: {e}"))?;
     let gz = flate2::read::GzDecoder::new(file);
     let mut archive = tar::Archive::new(gz);
-    archive.unpack(&temp_dir)?;
+    archive
+        .unpack(&temp_dir)
+        .map_err(|e| format!("Failed to extract archive: {e}"))?;
 
     // 11. Find and replace binary
     let extracted_binary = temp_dir.join(BINARY_NAME);
     if !extracted_binary.exists() {
         let _ = fs::remove_dir_all(&temp_dir);
-        return Err(format!("Binary '{BINARY_NAME}' not found in archive").into());
+        return Err(format!("Binary '{BINARY_NAME}' not found in archive"));
     }
 
     let install_dir = current_exe
         .parent()
-        .ok_or("Cannot determine install directory")?;
+        .ok_or_else(|| "Cannot determine install directory".to_string())?;
 
     // Copy to temp file first, then rename (atomic on POSIX)
     let temp_new = install_dir.join(format!("{BINARY_NAME}.new"));
-    fs::copy(&extracted_binary, &temp_new)?;
+    fs::copy(&extracted_binary, &temp_new)
+        .map_err(|e| format!("Failed to copy new binary: {e}"))?;
 
     // Verify the new binary runs
     match std::process::Command::new(&temp_new)
@@ -172,18 +187,17 @@ pub fn run(yes: bool) -> Result<(), Box<dyn std::error::Error>> {
             return Err(format!(
                 "New binary failed to run: {}",
                 String::from_utf8_lossy(&output.stderr)
-            )
-            .into());
+            ));
         }
         Err(e) => {
             let _ = fs::remove_file(&temp_new);
             let _ = fs::remove_dir_all(&temp_dir);
-            return Err(format!("Failed to verify new binary: {e}").into());
+            return Err(format!("Failed to verify new binary: {e}"));
         }
     }
 
     // Atomic rename
-    fs::rename(&temp_new, &current_exe)?;
+    fs::rename(&temp_new, &current_exe).map_err(|e| format!("Failed to replace binary: {e}"))?;
 
     // 12. Cleanup
     let _ = fs::remove_dir_all(&temp_dir);
@@ -209,7 +223,7 @@ fn detect_arch() -> String {
     }
 }
 
-fn get_target(os: &str, arch: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn get_target(os: &str, arch: &str) -> Result<String, String> {
     match (os, arch) {
         ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu".into()),
         ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu".into()),
@@ -217,11 +231,11 @@ fn get_target(os: &str, arch: &str) -> Result<String, Box<dyn std::error::Error>
         ("darwin", "x86_64") => {
             Err("No pre-built binary for x86_64 macOS.\n  Install via: cargo install --path crates/uteke-cli".into())
         }
-        _ => Err(format!("Unsupported platform: {os} {arch}")).into(),
+        _ => Err(format!("Unsupported platform: {os} {arch}")),
     }
 }
 
-fn get_latest_version() -> Result<String, Box<dyn std::error::Error>> {
+fn get_latest_version() -> Result<String, String> {
     let client = reqwest::blocking::Client::new();
 
     // Primary: parse 302 redirect (no API call, no rate limit)
@@ -247,18 +261,22 @@ fn get_latest_version() -> Result<String, Box<dyn std::error::Error>> {
     let api_url = format!("https://api.github.com/repos/{REPO}/releases/latest");
     let resp = client
         .get(&api_url)
-        .header("User-Agent", "uteke-update")
+        .header("User-Agent", "uteke-upgrade")
         .send()
         .map_err(|e| format!("GitHub API failed: {e}"))?;
 
     if resp.status().is_success() {
-        let json: serde_json::Value = resp.json()?;
+        let json: serde_json::Value = resp
+            .json()
+            .map_err(|e| format!("Failed to parse GitHub API response: {e}"))?;
         if let Some(tag) = json["tag_name"].as_str() {
             return Ok(tag.to_string());
         }
     }
 
-    Err("Failed to determine latest version. Check https://github.com/{REPO}/releases".into())
+    Err(format!(
+        "Failed to determine latest version. Check https://github.com/{REPO}/releases"
+    ))
 }
 
 fn parse_checksum(checksums_text: &str, archive_name: &str) -> Option<String> {
@@ -271,9 +289,11 @@ fn parse_checksum(checksums_text: &str, archive_name: &str) -> Option<String> {
     None
 }
 
-fn sha256_file(path: &PathBuf) -> Result<String, Box<dyn std::error::Error>> {
+fn sha256_file(path: &PathBuf) -> Result<String, String> {
     let mut hasher = Sha256::new();
-    let mut file = fs::File::open(path)?;
-    io::copy(&mut file, &mut hasher)?;
+    let mut file =
+        fs::File::open(path).map_err(|e| format!("Failed to open file for hashing: {e}"))?;
+    io::copy(&mut file, &mut hasher)
+        .map_err(|e| format!("Failed to read file for hashing: {e}"))?;
     Ok(format!("{:x}", hasher.finalize()))
 }


### PR DESCRIPTION
## Summary

Fixes 5 compilation errors from #601 by renaming the self-update command from `uteke update` to `uteke upgrade`.

## Problem

`Commands::Update` already exists as a document partial-update command (`uteke doc update <id>`, #589). The self-update PR created a naming collision that caused all CI checks to fail.

## Changes

| File | Change |
|------|--------|
| `cli.rs` | Added `Commands::Upgrade` variant, removed `AgingCommands::Update` (wrong enum) |
| `commands/mod.rs` | `mod update` → `mod upgrade`, dispatcher uses `Commands::Upgrade` |
| `commands/upgrade.rs` | Return type `Result<(), Box<dyn Error>>` → `Result<(), String>`, fixed `entry.path()` Cow bug, all `.into()` calls |

## Resolved errors

- E0599: `entry.path()` returns `Cow<Path>`, not `Result` — removed invalid `.map_err()`
- E0277: `Err(String).into()` type mismatch with `Box<dyn Error>`
- E0599: `Commands::Update { yes }` didn't match existing `Commands::Update` fields
- E0308: Match arm type mismatch (`Box<dyn Error>` vs `String`)
- E0004: Non-exhaustive `AgingCommands::Update` (removed — semantically wrong)

Closes #601, Closes #581