### PR TITLE
fix(core): filter deprecated memories in recall() (#748)

### DIFF
--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -465,6 +465,11 @@ impl crate::Uteke {
                     }
                 }
 
+                // Filter deprecated memories (#748)
+                if memory.deprecated {
+                    continue;
+                }
+
                 let score = cosine_distance_to_similarity(*distance);
 
                 // Boost hot memories (configurable boost)


### PR DESCRIPTION
## Summary

Fixes #748 —  vector search path was missing a deprecated filter, causing deprecated memories (61.7% in reported case) to appear in all vector-based search results.

## Root Cause

In `operations.rs`, the `recall()` loop filters namespace, tags, entity, and category — but never checks `memory.deprecated`. Since `recall_rrf()` and Graph strategy both call `recall()`, deprecated memories leaked into hybrid and graph search paths too.

## Fix

Added deprecated filter in `recall()` after category filter (before scoring). One change point covers all downstream paths:

| Strategy | Was filtered? | After fix |
|----------|--------------|-----------|
| Vector | ❌ | ✅ |
| Hybrid RRF | ❌ | ✅ (calls recall) |
| Graph | ❌ | ✅ (calls recall → recall_rrf) |
| FTS5 | ✅ | ✅ (already filtered at SQL level) |
| recall_at_time | ✅ | ✅ (already filtered in post-filter) |

## Test

- `cargo fmt --all -- --check` ✅
- CI will run full test + clippy + cora