### PR TITLE
feat(cli): add opencode init + bundle SKILL.md v0.6.7

### DIFF
--- a/.agents/skills/uteke-memory/SKILL.md
+++ b/.agents/skills/uteke-memory/SKILL.md
@@ -1,11 +1,11 @@
 ---
-description: "Persistent memory engine for AI agents via the uteke CLI — remember, recall, search, forget with semantic + FTS5 hybrid search, metadata enrichment, and multi-agent namespaces."
+description: "Persistent memory engine for AI agents via the uteke CLI — remember, recall, search, forget with semantic + FTS5 hybrid search, documents, knowledge graph, rooms, tiered memory, and multi-agent namespaces."
 ---
 
 # Uteke Memory Skill
 
 Persistent memory engine for AI agents via the `uteke` CLI.
-Version: **0.0.13** — FTS5 hybrid search with RRF, metadata enrichment, concurrent reads.
+Version: **0.6.7** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Zero unsafe code.
 
 ## Global Flags (all commands)
 
@@ -22,19 +22,76 @@ Version: **0.0.13** — FTS5 hybrid search with RRF, metadata enrichment, concur
 
 | Command | Description | Key Options |
 |---------|-------------|-------------|
-| `uteke remember <TEXT>` | Store a new memory with metadata | `--tags <tags>`, `--entity <name>`, `--category <cat>`, `--meta <k:v,...>` |
-| `uteke recall <QUERY>` | Hybrid search (vector + FTS5, ranked by RRF) | `--limit <n>` (default 5), `--entity <name>`, `--category <cat>` |
-| `uteke search <QUERY>` | Keyword text search | `--limit <n>` (default 10), `--tags <tags>` |
-| `uteke list` | List memories with filters | `--tag <tag>`, `--entity <name>`, `--category <cat>`, `--limit <n>`, `--offset <n>` |
+| `uteke remember <TEXT>` | Store a new memory | `--tags`, `--type`, `--entity`, `--category`, `--meta`, `--room`, `--author`, `--source`, `--source-type`, `--detect-contradiction` |
+| `uteke recall <QUERY>` | Hybrid search (vector + FTS5, RRF) | `--limit`, `--tags`, `--entity`, `--category`, `--min`, `--strategy` (vector/fts5/hybrid/graph), `--salience`, `--recency`, `--related`, `--depth`, `--context`, `--at` (time-travel), `--type` (all/memory/doc), `--where` (JSON field filter) |
+| `uteke search <QUERY>` | Keyword text search | `--limit`, `--tags` |
+| `uteke list` | List memories with filters | `--tag`, `--entity`, `--category`, `--limit`, `--offset`, `--at` |
 | `uteke get <ID>` | Get single memory by UUID | |
-| `uteke forget <ID>` | Delete memory by ID, tag, tier, or all | `--tag <tag>`, `--cold`, `--all`, `--confirm` |
+| `uteke forget <ID>` | Delete memory by ID, tag, tier, or all | `--tag`, `--cold`, `--all`, `--confirm` |
 
-### Memory Intelligence
+### Documents (Wiki / Knowledge Base)
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke doc create <SLUG>` | Create document from file/stdin | `--title`, `--file`, `--content`, `--tags`, `--parent` |
+| `uteke doc get <ID_OR_SLUG>` | Get a document | |
+| `uteke doc update <ID_OR_SLUG>` | Partial update — only provided fields change | `--title`, `--content`, `--file`, `--tags`, `--metadata` |
+| `uteke doc delete <ID>` | Delete document (cascades to children) | |
+| `uteke doc list` | List documents | `--limit`, `--tree` (hierarchy) |
+| `uteke doc search <QUERY>` | Search documents (semantic + FTS5) | `--limit`, `--mode` (semantic/fts/hybrid) |
+| `uteke doc children <PARENT>` | List child documents | `--limit` |
+| `uteke doc move <ID_OR_SLUG>` | Move to new parent or root | `--parent` |
+| `uteke doc breadcrumbs <ID_OR_SLUG>` | Show path from root | |
+| `uteke doc descendants <ID_OR_SLUG>` | List all descendants | `--max-depth`, `--limit` |
+| `uteke doc export` | Export all documents as JSON | `--output` |
+
+### Knowledge Graph
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke graph nodes` | List all graph nodes | `--entity-type` |
+| `uteke graph edges` | List all graph edges | `--relation` |
+| `uteke graph neighbors <LABEL>` | Find neighbors (BFS) | `--depth` |
+| `uteke graph path <SRC> <TGT>` | Shortest path (BFS) | `--max-depth` |
+| `uteke graph query <RELATION>` | Query edges by relation type | |
+| `uteke graph stats` | Graph statistics | |
+
+### Memory Relationships
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke edges <ID>` | List edges for a memory (auto-wired backlinks/forward links) | `--deep` (BFS depth), `--direction` (incoming/outgoing/both) |
+| `uteke rebuild-backlinks` | Rebuild `referenced_by` from forward edges | `--quiet` |
+
+### Rooms (Collaborative Memory)
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke room create <ID>` | Create a room | `--title` |
+| `uteke room list` | List all rooms | `--namespace` |
+| `uteke room stats <ID>` | Room statistics and participants | |
+| `uteke room recall <ID>` | Recall room memories | `--query`, `--author`, `--limit`, `--min` |
+| `uteke room summary <ID>` | Topic clustering summary | |
+| `uteke room document <ID>` | Generate structured document from room | |
+| `uteke room delete <ID>` | Delete room (memories preserved) | `--confirm` |
+
+### Pinning & Importance
 
 | Command | Description |
 |---------|-------------|
-| `uteke consolidate` | Find and merge duplicate memories (`--threshold 0.60 --dry-run`) |
-| `uteke prune` | Remove deprecated/expired temporal memories (`--ttl 30 --dry-run`) |
+| `uteke pin <ID>` | Pin a memory (never decays) |
+| `uteke unpin <ID>` | Unpin a memory |
+| `uteke importance` | Recalculate importance scores for all memories |
+| `uteke orphans` | Find disconnected memories with low importance | `--threshold` (default 0.3), `--limit` (default 50) |
+
+### Maintenance
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke dream` | Full maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify | `--phases`, `--skip`, `--dry-run`, `--quiet` |
+| `uteke consolidate` | Merge near-duplicate memories | `--threshold` (default 0.90), `--dry-run` |
+| `uteke prune` | Remove deprecated/expired memories | `--ttl` (default 30), `--dry-run` |
+| `uteke timeline <ID>` | Show audit log events for a memory | `--limit` (default 20) |
 
 ### Tags & Namespaces
 
@@ -42,123 +99,108 @@ Version: **0.0.13** — FTS5 hybrid search with RRF, metadata enrichment, concur
 |---------|-------------|
 | `uteke tags list` | List all tags with counts (`--by-count`) |
 | `uteke tags rename <old> <new>` | Rename a tag across all memories |
-| `uteke tags delete <tag>` | Delete a tag from all memories |
+| `uteke tags delete <tag>` | Delete a tag from all memories (`--confirm`) |
 | `uteke namespace list` | List all namespaces with counts |
+| `uteke namespace stats <name>` | Stats for a specific namespace |
 | `uteke namespace switch <name>` | Set default namespace in config |
 
 ### Memory Aging
 
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke aging status` | Hot/warm/cold/never-accessed breakdown | |
+| `uteke aging preview` | Preview stale memories | `--older-than-days` (default 180), `--max-access-count` (default 1) |
+| `uteke aging cleanup` | Delete aged memories | `--older-than-days`, `--max-access-count`, `--yes` |
+
+### Health, Stats & Data
+
 | Command | Description |
 |---------|-------------|
-| `uteke aging status` | Show hot/warm/cold/never-accessed breakdown |
-| `uteke aging preview --days N` | Preview memories older than N days |
-| `uteke aging cleanup --days N --confirm` | Delete stale memories |
-
-### Health & Maintenance
-
-| Command | Description |
-|---------|-------------|
-| `uteke stats` | Memory store statistics + tier breakdown (🔥 Hot / 🟡 Warm / ❄️ Cold) |
+| `uteke stats` | Memory store statistics + tier breakdown |
 | `uteke doctor` | Full health check: DB, index, embedding model, consistency |
 | `uteke verify` | Compare DB count vs vector index count |
+| `uteke verify-checksums` | Verify binary integrity against SHA256 checksums |
 | `uteke repair` | Rebuild vector index from SQLite |
+| `uteke export [FILE]` | Export to JSONL (no embeddings). Default: stdout |
+| `uteke import [FILE]` | Import from JSONL/Markdown/text. Default: stdin |
+| `uteke bench` | Performance benchmarks | `--counts`, `--json` |
 
-### Data Portability
-
-| Command | Description |
-|---------|-------------|
-| `uteke export [FILE]` | Export to JSONL (no embeddings — portable). Default: stdout |
-| `uteke import [FILE]` | Import from JSONL (re-embeds content). Default: stdin |
-
-### Setup & Shell
+### Setup & Upgrade
 
 | Command | Description |
 |---------|-------------|
-| `uteke hook install <shell>` | Install shell hook for auto-context loading (bash/zsh/fish) |
-| `uteke completions <SHELL>` | Generate shell completions |
+| `uteke init --agent <TYPE>` | Initialize integration (pi/claude/cursor/opencode/hermes) |
+| `uteke hook install <SHELL>` | Install shell hook (bash/zsh/fish) |
+| `uteke completions <SHELL>` | Generate shell completions (bash/zsh/fish/powershell) |
+| `uteke upgrade` | Check for updates and upgrade | `-y` (skip confirmation) |
 
 ## Architecture
 
-- **Storage:** SQLite (WAL mode, bundled) with `namespace` column + FTS5 virtual table
-- **Vector index:** usearch persistent HNSW (768d, cosine similarity) with `RwLock` for concurrent reads
-- **Full-text search:** SQLite FTS5 with phrase + token-OR fallback
-- **Hybrid search:** Reciprocal Rank Fusion (RRF, k=60) merges vector + FTS5 results
+- **Storage:** SQLite (WAL mode) with namespace column + FTS5 virtual table
+- **Vector index:** usearch persistent HNSW (768d, cosine similarity)
+- **Hybrid search:** RRF (k=60) merges vector + FTS5 results; graph strategy adds graph-signal reranking
 - **Embedding:** ONNX EmbeddingGemma Q4 (768d), auto-downloaded
 - **Tiered memory:** Hot (<7d, +0.1 boost), Warm (<30d), Cold (>30d)
-- **Metadata:** Entity, category, and key:value pairs stored as JSON blob
-- **Schema versioning:** Integer counter, auto-migration on upgrade (currently v2)
-- **Index files:** `uteke_index.usearch` + `uteke_index.keys` (atomic save)
+- **Schema versioning:** Integer counter, auto-migration on upgrade
 - **Zero unsafe code** (`unsafe_code = "forbid"`)
+- **Project-scoped stores:** `uteke --store .uteke remember "..."`
 
 ## Usage Patterns
 
 ### Session lifecycle
 ```bash
-# Before work — load context
 uteke recall "project architecture decisions" --namespace pi-agent
-
-# After decisions — persist with metadata
-uteke remember "Use WAL mode for concurrent reads" \
-  --tags architecture,db \
-  --entity db-layer \
-  --category decision \
-  --namespace pi-agent
-
-# End of session — summarize
-uteke remember "Refactored auth middleware, token expiry fix" \
-  --tags session,auth --namespace pi-agent
-
-# Session handoff
+uteke remember "Use WAL mode for concurrent reads" --tags architecture,db --entity db-layer
 uteke recall "last session state" --namespace pi-agent
 ```
 
 ### Metadata-enriched storage
 ```bash
 uteke remember "Deploy staging to AWS us-east-1" \
-  --tags deploy,aws \
-  --entity staging-server \
-  --category infrastructure \
-  --meta "source:meeting-note,confidence:0.9"
+  --tags deploy,aws --entity staging-server --category infrastructure \
+  --source "meeting-notes.md" --source-type file
 ```
 
-### Filter by entity or category
+### Time-travel queries
 ```bash
-uteke recall "server" --entity staging-server
-uteke list --category infrastructure --limit 10
+uteke recall "auth flow" --at 2026-06-01T12:00:00Z
+uteke list --at 2026-06-01T12:00:00Z
 ```
 
-### Project-scoped memory
+### Graph-enhanced recall
 ```bash
-uteke --store .uteke remember "Uses React Server Components" --tags frontend
+uteke recall "database design" --strategy graph --related --depth 2
+uteke graph neighbors "auth-service" --depth 3
+uteke graph path "api-gateway" "database"
 ```
 
-### Multi-agent isolation
+### Document wiki
 ```bash
-uteke remember "Agent-specific context" --namespace code-reviewer
-uteke recall "recent decisions" --namespace code-reviewer
+uteke doc create architecture/overview --title "Architecture Overview" --file overview.md --parent docs
+uteke doc search "authentication" --mode hybrid
+uteke doc list --tree
 ```
 
-### Health check
+### Room collaboration
 ```bash
-uteke stats          # 🔥 Hot: 12 | 🟡 Warm: 45 | ❄️ Cold: 200
-uteke doctor         # Full diagnostics
-uteke verify         # Quick consistency check
-uteke repair         # Fix broken index
+uteke remember "Decision: use PostgreSQL" --room design-review --author alice
+uteke room recall design-review --query "database"
+uteke room summary design-review
 ```
 
-### Data portability
-```bash
-uteke export backup.jsonl           # Export all memories
-uteke export --namespace agent-x > agent-x.jsonl
-uteke import backup.jsonl           # Import (re-embeds automatically)
-```
-
-### Programmatic (JSON output)
+### Programmatic (JSON)
 ```bash
 uteke recall "auth flow" --json --limit 3
 uteke stats --json
 uteke list --tag architecture --json --limit 50
-uteke remember "test" --json        # {"id":"a1b2c3d4-..."}
+```
+
+### Maintenance pipeline
+```bash
+uteke dream                           # Full pipeline
+uteke dream --phases lint,verify --dry-run  # Selective, safe
+uteke importance                      # Recompute scores
+uteke orphans --threshold 0.2         # Find disconnected
 ```
 
 ## When to Use
@@ -167,16 +209,18 @@ uteke remember "test" --json        # {"id":"a1b2c3d4-..."}
 |---------|--------|
 | Before starting work | `uteke recall "<project context>"` |
 | After making decisions | `uteke remember "<decision>" --tags <tags> --entity <name>` |
-| Before closing session | `uteke remember "<session summary>" --tags session` |
-| Important findings | `uteke remember "<finding>" --tags finding,<topic>` |
-| Multi-agent context | Use `--namespace <agent-name>` |
-| Index feels slow/corrupt | `uteke doctor` → `uteke repair` if needed |
+| Important documents | `uteke doc create <slug> --file <path> --parent <slug>` |
+| Collaborative decisions | `uteke remember "..." --room <room> --author <name>` |
+| Memory feels stale | `uteke dream` or `uteke importance` |
+| Index feels corrupt | `uteke doctor` → `uteke repair` |
 
-## Server Mode
+## Server Mode (uteke-serve)
 
-For real-time agent use, start a persistent daemon:
+HTTP daemon with REST API for all operations + monitoring/maintenance endpoints.
 
 ```bash
 uteke-serve --port 8767
-# Now CLI auto-routes to server: ~42ms recall vs ~3s cold start
+# CLI auto-routes to server when running: ~42ms recall vs ~3s cold start
 ```
+
+Endpoints mirror CLI commands (e.g., `POST /remember`, `POST /recall`, `POST /doc/create`). Supports read-only API tokens for restricted access.

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -272,7 +272,7 @@ pub enum Commands {
     },
     /// Initialize uteke integration for an AI agent
     Init {
-        /// Agent type: pi, claude, cursor, hermes
+        /// Agent type: pi, claude, cursor, opencode, hermes
         #[arg(long, default_value = "pi")]
         agent: String,
         /// For --agent hermes: install the memory-provider plugin (automatic

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -39,6 +39,13 @@ pub(crate) fn run_init(agent: &str, memory_provider: bool, json: bool) -> Result
                 init_cursor(json)
             }
         }
+        "opencode" => {
+            if memory_provider {
+                init_opencode_memory_provider(json)
+            } else {
+                init_opencode(json)
+            }
+        }
         "hermes" => {
             if memory_provider {
                 init_hermes_memory_provider(json)
@@ -47,68 +54,40 @@ pub(crate) fn run_init(agent: &str, memory_provider: bool, json: bool) -> Result
             }
         }
         _ => Err(format!(
-            "Unknown agent: {agent}. Supported: pi, claude, cursor, hermes"
+            "Unknown agent: {agent}. Supported: pi, claude, cursor, opencode, hermes"
         )),
     }
 }
 
-/// Initialize uteke integration for Pi agents.
-fn init_pi(json: bool) -> Result<(), String> {
-    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+/// Copy the bundled SKILL.md to a target `.agents/skills/uteke-memory/` directory.
+/// Returns the path to the written file.
+fn install_skill_md(cwd: &std::path::Path) -> Result<std::path::PathBuf, String> {
     let skill_dir = cwd.join(".agents").join("skills").join("uteke-memory");
     std::fs::create_dir_all(&skill_dir).map_err(|e| format!("Failed to create skill dir: {e}"))?;
+    let dest = skill_dir.join("SKILL.md");
+    // Bundled SKILL.md is in .agents/skills/uteke-memory/ relative to repo root.
+    // For `cargo install` builds it's embedded; for `cargo run` it lives in the
+    // crate's CWD.  We embed the content at compile time to always have it.
+    let bundled = include_str!("../../../.agents/skills/uteke-memory/SKILL.md");
+    std::fs::write(&dest, bundled).map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
+    Ok(dest)
+}
 
-    let skill_content = r#"# Uteke Memory Skill
-
-Provides persistent memory for AI agents via the `uteke` CLI.
-
-## Commands
-
-- `uteke remember "<text>" --tags <tags>` — Store a memory
-- `uteke recall "<query>" --limit <n>` — Semantic search
-- `uteke search "<keywords>"` — Keyword search
-- `uteke list --tag <tag>` — List memories
-- `uteke get <id>` — Get a memory by ID
-- `uteke forget <id>` — Delete a memory
-- `uteke stats` — Show statistics
-- `uteke export [file]` — Export memories to JSONL
-- `uteke import [file]` — Import memories from JSONL
-
-## Usage Patterns
-
-### Store important context
-```bash
-uteke remember "Database uses WAL mode for concurrent reads" --tags architecture,db
-```
-
-### Recall relevant context
-```bash
-uteke recall "how does the database work?"
-```
-
-### Project-specific store
-```bash
-uteke --store .uteke remember "Uses React Server Components" --tags frontend
-```
-
-## When to Use
-- Before starting work: `uteke recall "<project context>"`
-- After making decisions: `uteke remember "<decision>" --tags <tags>`
-- Before closing session: `uteke remember "<session state>" --tags session`
-"#;
-
-    std::fs::write(skill_dir.join("SKILL.md"), skill_content)
-        .map_err(|e| format!("Failed to write skill: {e}"))?;
+/// Initialize uteke integration for Pi agents.
+/// Writes the bundled SKILL.md to `.agents/skills/uteke-memory/SKILL.md`.
+fn init_pi(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let dest = install_skill_md(&cwd)?;
 
     if json {
         let obj = serde_json::json!({
             "agent": "pi",
-            "skill": skill_dir.to_string_lossy(),
+            "skill": dest.to_string_lossy(),
             "status": "installed"
         });
         println!("{obj}");
     } else {
-        println!("✓ Pi skill installed: {}", skill_dir.display());
+        println!("✓ Pi skill installed: {}", dest.display());
         println!("  Restart your agent to activate.");
     }
     Ok(())
@@ -432,6 +411,135 @@ After meaningful decisions, discoveries, or progress: call `uteke_remember` with
         println!();
         println!("  Add MCP server to .cursor/mcp.json:");
         println!("    {{\"mcpServers\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}}");
+    }
+    Ok(())
+}
+
+/// Initialize uteke integration for OpenCode.
+/// Writes AGENTS.md (or appends to existing) with uteke instructions.
+fn init_opencode(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let agents_path = cwd.join("AGENTS.md");
+
+    let md_content = r#"# Uteke Memory Integration
+
+## Commands
+- `uteke remember "<text>" --tags <tags>` — Store a memory
+- `uteke recall "<query>" --limit <n>` — Semantic search
+- `uteke search "<keywords>"` — Keyword search
+- `uteke list --tag <tag>` — List memories
+- `uteke get <id>` — Get by ID
+- `uteke forget <id>` — Delete
+- `uteke stats` — Statistics
+- `uteke export [file]` — Export to JSONL
+- `uteke import [file]` — Import from JSONL
+
+## Guidelines
+1. Before starting work: recall relevant context
+2. After making decisions: store them with tags
+3. Before closing session: store session state
+4. Use project-specific stores with `--store .uteke`
+"#;
+
+    if agents_path.exists() {
+        let existing = std::fs::read_to_string(&agents_path)
+            .map_err(|e| format!("Failed to read AGENTS.md: {e}"))?;
+        if !existing.contains("Uteke Memory") {
+            let updated = format!("{existing}\n\n{md_content}");
+            std::fs::write(&agents_path, updated)
+                .map_err(|e| format!("Failed to update AGENTS.md: {e}"))?;
+        }
+    } else {
+        std::fs::write(&agents_path, md_content)
+            .map_err(|e| format!("Failed to write AGENTS.md: {e}"))?;
+    }
+
+    // Also install the bundled SKILL.md for agents that read .agents/skills/
+    let _skill = install_skill_md(&cwd);
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "opencode",
+            "file": agents_path.to_string_lossy(),
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!(
+            "✓ OpenCode integration installed: {}",
+            agents_path.display()
+        );
+        println!("  Restart OpenCode to activate.");
+    }
+    Ok(())
+}
+
+/// Initialize uteke memory-provider integration for OpenCode.
+///
+/// OpenCode has no lifecycle hooks. Strategy:
+/// 1. Generate enhanced AGENTS.md with auto-recall rules
+/// 2. Include MCP server config snippet
+fn init_opencode_memory_provider(json: bool) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    let agents_path = cwd.join("AGENTS.md");
+
+    let md_content = r#"# Uteke Memory Integration (Auto Mode)
+
+## MCP Tools Available
+`uteke_recall`, `uteke_remember`, `uteke_search`, `uteke_list`, `uteke_forget`, `uteke_stats`, `uteke_context`
+
+## Auto-Recall Rule
+**Before starting any task**, call `uteke_recall` with the task summary as the query. Use the results to restore context from prior sessions.
+
+## Store Proactively
+After meaningful decisions, discoveries, or progress: call `uteke_remember` with relevant tags.
+
+## MCP Config (add to opencode.json)
+```json
+{
+  "mcp": {
+    "uteke": {
+      "command": "uteke-mcp",
+      "args": []
+    }
+  }
+}
+```
+"#;
+
+    if agents_path.exists() {
+        let existing = std::fs::read_to_string(&agents_path)
+            .map_err(|e| format!("Failed to read AGENTS.md: {e}"))?;
+        if !existing.contains("uteke_recall") {
+            let updated = format!("{existing}\n\n{md_content}");
+            std::fs::write(&agents_path, updated)
+                .map_err(|e| format!("Failed to update AGENTS.md: {e}"))?;
+        }
+    } else {
+        std::fs::write(&agents_path, md_content)
+            .map_err(|e| format!("Failed to write AGENTS.md: {e}"))?;
+    }
+
+    // Also install the bundled SKILL.md
+    let _skill = install_skill_md(&cwd);
+
+    if json {
+        let obj = serde_json::json!({
+            "agent": "opencode",
+            "plugin": "memory-provider",
+            "file": agents_path.to_string_lossy(),
+            "status": "installed"
+        });
+        println!("{obj}");
+    } else {
+        println!(
+            "✓ OpenCode memory-provider installed: {}",
+            agents_path.display()
+        );
+        println!("  AGENTS.md includes auto-recall + MCP config snippet.");
+        println!();
+        println!("  Add MCP server to your opencode.json:");
+        println!("    {{\"mcp\":{{\"uteke\":{{\"command\":\"uteke-mcp\"}}}}}}");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `init --agent opencode` support: generates AGENTS.md with uteke instructions
- Refactor `init --agent pi`: now uses bundled SKILL.md via install_skill_md() helper
- Update bundled SKILL.md to v0.6.7
- Fix CLI help text and escaped-quote bug

## Breaking changes
None. All changes additive.
