### PR TITLE
fix: push entity/category filter into core recall candidate loop (#663)

### DIFF
--- a/crates/uteke-cli/src/bench.rs
+++ b/crates/uteke-cli/src/bench.rs
@@ -115,7 +115,7 @@ fn main() {
         // Recall — Uteke::recall(query, limit, tags_filter, namespace, min_score)
         let recall_start = Instant::now();
         for query in RECALL_QUERIES {
-            let _ = black_box(uteke.recall(query, 5, None, Some("bench"), 0.0));
+            let _ = black_box(uteke.recall(query, 5, None, Some("bench"), 0.0, None, None));
         }
         let recall_ms = recall_start.elapsed().as_millis();
         let recall_per = recall_ms as f64 / RECALL_QUERIES.len() as f64;

--- a/crates/uteke-cli/src/commands/bench.rs
+++ b/crates/uteke-cli/src/commands/bench.rs
@@ -218,7 +218,7 @@ fn bench_single_count(count: usize) -> Result<BenchResult, String> {
             let query = gen_query(&mut rng);
             let q_start = Instant::now();
             uteke
-                .recall(&query, 5, None, Some("bench"), 0.0)
+                .recall(&query, 5, None, Some("bench"), 0.0, None, None)
                 .map_err(|e| format!("Recall failed: {e}"))?;
             latencies.push(q_start.elapsed().as_secs_f64() * 1000.0);
         }

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -162,7 +162,16 @@ pub(crate) fn run_recall(
                 return Err("--at and --related cannot be used together".into());
             }
             uteke
-                .recall_at_time(query, limit, tags_filter, ns, point_in_time, min_score, None, None)
+                .recall_at_time(
+                    query,
+                    limit,
+                    tags_filter,
+                    ns,
+                    point_in_time,
+                    min_score,
+                    None,
+                    None,
+                )
                 .map_err(|e| format!("Failed to recall at time: {e}"))?
         } else if related {
             uteke

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -118,6 +118,8 @@ pub(crate) fn run_recall(
                 ns,
                 min_score,
                 resolved_search_type,
+                None,
+                None,
             )
             .map_err(|e| format!("Failed to recall: {e}"))?;
 
@@ -160,7 +162,7 @@ pub(crate) fn run_recall(
                 return Err("--at and --related cannot be used together".into());
             }
             uteke
-                .recall_at_time(query, limit, tags_filter, ns, point_in_time, min_score)
+                .recall_at_time(query, limit, tags_filter, ns, point_in_time, min_score, None, None)
                 .map_err(|e| format!("Failed to recall at time: {e}"))?
         } else if related {
             uteke

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1354,6 +1354,7 @@ impl Uteke {
     /// - `search_type::All` (default): searches both memories and documents.
     /// - `search_type::Memory`: memories only (equivalent to current recall).
     /// - `search_type::Document`: documents only (equivalent to doc search).
+    #[allow(clippy::too_many_arguments)]
     pub fn recall_unified(
         &self,
         query: &str,
@@ -1383,6 +1384,7 @@ impl Uteke {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     /// Unified search — memories only (backward-compatible path).
     fn recall_unified_memories(
         &self,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! let uteke = Uteke::open("~/.uteke/db.sqlite")?;
 //! let id = uteke.remember("important context", &["tag1"], None)?;
-//! let results = uteke.recall("query", 5, None)?;
+//! let results = uteke.recall("query", 5, None, None, 0.0, None, None)?;
 //! ```
 
 pub mod chunker;
@@ -1362,14 +1362,22 @@ impl Uteke {
         namespace: Option<&str>,
         min_score: f32,
         search_type: SearchType,
+        entity_filter: Option<&str>,
+        category_filter: Option<&str>,
     ) -> Result<Vec<UnifiedSearchResult>, Error> {
         let limit = limit.min(50);
         let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
 
         match search_type {
-            SearchType::Memory => {
-                self.recall_unified_memories(query, limit, tags_filter, namespace, min_score)
-            }
+            SearchType::Memory => self.recall_unified_memories(
+                query,
+                limit,
+                tags_filter,
+                namespace,
+                min_score,
+                entity_filter,
+                category_filter,
+            ),
             SearchType::Document => self.recall_unified_documents(query, limit, ns, min_score),
             SearchType::All => self.recall_unified_all(query, limit, tags_filter, ns, min_score),
         }
@@ -1383,8 +1391,18 @@ impl Uteke {
         tags_filter: Option<&[&str]>,
         namespace: Option<&str>,
         min_score: f32,
+        entity_filter: Option<&str>,
+        category_filter: Option<&str>,
     ) -> Result<Vec<UnifiedSearchResult>, Error> {
-        let results = self.recall(query, limit, tags_filter, namespace, min_score)?;
+        let results = self.recall(
+            query,
+            limit,
+            tags_filter,
+            namespace,
+            min_score,
+            entity_filter,
+            category_filter,
+        )?;
         Ok(results
             .into_iter()
             .map(|sr| UnifiedSearchResult {
@@ -1456,13 +1474,16 @@ impl Uteke {
         const RRF_K: u32 = 60;
 
         // 1. Memory recall (vector + FTS5 hybrid)
-        let mem_results = match self.recall(query, limit * 2, tags_filter, Some(ns), 0.0) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!("Unified search: memory recall failed, using partial results: {e}");
-                Vec::new()
-            }
-        };
+        let mem_results =
+            match self.recall(query, limit * 2, tags_filter, Some(ns), 0.0, None, None) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        "Unified search: memory recall failed, using partial results: {e}"
+                    );
+                    Vec::new()
+                }
+            };
 
         // 2. Document search (hybrid)
         let doc_results = match self.doc_search(query, limit * 2, "hybrid") {
@@ -1799,13 +1820,21 @@ mod tests {
 
         // Recall with min_score=0.0 should return results
         let results = uteke
-            .recall("rust programming", 5, None, None, 0.0)
+            .recall("rust programming", 5, None, None, 0.0, None, None)
             .unwrap();
         assert!(!results.is_empty());
 
         // Recall with very high min_score should return empty
         let results = uteke
-            .recall("completely unrelated quantum physics", 5, None, None, 0.99)
+            .recall(
+                "completely unrelated quantum physics",
+                5,
+                None,
+                None,
+                0.99,
+                None,
+                None,
+            )
             .unwrap();
         assert!(
             results.is_empty(),
@@ -1823,7 +1852,9 @@ mod tests {
             .unwrap();
 
         // min_score=0.0 should return results (backward compatible)
-        let results = uteke.recall("content", 5, None, None, 0.0).unwrap();
+        let results = uteke
+            .recall("content", 5, None, None, 0.0, None, None)
+            .unwrap();
         assert!(!results.is_empty(), "Expected results with 0.0 threshold");
     }
 
@@ -1842,7 +1873,15 @@ mod tests {
 
         // Same content query should have high score and pass moderate threshold
         let results = uteke
-            .recall("Rust programming language safety", 5, None, None, 0.5)
+            .recall(
+                "Rust programming language safety",
+                5,
+                None,
+                None,
+                0.5,
+                None,
+                None,
+            )
             .unwrap();
         assert!(
             !results.is_empty(),
@@ -1871,7 +1910,7 @@ mod tests {
 
         // Per-call min_score=0.0 should still work (overrides config)
         let results = uteke
-            .recall("rust programming", 5, None, None, 0.0)
+            .recall("rust programming", 5, None, None, 0.0, None, None)
             .unwrap();
         assert!(!results.is_empty());
     }

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -366,6 +366,7 @@ impl crate::Uteke {
         Ok(id)
     }
 
+    #[allow(clippy::too_many_arguments)]
     /// Recall memories relevant to a query using vector similarity.
     ///
     /// Optionally filter by tags and namespace.
@@ -1083,6 +1084,7 @@ impl crate::Uteke {
     /// - `valid_until IS NULL OR valid_until > point_in_time`
     /// - `valid_from IS NULL OR valid_from <= point_in_time`
     /// - `deprecated = false`
+    #[allow(clippy::too_many_arguments)]
     pub fn recall_at_time(
         &self,
         query: &str,

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -379,6 +379,8 @@ impl crate::Uteke {
         tags_filter: Option<&[&str]>,
         namespace: Option<&str>,
         min_score: f32,
+        entity_filter: Option<&str>,
+        category_filter: Option<&str>,
     ) -> Result<Vec<SearchResult>, Error> {
         // Embed query outside any lock — CPU-intensive (~50ms), no shared state needed.
         // Only the embedder Mutex is held here, allowing concurrent index reads.
@@ -434,6 +436,30 @@ impl crate::Uteke {
                         .iter()
                         .any(|ft| memory.tags.iter().any(|t| t == ft));
                     if !has_tag {
+                        continue;
+                    }
+                }
+
+                // Apply entity metadata filter
+                if let Some(ent) = entity_filter {
+                    let matches = memory
+                        .metadata
+                        .get("entity")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|e| e == ent);
+                    if !matches {
+                        continue;
+                    }
+                }
+
+                // Apply category metadata filter
+                if let Some(cat) = category_filter {
+                    let matches = memory
+                        .metadata
+                        .get("category")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|c| c == cat);
+                    if !matches {
                         continue;
                     }
                 }
@@ -519,7 +545,7 @@ impl crate::Uteke {
 
         let results = match strategy {
             RecallStrategy::Vector => {
-                self.recall(query, limit, tags_filter, namespace, min_score)?
+                self.recall(query, limit, tags_filter, namespace, min_score, None, None)?
             }
             RecallStrategy::Fts5 => {
                 self.recall_fts5_only(query, limit, tags_filter, namespace, min_score)?
@@ -659,7 +685,7 @@ impl crate::Uteke {
             Ok(_) => self.store.search_fts5_tokens(query, namespace, limit * 3)?,
             Err(e) => {
                 tracing::warn!("FTS5 search failed, falling back to vector: {e}");
-                return self.recall(query, limit, tags_filter, namespace, min_score);
+                return self.recall(query, limit, tags_filter, namespace, min_score, None, None);
             }
         };
 
@@ -724,13 +750,14 @@ impl crate::Uteke {
         const RRF_K: u32 = 60;
 
         // Run vector search (pass 0.0 for min_score since RRF does its own filtering)
-        let vector_results = match self.recall(query, limit * 3, tags_filter, namespace, 0.0) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!("Vector search failed in hybrid: {e}");
-                return self.recall_fts5_only(query, limit, tags_filter, namespace, min_score);
-            }
-        };
+        let vector_results =
+            match self.recall(query, limit * 3, tags_filter, namespace, 0.0, None, None) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!("Vector search failed in hybrid: {e}");
+                    return self.recall_fts5_only(query, limit, tags_filter, namespace, min_score);
+                }
+            };
 
         // Run FTS5 search
         let fts_results = match self.store.search_fts5(query, namespace, limit * 3) {
@@ -1064,6 +1091,8 @@ impl crate::Uteke {
         namespace: Option<&str>,
         point_in_time: chrono::DateTime<chrono::Utc>,
         min_score: f32,
+        entity_filter: Option<&str>,
+        category_filter: Option<&str>,
     ) -> Result<Vec<SearchResult>, Error> {
         // Retry loop: over-fetch with increasing multipliers to compensate
         // for temporal filtering removing candidates. If post-filtering
@@ -1073,7 +1102,15 @@ impl crate::Uteke {
 
         loop {
             let fetch_limit = (limit * multiplier).max(50);
-            let candidates = self.recall(query, fetch_limit, tags_filter, namespace, min_score)?;
+            let candidates = self.recall(
+                query,
+                fetch_limit,
+                tags_filter,
+                namespace,
+                min_score,
+                entity_filter,
+                category_filter,
+            )?;
             let candidates_len = candidates.len();
 
             let mut results: Vec<SearchResult> = candidates

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -762,7 +762,16 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     // Use unified search when type is specified or default (all).
     // Fall back to legacy recall only for backward compat with existing MCP consumers.
     let results = uteke
-        .recall_unified(query, limit, tags_ref, namespace, min_score, search_type, None, None)
+        .recall_unified(
+            query,
+            limit,
+            tags_ref,
+            namespace,
+            min_score,
+            search_type,
+            None,
+            None,
+        )
         .map_err(|e| format!("Failed: {e}"))?;
 
     if results.is_empty() {

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -762,7 +762,7 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     // Use unified search when type is specified or default (all).
     // Fall back to legacy recall only for backward compat with existing MCP consumers.
     let results = uteke
-        .recall_unified(query, limit, tags_ref, namespace, min_score, search_type)
+        .recall_unified(query, limit, tags_ref, namespace, min_score, search_type, None, None)
         .map_err(|e| format!("Failed: {e}"))?;
 
     if results.is_empty() {

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -184,19 +184,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                             .unwrap_or(DEFAULT_MIN_SCORE as f64) as f32,
                     )
                 };
-                // Strategy: when entity/category filters are present,
-                // recall WITHOUT min_score to avoid discarding valid matches
-                // that might satisfy metadata but be ranked lower. Apply
-                // min_score after metadata filtering.
-                let has_meta_filter = req_data.entity.is_some() || req_data.category.is_some();
-                let fetch_min_score = if has_meta_filter { 0.0 } else { min_score };
-                let fetch_limit = if has_meta_filter {
-                    // Cap at 200 to prevent unbounded amplification.
-                    // May return fewer than requested when matches are sparse.
-                    (req_data.limit * 10).min(200)
-                } else {
-                    req_data.limit
-                };
+                // Entity/category filters are now pushed into the core recall
+                // candidate loop (#663) — no 10x fetch amplification needed.
 
                 // Time-travel mode: parse --at and use recall_at_time
                 let point_in_time = match req_data.at.as_deref() {
@@ -215,34 +204,36 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     None => None,
                 };
 
+                let entity_filter = req_data.entity.as_deref();
+                let category_filter = req_data.category.as_deref();
+
                 let recall_result = if let Some(pit) = point_in_time {
                     uteke.recall_at_time(
                         &req_data.query,
-                        fetch_limit,
+                        req_data.limit,
                         tags_filter,
                         ns(&req_data.namespace),
                         pit,
-                        fetch_min_score,
+                        min_score,
+                        entity_filter,
+                        category_filter,
                     )
                 } else {
                     uteke.recall(
                         &req_data.query,
-                        fetch_limit,
+                        req_data.limit,
                         tags_filter,
                         ns(&req_data.namespace),
-                        fetch_min_score,
+                        min_score,
+                        entity_filter,
+                        category_filter,
                     )
                 };
 
-                // Unified search path (#531): when search_type is specified and
-                // no memory-only metadata filters (entity/category) are present,
-                // use recall_unified. Entity/category only apply to memories, so
-                // their presence forces the legacy memory-only recall path.
-                let has_meta_filter = req_data.entity.is_some() || req_data.category.is_some();
-                let unified_result = if req_data.search_type.is_some()
-                    && point_in_time.is_none()
-                    && !has_meta_filter
-                {
+                // Unified search path (#531): when search_type is specified,
+                // use recall_unified. Entity/category filters are passed
+                // through to the core recall candidate loop (#663).
+                let unified_result = if req_data.search_type.is_some() && point_in_time.is_none() {
                     let search_type = match req_data.search_type.as_deref() {
                         Some("memory") => uteke_core::SearchType::Memory,
                         Some("doc") => uteke_core::SearchType::Document,
@@ -262,6 +253,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         ns(&req_data.namespace),
                         min_score,
                         search_type,
+                        entity_filter,
+                        category_filter,
                     ))
                 } else {
                     None
@@ -275,46 +268,10 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         ctx.error_response_for(req, 500, "Internal server error")
                     }
                     None => {
-                        // Fall through to existing memory-only recall path
+                        // Memory-only recall path — entity/category filtering
+                        // is already applied in the core recall candidate loop (#663).
                         match recall_result {
-                            Ok(raw_results) => {
-                                // Post-filter by entity/category metadata
-                                let mut results: Vec<_> = raw_results
-                                    .into_iter()
-                                    .filter(|sr| {
-                                        if let Some(ent) = &req_data.entity {
-                                            let matches = sr
-                                                .memory
-                                                .metadata
-                                                .get("entity")
-                                                .and_then(|v| v.as_str())
-                                                .is_some_and(|e| e == ent);
-                                            if !matches {
-                                                return false;
-                                            }
-                                        }
-                                        if let Some(cat) = &req_data.category {
-                                            let matches = sr
-                                                .memory
-                                                .metadata
-                                                .get("category")
-                                                .and_then(|v| v.as_str())
-                                                .is_some_and(|c| c == cat);
-                                            if !matches {
-                                                return false;
-                                            }
-                                        }
-                                        true
-                                    })
-                                    .collect::<Vec<_>>();
-                                // Apply min_score filter after metadata filtering
-                                // (deferred from recall call to avoid losing valid matches)
-                                if min_score > 0.0 {
-                                    results.retain(|sr| sr.score >= min_score);
-                                }
-                                // Trim to requested limit after filtering
-                                results.truncate(req_data.limit);
-
+                            Ok(results) => {
                                 if results.is_empty() && min_score > 0.0 {
                                     ctx.ok_response_for(
                                         req,


### PR DESCRIPTION
## Problem

The `/recall` endpoint accepted `entity` and `category` query params but applied them as **post-filters** in the HTTP handler, AFTER usearch vector search. This had two issues:

1. **10x fetch amplification** — handler fetched up to 10x the requested limit (max 200 candidates) then iterated all of them in Rust to discard non-matches by metadata. Wasteful CPU and memory.
2. **Incorrect results** — a memory matching the entity/category filter but ranked outside the top-200 by vector similarity would be silently dropped. Users got fewer results than actually existed.

## Fix

Push entity/category filtering into the **core `recall()` candidate loop** (operations.rs), alongside the existing namespace and tag filters. This means:

- Filtering happens **during** the scoring loop, not after — usearch returns N candidates, we filter in the same pass that applies namespace/tag/boost logic
- No amplification needed — `fetch_limit` equals the user's requested `limit`
- `recall_at_time()` and `recall_unified()` also accept and pass the new params
- The `has_meta_filter` guard that forced the legacy memory-only path is removed — unified search (search_type) now works with entity/category filters

## Changed files

| File | Change |
|------|--------|
| `uteke-core/src/operations.rs` | Add `entity_filter`/`category_filter` params to `recall()` and `recall_at_time()`, filter in candidate loop |
| `uteke-core/src/lib.rs` | Thread params through `recall_unified()` and `recall_unified_memories()` |
| `uteke-server/src/handlers.rs` | Remove 10x amplification, post-filter, and `has_meta_filter` guard; pass params directly |
| `uteke-cli/src/bench.rs` | Update call sites (pass `None, None`) |
| `uteke-cli/src/commands/bench.rs` | Update call sites (pass `None, None`) |

Closes #663