### PR TITLE
fix(server): raise /doc/list default limit from 5 to 1000

### DIFF
--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -26,7 +26,7 @@ pub struct DocGetRequest {
 
 #[derive(Deserialize)]
 pub struct DocListParams {
-    #[serde(default = "default_limit")]
+    #[serde(default = "default_doc_limit")]
     pub limit: usize,
     #[serde(default)]
     pub roots_only: bool,
@@ -183,6 +183,13 @@ pub struct ErrorResponse {
 
 pub fn default_limit() -> usize {
     5
+}
+
+/// Document listings are not paginated like memories — callers (e.g. the Corin
+/// doc tree) need the full set to build the hierarchy client-side. Default high
+/// so omitting `limit` does not silently cap the tree at 5 docs.
+pub fn default_doc_limit() -> usize {
+    1000
 }
 #[derive(Deserialize)]
 pub struct RoomRecallRequest {


### PR DESCRIPTION
## Problem
`POST /doc/list` reused the memory pagination default (`default_limit() = 5`). Clients that build the full document hierarchy client-side (e.g. Corin's doc tree) silently received only 5 documents when omitting `limit`, so most of the tree never showed up.

## Fix
Documents are not paginated like memories. Add a dedicated `default_doc_limit() = 1000` and apply it to `DocListParams` only. Memory and room-recall defaults are unchanged.

## Files
- `crates/uteke-server/src/types.rs` — new `default_doc_limit()`, wired into `DocListParams`.

## Checks
- `cargo fmt --all -- --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` — 43 + 299 passed ✅