### PR TITLE
docs: CHANGELOG, CLI reference, architecture for v0.7.4 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
 - **Room ↔ Document junction table — schema v15 (#689, #692)** — New `room_documents` table links rooms to documents bidirectionally. Endpoints: `POST /room/document/list`, `PUT /room/document/add`, `DELETE /room/document/remove`, `POST /doc/room/list`.
 - **memory↔document cross-entity linking via [[doc-slug]] wikilinks (#691)** — Memories containing `[[doc-slug]]` patterns are auto-wired to document references. Query endpoints: `POST /memory/doc-refs` (doc slugs for a memory) and `POST /doc/mem-refs` (memory IDs referencing a doc).
 - **Schema v14: memory_type added to FTS5 index (#662)** — FTS5 full-text search now indexes `memory_type`, enabling keyword search by type. Migration rebuilds the FTS5 index from existing memories.
+- **Trust scoring with feedback API (#718, PR #725)** — `uteke feedback helpful <id>` (+0.05 importance) and `uteke feedback unhelpful <id>` (-0.10 importance). HTTP endpoint: `POST /memory/feedback` with `{ id, feedback: 'helpful'|'unhelpful' }`. Importance clamped to [0.0, 1.0]. Adopted from Hermes holographic memory trust scoring.
+- **Jaccard token similarity as post-RRF reranking signal (#719, PR #723)** — Token-level Jaccard similarity applied after RRF score normalization in `recall_rrf`. Configurable via `jaccard_weight` in config (default 0.0, opt-in). `set_jaccard_weight()` method on Uteke struct. Module: `jaccard.rs` with `tokenize()`, `jaccard_similarity()`, `rerank_by_jaccard()`.
+- **Auto-contradiction scan as Dream pipeline phase (#720, PR #726)** — New Phase 4 (Contradict) in Dream maintenance pipeline. Scans top-200 recently updated memories for pairs with high tag overlap (Jaccard ≥ 0.3) + low embedding cosine similarity (≤ 0.6). Creates `contradicts` graph edges (older → newer). Supports `--dry-run` and `--phases contradict`. Pipeline order now: lint → backlinks → dedup → contradict → orphans → compact → verify.
 
 ### Changed
 - **Entity/category filter pushed into core recall (#667)** — Entity and category metadata filters now run inside the core recall candidate loop instead of post-fetch amplification. Eliminates the 10x fetch overhead for filtered queries.
 - **Full memory detail fields in UnifiedSearchResult (#688)** — Unified search results now include complete memory metadata (tags, importance, pinned, namespace, memory_type, source info) directly in the response, eliminating secondary lookups.
+- **Salience/recency boosts enabled by default (#721, PR #722)** — Default weights changed from 0.0 to 0.1 for both salience and recency. CLI flags now tri-state: `--salience`/`--recency` (explicit, use config weight), `--no-salience`/`--no-recency` (disable), omit (use default 0.1). No longer opt-in — users must explicitly disable to get neutral scoring.
+- **Dream pipeline expanded to 7 phases** — Added Contradict phase between Dedup and Orphans. `all_in_order()` returns 7 phases. CLI `--phases` filter accepts `contradict`.
 
 ### Fixed
 - **Search access count tracking** — Search operations now correctly increment the access count on recalled memories, improving tier scoring accuracy.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,11 +214,11 @@ Dual-axis recall boost applied after the RRF merge:
 - **Salience**: higher-scored by type weight (decision > insight > fact > note)
 - **Recency**: exponential decay `exp(-age/τ)` where τ is a per-type time constant
 
-Both are opt-in via `--salience` / `--recency` CLI flags or the API. Config leaks are prevented by setting/resetting config around each query.
+Both are enabled by default (weight 0.1). Use `--no-salience` / `--no-recency` to disable. Previously opt-in (v0.7.3), now opt-out (#721). Config leaks are prevented by setting/resetting config around each query.
 
 ### Dream Cycle (#353)
 
-The `dream` command runs a coordinated maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify. Phases run in canonical dependency order regardless of user-supplied order. Individual phase errors are recorded but don't abort the pipeline. Namespace-scoped phases (lint, dedup, orphans, compact) only affect the target namespace; global phases (backlinks, verify) run across all namespaces.
+The `dream` command runs a coordinated maintenance pipeline: lint → backlinks → dedup → contradict → orphans → compact → verify. Phase 4 (Contradict) scans for contradictory memories via tag overlap + embedding divergence (#720). Phases run in canonical dependency order regardless of user-supplied order. Individual phase errors are recorded but don't abort the pipeline. Namespace-scoped phases (lint, dedup, contradict, orphans, compact) only affect the target namespace; global phases (backlinks, verify) run across all namespaces.
 
 ### Citation & Source Attribution (#348)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -283,8 +283,9 @@ uteke recall "api design" --context
 | `--related` | Follow relationship edges |
 | `--depth <n>` | Traversal depth for --related |
 | `--context` | AI-prompt formatted output |
-| `--salience` | Enable salience boost (higher score for decision/insight types) |
-| `--recency` | Enable recency boost (higher score for recently created memories) |
+| `--salience` | Enable salience boost (default: on, weight 0.1). Use `--no-salience` to disable |
+| `--recency` | Enable recency boost (default: on, weight 0.1). Use `--no-recency` to disable |
+| `--jaccard` | Enable Jaccard token reranking signal (default: off, requires `jaccard_weight` > 0 in config) |
 
 ## uteke list (enhanced)
 
@@ -565,7 +566,7 @@ uteke rebuild-backlinks --json
 
 Run the full maintenance pipeline in one command (v0.2.1, #353).
 
-Executes phases in dependency order: lint → backlinks → dedup → orphans → compact → verify.
+Executes phases in dependency order: lint → backlinks → dedup → contradict → orphans → compact → verify.
 Each phase records its status. Errors in individual phases are recorded but do not abort the pipeline.
 
 ```bash
@@ -580,11 +581,14 @@ uteke dream --dry-run
 
 # Scoped to a namespace
 uteke dream --namespace my-agent
+
+# Run only contradiction detection
+uteke dream --phases contradict
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--phases <list>` | Comma-separated subset: lint, backlinks, dedup, orphans, compact, verify |
+| `--phases <list>` | Comma-separated subset: lint, backlinks, dedup, contradict, orphans, compact, verify |
 | `--dry-run` | Preview without making changes |
 | `--namespace <ns>` | Run scoped to a specific namespace (backlinks and verify are global) |
 | `--json` | JSON output |
@@ -596,9 +600,21 @@ uteke dream --namespace my-agent
 | `lint` | Check for invalid memory types, missing slugs, stale deprecated flags |
 | `backlinks` | Rebuild `referenced_by` edges (same as `rebuild-backlinks`) |
 | `dedup` | Find and merge near-duplicate memories (cosine ≥ 0.90) |
+| `contradict` | Detect contradictory memories (threshold 0.65) and flag for review |
 | `orphans` | Find disconnected, low-importance memories |
 | `compact` | Apply auto-prune to cold-tier and deprecated memories |
 | `verify` | Verify DB and index consistency |
+
+## uteke feedback
+
+Record feedback on a memory's usefulness (v0.7.4, #718). Adjusts importance score: +0.05 for helpful, -0.10 for unhelpful.
+
+```bash
+uteke feedback helpful <memory-id>
+uteke feedback unhelpful <memory-id>
+```
+
+With `--json` flag, outputs structured JSON with id, feedback type, delta, and new importance value.
 
 ## uteke orphans
 
@@ -752,6 +768,7 @@ When `[server] enabled = true` is set in config, the CLI auto-routes commands th
 | POST | `/graph/edge` | Create a typed edge between two memories (#542) |
 | DELETE | `/graph/edge` | Remove an edge by ID (#542) |
 | POST | `/mcp` | MCP JSON-RPC endpoint (#381) |
+| POST | `/memory/feedback` | Record helpful/unhelpful feedback on a memory. Body: `{ id, feedback: 'helpful'|'unhelpful' }`. Returns updated importance. (#718) |
 
 ### MCP Server
 


### PR DESCRIPTION
## Summary

Documentation updates for the 4 features merged in v0.7.4:

### CHANGELOG.md
- **Added**: Trust scoring (#718), Jaccard reranking (#719), Contradiction scan (#720)
- **Changed**: Salience default-on (#721), Dream 7 phases (#720)

### docs/cli-reference.md
- Updated recall flags: --salience/--recency now default-on with --no-* opt-out
- Added --jaccard flag for recall reranking
- Updated dream phases: added contradict between dedup and orphans
- New `uteke feedback` command section
- Added POST /memory/feedback to HTTP endpoint table

### docs/architecture.md
- Salience/recency: opt-in → opt-out description
- Dream pipeline: 6 → 7 phases with contradict phase