### PR TITLE
fix: add missing metadata fields to HTTP POST /remember (#682)

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -110,7 +110,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
 
                 let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
 
-                // Build metadata from optional fields
+                // Build metadata from optional fields — matches CLI behavior.
                 let mut meta = serde_json::Map::new();
                 if let Some(t) = &req_data.r#type {
                     meta.insert("type".into(), serde_json::Value::String(t.clone()));
@@ -120,6 +120,21 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 }
                 if let Some(vu) = &req_data.valid_until {
                     meta.insert("valid_until".into(), serde_json::Value::String(vu.clone()));
+                }
+                if let Some(entity) = &req_data.entity {
+                    meta.insert("entity".into(), serde_json::Value::String(entity.clone()));
+                }
+                if let Some(category) = &req_data.category {
+                    meta.insert(
+                        "category".into(),
+                        serde_json::Value::String(category.clone()),
+                    );
+                }
+                // Merge caller-supplied metadata object into the map (#682).
+                if let Some(serde_json::Value::Object(extra)) = &req_data.metadata {
+                    for (k, v) in extra {
+                        meta.insert(k.clone(), v.clone());
+                    }
                 }
                 let metadata = if meta.is_empty() {
                     None
@@ -148,7 +163,16 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 };
 
                 match result {
-                    Ok(id) => ctx.ok_response_for(req, &serde_json::json!({"id": id})),
+                    Ok(id) => {
+                        // Set source provenance after storage (#682) — matches CLI.
+                        if req_data.source.is_some() || req_data.source_type.is_some() {
+                            let st = req_data.source_type.as_deref().unwrap_or("user");
+                            if let Err(e) = uteke.set_source(&id, req_data.source.as_deref(), st) {
+                                error!("Failed to set source for {id}: {e}");
+                            }
+                        }
+                        ctx.ok_response_for(req, &serde_json::json!({"id": id}))
+                    }
                     Err(e) => {
                         error!("Internal error: {e}");
                         ctx.error_response_for(req, 500, "Internal server error")

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -112,6 +112,22 @@ pub struct RememberRequest {
     pub valid_until: Option<String>,
     #[serde(default)]
     pub detect_contradiction: bool,
+    /// Entity name — stored as metadata key "entity".
+    #[serde(default)]
+    pub entity: Option<String>,
+    /// Category — stored as metadata key "category".
+    #[serde(default)]
+    pub category: Option<String>,
+    /// Extra metadata key=value pairs, merged into the metadata map.
+    /// Accepts an object (e.g. {"project": "uteke"}).
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+    /// Source provenance — set via set_source() after storage.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Source type (defaults to "user").
+    #[serde(default)]
+    pub source_type: Option<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
Fixes #682

`RememberRequest` was missing 5 fields that the CLI supports, making `/recall` entity/category filters unusable for HTTP-stored memories.

## Changes
- **types.rs**: Added 5 new `Option` fields to `RememberRequest`:
  - `entity` — stored as metadata key "entity"
  - `category` — stored as metadata key "category"  
  - `metadata` — arbitrary JSON object merged into metadata map
  - `source` — provenance, set via `set_source()` after storage
  - `source_type` — defaults to "user"
- **handlers.rs**: Merges entity/category/metadata into the metadata map (matching CLI), and calls `set_source()` after successful remember (matching CLI). Logs error if set_source fails.

## Backward Compatibility
All new fields are `Option<String>` / `Option<serde_json::Value>` with `#[serde(default)]`. Existing clients that don't send these fields are unaffected — zero breaking change.

## Test Plan
- [ ] `curl -X POST /remember -d '{"content":"test","entity":"foo","category":"bar"}'` → stores with metadata
- [ ] `curl -X POST /recall -d '{"query":"test","entity":"foo"}'` → returns the memory
- [ ] `curl -X POST /remember -d '{"content":"test","source":"cli","source_type":"manual"}'` → source columns set
- [ ] Existing clients without new fields → unchanged behavior