### PR TITLE
feat(api): add POST /memory/pin and POST /memory/importance endpoints

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -643,6 +643,11 @@ impl Uteke {
         self.store.unpin(id)
     }
 
+    /// Set a memory's importance score directly (0.0-1.0).
+    pub fn set_importance(&self, id: &str, importance: f64) -> Result<bool, Error> {
+        self.store.set_importance(id, importance)
+    }
+
     /// Set source provenance on a memory (#348).
     pub fn set_source(
         &self,

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -202,6 +202,22 @@ impl Store {
         Ok(store)
     }
 
+    /// Set a memory's importance score directly (0.0-1.0).
+    /// Returns false if the memory does not exist.
+    pub fn set_importance(&self, id: &str, importance: f64) -> Result<bool, Error> {
+        if !(0.0..=1.0).contains(&importance) {
+            return Err(Error::validation("importance must be between 0.0 and 1.0"));
+        }
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE memories SET importance = ?1 WHERE id = ?2",
+                rusqlite::params![importance, id],
+            )
+            .map_err(|e| Error::db("set importance", e))?;
+        Ok(rows > 0)
+    }
+
     /// Pin a memory (never decays).
     pub fn pin(&self, id: &str) -> Result<bool, Error> {
         let rows = self

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -699,6 +699,91 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // ── Memory Pin/Unpin (#660) ──────────────────────────────────────
+        (Method::Post, "/memory/pin") => match read_body::<MemoryPinRequest>(req.as_reader()) {
+            Ok(req_data) => {
+                if uuid::Uuid::parse_str(&req_data.id).is_err() {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        format!("Invalid UUID format: {}", req_data.id),
+                    );
+                }
+                let result = if req_data.pinned {
+                    uteke.pin(&req_data.id)
+                } else {
+                    uteke.unpin(&req_data.id)
+                };
+                match result {
+                    Ok(true) => match uteke.get_by_id(&req_data.id) {
+                        Ok(Some(memory)) => ctx.ok_response_for(req, &memory),
+                        Ok(None) => ctx.error_response_for(
+                            req,
+                            500,
+                            "Memory updated but could not be retrieved",
+                        ),
+                        Err(e) => {
+                            error!("Internal error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    },
+                    Ok(false) => ctx.error_response_for(
+                        req,
+                        404,
+                        format!("Memory not found: {}", req_data.id),
+                    ),
+                    Err(e) => {
+                        error!("Pin/unpin error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                }
+            }
+            Err(e) => ctx.error_response_for(req, 400, e),
+        },
+
+        // ── Memory Set Importance (#660) ──────────────────────────────────
+        (Method::Post, "/memory/importance") => {
+            match read_body::<MemoryImportanceRequest>(req.as_reader()) {
+                Ok(req_data) => {
+                    if uuid::Uuid::parse_str(&req_data.id).is_err() {
+                        return ctx.error_response_for(
+                            req,
+                            400,
+                            format!("Invalid UUID format: {}", req_data.id),
+                        );
+                    }
+                    match uteke.set_importance(&req_data.id, req_data.importance) {
+                        Ok(true) => match uteke.get_by_id(&req_data.id) {
+                            Ok(Some(memory)) => ctx.ok_response_for(req, &memory),
+                            Ok(None) => ctx.error_response_for(
+                                req,
+                                500,
+                                "Memory updated but could not be retrieved",
+                            ),
+                            Err(e) => {
+                                error!("Internal error: {e}");
+                                ctx.error_response_for(req, 500, "Internal server error")
+                            }
+                        },
+                        Ok(false) => ctx.error_response_for(
+                            req,
+                            404,
+                            format!("Memory not found: {}", req_data.id),
+                        ),
+                        Err(e) => {
+                            if e.to_string().contains("importance must be") {
+                                ctx.error_response_for(req, 400, e.to_string())
+                            } else {
+                                error!("Set importance error: {e}");
+                                ctx.error_response_for(req, 500, "Internal server error")
+                            }
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
         // ── Room Memories (chronological listing — GET /room/memories) ────
         (Method::Get, p) if p == "/room/memories" || p.starts_with("/room/memories?") => {
             let query_str = p.strip_prefix("/room/memories?");

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -124,7 +124,9 @@ fn main() {
                 );
                 println!("  DELETE /forget?id=UUID     → {{ forgotten }}");
                 println!("  DELETE /forget?tag=TAG     → {{ deleted }}");
-                println!("  GET  /memory?id=UUID       → {{ memory }}");
+                println!("  GET  /memory?id=UUID       -> {{ memory }}");
+                println!("  POST /memory/pin           -> {{ id, pinned }} -> {{ memory }}");
+                println!("  POST /memory/importance    -> {{ id, importance }} -> {{ memory }}");
                 println!("  GET  /stats               → {{ stats }}");
                 println!("  GET  /namespaces           → {{ namespaces }}");
                 println!("  POST /room/create          → {{ room_id, title, namespace }} → {{ created }}");

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -330,6 +330,20 @@ pub struct PinRequest {
     pub id: String,
 }
 
+// ── Memory Mutation Types (#660) ───────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct MemoryPinRequest {
+    pub id: String,
+    pub pinned: bool,
+}
+
+#[derive(Deserialize)]
+pub struct MemoryImportanceRequest {
+    pub id: String,
+    pub importance: f64,
+}
+
 // ── Graph Types ────────────────────────────────────────────────────────────
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Add RESTful endpoints for pinning/unpinning and setting importance on individual memories (#660).

POST /memory/pin { id, pinned: bool } - pin or unpin, returns updated memory
POST /memory/importance { id, importance: float } - set importance 0.0-1.0, returns updated memory

Changes: Store::set_importance with range validation, MemoryPinRequest/MemoryImportanceRequest types, UUID validation, 404/400 error handling.

Closes #660