### PR TITLE
chore: release v0.9.0 — version bump, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [Unreleased]
 
+## [0.9.0] — 2026-07-20
+
+### Added
+- **`uteke onboard` — interactive onboarding wizard (#743)** — guides new users from zero to productive in one command. Detects install, picks AI agent (Hermes/Claude/Cursor/Pi/OpenCode), integration mode (tool vs memory-provider), feature toggles (Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode), writes `uteke.toml`, runs `uteke init`, feature showcase. Non-interactive: `uteke onboard --yes --agent hermes`.
+- **API URL versioning /api/v1 and /api/v2 (#741)** — prefix-based API versioning on uteke-server for backward compatibility.
+- **Configurable dream pipeline thresholds (#742)** — dedup threshold, contradiction similarity, tag jaccard, max memories, orphan importance now configurable via config (previously hardcoded).
+- **SECURITY.md and PR template (#746)** — security policy with private vulnerability reporting, SLA by severity. GitHub PR template with type checklist and CI verification steps.
+
+### Changed
+- **POST /room/document renamed to POST /room/summary-document (#735, #739)** — avoids collision with /room/summary. Old endpoint logs deprecation warning.
+
+### Fixed
+- **Deprecated memories appearing in vector search results (#748, #749)** — `recall()` was missing deprecated filter, causing 61.7% deprecated memories to leak into all vector-based search paths (Vector, Hybrid RRF, Graph). FTS5 was already filtered at SQL level.
+- **Windows ERROR_LOCK_VIOLATION (OS error 33) (#747)** — usearch index now reads from the locked file handle directly instead of opening a second handle, preventing exclusive lock conflicts on Windows.
+- **Embedding model download robustness (#740, #744)** — streaming download (no more buffering 187MB in RAM), retry with 3 attempts, connect/read timeouts, progress indicator, integrity verification.
+
 ## [0.8.0] — 2026-07-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.8.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.8.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.8.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.8.0" }
+uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.9.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"


### PR DESCRIPTION
## Release v0.9.0

### Added
- `uteke onboard` interactive onboarding wizard (#743)
- API URL versioning /api/v1 and /api/v2 (#741)
- Configurable dream pipeline thresholds (#742)
- SECURITY.md + PR template (#746)

### Changed
- POST /room/document → POST /room/summary-document (#735, #739)

### Fixed
- Deprecated memories in vector search (#748, #749)
- Windows OS error 33 (#747)
- Embedding download robustness (#740, #744)

### Stats
- 32 files changed, +1,407 lines since v0.8.0
- 6 PRs merged