### PR TITLE
feat: --enrich CLI flag for cross-entity recall (#689 PR4)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -141,6 +141,11 @@ pub enum Commands {
         /// 'doc' returns documents only.
         #[arg(long)]
         r#type: Option<String>,
+        /// Enrich results with cross-entity links (doc↔memory references).
+        /// Populates linked_doc_slugs on memory results and linked_memory_ids
+        /// on document results (#689).
+        #[arg(long)]
+        enrich: bool,
     },
     /// Search memories by content keywords (text search)
     Search {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -81,6 +81,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             content_format,
             r#where,
             r#type,
+            enrich,
         } => recall::run_recall(
             cli,
             uteke,
@@ -103,6 +104,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             *salience,
             *recency,
             r#type.as_deref(),
+            *enrich,
         ),
 
         Commands::Search { query, limit, tags } => {

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -29,6 +29,7 @@ pub(crate) fn run_recall(
     salience: bool,
     recency: bool,
     search_type: Option<&str>,
+    enrich: bool,
 ) -> Result<(), String> {
     // Resolve search type: --type flag > default (All = unified)
     let resolved_search_type = match search_type {
@@ -120,7 +121,7 @@ pub(crate) fn run_recall(
                 resolved_search_type,
                 None,
                 None,
-                false,
+                enrich,
             )
             .map_err(|e| format!("Failed to recall: {e}"))?;
 

--- a/crates/uteke-cli/src/output.rs
+++ b/crates/uteke-cli/src/output.rs
@@ -94,6 +94,9 @@ pub(crate) fn print_unified_human(results: &[uteke_core::UnifiedSearchResult]) {
                 if let Some(count) = r.access_count {
                     println!("     Accessed: {}x", count);
                 }
+                if let Some(ref doc_slugs) = r.linked_doc_slugs {
+                    println!("     📄 Docs: {}", doc_slugs.join(", "));
+                }
             }
             uteke_core::SearchResultType::Document => {
                 if let Some(slug) = &r.doc_slug {
@@ -104,6 +107,9 @@ pub(crate) fn print_unified_human(results: &[uteke_core::UnifiedSearchResult]) {
                 }
                 if let Some(heading) = &r.chunk_heading {
                     println!("     ↳ {}", heading);
+                }
+                if let Some(ref mem_ids) = r.linked_memory_ids {
+                    println!("     🔗 Memories: {}", mem_ids.len());
                 }
             }
         }


### PR DESCRIPTION
## Summary

Wire up the `enrich` parameter added by PR702 so users can opt into cross-entity link resolution via `uteke recall --enrich`.

## Changes

- **cli.rs**: Add `--enrich` bool flag to the `Recall` subcommand
- **commands/mod.rs**: Thread `enrich` from CLI dispatch to `run_recall()`
- **commands/recall.rs**: Pass `enrich` to `recall_unified()` instead of hardcoded `false`
- **output.rs**: Display cross-entity links in human output:
  - Memory results: `📄 Docs: <slugs>` when `linked_doc_slugs` is populated
  - Document results: `🔗 Memories: <count>` when `linked_memory_ids` is populated

## MCP

Left `enrich=false` for MCP recall — MCP enrichment can be a separate enhancement with its own tool schema update.

## References

Closes part of #689 (PR4 of the enrichment series).