### PR TITLE
feat: trust scoring with feedback API

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -334,6 +334,16 @@ pub enum Commands {
         /// Memory ID (UUID)
         id: String,
     },
+    /// Record feedback on a memory's usefulness (#718)
+    ///
+    /// Boosts (helpful) or reduces (unhelpful) the memory's importance score.
+    /// Helpful: +0.05, Unhelpful: -0.10 (asymmetric — penalty > reward).
+    Feedback {
+        /// Memory ID (UUID)
+        id: String,
+        #[command(subcommand)]
+        action: FeedbackAction,
+    },
     /// Recalculate importance scores for all memories
     Importance,
     /// Room management: list, stats, recall
@@ -616,6 +626,15 @@ pub enum NamespaceCommands {
         /// Namespace name to set as default
         name: String,
     },
+}
+
+/// Feedback actions for trust scoring (#718).
+#[derive(Subcommand, Clone)]
+pub enum FeedbackAction {
+    /// Mark memory as helpful: importance += 0.05
+    Helpful,
+    /// Mark memory as unhelpful: importance -= 0.10
+    Unhelpful,
 }
 
 /// Subcommands for room management.

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ mod upgrade;
 
 use crate::cli::Cli;
 use crate::cli::Commands;
+use crate::cli::FeedbackAction;
 use crate::resolve_namespace;
 use crate::Config;
 use uteke_core::Uteke;

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -285,16 +285,17 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
         }
 
         Commands::Feedback { id, action } => {
+            let id_str = id.as_str();
             let (label, delta_str, new_importance) = match action {
                 FeedbackAction::Helpful => {
                     let new_imp = uteke
-                        .feedback_helpful(&id)
+                        .feedback_helpful(id_str)
                         .map_err(|e| format!("Feedback failed: {e}"))?;
                     ("helpful", "+0.05", new_imp)
                 }
                 FeedbackAction::Unhelpful => {
                     let new_imp = uteke
-                        .feedback_unhelpful(&id)
+                        .feedback_unhelpful(id_str)
                         .map_err(|e| format!("Feedback failed: {e}"))?;
                     ("unhelpful", "-0.10", new_imp)
                 }

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -283,6 +283,37 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             Ok(())
         }
 
+        Commands::Feedback { id, action } => {
+            let (label, delta_str, new_importance) = match action {
+                FeedbackAction::Helpful => {
+                    let new_imp = uteke
+                        .feedback_helpful(&id)
+                        .map_err(|e| format!("Feedback failed: {e}"))?;
+                    ("helpful", "+0.05", new_imp)
+                }
+                FeedbackAction::Unhelpful => {
+                    let new_imp = uteke
+                        .feedback_unhelpful(&id)
+                        .map_err(|e| format!("Feedback failed: {e}"))?;
+                    ("unhelpful", "-0.10", new_imp)
+                }
+            };
+            if cli.json {
+                println!(
+                    r#"{{"id": "{id}", "feedback": "{label}", "delta": "{delta_str}", "importance": {new_importance:.4}}}"#
+                );
+            } else {
+                println!(
+                    "Feedback recorded for {}: {} {}. New importance: {:.4}",
+                    &id[..8.min(id.len())],
+                    label,
+                    delta_str,
+                    new_importance
+                );
+            }
+            Ok(())
+        }
+
         Commands::Importance => {
             let updated = uteke
                 .recompute_importance()

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -648,6 +648,37 @@ impl Uteke {
         self.store.set_importance(id, importance)
     }
 
+    /// Record positive feedback: boost importance (#718).
+    ///
+    /// Increments importance by `delta` (clamped to 1.0).
+    /// Default delta: 0.05 (adopted from Hermes trust scoring).
+    /// Returns the new importance value.
+    pub fn feedback_helpful(&self, id: &str) -> Result<f64, Error> {
+        self.feedback_adjust(id, 0.05)
+    }
+
+    /// Record negative feedback: reduce importance (#718).
+    ///
+    /// Decrements importance by `delta` (clamped to 0.0).
+    /// Default delta: 0.10 (adopted from Hermes trust scoring).
+    /// Unhelpful feedback is penalized more than helpful is rewarded.
+    /// Returns the new importance value.
+    pub fn feedback_unhelpful(&self, id: &str) -> Result<f64, Error> {
+        self.feedback_adjust(id, -0.10)
+    }
+
+    /// Internal: adjust importance by delta, clamped to [0.0, 1.0].
+    fn feedback_adjust(&self, id: &str, delta: f64) -> Result<f64, Error> {
+        let memory = self
+            .store
+            .get(id)
+            .ok_or_else(|| Error::db_msg(format!("Memory not found: {id}")))?
+            .ok_or_else(|| Error::db_msg(format!("Memory not found: {id}")))?;
+        let new_importance = (memory.importance + delta).clamp(0.0, 1.0);
+        self.store.set_importance(id, new_importance)?;
+        Ok(new_importance)
+    }
+
     /// Set source provenance on a memory (#348).
     pub fn set_source(
         &self,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -669,12 +669,17 @@ impl Uteke {
 
     /// Internal: adjust importance by delta, clamped to [0.0, 1.0].
     fn feedback_adjust(&self, id: &str, delta: f64) -> Result<f64, Error> {
-        let memory = self
+        let current: f64 = self
             .store
-            .get(id)
-            .ok_or_else(|| Error::db_msg(format!("Memory not found: {id}")))?
-            .ok_or_else(|| Error::db_msg(format!("Memory not found: {id}")))?;
-        let new_importance = (memory.importance + delta).clamp(0.0, 1.0);
+            .conn
+            .query_row(
+                "SELECT importance FROM memories WHERE id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::db("feedback_adjust read", e))?;
+
+        let new_importance = (current + delta).clamp(0.0, 1.0);
         self.store.set_importance(id, new_importance)?;
         Ok(new_importance)
     }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -772,6 +772,54 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // ── Memory Feedback (Trust Scoring) (#718) ────────────────────
+        (Method::Post, "/memory/feedback") => {
+            match read_body::<MemoryFeedbackRequest>(req.as_reader()) {
+                Ok(req_data) => {
+                    if uuid::Uuid::parse_str(&req_data.id).is_err() {
+                        return ctx.error_response_for(
+                            req,
+                            400,
+                            format!("Invalid UUID format: {}", req_data.id),
+                        );
+                    }
+                    let result = match req_data.feedback.as_str() {
+                        "helpful" => uteke.feedback_helpful(&req_data.id).map(|imp| {
+                            serde_json::json!({
+                                "id": req_data.id,
+                                "feedback": "helpful",
+                                "delta": 0.05,
+                                "importance": imp,
+                            })
+                        }),
+                        "unhelpful" => uteke.feedback_unhelpful(&req_data.id).map(|imp| {
+                            serde_json::json!({
+                                "id": req_data.id,
+                                "feedback": "unhelpful",
+                                "delta": -0.10,
+                                "importance": imp,
+                            })
+                        }),
+                        _ => {
+                            return ctx.error_response_for(
+                                req,
+                                400,
+                                "Invalid feedback value. Use 'helpful' or 'unhelpful'.".to_string(),
+                            );
+                        }
+                    };
+                    match result {
+                        Ok(data) => ctx.ok_response_for(req, &data),
+                        Err(e) => {
+                            error!("Feedback error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
         // ── Update memory by ID (PUT /memory, #659) ──────────────────
         (Method::Put, "/memory") => match read_body::<MemoryUpdateRequest>(req.as_reader()) {
             Ok(req_data) => {

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -127,6 +127,7 @@ fn main() {
                 println!("  GET  /memory?id=UUID       -> {{ memory }}");
                 println!("  POST /memory/pin           -> {{ id, pinned }} -> {{ memory }}");
                 println!("  POST /memory/importance    -> {{ id, importance }} -> {{ memory }}");
+                println!("  POST /memory/feedback      -> {{ id, feedback }} -> {{ id, delta, importance }} (#718)");
                 println!("  GET  /stats               → {{ stats }}");
                 println!("  GET  /namespaces           → {{ namespaces }}");
                 println!("  POST /room/create          → {{ room_id, title, namespace }} → {{ created }}");

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -391,6 +391,14 @@ pub struct MemoryImportanceRequest {
     pub importance: f64,
 }
 
+/// Request for memory feedback / trust scoring (#718).
+#[derive(Deserialize)]
+pub struct MemoryFeedbackRequest {
+    pub id: String,
+    /// "helpful" or "unhelpful"
+    pub feedback: String,
+}
+
 // ── Graph Types ────────────────────────────────────────────────────────────
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

Add helpful/unhelpful feedback mechanism for trust scoring (#718).

## Problem

Uteke memories have an `importance` field (0.0–1.0, default 0.5) used by salience boost and orphan detection. Currently importance can only be set directly or recomputed globally — there's no way to signal that a specific memory was useful or not in a given context. Hermes solves this with a feedback loop: +0.05 for helpful, -0.10 for unhelpful (asymmetric — penalizing bad memories more than rewarding good ones).

## Changes

### `uteke-core/src/lib.rs`
- `Uteke::feedback_helpful(id)` → importance += 0.05, returns new value
- `Uteke::feedback_unhelpful(id)` → importance -= 0.10, returns new value
- Internal `feedback_adjust(id, delta)` with clamp to [0.0, 1.0]

### `uteke-cli/src/cli.rs`
- `uteke feedback <id> {helpful|unhelpful}` subcommand
- `FeedbackAction` enum

### `uteke-cli/src/commands/mod.rs`
- Handler with JSON (`--json`) and human-readable output

### `uteke-server/src/{handlers.rs, types.rs, main.rs}`
- `POST /memory/feedback` — `{ id, feedback: "helpful"|"unhelpful" }`
- Returns `{ id, feedback, delta, importance }`
- UUID validation, 400 for invalid feedback value

## Usage

**CLI:**
```bash
uteke feedback <uuid> helpful     # importance += 0.05
uteke feedback <uuid> unhelpful   # importance -= 0.10
uteke --json feedback <uuid> helpful
```

**API:**
```bash
curl -X POST http://localhost:8767/memory/feedback \
  -H 'Content-Type: application/json' \
  -d '{"id": "uuid", "feedback": "helpful"}'
# → {"id": "...", "feedback": "helpful", "delta": 0.05, "importance": 0.55}
```

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Asymmetric delta (±0.05 vs -0.10) | Adopted from Hermes. Bad memories should be demoted faster than good ones are promoted. |
| Clamp to [0.0, 1.0] | Prevents out-of-range importance from repeated feedback. |
| Separate helpful/unhelpful (not a generic delta) | Clearer API contract. Future: per-namespace delta config. |
| Returns new importance | Caller can track trust trajectory without a separate GET. |

Closes #718