### PR TITLE
feat: add full memory detail fields to UnifiedSearchResult

### DIFF
--- a/crates/uteke-cli/src/output.rs
+++ b/crates/uteke-cli/src/output.rs
@@ -79,6 +79,21 @@ pub(crate) fn print_unified_human(results: &[uteke_core::UnifiedSearchResult]) {
                 if let Some(id) = &r.memory_id {
                     println!("     ID: {}", id);
                 }
+                if let Some(mt) = &r.memory_type {
+                    println!("     Type: {}", mt);
+                }
+                if let Some(src) = &r.source {
+                    println!("     Source: {}", src);
+                }
+                if let Some(imp) = r.importance {
+                    println!("     Importance: {:.2}", imp);
+                }
+                if r.pinned == Some(true) {
+                    println!("     📌 Pinned");
+                }
+                if let Some(count) = r.access_count {
+                    println!("     Accessed: {}x", count);
+                }
             }
             uteke_core::SearchResultType::Document => {
                 if let Some(slug) = &r.doc_slug {

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1412,17 +1412,30 @@ impl Uteke {
         )?;
         Ok(results
             .into_iter()
-            .map(|sr| UnifiedSearchResult {
-                result_type: SearchResultType::Memory,
-                score: sr.score,
-                content: sr.memory.content,
-                memory_id: Some(sr.memory.id),
-                tags: sr.memory.tags,
-                doc_slug: None,
-                doc_title: None,
-                chunk_heading: None,
-                chunk_snippet: None,
-                metadata: Some(sr.memory.metadata),
+            .map(|sr| {
+                let m = &sr.memory;
+                UnifiedSearchResult {
+                    result_type: SearchResultType::Memory,
+                    score: sr.score,
+                    content: m.content.clone(),
+                    memory_id: Some(m.id.clone()),
+                    tags: m.tags.clone(),
+                    doc_slug: None,
+                    doc_title: None,
+                    chunk_heading: None,
+                    chunk_snippet: None,
+                    metadata: Some(m.metadata.clone()),
+                    memory_type: Some(m.memory_type.clone()),
+                    namespace: Some(m.namespace.clone()),
+                    source: m.source.clone(),
+                    source_type: Some(m.source_type.clone()),
+                    importance: Some(m.importance),
+                    pinned: Some(m.pinned),
+                    access_count: Some(m.access_count),
+                    last_accessed: m.last_accessed,
+                    created_at: Some(m.created_at),
+                    updated_at: Some(m.updated_at),
+                }
             })
             .collect())
     }
@@ -1462,6 +1475,16 @@ impl Uteke {
                 },
                 tags: vec![],
                 metadata: None,
+                memory_type: None,
+                namespace: None,
+                source: None,
+                source_type: None,
+                importance: None,
+                pinned: None,
+                access_count: None,
+                last_accessed: None,
+                created_at: None,
+                updated_at: None,
             })
             .collect())
     }
@@ -1536,17 +1559,28 @@ impl Uteke {
             .map(|(key, score)| {
                 let normalized = (score / max_rrf).clamp(0.0, 1.0) as f32;
                 if let Some(sr) = mem_map.remove(&key) {
+                    let m = &sr.memory;
                     UnifiedSearchResult {
                         result_type: SearchResultType::Memory,
                         score: normalized,
-                        content: sr.memory.content.clone(),
-                        memory_id: Some(sr.memory.id),
-                        tags: sr.memory.tags,
+                        content: m.content.clone(),
+                        memory_id: Some(m.id.clone()),
+                        tags: m.tags.clone(),
                         doc_slug: None,
                         doc_title: None,
                         chunk_heading: None,
                         chunk_snippet: None,
-                        metadata: Some(sr.memory.metadata.clone()),
+                        metadata: Some(m.metadata.clone()),
+                        memory_type: Some(m.memory_type.clone()),
+                        namespace: Some(m.namespace.clone()),
+                        source: m.source.clone(),
+                        source_type: Some(m.source_type.clone()),
+                        importance: Some(m.importance),
+                        pinned: Some(m.pinned),
+                        access_count: Some(m.access_count),
+                        last_accessed: m.last_accessed,
+                        created_at: Some(m.created_at),
+                        updated_at: Some(m.updated_at),
                     }
                 } else if let Some(dr) = doc_map.remove(&key) {
                     UnifiedSearchResult {
@@ -1572,6 +1606,16 @@ impl Uteke {
                         },
                         tags: vec![],
                         metadata: None,
+                        memory_type: None,
+                        namespace: None,
+                        source: None,
+                        source_type: None,
+                        importance: None,
+                        pinned: None,
+                        access_count: None,
+                        last_accessed: None,
+                        created_at: None,
+                        updated_at: None,
                     }
                 } else {
                     unreachable!("RRF key must reference either mem_map or doc_map")

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -147,6 +147,37 @@ pub struct UnifiedSearchResult {
     /// Arbitrary JSON metadata from the memory (populated for type=memory).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    // ── Memory detail fields (populated for type=memory) ──────────────
+    /// Memory type: fact, procedure, preference, decision, context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_type: Option<String>,
+    /// Namespace for multi-agent isolation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    /// Source of the memory (e.g. "user", "system").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Source type of the memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_type: Option<String>,
+    /// Composite importance score (0.0–1.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub importance: Option<f64>,
+    /// Whether this memory is pinned (never decays).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
+    /// How many times this memory has been accessed (recall, get).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_count: Option<u32>,
+    /// When this memory was last accessed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_accessed: Option<chrono::DateTime<chrono::Utc>>,
+    /// When this memory was created.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When this memory was last updated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Filter for unified search — which sources to query (#531).
@@ -924,6 +955,7 @@ mod tests {
 
     #[test]
     fn unified_search_result_memory_serde() {
+        let now = chrono::Utc::now();
         let result = UnifiedSearchResult {
             result_type: SearchResultType::Memory,
             score: 0.85,
@@ -935,6 +967,16 @@ mod tests {
             chunk_heading: None,
             chunk_snippet: None,
             metadata: Some(serde_json::json!({"session_id": "abc123"})),
+            memory_type: Some("fact".to_string()),
+            namespace: Some("default".to_string()),
+            source: Some("user".to_string()),
+            source_type: Some("user".to_string()),
+            importance: Some(0.8),
+            pinned: Some(false),
+            access_count: Some(5),
+            last_accessed: Some(now),
+            created_at: Some(now),
+            updated_at: Some(now),
         };
         let json = serde_json::to_string(&result).unwrap();
         // Verify result_type field is lowercase "memory"
@@ -945,11 +987,27 @@ mod tests {
             !json.contains("memory_id") || json.contains("\"memory_id\":\"abc-123\""),
             "memory_id should be present when Some"
         );
+        // Verify new memory detail fields are present
+        assert!(
+            json.contains("\"memory_type\":\"fact\""),
+            "memory_type should be present"
+        );
+        assert!(
+            json.contains("\"access_count\":5"),
+            "access_count should be present"
+        );
+        assert!(
+            json.contains("\"pinned\":false"),
+            "pinned should be present"
+        );
         // Roundtrip
         let parsed: UnifiedSearchResult = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.result_type, SearchResultType::Memory);
         assert_eq!(parsed.score, 0.85);
         assert_eq!(parsed.memory_id.as_deref(), Some("abc-123"));
+        assert_eq!(parsed.memory_type.as_deref(), Some("fact"));
+        assert_eq!(parsed.access_count, Some(5));
+        assert_eq!(parsed.pinned, Some(false));
     }
 
     #[test]
@@ -965,11 +1023,34 @@ mod tests {
             chunk_heading: Some("Section 2".to_string()),
             chunk_snippet: Some("chunk excerpt here".to_string()),
             metadata: None,
+            memory_type: None,
+            namespace: None,
+            source: None,
+            source_type: None,
+            importance: None,
+            pinned: None,
+            access_count: None,
+            last_accessed: None,
+            created_at: None,
+            updated_at: None,
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"result_type\":\"document\""), "got: {json}");
         // memory_id is None so it should be omitted
         assert!(!json.contains("memory_id"), "memory_id should be skipped");
+        // Memory detail fields should all be omitted for documents
+        assert!(
+            !json.contains("memory_type"),
+            "memory_type should be skipped for doc"
+        );
+        assert!(
+            !json.contains("access_count"),
+            "access_count should be skipped for doc"
+        );
+        assert!(
+            !json.contains("importance"),
+            "importance should be skipped for doc"
+        );
         let parsed: UnifiedSearchResult = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.result_type, SearchResultType::Document);
         assert_eq!(parsed.doc_slug.as_deref(), Some("my-doc"));


### PR DESCRIPTION
## Summary

`UnifiedSearchResult` (used by `/recall` with `search_type`) now includes all memory detail fields that `SearchResult` already had via its full `Memory` struct.

## Changes

### `UnifiedSearchResult` struct (types.rs)
Added 11 new fields with `skip_serializing_if = "Option::is_none"`:
- `memory_type`, `namespace`, `source`, `source_type`
- `importance`, `pinned`, `access_count`
- `last_accessed`, `created_at`, `updated_at`

### Population sites (lib.rs)
- `recall_unified_memories()` — all fields populated from `Memory` struct
- `recall_unified_documents()` — all memory fields set to `None`
- `recall_unified_all()` — both memory and document branches updated

### Tests (types.rs)
- Memory serde test: verifies new fields appear in JSON output + roundtrip
- Document serde test: verifies new fields are omitted when `None`

### CLI (output.rs)
- `print_unified_human()` now shows type, source, importance, pinned 📌, access count

## Before vs After

**Before** — `search_type=memory` response:**
```json
{"content": "...", "memory_id": "...", "score": 0.85, "tags": [...], "metadata": {...}}
```

**After** — `search_type=memory` response:**
```json
{"content": "...", "memory_id": "...", "score": 0.85, "tags": [...], "metadata": {...},
 "memory_type": "fact", "namespace": "default", "source": "user", "source_type": "user",
 "importance": 0.8, "pinned": false, "access_count": 5, "last_accessed": "...",
 "created_at": "...", "updated_at": "..."}
```

Document results are unaffected — all memory fields remain `None` and are omitted from JSON.