### PR TITLE
chore: release v0.7.0 prep — changelog, version bump, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## [Unreleased]
 
+
+## [0.7.0] — 2026-07-08
+
+### Added
+- **Project-aware memory tagging for noise-free recall (#616)** — Tag-based project scoping using `project:<name>` convention. SKILL.md includes mandatory project-aware memory section. pi-memory-provider extension auto-detects project from CWD and auto-tags recall. Hermes hooks detect project from `/repos/<project>/` paths. No binary changes — works with existing `--tags` flag.
+- **OpenCode init support (#612)** — `uteke init --agent opencode` generates AGENTS.md with uteke instructions. Bundled SKILL.md updated to v0.6.7.
+- **Maintenance HTTP endpoints (#607)** — `POST /prune` (TTL-based deprecated memory cleanup), `POST /consolidate` (near-duplicate merging), `POST /aging` (memory lifecycle: status/preview/cleanup). Write token required.
+- **Monitoring HTTP endpoints (#608)** — `POST /importance` (recalculate importance scores), `POST /orphans` (find disconnected low-importance memories, read-only), `POST /rebuild-backlinks` (rebuild referenced_by edges). Orphans accepts read-only token.
+- **Extract/Import/Export HTTP endpoints (#604–#606)** — `POST /extract` (LLM fact extraction + auto-store, 1MB limit), `POST /import` (JSONL import with re-embedding, 5MB limit), `GET /export` (JSONL export with optional namespace filter). Extractor moved from uteke-cli to uteke-core (shared module).
+- **Document partial update CLI + HTTP (#589, #583)** — `uteke doc update <slug>` for partial document updates (title, content, tags, metadata) with automatic chunk rebuild. `POST /doc/update` endpoint.
+- **MCP: pin/unpin tools (#588)** — `uteke_pin` and `uteke_unpin` MCP tools for memory persistence control.
+- **MCP: 6 room tools (#586)** — `uteke_room_create`, `uteke_room_delete`, `uteke_room_stats`, `uteke_room_summary`, `uteke_room_document`, `uteke_room_memories` MCP tools for full room management.
+- **MCP: tag management tools (#566)** — `uteke_tags_list`, `uteke_tags_rename`, `uteke_tags_delete` MCP tools.
+- **MCP: document update + move tools (#589, #438)** — `uteke_doc_update` (partial document update with chunk rebuild), `uteke_doc_move` (move document to new parent).
+- **`uteke upgrade` command (#603)** — Renamed from `uteke update` (which conflicted with `uteke doc update`). Self-update mechanism for installing latest Uteke release.
+
+### Changed
+- **Documents are now global — no namespace isolation (#614, #615)** — Documents use unique slugs across all namespaces. Schema migration v12→v13 adds `author` column, deprecates namespace on documents, migrates duplicate slugs. All document CRUD (CLI, server, MCP) no longer accepts namespace parameter.
+- **Extractor moved to uteke-core** — `Extractor` struct moved from `uteke-cli` to `uteke-core` shared module. CLI extract command delegates to core. Net -213 lines.
+- **Schema version v13** — Migration v12→v13: documents namespace deprecated, `author` column added, duplicate slug cleanup, global unique slug index.
+
+### Fixed
+- **Security: fail-hard on checksum verification failure (#609)** — `uteke upgrade` now fails with error when checksums download fails or archive checksum is missing, preventing MITM tampering. Found by Cora code review (GLM-5.2).
+- **Room tables in SCHEMA constant (#596)** — Fresh databases now include room tables in the base SCHEMA, preventing issues when schema_version check doesn't run migrations.
+- **CI: graceful sync workflow (#598)** — Fixed sync workflow + added missing cargo audit ignores for known advisories.
+- **Deps: crossbeam-epoch 0.9.18 → 0.9.20 (#597)** — Security update (RUSTSEC-2026-0204).
+
 ## [0.6.7] — 2026-07-06
 
 ### Added
@@ -1133,7 +1160,7 @@
 - **Binary name:** `uteke`
 - **Minimum Rust version:** 1.75+
 
-[Unreleased]: https://github.com/codecoradev/uteke/compare/v0.6.7...HEAD
+[Unreleased]: https://github.com/codecoradev/uteke/compare/v0.7.0...HEAD
 [0.6.7]: https://github.com/codecoradev/uteke/releases/tag/v0.6.7
 [0.6.6]: https://github.com/codecoradev/uteke/releases/tag/v0.6.6
 [0.6.5]: https://github.com/codecoradev/uteke/releases/tag/v0.6.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.7"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,36 @@ ID → usearch REMOVE (RwLock write, acquired first)
 
 Index lock acquired **before** SQLite delete — narrows the inconsistency window.
 
+
+### Extract / Import / Export (v0.7.0)
+
+Three new endpoints move the Extractor from CLI-only to a shared core module:
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/extract` | POST | Write | LLM fact extraction + auto-store (1MB body limit) |
+| `/import` | POST | Write | JSONL import with re-embedding (5MB body limit) |
+| `/export` | GET | Read | JSONL export (optional `?namespace=` filter) |
+
+### Maintenance & Monitoring (v0.7.0)
+
+Six new endpoints provide CLI parity for maintenance and monitoring operations:
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/prune` | POST | Write | TTL-based deprecated memory cleanup (`dry_run` support) |
+| `/consolidate` | POST | Write | Near-duplicate merging (`dry_run` → find only) |
+| `/aging` | POST | Write | Memory lifecycle: `status`, `preview`, `cleanup` |
+| `/importance` | POST | Write | Recalculate importance scores |
+| `/orphans` | POST | Read | Find disconnected, low-importance memories |
+| `/rebuild-backlinks` | POST | Write | Rebuild `referenced_by` from forward edges |
+
+### Document Update (v0.7.0)
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/doc/update` | POST | Write | Partial document update (title, content, tags, metadata) with chunk rebuild |
+
 ## Key Design Decisions
 
 ### RwLock for Vector Index (not Mutex)
@@ -141,7 +171,7 @@ All critical file I/O uses the `.tmp` + `rename` pattern. On POSIX filesystems, 
 
 ### Schema Versioning
 
-Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v12. Schema history: v4 rooms, v5 memory_tags junction, v6 content_type column, v7 knowledge graph, v8 `memory_edges` + `slug` (#346), v9 `timeline_events` table (#347), v10 `source` + `source_type` (#348), v11 documents + document_chunks (#406), v12 hierarchy (parent_id on documents, room tables added to SCHEMA constant). Zero data loss guaranteed.
+Integer counter in `schema_version` table. Migrations run automatically on upgrade. Currently at v13. Schema history: v4 rooms, v5 memory_tags junction, v6 content_type column, v7 knowledge graph, v8 `memory_edges` + `slug` (#346), v9 `timeline_events` table (#347), v10 `source` + `source_type` (#348), v11 documents + document_chunks (#406), v12 hierarchy (parent_id on documents, room tables added to SCHEMA constant), v13 global documents (namespace deprecated, author column, slug uniqueness). Zero data loss guaranteed.
 
 ### Rooms
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.6.7**.
+Complete reference for all uteke commands. Version **0.7.0**.
 
 ## Global Flags
 
@@ -16,6 +16,25 @@ Complete reference for all uteke commands. Version **0.6.7**.
 | `--verbose` | Enable debug logging | off |
 
 Config file path is auto-resolved (`~/.uteke/uteke.toml` + `.uteke/uteke.toml`); there is no `--config` flag.
+
+
+## uteke upgrade
+
+Check for updates and upgrade to the latest Uteke release.
+
+```bash
+# Check current version and upgrade
+uteke upgrade
+
+# Skip confirmation
+uteke upgrade --yes
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Skip confirmation prompt |
+
+> **Note:** Renamed from `uteke update` in v0.7.0 to avoid conflict with `uteke doc update`. The upgrade command verifies SHA-256 checksums by default. Set `UTEKE_UPGRADE_SKIP_CHECKSUM=1` to skip verification (not recommended).
 
 ## uteke remember
 
@@ -653,11 +672,12 @@ uteke timeline <memory-id> --json
 | `uteke namespace stats <name>` | Show stats for a namespace |
 | `uteke namespace switch <name>` | Set default namespace in config |
 | `uteke hook <shell>` | Print shell hook script (bash/zsh/fish) |
-| `uteke init --agent <type>` | Initialize integration (pi, claude, cursor, hermes) |
+| `uteke init --agent <type>` | Initialize integration (opencode, pi, claude, cursor, hermes) |
 | `uteke init --agent hermes --memory-provider` | Install uteke as Hermes's default memory provider (auto recall + extraction). See [Hermes integration, Mode B](integrations/hermes.md). **Note:** Hermes Mode B deprecated — see [integrations/hermes.md](integrations/hermes.md) for migration. |
 | `uteke init --agent pi --memory-provider` | Install uteke as pi's default memory provider (auto recall + extraction, #575/#577) |
 | `uteke init --agent claude --memory-provider` | Install uteke as Claude Code's default memory provider (auto recall + extraction, #575/#577) |
 | `uteke init --agent cursor --memory-provider` | Install uteke as Cursor's default memory provider (auto recall + extraction, #575/#577) |
+| `uteke init --agent opencode` | Generate AGENTS.md with uteke instructions for OpenCode (#612) |
 | `uteke completions <shell>` | Generate shell completions |
 
 ## uteke-serve (Server Mode)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,7 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.6.7` | Specific version |
+| `v0.7.0` | Specific version |
 | `v0.6.6` | Specific version |
 | `0.6` | Minor version (latest patch) |
 | `slim` | Slim image (no embedded model — mount model volume separately, see below) |

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -83,6 +83,16 @@ The `--namespace` flag works on every command:
 | `export` | Export from namespace |
 | `import` | Import to namespace |
 
+## Documents Are Global
+
+Unlike memories, **documents are global** (v0.7.0, #614/#615). Documents use unique slugs across all namespaces — no namespace isolation. This means:
+
+- Documents created in any namespace are visible in all namespaces via `uteke doc list`
+- Document commands (`create`, `get`, `update`, `search`, `list`, `delete`) do not accept `--namespace`
+- Slugs must be globally unique — a duplicate slug across namespaces will be auto-migrated on upgrade (schema v12→v13)
+
+This is intentional: documents represent shared knowledge (wiki, architecture guides, runbooks) that should be accessible to all agents regardless of their memory namespace.
+
 ## Best Practices
 
 - **One namespace per agent role** — Use descriptive names like "planner", "coder", "reviewer" instead of "agent-1", "agent-2".


### PR DESCRIPTION
## Summary

Release preparation for v0.7.0 — all post-v0.6.7 changes documented and version bumped.

### Changes

| File | Change |
|------|--------|
| **CHANGELOG.md** | Add v0.7.0 section — 18 PRs (features, fixes, breaking changes) |
| **Cargo.toml** | Workspace version 0.6.7 → 0.7.0 |
| **docs/cli-reference.md** | Version → 0.7.0, add `uteke upgrade` command, add opencode init |
| **docs/architecture.md** | Schema v12→v13, new HTTP endpoints (extract/import/export, maintenance/monitoring, doc update), updated endpoint diagram |
| **docs/multi-agent.md** | Add 'Documents Are Global' section (breaking change from #614/#615) |
| **docs/docker.md** | Version example → v0.7.0 |

### Breaking Changes (documented)

- **Documents are now global** — no namespace isolation (#614/#615). Schema migration v12→v13 handles auto-migration of duplicate slugs. Document commands no longer accept `--namespace`.

### Post-merge

Tag `v0.7.0` from develop to trigger release workflow.