### PR TITLE
feat(server): report version in /health response

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -93,6 +93,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 req,
                 &HealthResponse {
                     status: "ok",
+                    version: env!("CARGO_PKG_VERSION"),
                     memories: total,
                     namespaces,
                 },

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
                 println!("  Configure CORS origins in uteke.toml [server].cors_origins.");
                 println!();
                 println!("API:");
-                println!("  GET  /health              → {{ status, memories }}");
+                println!("  GET  /health              → {{ status, version, memories, namespaces }}");
                 println!("  POST /remember            → {{ content, tags? }} → {{ id }}");
                 println!("  POST /recall              → {{ query, limit? }} → {{ results }}");
                 println!("  POST /search              → {{ query, limit? }} → {{ results }}");

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -113,7 +113,9 @@ fn main() {
                 println!("  Configure CORS origins in uteke.toml [server].cors_origins.");
                 println!();
                 println!("API:");
-                println!("  GET  /health              → {{ status, version, memories, namespaces }}");
+                println!(
+                    "  GET  /health              → {{ status, version, memories, namespaces }}"
+                );
                 println!("  POST /remember            → {{ content, tags? }} → {{ id }}");
                 println!("  POST /recall              → {{ query, limit? }} → {{ results }}");
                 println!("  POST /search              → {{ query, limit? }} → {{ results }}");

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -172,6 +172,9 @@ pub struct ListParams {
 #[derive(Serialize)]
 pub struct HealthResponse {
     pub status: &'static str,
+    /// Server version (uteke-server crate version), so HTTP clients can gate
+    /// features on the actual server capability rather than a local CLI probe.
+    pub version: &'static str,
     pub memories: usize,
     pub namespaces: usize,
 }


### PR DESCRIPTION
## Why
HTTP clients (Corin) need to know the **server's** version to gate features. Corin currently derives the uteke version from the local `uteke` CLI — meaningless when talking to a user-managed **remote** server that may be older or newer than the CLI. This causes false "uteke upgrade required" prompts for remote users.

## Change
Add a `version` field to `GET /health` (uteke-server crate version via `CARGO_PKG_VERSION`).

```json
{ "status": "ok", "version": "0.7.1", "memories": 123, "namespaces": 4 }
```

Backward compatible — `version` is an added JSON field; existing consumers ignore it.

Corin-side consumer: codecoradev/corin#159 (remote-aware version gating).

## Checks
- `cargo fmt` / `cargo clippy -D warnings` ✅
- `cargo test -p uteke-server` ✅