### PR TITLE
release: v0.7.2 — patch release prep (version bump + changelog)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.7.1
+- **Version:** 0.7.2
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [0.7.2] — 2026-07-09
+
+### Added
+- **Version field in `/health` response (#636)** — `GET /health` now reports the server's crate version (`CARGO_PKG_VERSION`). HTTP clients (e.g. Corin) can gate features against the remote server version instead of guessing from the local CLI. Backward compatible — `version` is an added JSON field.
+
+### Fixed
+- **Defensive datetime parsing — tolerate missing timezone in RFC3339 fields (#635)** — A single corrupted row with timezone-less `updated_at` (ISO 8601 but not RFC3339) crashed `load_all()`, making the entire memory database inaccessible. Fix: new `parse_datetime_flexible()` falls back to assuming UTC (`+00:00`) when strict RFC3339 parse fails; new idempotent `repair_datetime_timezones()` scans `memories` + `documents` on every DB open and repairs bad rows in-place.
+- **`POST /doc/list` default limit 5 → 1000 (#634)** — Document listing reused the memory pagination default (`5`), silently truncating client-side document trees. Documents are not paginated like memories — added dedicated `default_doc_limit() = 1000`. Memory and room-recall defaults unchanged.
+
 ## [0.7.1] — 2026-07-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "dirs",
  "serde",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.7.1-green.svg" alt="v0.7.1" />
+  <img src="https://img.shields.io/badge/status-v0.7.2-green.svg" alt="v0.7.2" />
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/codecoradev/uteke/actions/workflows/ci.yml?branch=develop"><img src="https://github.com/codecoradev/uteke/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust 1.75+" />
-  <img src="https://img.shields.io/badge/status-v0.7.1-green.svg" alt="v0.7.1" />
+  <img src="https://img.shields.io/badge/status-v0.7.2-green.svg" alt="v0.7.2" />
 </p>
 
 <p align="center">

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.1", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.7.2", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.1", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.7.2", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.1", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.7.1" }
+uteke-core = { path = "../uteke-core", version = "0.7.2", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.7.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.7.1**.
+Complete reference for all uteke commands. Version **0.7.2**.
 
 ## Global Flags
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,7 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.7.1` | Specific version |
+| `v0.7.2` | Specific version |
 | `v0.6.6` | Specific version |
 | `0.6` | Minor version (latest patch) |
 | `slim` | Slim image (no embedded model — mount model volume separately, see below) |


### PR DESCRIPTION
## Summary

Patch release prep for **v0.7.2**. Version bump + changelog only — no code changes. Contains the 3 fixes merged to develop since v0.7.1.

## Post-v0.7.1 fixes included

| PR | Type | Change |
|----|------|--------|
| #634 | fix(server) | `POST /doc/list` default limit 5 → 1000 (silent truncation of doc trees) |
| #635 | fix(core) | Defensive datetime parsing — tolerate missing timezone in RFC3339 (corruption row crash fix) |
| #636 | feat(server) | `version` field in `/health` response (remote server version gating) |

## Changes in this PR
- Workspace version `0.7.1 → 0.7.2`
- Crate dependency versions synced (uteke-core, uteke-mcp)
- Cargo.lock updated
- README.md + README.id.md badges updated
- AGENT.md version string updated
- docs/cli-reference.md + docs/docker.md version refs updated
- CHANGELOG: `[Unreleased] → [0.7.2]`

## Checks
- `cargo check --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- cora review ✅

## Release flow (after merge)
1. PR develop → main
2. Tag `v0.7.2` on main
3. Push tag → triggers `release.yml` (cross-platform binary build)
4. `gh release create v0.7.2` with CHANGELOG notes