### PR TITLE
fix(core): validate room_id + doc_slug exist in room_add_document

### DIFF
--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -904,7 +904,39 @@ impl super::Store {
     // ── Room ↔ Document junction table (v15, #689) ──────────────────────
 
     /// Link a document to a room. No-op if already linked.
+    ///
+    /// Validates that both `room_id` and `doc_slug` reference existing rows.
+    /// The `room_documents` table enforces an FK on `room_id` (→ rooms) but
+    /// has none on `doc_slug`, so both are checked here to return a clean
+    /// `Validation` error (→ 400) rather than a dangling insert or a raw FK
+    /// violation surfacing as a 500 (#698).
     pub fn room_add_document(&self, room_id: &str, doc_slug: &str) -> Result<(), Error> {
+        let room_exists: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM rooms WHERE id = ?1)",
+                params![room_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("room_add_document room check", e))?;
+        if !room_exists {
+            return Err(Error::validation(format!("Unknown room: {room_id}")));
+        }
+
+        let doc_exists: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM documents WHERE slug = ?1)",
+                params![doc_slug],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("room_add_document doc check", e))?;
+        if !doc_exists {
+            return Err(Error::validation(format!(
+                "Unknown document slug: {doc_slug}"
+            )));
+        }
+
         let now = chrono::Utc::now().to_rfc3339();
         self.conn
             .execute(

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -988,10 +988,15 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             match read_body::<RoomDocAddReq>(req.as_reader()) {
                 Ok(req_data) => match uteke.room_add_document(&req_data.room_id, &req_data.doc_slug) {
                     Ok(()) => ctx.ok_response_for(req, &serde_json::json!({ "status": "linked", "room_id": req_data.room_id, "doc_slug": req_data.doc_slug })),
-                    Err(e) => {
-                        error!("Internal error: {e}");
-                        ctx.error_response_for(req, 500, "Internal server error")
-                    }
+                    Err(e) => match e {
+                        uteke_core::Error::Validation(_) => {
+                            ctx.error_response_for(req, 400, e.to_string())
+                        }
+                        _ => {
+                            error!("Internal error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    },
                 },
                 Err(e) => ctx.error_response_for(req, 400, e),
             }


### PR DESCRIPTION
## Summary

The `room_documents` junction table enforces an FK on `room_id` (→ `rooms`) but has **no FK on `doc_slug`**. As a result `POST /room/document/add` accepted any `doc_slug` string — even one with no matching document — and created a **dangling** room→document link. A bogus `room_id` also surfaced as a raw FK violation returning `500`.

This PR validates that **both** `room_id` and `doc_slug` reference existing rows before the insert, returning `Error::Validation` (→ `400`) for unknown values.

## Changes

**`crates/uteke-core/src/memory/rooms.rs` — `room_add_document`**
- Pre-check `SELECT EXISTS(... FROM rooms WHERE id = ?)` → `Error::validation("Unknown room: …")` if missing.
- Pre-check `SELECT EXISTS(... FROM documents WHERE slug = ?)` → `Error::validation("Unknown document slug: …")` if missing.
- (`documents.slug` is `UNIQUE` and `COLLATE NOCASE`, so the lookup is consistent with how slugs are stored.)

**`crates/uteke-server/src/handlers.rs` — `PUT /room/document/add`**
- Map `Error::Validation(_)` → `400` instead of the previous blanket `500` (mirrors `PUT /memory` and the #697 fix).

## Behavior
| Input | Before | After |
|---|---|---|
| valid room + valid slug | 200 linked | 200 linked (unchanged) |
| valid room + **bogus slug** | **200 linked (dangling!)** | **400** Unknown document slug |
| bogus room | 500 (raw FK error) | 400 Unknown room |
| DB/infra error | 500 | 500 (unchanged) |

Idempotent inserts (`INSERT OR IGNORE`) and the existing `room_remove_document` are unchanged.

Closes #698

## Checklist
- [x] `cargo fmt` clean
- [x] Validation queries use parameterized SQL (no injection)
- [x] Existing happy path + idempotency preserved
- [x] `room_remove_document` left as-is (noted in #698: returns Ok even when nothing deleted — separate concern)