### PR TITLE
docs: restructure — split pages, add install/comparison/feature docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -17,8 +17,8 @@ export default createConfig({
     {
       text: 'Getting Started',
       items: [
-        { text: 'Installation', link: '/getting-started' },
-        { text: 'CLI Reference', link: '/cli-reference' },
+        { text: 'Installation', link: '/install' },
+        { text: 'Quick Start', link: '/getting-started' },
         { text: 'Configuration', link: '/configuration' },
         { text: 'Docker', link: '/docker' },
       ],
@@ -26,20 +26,21 @@ export default createConfig({
     {
       text: 'Features',
       items: [
-        { text: 'Rooms', link: '/getting-started#rooms' },
-        { text: 'Time-Travel', link: '/getting-started#time-travel-queries' },
+        { text: 'Rooms', link: '/rooms' },
+        { text: 'Time-Travel', link: '/time-travel' },
         { text: 'Multi-Agent', link: '/multi-agent' },
-        { text: 'Smart Decay', link: '/getting-started#memory-importance-pinning' },
-        { text: 'Relationship Graph', link: '/getting-started#relationship-graph' },
-        { text: 'Benchmarks', link: '/getting-started#benchmarking' },
+        { text: 'Smart Decay', link: '/smart-decay' },
+        { text: 'Relationship Graph', link: '/relationship-graph' },
+        { text: 'Benchmarks', link: '/benchmarks' },
+        { text: 'Shell Hooks', link: '/shell-hooks' },
         { text: 'MCP Server', link: '/mcp' },
-        { text: 'Document Commands', link: '/cli-reference#document-commands-406-411-438-440' },
-        { text: 'Graph API', link: '/cli-reference#graph-api-408-542' },
       ],
     },
     {
       text: 'Reference',
       items: [
+        { text: 'CLI Reference', link: '/cli-reference' },
+        { text: 'Comparison', link: '/comparison' },
         { text: 'Architecture', link: '/architecture' },
         { text: 'Hermes Integration', link: '/integrations/hermes' },
         { text: 'Pi Extension', link: '/extensions' },

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,7 +1,11 @@
-# Uteke Performance Benchmarks
+---
+title: Benchmarks
+---
 
-> Real numbers from `uteke bench` on Oracle Cloud ARM (Ampere A1, 4 vCPU, 24GB RAM).
-> Embedding model: EmbeddingGemma Q4 (768d, ONNX Runtime, CPU-only).
+# Benchmarks
+
+Real numbers from `uteke bench` on Oracle Cloud ARM (Ampere A1, 4 vCPU, 24GB RAM).
+Embedding model: EmbeddingGemma Q4 (768d, ONNX Runtime, CPU-only).
 
 ## Results
 
@@ -14,6 +18,7 @@
 ## Key Takeaways
 
 ### Recall Latency: Flat ~40-45ms from 100 to 10K memories
+
 The killer stat: recall latency barely changes as the store grows.
 
 - 100 memories → **40ms**
@@ -22,7 +27,8 @@ The killer stat: recall latency barely changes as the store grows.
 
 HNSW search is O(log N), so even at 10K memories, the vector index adds <1ms.
 The ~40ms floor is dominated by ONNX embedding inference, not search.
-This is the full pipeline:
+
+The full pipeline:
 1. Query → ONNX embedding generation
 2. HNSW vector search
 3. FTS5 full-text search
@@ -31,17 +37,17 @@ This is the full pipeline:
 No network round-trip. No API call. Everything in-process.
 
 ### Insert Throughput: 6-22 ops/s (CPU-bound)
-Each insert requires an ONNX embedding pass (CPU inference). Throughput drops at scale
-because HNSW graph traversal grows as the index expands:
+
+Each insert requires an ONNX embedding pass (CPU inference). Throughput drops at scale because HNSW graph traversal grows as the index expands:
 
 - 100 memories → **18.5 ops/s**
 - 1,000 memories → **21.8 ops/s**
 - 10,000 memories → **6.0 ops/s**
 
-At 6 ops/s, inserting 10K memories takes ~28 minutes. For bulk ingestion, use
-`uteke import` (batch mode) which pipelines embeddings.
+At 6 ops/s, inserting 10K memories takes ~28 minutes. For bulk ingestion, use `uteke import` (batch mode) which pipelines embeddings.
 
 ### Storage Efficiency
+
 - 100 memories → 708KB DB + 319KB index = **~10KB per memory**
 - 1,000 memories → 5.3MB DB + 3.2MB index = **~8.5KB per memory**
 - 10,000 memories → 81.3MB DB + 30.3MB index = **~11.2KB per memory**
@@ -60,13 +66,19 @@ Or with a custom store path:
 uteke bench --counts 100,1000 --store /tmp/bench --json
 ```
 
+## External Evaluation
+
+See [LongMemEval retrieval harness](https://github.com/codecoradev/uteke/tree/develop/benchmarks/longmemeval) for accuracy evaluation against standard benchmarks.
+
 ## Environment
 
-- **Hardware:** Oracle Cloud ARM (Ampere A1, 4 vCPU, 24GB RAM)
-- **OS:** Linux 6.8.0 (aarch64)
-- **Rust:** 1.75+
-- **Embedding:** EmbeddingGemma Q4, 768d, ONNX Runtime CPU
-- **Uteke:** v0.7.2
+| Component | Details |
+|-----------|---------|
+| Hardware | Oracle Cloud ARM (Ampere A1, 4 vCPU, 24GB RAM) |
+| OS | Linux 6.8.0 (aarch64) |
+| Rust | 1.75+ |
+| Embedding | EmbeddingGemma Q4, 768d, ONNX Runtime CPU |
+| Uteke | v0.7.2 |
 
 ## Methodology
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,37 @@
+---
+title: Comparison
+---
+
+# Comparison
+
+## uteke vs Alternatives
+
+| Feature | uteke | Mem0 | Letta | Cognee |
+|---------|-------|------|-------|--------|
+| Install | 1 binary | pip + Docker + Qdrant | pip + Docker + Postgres | pip + Docker + Neo4j |
+| API Keys | ✅ None needed | ❌ OpenAI/LLM key | ❌ LLM key | ❌ LLM + vector DB |
+| Offline | ✅ Fully | ❌ Cloud embedding | ❌ Needs server | ❌ Needs LLM + DB |
+| Semantic Search | ✅ Local ONNX | ✅ Cloud embedding | ⚠️ Keyword + archival | ✅ GraphRAG |
+| Rooms | ✅ Built-in | ❌ | ❌ | ❌ |
+| Time-travel | ✅ `--at` flag | ❌ | ❌ | ❌ |
+| MCP Server | ✅ Built-in | ❌ | ❌ | ❌ |
+| Relationship Graph | ✅ `--related` | ❌ | ❌ | ✅ GraphRAG |
+| Smart Decay | ✅ Pin + importance | ✅ | ✅ Core memory | ✅ TTL-based |
+| Recall Cache | ✅ LRU + TTL | ❌ | ❌ | ❌ |
+| Benchmarks | ✅ Built-in | ❌ | ❌ | ❌ |
+| Privacy | ✅ Data stays local | ⚠️ Sent to LLM | ⚠️ Sent to LLM | ⚠️ Sent to LLM |
+| Recall Speed | ~30ms | Network RTT | Network RTT | Network RTT |
+| Tag Management | ✅ list/rename/delete | ⚠️ Basic | ❌ | ⚠️ Basic |
+| Memory Aging | ✅ Auto-cleanup | ✅ | ✅ Core memory | ✅ TTL-based |
+| Shell Hooks | ✅ bash/zsh/fish | ❌ | ❌ | ❌ |
+| License | Apache-2.0 | Apache-2.0 | Apache-2.0 | Apache-2.0 |
+
+## Why Local?
+
+uteke runs entirely on your machine. No network calls, no API keys, no data leaving your machine. Your memories — your infrastructure.
+
+**Performance:** ~30ms recall is possible because embedding inference, HNSW vector search, and FTS5 all run in-process. No network round-trip.
+
+**Privacy:** Data never leaves your machine. No telemetry. No cloud dependency.
+
+**Simplicity:** Single binary. No Docker Compose, no database server, no Python environment. Just `curl | sh` and go.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,21 +6,13 @@ title: Getting Started
 
 ## Install
 
-One-liner install (macOS, Linux, Windows):
-
 ```bash
-curl -sSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
-Or install from source (requires [Rust](https://rustup.rs)):
+See the [Installation guide](/install) for all methods (Cargo, binary, Docker).
 
-```bash
-cargo install --git https://github.com/codecoradev/uteke
-```
-
-Pre-built binaries and Docker image also available from [GitHub Releases](https://github.com/codecoradev/uteke/releases) and [GHCR](https://github.com/codecoradev/uteke/pkgs/container/uteke). First run downloads the embedding model (~188MB) — no API keys needed.
-
-> 💡 **Using Docker?** See the [Docker guide](docker.md) for `docker compose` setup, env vars, and persistence.
+> 💡 First run downloads the embedding model (~188MB). No API keys needed.
 
 ## Your First Memory
 
@@ -59,19 +51,6 @@ uteke tags rename old-name new-name
 uteke tags delete unused-tag
 ```
 
-## Memory Aging
-
-```bash
-# Show hot/warm/cold/never-accessed breakdown
-uteke aging status
-
-# Preview memories older than 90 days
-uteke aging preview --older-than-days 90
-
-# Delete stale memories older than 180 days
-uteke aging cleanup --older-than-days 180 --yes
-```
-
 ## Multi-Agent Isolation
 
 Each agent gets its own namespace. Memories never leak between agents:
@@ -88,68 +67,6 @@ uteke --namespace architect recall "database"
 uteke --namespace dev recall "database"
 ```
 
-## Rooms
-
-Group related memories by context (meetings, projects, discussions):
-
-```bash
-# Create a room
-uteke room create "project-kickoff" --title "Project Kickoff"
-
-# Add a memory to a room with author attribution
-uteke room add "project-kickoff" <memory-id> --author alice
-
-# Semantic recall within a room
-uteke room recall "project-kickoff" --query "database decision"
-
-# Generate a structured document from room memories
-uteke room document "project-kickoff"
-
-# Get a summary of room discussions
-uteke room summary "project-kickoff"
-```
-
-## Time-Travel Queries
-
-Query memories as they existed at a specific point in time:
-
-```bash
-# List memories that existed on a given date
-uteke list --at 2026-06-01T12:00:00Z
-
-# Semantic recall filtered to memories valid at a point in time
-uteke recall "deployment process" --at 2026-06-01T12:00:00Z
-```
-
-Timestamps use [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339) format. Replace the example date with your actual target.
-
-## Memory Importance & Pinning
-
-Pin critical memories so they never decay:
-
-```bash
-# Pin a memory
-uteke pin <id>
-
-# Unpin a memory
-uteke unpin <id>
-
-# Recalculate importance scores
-uteke importance
-```
-
-## Relationship Graph
-
-Link related memories and traverse the graph:
-
-```bash
-# Store a memory that supersedes an old one
-uteke remember "API rate limit is now 2000/min" --meta "rel:supersedes:old-memory-id"
-
-# Recall with relationship traversal
-uteke recall "rate limit" --related --depth 2
-```
-
 ## Recall Cache
 
 The recall cache eliminates redundant embedding for repeated queries (~50ms savings). It's automatic — no configuration needed. Use `--context` for AI-prompt formatted output:
@@ -157,32 +74,6 @@ The recall cache eliminates redundant embedding for repeated queries (~50ms savi
 ```bash
 # AI-optimized context output
 uteke recall "api design" --context
-```
-
-## Benchmarking
-
-Test performance with synthetic data:
-
-```bash
-# Run full benchmark suite
-uteke bench
-
-# Custom counts + JSON output
-uteke bench --counts 100,1000 --json
-```
-
-See also: [LongMemEval retrieval harness](https://github.com/codecoradev/uteke/tree/develop/benchmarks/longmemeval) for accuracy evaluation.
-
-## Shell Hooks
-
-Auto-load project-scoped memory when you cd into a project directory:
-
-```bash
-# Install hook for your shell
-uteke hook install bash   # or zsh, fish
-
-# Now when you cd into a project with .uteke/uteke.db,
-# uteke auto-discovers it
 ```
 
 ## Export & Import
@@ -218,9 +109,8 @@ Add uteke as an MCP server to your AI coding agent in seconds:
 
 See [MCP Server](/mcp) for all supported clients and tools.
 
-
 > 💡 **Hermes users?** Three integration modes available:
-> - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](integrations/hermes.md).
+> - **Mode C (shell hook):** Lightest — automatic recall via `pre_llm_call` hook, no plugin/daemon needed. See [Hermes integration](/integrations/hermes).
 > - **Mode B (memory-provider):** Full auto — `uteke init --agent hermes --memory-provider`. Automatic recall + LLM fact extraction.
 > - **Mode A (uteke-tool):** Manual — `uteke init --agent hermes`. Explicit `uteke(action="...")` calls with multi-agent room support.
 >
@@ -241,7 +131,7 @@ uteke verify
 uteke repair
 ```
 
-## Where is data stored?
+## Where is Data Stored?
 
 All data lives in `~/.uteke/`:
 
@@ -258,3 +148,16 @@ All data lives in `~/.uteke/`:
 ```
 
 Copy the entire folder to back up or transfer to another machine.
+
+## Next Steps
+
+- [Installation](/install) — all install methods
+- [Rooms](/rooms) — group memories by context
+- [Time-Travel Queries](/time-travel) — recall memories at any point in time
+- [Smart Decay](/smart-decay) — pinning, importance scoring, aging
+- [Relationship Graph](/relationship-graph) — link and traverse memories
+- [Benchmarks](/benchmarks) — performance numbers
+- [Shell Hooks](/shell-hooks) — auto-load project context
+- [MCP Server](/mcp) — AI agent integration
+- [CLI Reference](/cli-reference) — complete command reference
+- [Configuration](/configuration) — config file and options

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ hero:
       text: Get Started
       link: /getting-started
     - theme: alt
+      text: Install
+      link: /install
+    - theme: alt
       text: GitHub
       link: https://github.com/codecoradev/uteke
 
@@ -57,19 +60,9 @@ features:
 | Feature | uteke | Mem0 | Letta | Cognee |
 |---------|-------|------|-------|--------|
 | Install | 1 binary | pip + Docker + Qdrant | pip + Docker + Postgres | pip + Docker + Neo4j |
-| API Keys | ✅ None needed | ❌ OpenAI/LLM key | ❌ LLM key | ❌ LLM + vector DB |
+| API Keys | ✅ None | ❌ OpenAI/LLM key | ❌ LLM key | ❌ LLM + vector DB |
 | Offline | ✅ Fully | ❌ Cloud embedding | ❌ Needs server | ❌ Needs LLM + DB |
-| Semantic Search | ✅ Local ONNX | ✅ Cloud embedding | ⚠️ Keyword + archival | ✅ GraphRAG |
-| Rooms | ✅ Built-in | ❌ | ❌ | ❌ |
-| Time-travel | ✅ --at flag | ❌ | ❌ | ❌ |
-| MCP Server | ✅ Built-in | ❌ | ❌ | ❌ |
-| Relationship Graph | ✅ --related | ❌ | ❌ | ✅ GraphRAG |
-| Smart Decay | ✅ Pin + importance | ✅ | ✅ Core memory | ✅ TTL-based |
-| Recall Cache | ✅ LRU + TTL | ❌ | ❌ | ❌ |
-| Benchmarks | ✅ Built-in | ❌ | ❌ | ❌ |
-| Privacy | ✅ Data stays local | ⚠️ Sent to LLM | ⚠️ Sent to LLM | ⚠️ Sent to LLM |
 | Recall Speed | ~30ms | Network RTT | Network RTT | Network RTT |
-| Tag Management | ✅ list/rename/delete | ⚠️ Basic | ❌ | ⚠️ Basic |
-| Memory Aging | ✅ Auto-cleanup | ✅ | ✅ Core memory | ✅ TTL-based |
-| Shell Hooks | ✅ bash/zsh/fish | ❌ | ❌ | ❌ |
-| License | Apache-2.0 | Apache-2.0 | Apache-2.0 | Apache-2.0 |
+| Privacy | ✅ Local | ⚠️ Sent to LLM | ⚠️ Sent to LLM | ⚠️ Sent to LLM |
+
+[See full comparison →](/comparison)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,104 @@
+---
+title: Installation
+---
+
+# Installation
+
+## Quick Install (Recommended)
+
+One-liner install — no Rust required. Installs `uteke`, `uteke-serve`, and `uteke-mcp`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+```
+
+Installs to `~/.local/bin`. Add to PATH if needed:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+```
+
+Pin a specific version:
+
+```bash
+UTEKE_VERSION=v0.7.3 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+```
+
+## Install via Cargo
+
+If you have [Rust](https://rustup.rs) 1.85+ installed:
+
+```bash
+cargo install --git https://github.com/codecoradev/uteke
+```
+
+This compiles uteke from source and installs it to Cargo's binary directory (typically `~/.cargo/bin/`).
+
+## Pre-built Binary
+
+Download from [GitHub Releases](https://github.com/codecoradev/uteke/releases):
+
+```bash
+# Linux (x86_64)
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-linux-x86_64.tar.gz | tar xz
+mv uteke ~/.local/bin/
+
+# macOS (Apple Silicon)
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-darwin-aarch64.tar.gz | tar xz
+mv uteke ~/.local/bin/
+```
+
+Supported platforms:
+
+| Platform | Architecture | Format |
+|----------|-------------|--------|
+| Linux | x86_64 | tar.gz |
+| Linux | aarch64 (ARM) | tar.gz |
+| macOS | aarch64 (Apple Silicon) | tar.gz |
+
+## Docker
+
+```bash
+docker pull ghcr.io/codecoradev/uteke:latest
+```
+
+> 💡 See the [Docker guide](/docker) for `docker compose` setup, environment variables, and volume persistence.
+
+## First Run
+
+On first run, uteke downloads the embedding model (~188MB). No API keys needed — fully offline.
+
+```bash
+uteke doctor   # Verify installation
+uteke --version
+```
+
+## Verify Installation
+
+```bash
+$ uteke --version
+uteke 0.7.3
+
+$ uteke doctor
+✓ Database     OK
+✓ Index         OK
+✓ Model         OK (embeddinggemma-q4, 768d)
+✓ Consistency   OK
+```
+
+## Updating
+
+```bash
+uteke upgrade          # Check + upgrade to latest release
+uteke upgrade --yes    # Skip confirmation
+```
+
+## What Gets Installed
+
+The install script deploys three binaries:
+
+| Binary | Purpose |
+|--------|---------|
+| `uteke` | Core CLI — remember, recall, search, list, etc. |
+| `uteke-serve` | HTTP server for remote access and MCP over HTTP |
+| `uteke-mcp` | Standalone MCP server for AI agent integration |

--- a/docs/relationship-graph.md
+++ b/docs/relationship-graph.md
@@ -1,0 +1,50 @@
+---
+title: Relationship Graph
+---
+
+# Relationship Graph
+
+Link related memories with typed edges and traverse the graph.
+
+## How It Works
+
+Memories can reference other memories using metadata relationships. This creates a directed graph where you can traverse connections.
+
+Supported relationship types:
+
+| Edge | Meaning |
+|------|---------|
+| `rel:supersedes` | This memory replaces an older one |
+| `rel:contradicts` | This memory contradicts another |
+| `rel:references` | This memory references another |
+| `rel:derived-from` | This memory was derived from another |
+
+## Linking Memories
+
+```bash
+# Store a memory that supersedes an old one
+uteke remember "API rate limit is now 2000/min" \
+  --meta "rel:supersedes:old-memory-id"
+```
+
+## Traversal
+
+Recall with relationship traversal:
+
+```bash
+# Recall with related memories, up to 2 hops
+uteke recall "rate limit" --related --depth 2
+```
+
+The `--related` flag includes connected memories in the result. `--depth` controls how many hops to traverse (default: 1).
+
+## Use Cases
+
+- **Knowledge evolution** — track when information changes and what it replaces
+- **Conflict detection** — find contradictions in your knowledge base
+- **Context enrichment** — automatically pull in related context during recall
+
+## See Also
+
+- [Time-Travel Queries](/time-travel) — temporal filtering for memory snapshots
+- [CLI Reference](/cli-reference) — full command options

--- a/docs/rooms.md
+++ b/docs/rooms.md
@@ -1,0 +1,50 @@
+---
+title: Rooms
+---
+
+# Rooms
+
+Group related memories by context — meetings, projects, discussions.
+
+## Create a Room
+
+```bash
+uteke room create "project-kickoff" --title "Project Kickoff"
+```
+
+## Add Memories to a Room
+
+```bash
+uteke room add "project-kickoff" <memory-id> --author alice
+```
+
+## Semantic Recall Within a Room
+
+```bash
+uteke room recall "project-kickoff" --query "database decision"
+```
+
+## Generate a Structured Document
+
+Combine room memories into a cohesive document:
+
+```bash
+uteke room document "project-kickoff"
+```
+
+## Get a Room Summary
+
+```bash
+uteke room summary "project-kickoff"
+```
+
+## Use Cases
+
+- **Meeting notes** — create a room per meeting, add memory IDs from discussions
+- **Project context** — group all project-related memories for easy recall
+- **Research** — compile findings into a structured document via `room document`
+
+## See Also
+
+- [Multi-Agent Isolation](/multi-agent) — each agent can have its own rooms
+- [CLI Reference — Room Commands](/cli-reference#room-commands) — full command reference

--- a/docs/shell-hooks.md
+++ b/docs/shell-hooks.md
@@ -1,0 +1,41 @@
+---
+title: Shell Hooks
+---
+
+# Shell Hooks
+
+Auto-load project-scoped memory when you cd into a project directory.
+
+## Installation
+
+```bash
+uteke hook install bash   # or zsh, fish
+```
+
+## How It Works
+
+When you `cd` into a directory containing `.uteke/uteke.db`, the shell hook automatically activates that project's memory store. No manual `--store` flag needed.
+
+## Supported Shells
+
+| Shell | Status |
+|-------|--------|
+| bash | ✅ |
+| zsh | ✅ |
+| fish | ✅ |
+
+## Project Setup
+
+Create a project-scoped memory database:
+
+```bash
+mkdir -p .uteke
+uteke --store .uteke remember "This project uses PostgreSQL"
+```
+
+Now when you cd into the project, uteke automatically uses `.uteke/uteke.db`.
+
+## See Also
+
+- [Configuration](/configuration) — store path and other config options
+- [CLI Reference](/cli-reference) — full command options

--- a/docs/smart-decay.md
+++ b/docs/smart-decay.md
@@ -1,0 +1,56 @@
+---
+title: Smart Decay
+---
+
+# Smart Decay
+
+Automatically manage memory freshness with importance scoring and aging.
+
+## Pinning
+
+Pin critical memories so they never decay:
+
+```bash
+uteke pin <id>
+uteke unpin <id>
+```
+
+## Importance Scoring
+
+uteke uses composite importance scoring based on access patterns, metadata, and pinning:
+
+```bash
+# Recalculate importance scores
+uteke importance
+```
+
+## Memory Aging
+
+Track memory freshness with hot/warm/cold tiers:
+
+```bash
+# Show hot/warm/cold/never-accessed breakdown
+uteke aging status
+
+# Preview memories older than 90 days
+uteke aging preview --older-than-days 90
+
+# Delete stale memories older than 180 days
+uteke aging cleanup --older-than-days 180 --yes
+```
+
+## How It Works
+
+| Tier | Description |
+|------|-------------|
+| **Hot** | Recently accessed, high importance |
+| **Warm** | Accessed within the aging window |
+| **Cold** | Older than the aging threshold |
+| **Never** | Never been recalled after creation |
+
+Pinned memories bypass aging entirely — they stay in the store regardless of access patterns.
+
+## See Also
+
+- [Installation](/install) — install uteke
+- [CLI Reference](/cli-reference) — full command options

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -1,0 +1,34 @@
+---
+title: Time-Travel Queries
+---
+
+# Time-Travel Queries
+
+Query memories as they existed at a specific point in time.
+
+## How It Works
+
+Every memory has temporal validity (`valid_from` / `valid_until`). The `--at` flag filters queries to only memories that existed at the given timestamp.
+
+## Usage
+
+```bash
+# List memories that existed on a given date
+uteke list --at 2026-06-01T12:00:00Z
+
+# Semantic recall filtered to memories valid at a point in time
+uteke recall "deployment process" --at 2026-06-01T12:00:00Z
+```
+
+Timestamps use [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339) format.
+
+## Use Cases
+
+- **Post-mortem analysis** — see what the system knew before an incident
+- **Audit trail** — trace how knowledge evolved over time
+- **Change tracking** — compare memory state between two points in time
+
+## See Also
+
+- [Relationship Graph](/relationship-graph) — link memories with temporal edges
+- [CLI Reference](/cli-reference) — full command options


### PR DESCRIPTION
## Changes

### New Pages
- `install.md` — dedicated install guide (curl, cargo, binary, docker)
- `rooms.md` — room commands, document, summary
- `time-travel.md` — `--at` flag temporal queries
- `smart-decay.md` — pinning, importance, aging
- `relationship-graph.md` — `--related`, `--depth`, metadata edges
- `benchmarks.md` — performance numbers (from BENCHMARKS.md)
- `shell-hooks.md` — hook install, auto-discovery
- `comparison.md` — full feature comparison table

### Modified
- `index.md` — 5-row ringkas comparison + link to /comparison
- `getting-started.md` — slimmed down (removed extracted sections)
- `config.ts` — sidebar updated (halaman terpisah, bukan anchor links)

### Removed
- `BENCHMARKS.md` — merged into `benchmarks.md`

### CF Worker Routes (separate commit, already deployed)
- `/{product}/install` → 302 → raw GitHub install.sh
- `/install` (legacy) → 302 → uteke install.sh

**No breaking changes** — semua existing URLs tetap valid.