### PR TITLE
fix(server): match Error::Validation instead of string in /memory/importance

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -756,14 +756,15 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                             404,
                             format!("Memory not found: {}", req_data.id),
                         ),
-                        Err(e) => {
-                            if e.to_string().contains("importance must be") {
+                        Err(e) => match e {
+                            uteke_core::Error::Validation(_) => {
                                 ctx.error_response_for(req, 400, e.to_string())
-                            } else {
+                            }
+                            _ => {
                                 error!("Set importance error: {e}");
                                 ctx.error_response_for(req, 500, "Internal server error")
                             }
-                        }
+                        },
                     }
                 }
                 Err(e) => ctx.error_response_for(req, 400, e),


### PR DESCRIPTION
## Summary

`POST /memory/importance` classified validation errors by **string-matching** the error message (`e.to_string().contains("importance must be")\)). This couples the `400`/`500` status to the exact wording of the validation message in `store.rs::set_importance`. If that wording ever changes, a `400 Bad Request` would silently degrade to `500`.

Fix: match the typed `uteke_core::Error::Validation(_)` variant instead — the same pattern already used by `PUT /memory`.

## Before
```rust
Err(e) => {
    if e.to_string().contains("importance must be") {
        ctx.error_response_for(req, 400, e.to_string())
    } else {
        error!("Set importance error: {e}");
        ctx.error_response_for(req, 500, "Internal server error")
    }
}
```

## After
```rust
Err(e) => match e {
    uteke_core::Error::Validation(_) => ctx.error_response_for(req, 400, e.to_string()),
    _ => {
        error!("Set importance error: {e}");
        ctx.error_response_for(req, 500, "Internal server error")
    }
},
```

Behavior is unchanged for current inputs (the validation message still contains "importance must be"), but the coupling is removed.

Closes #697

## Checklist
- [x] `cargo fmt` clean
- [x] No logic change for valid/invalid inputs — only the status-code dispatch is hardened