### PR TITLE
feat(server): maintenance + monitoring endpoints (#607 #608)

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -62,6 +62,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             "/doc/get",
             "/doc/list",
             "/doc/search",
+            "/orphans",
         ];
         let is_read = method == Method::Get || read_only_post_paths.iter().any(|ep| path == *ep);
         if !is_read {
@@ -1380,6 +1381,120 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     error!("Export error: {e}");
                     ctx.error_response_for(req, 500, "Internal server error")
                 }
+            }
+        }
+
+        // ── Prune (maintenance) ───────────────────────────────────────────
+        (Method::Post, "/prune") => match read_body::<PruneRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                let result =
+                    uteke.prune(req_data.ttl_days, ns(&req_data.namespace), req_data.dry_run);
+                match result {
+                    Ok(r) => ctx.ok_response_for(req, &r),
+                    Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Consolidate (maintenance) ────────────────────────────────────
+        (Method::Post, "/consolidate") => match read_body::<ConsolidateRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                if req_data.dry_run {
+                    let pairs = uteke.find_duplicates(ns(&req_data.namespace), req_data.threshold);
+                    match pairs {
+                        Ok(p) => ctx.ok_response_for(req, &p),
+                        Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+                    }
+                } else {
+                    let result =
+                        uteke.consolidate(ns(&req_data.namespace), req_data.threshold, false);
+                    match result {
+                        Ok(r) => ctx.ok_response_for(req, &r),
+                        Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+                    }
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Aging (maintenance) ─────────────────────────────────────────
+        (Method::Post, "/aging") => match read_body::<AgingRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                let result = match req_data.action.as_str() {
+                    "status" => {
+                        let status = uteke.aging_status(ns(&req_data.namespace));
+                        status.map(|s| serde_json::json!(s))
+                    }
+                    "preview" => {
+                        let older = req_data.older_than_days.unwrap_or(90);
+                        let max_acc = req_data.max_access_count.unwrap_or(1);
+                        let mems = uteke.aging_preview(older, max_acc, ns(&req_data.namespace));
+                        mems.map(|m| serde_json::json!(m))
+                    }
+                    "cleanup" => {
+                        if req_data.dry_run {
+                            let older = req_data.older_than_days.unwrap_or(90);
+                            let max_acc = req_data.max_access_count.unwrap_or(1);
+                            let mems = uteke.aging_preview(older, max_acc, ns(&req_data.namespace));
+                            mems.map(|m| serde_json::json!({ "dry_run": true, "candidates": m.len(), "memories": m }))
+                        } else {
+                            let older = req_data.older_than_days.unwrap_or(90);
+                            let max_acc = req_data.max_access_count.unwrap_or(1);
+                            let r = uteke.aging_cleanup(older, max_acc, ns(&req_data.namespace));
+                            r.map(|c| serde_json::json!(c))
+                        }
+                    }
+                    other => {
+                        return ctx.error_response_for(
+                            req,
+                            400,
+                            format!("Unknown action: {other}. Use: status, preview, cleanup"),
+                        )
+                    }
+                };
+                match result {
+                    Ok(r) => ctx.ok_response_for(req, &r),
+                    Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Importance (monitoring) ────────────────────────────────────────
+        (Method::Post, "/importance") => match read_body::<ImportanceRequest>(req.as_reader()) {
+            Ok(_req_data) => match uteke.recompute_importance() {
+                Ok(count) => ctx.ok_response_for(req, &serde_json::json!({ "updated": count })),
+                Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+            },
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Orphans (monitoring — read-only) ─────────────────────────────
+        (Method::Post, "/orphans") => match read_body::<OrphansRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                match uteke.find_orphans(
+                    ns(&req_data.namespace),
+                    req_data.threshold,
+                    req_data.limit,
+                ) {
+                    Ok(orphans) => ctx.ok_response_for(req, &orphans),
+                    Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Rebuild Backlinks (monitoring) ────────────────────────────────
+        (Method::Post, "/rebuild-backlinks") => {
+            match read_body::<RebuildBacklinksRequest>(req.as_reader()) {
+                Ok(_req_data) => match uteke.rebuild_backlinks() {
+                    Ok(count) => {
+                        ctx.ok_response_for(req, &serde_json::json!({ "backlinks_created": count }))
+                    }
+                    Err(e) => ctx.error_response_for(req, 500, e.to_string()),
+                },
+                Err(e) => ctx.error_response_for(req, 400, e),
             }
         }
 

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -375,3 +375,81 @@ pub struct ImportRequest {
     #[allow(dead_code)] // not yet merged into JSONL entries on import
     pub tags: Vec<String>,
 }
+
+// ── Maintenance Types (#607) ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct PruneRequest {
+    #[serde(default = "default_prune_ttl")]
+    pub ttl_days: u32,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+fn default_prune_ttl() -> u32 {
+    30
+}
+
+#[derive(Deserialize)]
+pub struct ConsolidateRequest {
+    #[serde(default = "default_consolidate_threshold")]
+    pub threshold: f32,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+fn default_consolidate_threshold() -> f32 {
+    0.9
+}
+
+#[derive(Deserialize)]
+pub struct AgingRequest {
+    #[serde(default = "default_aging_action")]
+    pub action: String,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Days threshold for preview/cleanup (default: warm_days from config, fallback 90).
+    #[serde(default)]
+    pub older_than_days: Option<u32>,
+    /// Max access count threshold for preview/cleanup (default: 1).
+    #[serde(default)]
+    pub max_access_count: Option<u32>,
+}
+
+fn default_aging_action() -> String {
+    "status".to_string()
+}
+
+// ── Monitoring Types (#608) ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ImportanceRequest {
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct OrphansRequest {
+    #[serde(default = "default_orphan_threshold")]
+    pub threshold: f64,
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+fn default_orphan_threshold() -> f64 {
+    0.3
+}
+
+#[derive(Deserialize)]
+pub struct RebuildBacklinksRequest {
+    #[serde(default)]
+    pub quiet: bool,
+}

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -431,6 +431,7 @@ fn default_aging_action() -> String {
 #[derive(Deserialize)]
 pub struct ImportanceRequest {
     #[serde(default)]
+    #[allow(dead_code)] // recompute_importance is global (no namespace filter)
     pub namespace: Option<String>,
 }
 
@@ -451,5 +452,6 @@ fn default_orphan_threshold() -> f64 {
 #[derive(Deserialize)]
 pub struct RebuildBacklinksRequest {
     #[serde(default)]
+    #[allow(dead_code)] // reserved for future verbose mode
     pub quiet: bool,
 }


### PR DESCRIPTION
## Summary

Add 6 new HTTP endpoints to uteke-serve for CLI parity.

### Maintenance (#607)

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/prune` | POST | TTL-based deprecated memory cleanup (`dry_run` support) |
| `/consolidate` | POST | Near-duplicate merging (`dry_run` → find only, no merge) |
| `/aging` | POST | Memory lifecycle: `status`, `preview`, `cleanup` actions |

### Monitoring (#608)

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/importance` | POST | Recalculate importance scores |
| `/orphans` | POST | Find disconnected low-importance memories (read-only) |
| `/rebuild-backlinks` | POST | Rebuild `referenced_by` from forward edges |

## Auth

- `/prune`, `/consolidate`, `/aging`, `/importance`, `/rebuild-backlinks` → **write token** required
- `/orphans` → **read-only token** allowed (read-only query)

## Changes

- `types.rs`: 7 new request structs with sensible defaults
- `handlers.rs`: 6 new route handlers + `/orphans` added to read-only POST paths

Closes #607, #608