### PR TITLE
feat: enable salience/recency boosts by default (opt-out)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -111,12 +111,14 @@ pub enum Commands {
         strategy: Option<String>,
         /// Enable salience boost (how much each result matters) (#352).
         /// Uses the configured `[recall].salience_weight` (default 0.15).
+        /// When absent, salience uses the default weight (0.1). Use --no-salience to disable (#721).
         #[arg(long)]
-        salience: bool,
+        salience: Option<bool>,
         /// Enable recency boost (how fresh each result is) (#352).
         /// Uses the configured `[recall].recency_weight` (default 0.15).
+        /// When absent, recency uses the default weight (0.1). Use --no-recency to disable (#721).
         #[arg(long)]
-        recency: bool,
+        recency: Option<bool>,
         /// Follow relationship edges in memory metadata
         #[arg(long)]
         related: bool,

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -26,8 +26,8 @@ pub(crate) fn run_recall(
     at: Option<&str>,
     content_format: &str,
     where_filter: Option<&str>,
-    salience: bool,
-    recency: bool,
+    salience: Option<bool>,
+    recency: Option<bool>,
     search_type: Option<&str>,
     enrich: bool,
 ) -> Result<(), String> {
@@ -45,17 +45,15 @@ pub(crate) fn run_recall(
 
     // When --type is explicitly set (not default unified), route to recall_unified.
     // When unified (default), use existing recall path for backward compat with
-    // --strategy, --at, --related, --salience, --recency, --entity, --category, --where flags
-    // which only apply to memory recall. If --type=all and no memory-only flags are used,
-    // use the unified path.
+    // --strategy, --at, --related, --entity, --category, --where flags
+    // which only apply to memory recall.
+    // --salience/--recency/--no-salience/--no-recency work on both paths (#721).
     let use_unified = match resolved_search_type {
         SearchType::All => {
             // Use unified only when no memory-only flags are active.
-            // Memory-only flags: --at, --related, --salience, --recency, --entity, --category, --where
+            // Memory-only flags: --at, --related, --entity, --category, --where
             at.is_none()
                 && !related
-                && !salience
-                && !recency
                 && entity.is_none()
                 && category.is_none()
                 && where_filter.is_none()
@@ -93,19 +91,19 @@ pub(crate) fn run_recall(
         }
     };
 
-    // #352: dual-axis salience/recency boost. Opt-in per query via
-    // --salience / --recency flags. Weights come from config so users can
-    // tune the boost strength in uteke.toml.
+    // #352/#721: dual-axis salience/recency boost.
+    // Tri-state via Option<bool>: None (absent) = use default (0.1),
+    // Some(true) = use config weight (0.15), Some(false) / --no-* = 0.0.
     uteke.set_salience_recency_config(uteke_core::SalienceRecencyConfig {
-        salience_weight: if salience {
-            config.recall.salience_weight
-        } else {
-            0.0
+        salience_weight: match salience {
+            Some(true) => config.recall.salience_weight,   // explicit --salience
+            Some(false) => 0.0,                           // explicit --no-salience
+            None => uteke_core::SalienceRecencyConfig::default().salience_weight, // default 0.1
         },
-        recency_weight: if recency {
-            config.recall.recency_weight
-        } else {
-            0.0
+        recency_weight: match recency {
+            Some(true) => config.recall.recency_weight,   // explicit --recency
+            Some(false) => 0.0,                           // explicit --no-recency
+            None => uteke_core::SalienceRecencyConfig::default().recency_weight, // default 0.1
         },
     });
 

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -96,13 +96,13 @@ pub(crate) fn run_recall(
     // Some(true) = use config weight (0.15), Some(false) / --no-* = 0.0.
     uteke.set_salience_recency_config(uteke_core::SalienceRecencyConfig {
         salience_weight: match salience {
-            Some(true) => config.recall.salience_weight,   // explicit --salience
-            Some(false) => 0.0,                           // explicit --no-salience
+            Some(true) => config.recall.salience_weight, // explicit --salience
+            Some(false) => 0.0,                          // explicit --no-salience
             None => uteke_core::SalienceRecencyConfig::default().salience_weight, // default 0.1
         },
         recency_weight: match recency {
-            Some(true) => config.recall.recency_weight,   // explicit --recency
-            Some(false) => 0.0,                           // explicit --no-recency
+            Some(true) => config.recall.recency_weight, // explicit --recency
+            Some(false) => 0.0,                         // explicit --no-recency
             None => uteke_core::SalienceRecencyConfig::default().recency_weight, // default 0.1
         },
     });

--- a/crates/uteke-core/src/salience_recency.rs
+++ b/crates/uteke-core/src/salience_recency.rs
@@ -257,7 +257,10 @@ mod tests {
         let cfg = SalienceRecencyConfig::default();
         assert!(!cfg.is_noop(), "default should be non-zero (#721)");
         let boosted = apply_boosts(0.5, &m, chrono::Utc::now(), cfg);
-        assert!(boosted > 0.5, "default boost should raise score, got {boosted}");
+        assert!(
+            boosted > 0.5,
+            "default boost should raise score, got {boosted}"
+        );
     }
 
     #[test]

--- a/crates/uteke-core/src/salience_recency.rs
+++ b/crates/uteke-core/src/salience_recency.rs
@@ -1,7 +1,6 @@
-//! Salience + recency dual-axis recall ranking (#352).
+//! Salience + recency dual-axis recall ranking (#352, #721).
 //!
-//! Two orthogonal boost functions that can be turned on per-query via
-//! `--salience` / `--recency` CLI flags (or the equivalent API params).
+//! Two orthogonal boost functions applied by default to every recall query.
 //! Both are computed from existing memory fields — **zero LLM**.
 //!
 //! ## Salience (mattering)
@@ -17,27 +16,32 @@
 //!
 //! Both axes are **additive boosts** capped to never dominate embedding
 //! similarity — they act as tie-breakers between otherwise similar results.
+//!
+//! ## Default behavior (#721)
+//!
+//! Both weights default to `0.1` (enabled by default). Use `--no-salience`
+//! / `--no-recency` CLI flags or pass weight 0.0 via API to opt out.
 
 use crate::memory::types::Memory;
 
-/// Per-query salience/recency boost weights (#352).
+/// Per-query salience/recency boost weights (#352, #721).
 ///
-/// All weights default to `0.0` so the feature is opt-in per query.
-/// `salience_weight` and `recency_weight` are applied additively to the
-/// final recall score after embedding similarity is computed.
+/// Both weights default to `0.1` (enabled by default). Set to `0.0` to
+/// disable. `salience_weight` and `recency_weight` are applied additively
+/// to the final recall score after embedding similarity is computed.
 #[derive(Debug, Clone, Copy)]
 pub struct SalienceRecencyConfig {
-    /// Weight for the salience boost (0.0 = off, 0.15 = default when enabled).
+    /// Weight for the salience boost (0.0 = off, 0.1 = default).
     pub salience_weight: f32,
-    /// Weight for the recency boost (0.0 = off, 0.15 = default when enabled).
+    /// Weight for the recency boost (0.0 = off, 0.1 = default).
     pub recency_weight: f32,
 }
 
 impl Default for SalienceRecencyConfig {
     fn default() -> Self {
         Self {
-            salience_weight: 0.0,
-            recency_weight: 0.0,
+            salience_weight: 0.1,
+            recency_weight: 0.1,
         }
     }
 }
@@ -238,9 +242,22 @@ mod tests {
     #[test]
     fn apply_boosts_noop_when_weights_zero() {
         let m = mem(0, 0.5, false, 0, "fact");
-        let cfg = SalienceRecencyConfig::default();
+        // Explicit zero weights → no-op regardless of default.
+        let cfg = SalienceRecencyConfig {
+            salience_weight: 0.0,
+            recency_weight: 0.0,
+        };
         assert!(cfg.is_noop());
         assert_eq!(apply_boosts(0.7, &m, chrono::Utc::now(), cfg), 0.7);
+    }
+
+    #[test]
+    fn apply_boosts_default_nonzero() {
+        let m = mem(100, 0.9, true, 0, "decision");
+        let cfg = SalienceRecencyConfig::default();
+        assert!(!cfg.is_noop(), "default should be non-zero (#721)");
+        let boosted = apply_boosts(0.5, &m, chrono::Utc::now(), cfg);
+        assert!(boosted > 0.5, "default boost should raise score, got {boosted}");
     }
 
     #[test]
@@ -267,7 +284,15 @@ mod tests {
 
     #[test]
     fn config_is_noop() {
-        assert!(SalienceRecencyConfig::default().is_noop());
+        // Default is now non-zero (#721)
+        assert!(!SalienceRecencyConfig::default().is_noop());
+        // Explicit zero weights are no-op
+        assert!(SalienceRecencyConfig {
+            salience_weight: 0.0,
+            recency_weight: 0.0,
+        }
+        .is_noop());
+        // One non-zero is not no-op
         assert!(!SalienceRecencyConfig {
             salience_weight: 0.1,
             recency_weight: 0.0,


### PR DESCRIPTION
## Summary

Enable salience + recency dual-axis recall boosts by default (#721).

Previously both weights defaulted to `0.0` (opt-in only). The exp(-age/t) per-type decay and salience scoring (access_count + importance + pinned) were fully implemented but never active unless explicitly requested.

## Changes

| File | Change |
|------|--------|
| `uteke-core/src/salience_recency.rs` | `SalienceRecencyConfig::default()` weights 0.0 → 0.1, updated tests |
| `uteke-cli/src/cli.rs` | `--salience`/`--recency` changed to `Option<bool>` (supports `--no-*`) |
| `uteke-cli/src/commands/recall.rs` | Tri-state: absent=0.1, --flag=0.15, --no-flag=0.0 |

## Behavior

| CLI | Salience | Recency |
|-----|----------|---------|
| `uteke recall "query"` (no flags) | **0.1** ✓ | **0.1** ✓ |
| `uteke recall "query" --salience` | 0.15 (config) | 0.1 (default) |
| `uteke recall "query" --no-salience` | 0.0 (off) | 0.1 (default) |
| `uteke recall "query" --no-salience --no-recency` | 0.0 | 0.0 |

## Impact

- Boost is additive, max +0.1 to final score — tie-breaker, not dominant signal
- API consumers (MCP, Hermes agents) automatically benefit without code changes
- Adopted from Hermes holographic memory analysis

## Breaking

None. Users who need old behavior can pass `--no-salience --no-recency`.

## Tests

Updated existing `is_noop` and `apply_boosts` tests. Added `apply_boosts_default_nonzero` test.

Closes #721