### PR TITLE
fix: add touch_access to search() for consistent recall tracking

### DIFF
--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -855,7 +855,7 @@ impl crate::Uteke {
     ) -> Result<Vec<SearchResult>, Error> {
         let memories = self.store.search_content(query, namespace, limit)?;
 
-        let results = memories
+        let results: Vec<SearchResult> = memories
             .into_iter()
             .filter(|memory| {
                 if let Some(filter_tags) = tags_filter {
@@ -871,6 +871,11 @@ impl crate::Uteke {
                 score: 1.0, // Text search doesn't have meaningful scores
             })
             .collect();
+
+        // Touch access for returned results
+        for r in &results {
+            self.store.touch_access(&r.memory.id).ok();
+        }
 
         Ok(results)
     }


### PR DESCRIPTION
## Summary

`search()` was the only recall path missing `access_count` increment. All other read operations already call `touch_access()`:

| Function | touch_access |
|----------|:---:|
| `recall()` | ✅ |
| `recall_hybrid()` | ✅ (via `_merge_rrf`) |
| `recall_context()` | ✅ |
| `recall_at_time()` | ✅ (delegates to `recall`) |
| `get()` | ✅ |
| **`search()`** | ❌ → ✅ |

This ensures `aging_cleanup` and `salience_recency` calculations have accurate access data across **all** query paths.