### PR TITLE
fix(core): defensive datetime parsing — tolerate missing timezone in RFC3339 fields

### DIFF
--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -155,6 +155,86 @@ impl super::Store {
             }
         }
 
+        // Repair datetime strings that lack timezone suffix.
+        //
+        // Older binaries (or manual inserts) may have written ISO 8601 strings
+        // without the mandatory RFC3339 timezone offset (e.g.
+        // "2026-07-09T19:53:45.493962" instead of
+        // "2026-07-09T19:53:45.493962+00:00"). This causes
+        // chrono::DateTime::parse_from_rfc3339() to fail with "premature end
+        // of input", crashing load_all().
+        self.repair_datetime_timezones()?;
+
+        Ok(())
+    }
+
+    /// Fix datetime columns that are missing the RFC3339 timezone suffix.
+    ///
+    /// Affected columns: `created_at`, `updated_at` in `memories` and
+    /// `created_at`, `updated_at` in `documents`. The fix appends `+00:00`
+    /// (assumes UTC) to any datetime string that doesn't contain a timezone
+    /// offset. This is idempotent — already-correct rows are untouched.
+    fn repair_datetime_timezones(&self) -> Result<(), Error> {
+        let datetime_cols: &[(&str, &str)] = &[
+            ("memories", "created_at"),
+            ("memories", "updated_at"),
+            ("documents", "created_at"),
+            ("documents", "updated_at"),
+        ];
+
+        let mut total_fixed = 0u64;
+
+        for &(table, column) in datetime_cols {
+            // Find rows where the datetime string doesn't contain '+' or 'Z' or
+            // a timezone-like offset pattern. Valid RFC3339 always ends with
+            // +HH:MM, -HH:MM, Z, or +00:00.
+            let sql = format!(
+                "SELECT id, {column} FROM {table} \
+                 WHERE {column} IS NOT NULL \
+                 AND {column} NOT LIKE '%+00:00' \
+                 AND {column} NOT LIKE '%+%' \
+                 AND {column} NOT LIKE '%Z'"
+            );
+
+            let rows: Vec<(String, String)> = {
+                let mut stmt = self
+                    .conn
+                    .prepare(&sql)
+                    .map_err(|e| Error::db("repair datetime: query", e))?;
+                let iter = stmt
+                    .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                    .map_err(|e| Error::db("repair datetime: iterate", e))?
+                    .filter_map(|r| r.ok());
+                // Drop stmt before the iterator temporary is dropped,
+                // avoiding a borrow-checker conflict (#E0597).
+                let rows: Vec<(String, String)> = iter.collect();
+                drop(stmt);
+                rows
+            };
+
+            if !rows.is_empty() {
+                tracing::info!(
+                    table,
+                    column,
+                    count = rows.len(),
+                    "Repairing datetime strings missing timezone suffix"
+                );
+            }
+
+            for (id, val) in &rows {
+                let fixed = format!("{val}+00:00");
+                let update_sql = format!("UPDATE {table} SET {column} = ?1 WHERE id = ?2");
+                self.conn
+                    .execute(&update_sql, params![fixed, id])
+                    .map_err(|e| Error::db("repair datetime: update", e))?;
+                total_fixed += 1;
+            }
+        }
+
+        if total_fixed > 0 {
+            tracing::info!(total_fixed, "Datetime timezone repair complete");
+        }
+
         Ok(())
     }
 

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -324,6 +324,43 @@ pub(super) fn deserialize_embedding(blob: &[u8]) -> Vec<f32> {
         .collect()
 }
 
+/// Parse a datetime string with fallback for missing timezone suffix.
+///
+/// Accepts both RFC3339 (`2026-07-09T19:53:45.493962+00:00`) and
+/// ISO 8601 without timezone (`2026-07-09T19:53:45.493962`),
+/// treating the latter as UTC.
+fn parse_datetime_flexible(
+    s: &str,
+    col_index: usize,
+) -> Result<chrono::DateTime<chrono::Utc>, rusqlite::Error> {
+    // Fast path: strict RFC3339 (the normal case)
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.to_utc());
+    }
+    // Fallback: try appending UTC offset for ISO 8601 without timezone
+    let with_tz = format!("{s}+00:00");
+    chrono::DateTime::parse_from_rfc3339(&with_tz)
+        .map(|dt| dt.to_utc())
+        .map_err(|e| {
+            tracing::warn!(
+                col = col_index,
+                value = s,
+                "Failed to parse datetime string (tried RFC3339 and ISO8601+UTC)"
+            );
+            rusqlite::Error::FromSqlConversionFailure(
+                col_index,
+                rusqlite::types::Type::Text,
+                Box::new(e),
+            )
+        })
+}
+
+/// Optional variant of [parse_datetime_flexible] — returns None on parse failure
+/// instead of an error. Used for nullable datetime columns (last_accessed, valid_from, etc).
+fn parse_datetime_opt(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    parse_datetime_flexible(s, 0).ok()
+}
+
 /// Convert a database row to a Memory.
 pub(crate) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite::Error> {
     let id: String = row.get(0)?;
@@ -356,40 +393,23 @@ pub(crate) fn row_to_memory(row: &rusqlite::Row<'_>) -> Result<Memory, rusqlite:
         })
         .unwrap_or(serde_json::Value::Null);
     let created_at_str: String = row.get(5)?;
-    let created_at = chrono::DateTime::parse_from_rfc3339(&created_at_str)
-        .map(|dt| dt.to_utc())
-        .map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(e))
-        })?;
+    let created_at = parse_datetime_flexible(&created_at_str, 5)?;
     let updated_at_str: String = row.get(6)?;
-    let updated_at = chrono::DateTime::parse_from_rfc3339(&updated_at_str)
-        .map(|dt| dt.to_utc())
-        .map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e))
-        })?;
+    let updated_at = parse_datetime_flexible(&updated_at_str, 6)?;
     let namespace: String = row
         .get(7)
         .unwrap_or_else(|_| crate::memory::types::DEFAULT_NAMESPACE.to_string());
     let access_count: u32 = row.get(8).unwrap_or(0);
     let last_accessed_str: Option<String> = row.get(9).ok().flatten();
-    let last_accessed = last_accessed_str
-        .as_deref()
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-        .map(|dt| dt.to_utc());
+    let last_accessed = last_accessed_str.as_deref().and_then(parse_datetime_opt);
     let deprecated: bool = row.get(10).unwrap_or_else(|e| {
         tracing::debug!("Failed to read deprecated field: {e}, defaulting to false");
         false
     });
     let valid_from_str: Option<String> = row.get(11).ok().flatten();
-    let valid_from = valid_from_str
-        .as_deref()
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-        .map(|dt| dt.to_utc());
+    let valid_from = valid_from_str.as_deref().and_then(parse_datetime_opt);
     let valid_until_str: Option<String> = row.get(12).ok().flatten();
-    let valid_until = valid_until_str
-        .as_deref()
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-        .map(|dt| dt.to_utc());
+    let valid_until = valid_until_str.as_deref().and_then(parse_datetime_opt);
     let memory_type: String = row.get(13).unwrap_or_else(|_| "fact".to_string());
     let importance: f64 = row.get(14).unwrap_or(0.5);
     let pinned: bool = row.get(15).unwrap_or(false);


### PR DESCRIPTION
## Summary

One corrupted row (ID `9565bc16-...`) had `updated_at` without timezone suffix: `2026-07-09T19:53:45.493962` (ISO 8601 but NOT RFC3339). This caused `load_all()` to crash with *premature end of input* because `chrono::DateTime::parse_from_rfc3339()` requires the `+HH:MM`/Z suffix.

The 17K memory database was completely inaccessible because 1 bad row poisoned the entire query.

## Root Cause

`row_to_memory()` used strict `parse_from_rfc3339()` for `created_at` and `updated_at` with hard-fail via `map_err + ?`. Any row with a timezone-less datetime would crash the entire `load_all()`.

The corrupted row likely came from a v0.7.0 binary or manual insert that wrote `chrono::Utc::now().to_string()` (which omits timezone) instead of `.to_rfc3339()`.

## Fix (two-pronged)

### 1. Defensive parsing (`store.rs`)
- New `parse_datetime_flexible()`: tries strict RFC3339 first, then falls back to appending `+00:00` (assumes UTC) for ISO 8601 without timezone
- Applied to: `created_at`, `updated_at` (required) + `last_accessed`, `valid_from`, `valid_until` (optional)
- Optional fields also unified via `parse_datetime_opt()` helper

### 2. Data repair (`schema.rs`)
- New `repair_datetime_timezones()`: idempotent post-migration consistency check
- Scans `memories` + `documents` tables for datetime strings missing timezone
- Appends `+00:00` to fix them in-place
- Runs on every DB open via `ensure_schema_version()`

## Test

- `cargo build`: ✅ clean
- `cargo clippy`: ✅ clean (0 warnings)
- `cargo test -p uteke-core -- test_load_all`: ✅ 3/3 pass
- All 72 store tests: ✅ pass

## Files Changed

```
crates/uteke-core/src/memory/store.rs   (+64 −22)
crates/uteke-core/src/memory/schema.rs   (+80)
```