### PR TITLE
fix(core): include metadata field in UnifiedSearchResult recall output

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1397,6 +1397,7 @@ impl Uteke {
                 doc_title: None,
                 chunk_heading: None,
                 chunk_snippet: None,
+                metadata: Some(sr.memory.metadata),
             })
             .collect())
     }
@@ -1435,6 +1436,7 @@ impl Uteke {
                     Some(dr.chunk_snippet)
                 },
                 tags: vec![],
+                metadata: None,
             })
             .collect())
     }
@@ -1516,6 +1518,7 @@ impl Uteke {
                         doc_title: None,
                         chunk_heading: None,
                         chunk_snippet: None,
+                        metadata: Some(sr.memory.metadata.clone()),
                     }
                 } else if let Some(dr) = doc_map.remove(&key) {
                     UnifiedSearchResult {
@@ -1540,6 +1543,7 @@ impl Uteke {
                             Some(dr.chunk_snippet)
                         },
                         tags: vec![],
+                        metadata: None,
                     }
                 } else {
                     unreachable!("RRF key must reference either mem_map or doc_map")

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -144,6 +144,9 @@ pub struct UnifiedSearchResult {
     /// Tags from the memory or document.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Arbitrary JSON metadata from the memory (populated for type=memory).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Filter for unified search — which sources to query (#531).
@@ -931,6 +934,7 @@ mod tests {
             doc_title: None,
             chunk_heading: None,
             chunk_snippet: None,
+            metadata: Some(serde_json::json!({"session_id": "abc123"})),
         };
         let json = serde_json::to_string(&result).unwrap();
         // Verify result_type field is lowercase "memory"
@@ -960,6 +964,7 @@ mod tests {
             doc_title: Some("My Document".to_string()),
             chunk_heading: Some("Section 2".to_string()),
             chunk_snippet: Some("chunk excerpt here".to_string()),
+            metadata: None,
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"result_type\":\"document\""), "got: {json}");


### PR DESCRIPTION
## Problem

`recall --json` output does not include the `metadata` field, even though `remember --meta` stores it. Consumers (Hermes agent, MCP server, LongMemEval benchmark) must round-trip lookup by `memory_id` to access metadata.

## Root Cause

`UnifiedSearchResult` struct lacked a `metadata` field — only had: result_type, score, content, memory_id, doc_slug, doc_title, chunk_heading, chunk_snippet, tags.

## Fix

- Add `metadata: Option<serde_json::Value>` to `UnifiedSearchResult` (with `skip_serializing_if = None`)
- Populate from `Memory.metadata` in all 3 memory construction sites (recall_unified_memories + RRF merge)
- Set `metadata: None` for document results (no metadata on documents)
- Updated test fixtures

## Testing

```
cargo test -p uteke-core --no-default-features -- unified_search_result
# test result: ok. 2 passed; 0 failed
```

## Impact

- **JSON output change**: recall results for memories now include `metadata` field
- **Backward compatible**: `skip_serializing_if = None` omits field when absent; serde `default` allows deserializing old JSON without it