### PR TITLE
chore: release v0.9.1 — patch fix for API versioning routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+## [0.9.1] — 2026-07-21
+
+### Fixed
+- **API versioning routes return 404** — `ApiVersion::from_path()` stripped `/api/v1/` prefix removing the trailing slash, producing `"recall"` instead of `"/recall"`. All versioned routes (`/api/v1/*`, `/api/v2/*`) returned 404. Fix: strip `/api/v1` without trailing slash, preserving leading `/` in remainder. (#754)
+
+### Contributors
+- [@gnoviawan](https://github.com/gnoviawan) — uteke onboard wizard implementation (#743)
+
 ## [0.9.0] — 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Contributors
 - [@webhop123](https://github.com/webhop123) — Windows OS error 33 fix (#747)
+- [@gnoviawan](https://github.com/gnoviawan) — uteke onboard wizard implementation (#743)
 
 ## [0.8.0] — 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.9.1", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.9.1", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -14,8 +14,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.9.0" }
+uteke-core = { path = "../uteke-core", version = "0.9.1", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.9.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -111,10 +111,30 @@ impl ApiVersion {
     /// Parse `/api/vN/` prefix from a path. Returns `(version, stripped_path)` on match,
     /// or `None` if the path is not versioned.
     pub fn from_path(path: &str) -> Option<(Self, &str)> {
-        if let Some(rest) = path.strip_prefix("/api/v1/") {
-            Some((Self::V1, rest))
-        } else if let Some(rest) = path.strip_prefix("/api/v2/") {
-            Some((Self::V2, rest))
+        // Strip "/api/v1" prefix, then ensure leading "/" for route matching.
+        // Before fix: strip_prefix("/api/v1/") produced "recall" (no leading /),
+        // causing all /api/vN/* routes to 404 against patterns like "/recall".
+        if path.starts_with("/api/v1") {
+            let rest = &path["/api/v1".len()..];
+            let stripped = if rest.is_empty() {
+                "/"
+            } else if rest.starts_with('/') {
+                rest
+            } else {
+                // Edge case — shouldn't occur in practice.
+                rest
+            };
+            Some((Self::V1, stripped))
+        } else if path.starts_with("/api/v2") {
+            let rest = &path["/api/v2".len()..];
+            let stripped = if rest.is_empty() {
+                "/"
+            } else if rest.starts_with('/') {
+                rest
+            } else {
+                rest
+            };
+            Some((Self::V2, stripped))
         } else {
             None
         }


### PR DESCRIPTION
## Changes
- **Fix:** API versioning routes (`/api/v1/*`, `/api/v2/*`) return 404 — `strip_prefix` removed trailing slash, producing `"recall"` instead of `"/recall"` (#754)
- **Docs:** Add @gnoviawan to CHANGELOG contributors (carried over from v0.9.0)
- **Chore:** Bump workspace + intra-workspace deps to 0.9.1

## Files changed
- `Cargo.toml` — workspace version 0.9.0 → 0.9.1
- `crates/*/Cargo.toml` — intra-workspace deps 0.9.0 → 0.9.1
- `CHANGELOG.md` — v0.9.1 section + contributors
- `Cargo.lock` — lockfile update