### PR TITLE
chore: release v0.7.3 prep — version bump, changelog

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.7.2
+- **Version:** 0.7.3
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [0.7.3] — 2026-07-13
+
+### Fixed
+- **Windows vector index 0 bytes after save (#647)** — usearch's C++ `fopen("wb")` silently fails on Windows due to MAX_PATH limits, file lock conflicts with `fs2` exclusive lock (#543), and Windows Defender interference. Fix: `save()` now serializes to an in-memory buffer via `save_to_buffer()`, then writes to disk using Rust's `std::fs::write()` with atomic temp+rename. Load still uses usearch native `Index::restore()` — the on-disk format is identical. New round-trip test proves compatibility.
+- **`recall --json` missing metadata field (#646)** — `UnifiedSearchResult` lacked a `metadata` field, so consumers (Hermes agent, MCP server, benchmarks) had to round-trip lookup by `memory_id` to access metadata stored via `--meta`. Fix: added `metadata` field to `UnifiedSearchResult` and populated it from the recall query.
+
+### Changed
+- **README fact-check and optimization (#642, #643)** — Verified all claims against source code and live data. Improved competitive positioning, added infographic, updated benchmarks.
+
 ## [0.7.2] — 2026-07-09
 
 ### Added
@@ -1182,7 +1191,10 @@
 - **Binary name:** `uteke`
 - **Minimum Rust version:** 1.75+
 
-[Unreleased]: https://github.com/codecoradev/uteke/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/codecoradev/uteke/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/codecoradev/uteke/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/codecoradev/uteke/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/codecoradev/uteke/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/codecoradev/uteke/compare/v0.6.7...v0.7.0
 [0.6.7]: https://github.com/codecoradev/uteke/releases/tag/v0.6.7
 [0.6.6]: https://github.com/codecoradev/uteke/releases/tag/v0.6.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "dirs",
  "serde",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.2", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.7.3", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.2", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.7.3", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.7.2", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.7.2" }
+uteke-core = { path = "../uteke-core", version = "0.7.3", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.7.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## Release v0.7.3 (Patch)

Release branch prep — version bump + CHANGELOG + link fixes.

### Changes (since v0.7.2)

| Type | Description |
|------|-------------|
| **Fixed** | Windows vector index 0 bytes after save (#647) — buffer-based serialization bypasses usearch C++ `fopen` |
| **Fixed** | `recall --json` missing metadata field (#646) — `UnifiedSearchResult` now includes metadata |
| **Changed** | README fact-check + optimization (#642, #643) |

### Checklist

- [x] `Cargo.toml` workspace version `0.7.2` → `0.7.3`
- [x] Inter-crate version pins (4 crates)
- [x] `Cargo.lock` synced
- [x] `CHANGELOG.md` — `[Unreleased]` → `[0.7.3] — 2026-07-13`
- [x] CHANGELOG links — added `0.7.1`, `0.7.2`, `0.7.3` (were missing)
- [x] `AGENT.md` version string updated

### Next Steps (after merge)

1. PR `develop` → `main`, merge
2. Tag `v0.7.3` from main
3. Release workflow auto-builds binaries + GitHub Release
