### PR TITLE
chore: release v0.7.1 prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
   push:
     branches: [main]
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.6.7
+- **Version:** 0.7.1
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+## [0.7.1] — 2026-07-09
+
+### Fixed
+- **Vector index silently desyncs from SQLite (#621)** — Memories exist in SQLite but have no vector embedding, invisible to `uteke recall`. Root cause: `index.save()` failure in `remember_precomputed` and `forget` silently returned `Ok(())`. Fix: explicit error propagation + `uteke verify` / `uteke repair` commands.
+- **`uteke remember` ignores stdin pipe content (#620)** — Piping content via `cat file | uteke remember -` stored literal `"-"` instead of reading stdin. Fix: added stdin detection when content argument is `"-"`, with `Box::leak` for lifetime extension.
+- **`uteke room recall` default limit 20 silently truncates (#623)** — Rooms with >20 memories had results silently cut. Fix: increased default limit to 100.
+- **Author metadata not exposed in room recall JSON (#624)** — `room_memories.author` was not selected in the recall SQL query. Fix: added `rm.author` to SELECT with fallback to `"unknown"`.
+
+### Changed
+- **Documentation audit (#618)** — Added 9 missing HTTP endpoints to docs, fixed CHANGELOG link, updated sidebar anchors, corrected `doc list` namespace description.
+
+### Dependencies
+- `clap_complete` 4.6.6 → 4.6.7
+
 ## [0.7.0] — 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.7-green.svg" alt="v0.6.7" />
+  <img src="https://img.shields.io/badge/status-v0.7.1-green.svg" alt="v0.7.1" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.6.7-green.svg" alt="v0.6.7" />
+  <img src="https://img.shields.io/badge/status-v0.7.1-green.svg" alt="v0.7.1" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.7.1", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.7.1", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.7.0" }
+uteke-core = { path = "../uteke-core", version = "0.7.1", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.7.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.7.0**.
+Complete reference for all uteke commands. Version **0.7.1**.
 
 ## Global Flags
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,7 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.7.0` | Specific version |
+| `v0.7.1` | Specific version |
 | `v0.6.6` | Specific version |
 | `0.6` | Minor version (latest patch) |
 | `slim` | Slim image (no embedded model — mount model volume separately, see below) |


### PR DESCRIPTION
## Release v0.7.1

### Version bump
- Workspace: 0.7.0 → 0.7.1
- Crate deps: uteke-core, uteke-cli, uteke-server, uteke-mcp all synced
- Cargo.lock updated

### Docs
- README.md + README.id.md badges: v0.6.7 → v0.7.1
- AGENT.md version string
- docs/cli-reference.md version string
- docs/docker.md version tag

### CHANGELOG
- Added [0.7.1] section with:
  - Fixed #620 (stdin pipe), #621 (vector desync), #623 (room limit), #624 (author metadata)
  - Changed: docs audit (#618)
  - Dependencies: clap_complete 4.6.7

### Checklist ✅
- [x] Cargo.toml workspace.package.version
- [x] crates/*/Cargo.toml dependency versions
- [x] Cargo.lock synced
- [x] CHANGELOG.md
- [x] AGENT.md version
- [x] README.md + README.id.md badges
- [x] docs/cli-reference.md version
- [x] docs/docker.md version tag