### PR TITLE
feat: project-aware memory tagging for noise-free recall

### DIFF
--- a/.agents/skills/uteke-memory/SKILL.md
+++ b/.agents/skills/uteke-memory/SKILL.md
@@ -203,12 +203,57 @@ uteke importance                      # Recompute scores
 uteke orphans --threshold 0.2         # Find disconnected
 ```
 
+## Project-Aware Memory (MANDATORY)
+
+**Always tag memories with `project:<name>` when working in a project.** This prevents noise when recalling — you only see memories relevant to the current project.
+
+### How to detect the project name
+
+1. From `workdir` / `cwd` — extract the repo folder name:
+   - `/home/user/repos/bond/` → `project:bond`
+   - `/home/user/repos/uteke/` → `project:uteke`
+   - `/home/user/repos/my-saas-app/` → `project:my-saas-app`
+2. From file paths mentioned in the conversation
+3. From the project name the user mentions
+
+### Rules
+
+| Rule | Details |
+|------|---------|
+| **REMEMBER** | Always include `project:<name>` in `--tags` when the memory is project-specific |
+| **RECALL** | Always include `--tags project:<name>` to scope recall to the current project |
+| **NO PROJECT** | If the conversation is not about any specific project (e.g., general chat), do NOT add a `project:` tag |
+| **TAG FORMAT** | Always lowercase: `project:bond`, `project:uteke` (not `project:Bond`) |
+
+### Examples
+
+```bash
+# Working on the "bond" project
+uteke recall "auth flow" --tags project:bond
+uteke remember "JWT rotation implemented with refresh tokens" --tags project:bond,decision,auth
+uteke remember "DB schema uses UUID v7 for primary keys" --tags project:bond,architecture,db
+
+# Working on the "uteke" project
+uteke recall "vector index corruption" --tags project:uteke
+uteke remember "Fixed usearch rebuild race condition" --tags project:uteke,bugfix,index
+
+# General conversation — no project tag
+uteke remember "User prefers concise responses" --tags preference
+
+# Cross-project recall (explicitly requested)
+uteke recall "shared auth pattern" --tags project:bond,project:corin
+```
+
+### Why this matters
+
+Without project tags, memories from all projects mix together. When you recall "fix auth bug" while working on project Bond, you might get results from project Corin's auth system — causing confusion and wasted context. Project tags ensure recall is scoped and noise-free.
+
 ## When to Use
 
 | Trigger | Action |
 |---------|--------|
-| Before starting work | `uteke recall "<project context>"` |
-| After making decisions | `uteke remember "<decision>" --tags <tags> --entity <name>` |
+| Before starting work | `uteke recall "<project context>" --tags project:<name>` |
+| After making decisions | `uteke remember "<decision>" --tags project:<name>,<other tags>` |
 | Important documents | `uteke doc create <slug> --file <path> --parent <slug>` |
 | Collaborative decisions | `uteke remember "..." --room <room> --author <name>` |
 | Memory feels stale | `uteke dream` or `uteke importance` |

--- a/extensions/pi-memory-provider/index.ts
+++ b/extensions/pi-memory-provider/index.ts
@@ -5,6 +5,9 @@
  * experience. Hooks `before_agent_start` to inject relevant memories into
  * every agent turn without manual tool calls.
  *
+ * Project-aware: auto-detects project name from the current working directory
+ * and tags all memories with `project:<name>` for noise-free recall.
+ *
  * Install:
  *   Global:  ~/.pi/agent/extensions/uteke-memory-provider/index.ts
  *   Project: .pi/extensions/uteke-memory-provider/index.ts
@@ -14,8 +17,8 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execSync } from "node:child_process";
-import { join } from "node:path";
-import { homedir } from "node:os";
+import { basename, resolve } from "node:path";
+import { existsSync } from "node:fs";
 
 // ---------------------------------------------------------------------------
 // Config (reads from env, can be extended)
@@ -25,6 +28,63 @@ const DEFAULT_NAMESPACE = "default";
 const RECALL_LIMIT = 6;
 const RECALL_MIN_SCORE = 0.45;
 const RECALL_TIMEOUT_MS = 15_000;
+
+// Known project root directories to scan for project detection
+const KNOWN_PROJECT_DIRS = [
+	"/opt/data/repos",
+	"/home",
+	process.env.HOME || "",
+].filter(Boolean);
+
+// ---------------------------------------------------------------------------
+// Project Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect project name from the current working directory.
+ * Walks up from cwd to find a known project root, then extracts the folder name.
+ * Returns lowercase project name or empty string.
+ */
+function detectProjectFromCwd(): string {
+	const cwd = process.cwd();
+
+	for (const root of KNOWN_PROJECT_DIRS) {
+		if (!root || !existsSync(root)) continue;
+		const resolved = resolve(root);
+
+		// Check if cwd is inside or equal to this project root
+		if (cwd.startsWith(resolved + "/") || cwd === resolved) {
+			// Extract the immediate subdirectory name
+			const relative = cwd.slice(resolved.length + 1);
+			const firstSegment = relative.split("/")[0];
+			if (firstSegment && !firstSegment.startsWith(".")) {
+				return firstSegment.toLowerCase();
+			}
+		}
+	}
+
+	return "";
+}
+
+/**
+ * Detect project name from text (file paths, mentions).
+ * Falls back to cwd detection if nothing found in text.
+ */
+function detectProject(text: string, fallbackToCwd = false): string {
+	if (!text) return fallbackToCwd ? detectProjectFromCwd() : "";
+
+	// Strategy 1: file paths containing known project roots
+	for (const root of KNOWN_PROJECT_DIRS) {
+		if (!root) continue;
+		const escaped = root.replace(/\//g, "\\/");
+		const match = text.match(new RegExp(`${escaped}/([a-zA-Z0-9_.-]+)`));
+		if (match && match[1] && !match[1].startsWith(".")) {
+			return match[1].toLowerCase();
+		}
+	}
+
+	return fallbackToCwd ? detectProjectFromCwd() : "";
+}
 
 // ---------------------------------------------------------------------------
 // Subprocess helpers
@@ -59,18 +119,25 @@ function runUteke(args: string[], timeout = RECALL_TIMEOUT_MS): string {
 	}
 }
 
-function recallMemories(query: string): string[] {
+function recallMemories(query: string, project: string): string[] {
 	const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
 	const limit = process.env.UTEKE_RECALL_LIMIT || String(RECALL_LIMIT);
 	const minScore = process.env.UTEKE_RECALL_MIN_SCORE || String(RECALL_MIN_SCORE);
 
-	const raw = runUteke([
+	const args: string[] = [
 		"recall", `"${query}"`,
 		"--namespace", ns,
 		"--limit", limit,
 		"--min-score", minScore,
 		"--json",
-	]);
+	];
+
+	// Filter by project tag if detected
+	if (project) {
+		args.push("--tags", `project:${project}`);
+	}
+
+	const raw = runUteke(args);
 
 	if (!raw.trim()) return [];
 
@@ -90,11 +157,12 @@ function recallMemories(query: string): string[] {
 	}
 }
 
-function formatMemories(memories: string[]): string {
+function formatMemories(memories: string[], project: string): string {
 	if (!memories.length) return "";
+	const projectHint = project ? ` [project: ${project}]` : "";
 	const lines = memories.map((m, i) => `${i + 1}. ${m}`).join("\n");
 	return (
-		"\n\n## Relevant Memories (uteke)\n\n" +
+		`\n\n## Relevant Memories (uteke)${projectHint}\n\n` +
 		lines +
 		"\n\nUse `uteke remember` to store new facts, `uteke recall` to search more."
 	);
@@ -112,11 +180,14 @@ export default function (pi: ExtensionAPI) {
 		const out = runUteke(["stats"], 3000);
 		available = out.trim().length > 0;
 
-		if (available) {
-			ctx.ui.setStatus("uteke", "🧠 uteke: active");
-		} else {
-			ctx.ui.setStatus("uteke", "🧠 uteke: not found");
-		}
+		const project = detectProjectFromCwd();
+		const status = project
+			? `🧠 uteke: active (${project})`
+			: available
+				? "🧠 uteke: active"
+				: "🧠 uteke: not found";
+
+		ctx.ui.setStatus("uteke", status);
 	});
 
 	// Core hook: inject relevant memories before every agent turn
@@ -126,10 +197,12 @@ export default function (pi: ExtensionAPI) {
 		const prompt = (event.prompt || "").trim();
 		if (!prompt || prompt.length < 3) return;
 
-		const memories = recallMemories(prompt);
+		// Detect project from prompt text, fallback to cwd
+		const project = detectProject(prompt, true);
+		const memories = recallMemories(prompt, project);
 		if (!memories.length) return;
 
-		const injection = formatMemories(memories);
+		const injection = formatMemories(memories, project);
 
 		return {
 			systemPrompt: event.systemPrompt + injection,
@@ -142,19 +215,32 @@ export default function (pi: ExtensionAPI) {
 		handler: async (args, _ctx) => {
 			const query = args.join(" ").trim();
 			if (!query) return "Usage: /uteke-recall <topic>";
-			const memories = recallMemories(query);
+			const project = detectProject(query, true);
+			const memories = recallMemories(query, project);
 			if (!memories.length) return "No relevant memories found.";
-			return formatMemories(memories);
+			return formatMemories(memories, project);
 		},
 	});
 
 	pi.registerCommand("uteke-save", {
-		description: "Save a memory to uteke",
+		description: "Save a memory to uteke (auto-tagged with project)",
 		handler: async (args, _ctx) => {
 			const content = args.join(" ").trim();
 			if (!content) return "Usage: /uteke-save <content>";
-			runUteke(["remember", `"${content}"`], RECALL_TIMEOUT_MS);
-			return "✓ Memory saved.";
+
+			const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
+			const project = detectProjectFromCwd();
+			const cmdArgs: string[] = [
+				"remember", `"${content}"`,
+				"--namespace", ns,
+			];
+			if (project) {
+				cmdArgs.push("--tags", `project:${project}`);
+			}
+
+			runUteke(cmdArgs, RECALL_TIMEOUT_MS);
+			const projectNote = project ? ` [project: ${project}]` : "";
+			return `✓ Memory saved.${projectNote}`;
 		},
 	});
 


### PR DESCRIPTION
## Problem

When agents work across multiple projects (Bond, Corin, Uteke, etc.), all memories are stored in a single namespace without project-level scoping. This causes noise during recall — querying "fix auth bug" while working on project Bond returns results from project Corin's auth system, wasting context tokens and creating confusion.

## Solution

Tag-based project scoping using existing `--tags` flag support. No Uteke binary changes required.

## Changes

### 1. SKILL.md — Project-Aware Memory (MANDATORY) section
- Instructions for all agents (pi, claude, cursor, opencode) to always tag `project:<name>`
- Detection rules from workdir, file paths, and conversation context
- Examples and rationale

### 2. pi-memory-provider extension — auto project detection
- Detects project from `cwd` (walks up to known project root directories)
- Falls back to detecting project name from user prompt text
- Recall filtered by `--tags project:<name>`
- `/uteke-save` command auto-tags with `project:<name>`
- Status bar shows active project name

### 3. Hermes hooks (external, applied separately)
- `uteke-extract`: Scans session messages for `/repos/<project>/` paths, auto-tags extracted facts
- `uteke-recall`: Detects project from user_message, filters recall by `--tags project:<name>`

## Detection Strategy

1. **File paths**: `/repos/<project>/` pattern in text
2. **CWD**: Walk up from current directory to known project roots (`/opt/data/repos/`, `~/repos/`)
3. **Majority vote**: When multiple projects mentioned in session, most frequent wins

## Example Flow

```
CTO works on Bond → session messages contain /opt/data/repos/bond/
→ hook extract detects "bond" → auto-tags: project:bond
→ hook recall filters --tags project:bond → only Bond memories appear

Pi works in /opt/data/repos/corin/
→ extension detects cwd → project:corin
→ recall automatically scoped to corin memories only
→ /uteke-save auto-tags project:corin
```

## What's NOT changed

- Uteke binary — no rebuild needed
- Existing memories — untouched (can be backfilled with project tags later)
- Namespace isolation — remains per-agent (cto, cfo, etc.)