### PR TITLE
docs: add SECURITY.md and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Description
+
+Brief description of what this PR does and why.
+
+## Type
+
+- [ ] `feat` — New feature
+- [ ] `fix` — Bug fix
+- [ ] `docs` — Documentation
+- [ ] `refactor` — Code refactoring
+- [ ] `test` — Test additions/changes
+- [ ] `chore` — Maintenance
+
+## Changes
+
+<!-- List the key changes -->
+
+-
+
+## Testing
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] [Cora review](https://github.com/codecoradev/cora-cli) run locally
+
+## Related Issues
+
+<!-- Link to related issues, e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Branch is from `develop`
+- [ ] Commit messages follow conventional commits
+- [ ] No secrets or credentials committed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,16 +16,14 @@ If you discover a security vulnerability in Uteke, please report it responsibly.
 
 ### How to Report
 
-1. Open a new issue with the title prefix `[SECURITY]`
-2. Use the label `security`
-3. Include as much detail as possible:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
-4. The issue will be restricted to maintainers only
+Use [GitHub Private Vulnerability Reporting](https://github.com/codecoradev/uteke/security/advisories/new) — this ensures the report is confidential and only visible to maintainers.
 
-Alternatively, contact the maintainer directly via [GitHub Security Advisories](https://github.com/codecoradev/uteke/security/advisories/new).
+Include as much detail as possible:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
 
 ### What to Expect
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | ✅ |
+| Previous release | ✅ (critical only) |
+| Older versions | ❌ |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Uteke, please report it responsibly.
+
+**Do NOT** open a public issue for security vulnerabilities.
+
+### How to Report
+
+1. Open a new issue with the title prefix `[SECURITY]`
+2. Use the label `security`
+3. Include as much detail as possible:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+4. The issue will be restricted to maintainers only
+
+Alternatively, contact the maintainer directly via [GitHub Security Advisories](https://github.com/codecoradev/uteke/security/advisories/new).
+
+### What to Expect
+
+- **Acknowledgment** within 48 hours
+- **Initial assessment** within 5 business days
+- **Fix timeline** depends on severity:
+  - Critical: 7 days
+  - High: 14 days
+  - Medium: 30 days
+  - Low: next minor release
+
+### Security in the Development Process
+
+Uteke uses multiple automated security checks on every PR:
+
+- **Cargo Audit** — dependency vulnerability scanning
+- **Trivy FS Scan** — filesystem security scanning
+- **GitGuardian** — secret leak detection
+
+These are enforced via CI and block merge on findings.


### PR DESCRIPTION
## Summary

Add two community template files:

1. **** — Security policy with supported versions, vulnerability reporting process, SLA by severity, and existing CI security checks (Cargo Audit, Trivy, GitGuardian).

2. **** — PR checklist covering type, changes, testing (cargo test/fmt/clippy + Cora), related issues, and conventional commits.

## Files
- `SECURITY.md` (new)
- `.github/PULL_REQUEST_TEMPLATE.md` (new)