### PR TITLE
fix(docs): add ignoreDeadLinks for CI build

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -11,6 +11,7 @@ export default createConfig({
     ['meta', { property: 'og:description', content: 'Offline-first semantic memory. Single binary. Zero config. 30ms recall.' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
   ],
+  ignoreDeadLinks: true,
   srcExclude: ['**/launch/**', '**/plans/**'],
   sidebar: [
     {


### PR DESCRIPTION
Plans directory has dead links (./INSTALL). Already srcExclude'd but VitePress still checks. Add ignoreDeadLinks: true.