### PR TITLE
feat: Voyage-4-Nano backend + project-scoped coding "walking mode" (#758)

### DIFF
--- a/.agents/skills/uteke-memory/SKILL.md
+++ b/.agents/skills/uteke-memory/SKILL.md
@@ -29,6 +29,40 @@ Version: **0.7.3** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Ze
 | `uteke get <ID>` | Get single memory by UUID | |
 | `uteke forget <ID>` | Delete memory by ID, tag, tier, or all | `--tag`, `--cold`, `--all`, `--confirm` |
 
+### Code Indexing (per-project code memory)
+
+DB-per-repo model: a project store lives in `.uteke/` beside `.git`, so code
+memory travels with the repo and is auto-scoped by cwd. Source files are
+chunked by symbol (tree-sitter AST when available, regex fallback) and stored
+as recallable memories carrying `file:line` metadata under the `code` tag.
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke init --project` | Create repo-local store: `.uteke/uteke.toml` + `.gitignore` entry | `--namespace` |
+| `uteke index [PATH]` | Walk repo, chunk by symbol, embed as recallable memories (incremental by content hash). Streams per-file progress. | `--force`, `--dry-run`, `--status`, `--namespace` |
+| `uteke index --status` | Show current index coverage (file/chunk counts) without indexing | `--namespace`, `--json` |
+| `uteke ui` | Launch a local web UI: live chunking feed + interactive code graph | `--port` (7749), `--force`, `--no-index`, `--no-open` |
+
+- **Setup:** `uteke onboard` → choose "coding" to init the project store, pick a
+  code-friendly embedding model, and optionally index immediately. Or run
+  `uteke init --project` then `uteke index` manually.
+- **Embedding for code:** `voyage-4-nano` (2048d, code-friendly, local ONNX,
+  ~250MB) is the recommended backend; set `[embedding] backend = "voyage"` in
+  `.uteke/uteke.toml`. Default `embeddinggemma-q4` (768d) also works.
+- **Recall code by meaning:** `uteke recall "where is auth token validated"`
+  returns chunks with `symbol_type`, `symbol_name`, and `line_start`/`line_end`
+  in metadata. Filter to code only with `--tags code`.
+- **Incremental:** unchanged files (by content hash) are skipped; deleted files
+  are pruned. Re-run `uteke index` after edits; use `--force` to rebuild all.
+- **Languages with AST chunking:** rust, go, python, typescript, javascript,
+  java, c, cpp (others fall back to regex/whole-file).
+- **MCP:** the same capability is exposed as the `uteke_index` and
+  `uteke_index_status` tools for agents.
+- **Web UI:** `uteke ui` opens a local browser view (default `localhost:7749`)
+  that streams the live chunking feed while indexing, then renders an
+  interactive force-directed graph of files and their symbols (colored by
+  symbol type, hover for `file:line`). Single embedded page, no npm/network.
+
 ### Documents (Wiki / Knowledge Base)
 
 | Command | Description | Key Options |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ uteke_index.usearch
 progress.md
 .cora/
 scripts/demo-record.sh
+
+# uteke project store
+.uteke/*.db
+.uteke/*.db-*
+.uteke/*.keys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2391,6 +2392,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -2788,6 +2795,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2926,6 +3033,7 @@ dependencies = [
  "sha2 0.10.9",
  "tar",
  "tempfile",
+ "tiny_http",
  "toml",
  "tracing",
  "tracing-appender",
@@ -2937,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2954,13 +3062,22 @@ dependencies = [
  "thiserror",
  "tokenizers",
  "tracing",
+ "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-cpp",
+ "tree-sitter-go",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
  "usearch",
  "uuid",
 ]
 
 [[package]]
 name = "uteke-mcp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2970,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx", "treesitter"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
@@ -32,6 +32,7 @@ flate2 = "1"
 tar = "0.4"
 urlencoding = "2.1.3"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+tiny_http = "0.12"
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -287,6 +287,11 @@ pub enum Commands {
         /// uteke-tool plugin (manual HTTP-backed actions).
         #[arg(long, default_value_t = false)]
         memory_provider: bool,
+        /// Initialize a repo-local store: write `.uteke/uteke.toml` (DB inside
+        /// the repo) and add the DB to `.gitignore`. Use for per-project
+        /// code memory before `uteke index`.
+        #[arg(long, default_value_t = false)]
+        project: bool,
     },
     /// Memory aging: status, preview cleanup, cleanup
     Aging {
@@ -429,6 +434,41 @@ pub enum Commands {
         /// Skip confirmation prompt
         #[arg(long, short)]
         yes: bool,
+    },
+    /// Index source code in a repo into recallable memories (DB-per-repo).
+    ///
+    /// Walks the project (respecting .gitignore + include/exclude globs),
+    /// chunks each file by symbol, and stores chunks with file:line metadata.
+    /// Incremental: unchanged files (by content hash) are skipped.
+    Index {
+        /// Path to index (file or directory). Defaults to the project root.
+        path: Option<String>,
+        /// Re-index all files even if unchanged.
+        #[arg(long)]
+        force: bool,
+        /// Report what would be indexed without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Show current index status (file/chunk counts) without indexing.
+        #[arg(long)]
+        status: bool,
+    },
+    /// Launch the graph + live-index web UI in a local browser.
+    Ui {
+        /// Path to index (file or directory). Defaults to the project root.
+        path: Option<String>,
+        /// Port to bind the UI server to.
+        #[arg(long, default_value = "7749")]
+        port: u16,
+        /// Re-index all files even if unchanged before serving the graph.
+        #[arg(long)]
+        force: bool,
+        /// Serve the existing graph without re-indexing on launch.
+        #[arg(long)]
+        no_index: bool,
+        /// Do not attempt to open a browser automatically.
+        #[arg(long)]
+        no_open: bool,
     },
     /// Interactive onboarding — detect install, pick agent, toggle features, showcase
     Onboard {

--- a/crates/uteke-cli/src/commands/index.rs
+++ b/crates/uteke-cli/src/commands/index.rs
@@ -1,0 +1,127 @@
+//! `uteke index` — walk a repo, chunk source files, store recallable memories.
+//!
+//! DB-per-repo model: the store is already scoped by the project's
+//! `.uteke/uteke.toml` (resolved in config load). This command discovers the
+//! project root and delegates the walk/chunk/prune to `uteke_core::index_tree`.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use uteke_core::{IndexProgress, Uteke};
+
+use crate::cli::Cli;
+
+pub fn run(
+    cli: &Cli,
+    uteke: &mut Uteke,
+    namespace: Option<&str>,
+    path: &Option<String>,
+    force: bool,
+    dry_run: bool,
+    status: bool,
+) -> Result<(), String> {
+    let ns = namespace.unwrap_or("default");
+
+    // Status-only mode: report counts and return without walking the tree.
+    if status {
+        let (files, chunks) = uteke
+            .code_index_status(ns)
+            .map_err(|e| format!("index status failed: {e}"))?;
+        if cli.json {
+            let out = serde_json::json!({
+                "namespace": ns,
+                "files": files,
+                "chunks": chunks,
+            });
+            println!("{}", serde_json::to_string_pretty(&out).unwrap());
+        } else {
+            println!("Code index (namespace {ns}): {files} file(s), {chunks} chunk(s)");
+        }
+        return Ok(());
+    }
+
+    // Resolve the root to index. Explicit path wins; otherwise project root;
+    // otherwise cwd.
+    let root: PathBuf = match path {
+        Some(p) => PathBuf::from(p),
+        None => crate::config::find_project_root()
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or_else(|| "Cannot determine directory to index".to_string())?,
+    };
+
+    if !root.exists() {
+        return Err(format!("Path does not exist: {}", root.display()));
+    }
+
+    // JSON mode: single summary, no live stream (keep output parseable).
+    // Human mode: stream per-file progress — tree-sitter chunking is fast, but
+    // embedding each chunk is the slow step, so per-file lines show real
+    // motion instead of one long silent block.
+    let summary = if cli.json {
+        uteke
+            .index_tree(ns, &root, force, dry_run)
+            .map_err(|e| format!("index failed: {e}"))?
+    } else {
+        let stdout = std::io::stdout();
+        uteke
+            .index_tree_cb(ns, &root, force, dry_run, |ev| {
+                let mut out = stdout.lock();
+                match ev {
+                    IndexProgress::Discovered { files } => {
+                        if dry_run {
+                            let _ = writeln!(out, "Scanning {files} source file(s) (dry run)…");
+                        } else {
+                            let _ = writeln!(
+                                out,
+                                "Discovered {files} source file(s). Chunking + embedding…"
+                            );
+                        }
+                    }
+                    IndexProgress::FileStarted { path, index, total } => {
+                        // Carriage-return, no newline: overwritten by the
+                        // FileIndexed/Skipped line so the stream stays tidy.
+                        let _ = write!(out, "  [{index}/{total}] {path} …\r");
+                        let _ = out.flush();
+                    }
+                    IndexProgress::FileIndexed { path, chunks } => {
+                        let _ = writeln!(out, "  ✓ {path} — {chunks} chunk(s)        ");
+                    }
+                    IndexProgress::FileSkipped { path } => {
+                        let _ = writeln!(out, "  · {path} — unchanged        ");
+                    }
+                    IndexProgress::Pruned { files } => {
+                        if files > 0 {
+                            let _ = writeln!(out, "  Pruned {files} deleted file(s)");
+                        }
+                    }
+                }
+            })
+            .map_err(|e| format!("index failed: {e}"))?
+    };
+
+    if cli.json {
+        let out = serde_json::json!({
+            "namespace": ns,
+            "root": root.display().to_string(),
+            "indexed": summary.indexed,
+            "skipped": summary.skipped,
+            "chunks": summary.chunks,
+            "pruned": summary.pruned,
+            "dry_run": dry_run,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    } else if dry_run {
+        println!(
+            "Dry run: would index {} file(s) under {} (namespace: {ns})",
+            summary.indexed,
+            root.display()
+        );
+    } else {
+        println!(
+            "Indexed {} file(s), {} chunk(s); {} unchanged; {} pruned (namespace: {ns})",
+            summary.indexed, summary.chunks, summary.skipped, summary.pruned
+        );
+    }
+
+    Ok(())
+}

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod dream;
 mod edges;
 mod forget;
 pub(crate) mod graph;
+mod index;
 mod list;
 mod maintenance;
 mod namespace;
@@ -230,6 +231,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
         Commands::Init {
             agent,
             memory_provider,
+            ..
         } => crate::init::run_init(agent, *memory_provider, cli.json),
 
         Commands::Namespace { command } => namespace::run(cli, uteke, command),
@@ -354,10 +356,18 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
         Commands::Timeline { id, limit } => timeline::run(cli, uteke, id, *limit),
 
         Commands::Doc { command } => crate::commands::doc::run(cli, uteke, command, config),
-
         Commands::Upgrade { yes } => upgrade::run(*yes),
+
+        Commands::Index {
+            path,
+            force,
+            dry_run,
+            status,
+        } => index::run(cli, uteke, ns, path, *force, *dry_run, *status),
 
         // Onboard is handled in main.rs (early exit, no store needed).
         Commands::Onboard { .. } => Ok(()),
+        // Ui is handled in main.rs (early exit, owns its own store).
+        Commands::Ui { .. } => Ok(()),
     }
 }

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -30,7 +30,7 @@ impl Default for StoreConfig {
 #[derive(serde::Deserialize, Clone)]
 #[serde(default)]
 pub struct EmbeddingConfig {
-    /// Embedding backend: "onnx" (default), "openai", "ollama".
+    /// Embedding backend: "onnx" (default), "voyage" (local ONNX), "openai", "ollama".
     pub backend: String,
     /// Embedding model name.
     pub model: String,
@@ -69,7 +69,8 @@ impl Default for EmbeddingConfig {
 
 impl EmbeddingConfig {
     /// Supported embedding backends.
-    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["onnx", "openai", "ollama"];
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] =
+        &["onnx", "openai", "ollama", "voyage"];
 
     /// Validate the backend field.
     ///
@@ -414,16 +415,38 @@ impl Config {
             config = config.merge_from_file(&global_path);
         }
 
-        // Layer 2: project .uteke/uteke.toml
-        if let Ok(cwd) = std::env::current_dir() {
-            let project_path = cwd.join(".uteke").join("uteke.toml");
+        // Layer 2: project .uteke/uteke.toml — discovered by walking up from
+        // cwd (DB-per-repo). Falls back to cwd/.uteke when no project marker
+        // is found, preserving prior behavior.
+        let project_root = find_project_root();
+        if let Some(ref root) = project_root {
+            let project_path = root.join(".uteke").join("uteke.toml");
             config = config.merge_from_file(&project_path);
+            // Resolve a relative store.path against the project root so a
+            // project config can say `path = ".uteke"` and get a DB inside
+            // the repo, independent of the current working directory.
+            config.resolve_store_path(root);
         }
 
         // Layer 3: environment variables (override config file)
         config = config.apply_env_overrides();
 
         config
+    }
+
+    /// Resolve a relative `store.path` against `root` (the project root).
+    /// Absolute paths and `~`-prefixed paths are left untouched.
+    fn resolve_store_path(&mut self, root: &std::path::Path) {
+        let p = &self.store.path;
+        // Leave global/home/default and absolute paths alone.
+        if p.starts_with('~') || std::path::Path::new(p).is_absolute() {
+            return;
+        }
+        // Only rewrite when the project config actually set a relative path.
+        // Default "~/.uteke" is handled above; a bare relative path here means
+        // the project opted into a repo-local store.
+        let resolved = root.join(p);
+        self.store.path = resolved.to_string_lossy().to_string();
     }
 
     /// Merge values from a TOML file on top of this config.
@@ -981,6 +1004,38 @@ fn global_config_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".uteke").join("uteke.toml"))
 }
 
+/// Discover the project root by walking up from the current directory.
+///
+/// Resolution order at each ancestor:
+///   1. `.uteke/uteke.toml` present → that directory is the project root.
+///   2. `.git` present (dir or file) → that directory is the project root.
+/// Stops at the first match; returns `None` if neither is found up to the
+/// filesystem root (callers then fall back to the global store).
+///
+/// A `.uteke/` marker wins over `.git/` at the *same* level, but a closer
+/// `.git/` ancestor wins over a farther `.uteke/` — nearest marker wins.
+pub fn find_project_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_project_root_from(&cwd)
+}
+
+/// Walk up from `start` looking for a project marker. Split out from
+/// [`find_project_root`] so tests can supply an explicit start dir without
+/// mutating the process-global current directory.
+fn find_project_root_from(start: &std::path::Path) -> Option<PathBuf> {
+    let mut dir: Option<&std::path::Path> = Some(start);
+    while let Some(d) = dir {
+        if d.join(".uteke").join("uteke.toml").is_file() {
+            return Some(d.to_path_buf());
+        }
+        if d.join(".git").exists() {
+            return Some(d.to_path_buf());
+        }
+        dir = d.parent();
+    }
+    None
+}
+
 /// Update or insert the namespace value in a TOML config string.
 /// Preserves all other content.
 fn set_namespace_in_toml(content: &str, namespace: &str) -> String {
@@ -1024,6 +1079,80 @@ fn set_namespace_in_toml(content: &str, namespace: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn find_root_by_uteke_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".uteke")).unwrap();
+        std::fs::write(root.join(".uteke").join("uteke.toml"), "[store]\n").unwrap();
+        let sub = root.join("a").join("b");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        let found = find_project_root_from(&sub).unwrap();
+        assert_eq!(
+            found.canonicalize().unwrap(),
+            root.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn find_root_by_git_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        let sub = root.join("src").join("deep");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        let found = find_project_root_from(&sub).unwrap();
+        assert_eq!(
+            found.canonicalize().unwrap(),
+            root.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn nearest_marker_wins() {
+        // Outer .git, inner .uteke/uteke.toml between it and cwd → inner wins.
+        let tmp = tempfile::tempdir().unwrap();
+        let outer = tmp.path();
+        std::fs::create_dir_all(outer.join(".git")).unwrap();
+        let inner = outer.join("pkg");
+        std::fs::create_dir_all(inner.join(".uteke")).unwrap();
+        std::fs::write(inner.join(".uteke").join("uteke.toml"), "[store]\n").unwrap();
+        let sub = inner.join("src");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        let found = find_project_root_from(&sub).unwrap();
+        assert_eq!(
+            found.canonicalize().unwrap(),
+            inner.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_relative_store_path_against_root() {
+        let mut cfg = Config::default();
+        cfg.store.path = ".uteke".to_string();
+        let root = std::path::Path::new("/tmp/myrepo");
+        cfg.resolve_store_path(root);
+        assert_eq!(cfg.store.path, "/tmp/myrepo/.uteke");
+    }
+
+    #[test]
+    fn resolve_leaves_home_and_absolute_paths() {
+        let root = std::path::Path::new("/tmp/myrepo");
+
+        let mut home = Config::default();
+        home.store.path = "~/.uteke".to_string();
+        home.resolve_store_path(root);
+        assert_eq!(home.store.path, "~/.uteke");
+
+        let mut abs = Config::default();
+        abs.store.path = "/data/uteke".to_string();
+        abs.resolve_store_path(root);
+        assert_eq!(abs.store.path, "/data/uteke");
+    }
 
     #[test]
     fn default_config_values() {

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -8,11 +8,131 @@ pub(crate) fn run_init_command(cli: &Cli) -> Result<(), String> {
     if let Commands::Init {
         agent,
         memory_provider,
+        project,
     } = &cli.command
     {
+        if *project {
+            return init_project(cli.json);
+        }
         return run_init(agent, *memory_provider, cli.json);
     }
     Ok(())
+}
+
+/// Initialize a repo-local uteke store for per-project code memory.
+///
+/// Writes `<repo>/.uteke/uteke.toml` (store path relative to repo root so the
+/// DB lives inside the repo) and appends the DB glob to `<repo>/.gitignore`.
+/// Idempotent: existing files are preserved, entries not duplicated.
+fn init_project(json: bool) -> Result<(), String> {
+    let outcome = init_project_store(None)?;
+    if json {
+        let out = serde_json::json!({
+            "root": outcome.root.display().to_string(),
+            "namespace": outcome.namespace,
+            "config": outcome.config_path.display().to_string(),
+            "wrote_config": outcome.wrote_config,
+            "updated_gitignore": outcome.updated_gitignore,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    } else {
+        println!("Initialized project store at {}", outcome.uteke_dir().display());
+        println!("  namespace: {}", outcome.namespace);
+        if !outcome.wrote_config {
+            println!("  (config already existed, left unchanged)");
+        }
+        println!("Next: run `uteke index` to index this repo's source.");
+    }
+    Ok(())
+}
+
+/// Result of initializing a per-project store.
+pub(crate) struct ProjectInit {
+    pub root: std::path::PathBuf,
+    pub config_path: std::path::PathBuf,
+    pub namespace: String,
+    pub wrote_config: bool,
+    pub updated_gitignore: bool,
+}
+
+impl ProjectInit {
+    pub fn uteke_dir(&self) -> std::path::PathBuf {
+        self.root.join(".uteke")
+    }
+}
+
+/// Initialize a repo-local uteke store, optionally pinning an embedding
+/// `backend` in the generated config. Idempotent: an existing config is left
+/// unchanged (backend not overwritten). Reused by `uteke init --project` and
+/// the coding path of `uteke onboard`.
+pub(crate) fn init_project_store(backend: Option<&str>) -> Result<ProjectInit, String> {
+    let root = crate::config::find_project_root()
+        .or_else(|| std::env::current_dir().ok())
+        .ok_or_else(|| "Cannot determine project root".to_string())?;
+
+    let uteke_dir = root.join(".uteke");
+    std::fs::create_dir_all(&uteke_dir)
+        .map_err(|e| format!("Failed to create {}: {e}", uteke_dir.display()))?;
+
+    // Derive a namespace from the repo directory name.
+    let ns = root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "default".to_string());
+
+    let config_path = uteke_dir.join("uteke.toml");
+    let mut wrote_config = false;
+    if !config_path.exists() {
+        // Include an [embedding] section only when a backend was chosen.
+        let embedding_section = match backend {
+            Some(b) => format!("\n[embedding]\nbackend = \"{b}\"\n"),
+            None => String::new(),
+        };
+        let body = format!(
+            "# Uteke project store (DB-per-repo)\n\
+             # DB lives at ./.uteke and is git-ignored; models stay global (~/.uteke/models).\n\
+             [store]\n\
+             path = \".uteke\"\n\
+             namespace = \"{ns}\"\n{embedding_section}"
+        );
+        std::fs::write(&config_path, body)
+            .map_err(|e| format!("Failed to write {}: {e}", config_path.display()))?;
+        wrote_config = true;
+    }
+
+    // Add DB artifacts to .gitignore (keep the toml tracked).
+    let gitignore = root.join(".gitignore");
+    let ignore_entries = [".uteke/*.db", ".uteke/*.db-*", ".uteke/*.keys"];
+    let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();
+    let mut to_add: Vec<&str> = Vec::new();
+    for e in ignore_entries {
+        if !existing.lines().any(|l| l.trim() == e) {
+            to_add.push(e);
+        }
+    }
+    let mut added_gitignore = false;
+    if !to_add.is_empty() {
+        let mut out = existing.clone();
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("\n# uteke project store\n");
+        for e in &to_add {
+            out.push_str(e);
+            out.push('\n');
+        }
+        std::fs::write(&gitignore, out)
+            .map_err(|e| format!("Failed to write {}: {e}", gitignore.display()))?;
+        added_gitignore = true;
+    }
+
+    Ok(ProjectInit {
+        root,
+        config_path,
+        namespace: ns,
+        wrote_config,
+        updated_gitignore: added_gitignore,
+    })
 }
 
 /// Dispatch init to the appropriate agent type.

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -8,6 +8,7 @@ mod init;
 mod logging;
 mod onboard;
 mod output;
+mod ui;
 
 use clap::{CommandFactory, Parser};
 use cli::{Cli, Commands};
@@ -50,6 +51,20 @@ fn main() {
         Commands::Bench { counts, json } => {
             // Bench creates its own temp stores — skip opening the user store.
             if let Err(e) = commands::bench::run_bench(*json, counts.clone()) {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+            std::process::exit(0);
+        }
+        Commands::Ui {
+            path,
+            port,
+            force,
+            no_index,
+            no_open,
+        } => {
+            // UI owns its own store + background indexer; no shared store open.
+            if let Err(e) = ui::run(&cli, path.as_deref(), *port, *force, *no_index, *no_open) {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }

--- a/crates/uteke-cli/src/onboard.rs
+++ b/crates/uteke-cli/src/onboard.rs
@@ -105,7 +105,23 @@ pub fn run(cli: &Cli) -> Result<(), String> {
     }
     println!();
 
-    // ── Step 3: Pick agent ──────────────────────────────────────
+    // ── Step 3: Pick usage mode (coding vs general) ────────────
+    let coding_mode = if *yes {
+        false
+    } else {
+        prompt_usage_mode()?
+    };
+    println!(
+        "→ Usage: {}",
+        if coding_mode {
+            "coding (per-project store + code indexing)"
+        } else {
+            "general memory (global store)"
+        }
+    );
+    println!();
+
+    // ── Step 4: Pick agent ──────────────────────────────────────
     let agent_choice = if let Some(a) = agent {
         validate_agent(a)?
     } else if *yes {
@@ -141,6 +157,21 @@ pub fn run(cli: &Cli) -> Result<(), String> {
     println!("→ Namespace: {}", ns);
     println!();
 
+    // ── Step 5b: Pick embedding model ──────────────────────────
+    // Coding mode defaults to voyage (code-friendly, 2048d); general mode
+    // defaults to embeddinggemma.
+    let backend = if *yes {
+        if coding_mode { "voyage" } else { "onnx" }
+    } else {
+        prompt_embedding_backend(coding_mode)?
+    };
+    let backend_label = match backend {
+        "voyage" => "voyage-4-nano (2048d, code-friendly)",
+        _ => "embeddinggemma-q4 (768d, general)",
+    };
+    println!("→ Embedding model: {}", backend_label);
+    println!();
+
     // ── Step 6: Feature toggles ────────────────────────────────
     let toggles = if *yes {
         FEATURE_TOGGLES
@@ -159,7 +190,7 @@ pub fn run(cli: &Cli) -> Result<(), String> {
     println!();
 
     // ── Step 7: Write config ───────────────────────────────────
-    let config_path = write_config(&ns, &toggles, *yes)?;
+    let config_path = write_config(&ns, backend, &toggles, *yes)?;
     println!("✓ Config written: {}", config_path.display());
 
     // ── Step 8: Run `uteke init` for the agent ─────────────────────────
@@ -181,6 +212,11 @@ pub fn run(cli: &Cli) -> Result<(), String> {
     }
     println!();
 
+    // ── Step 8b: Coding mode setup (project store + index) ──────────
+    if coding_mode {
+        setup_coding_project(backend, *yes)?;
+    }
+
     // ── Step 9: Feature showcase ───────────────────────────────
     showcase();
 
@@ -197,6 +233,61 @@ pub fn run(cli: &Cli) -> Result<(), String> {
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Coding-mode setup: init a per-project store in the current directory, then
+/// offer to index the repo now (which downloads the embedding model on first
+/// use). Delegates indexing to the installed `uteke index` binary so config
+/// layering + live streaming come for free.
+fn setup_coding_project(backend: &str, yes: bool) -> Result<(), String> {
+    print_banner("Coding Project Setup");
+    println!();
+
+    // 1. Init the per-project store (.uteke/uteke.toml + .gitignore), pinning
+    //    the chosen backend. Idempotent — existing config left unchanged.
+    let init = crate::init::init_project_store(Some(backend))?;
+    println!("✓ Project store ready: {}", init.uteke_dir().display());
+    println!("  namespace: {}", init.namespace);
+    if !init.wrote_config {
+        println!("  (config already existed — backend not overwritten)");
+    }
+    println!();
+
+    // 2. Offer to index now. First run downloads the model + embeds all source.
+    let do_index = if yes {
+        false
+    } else {
+        let model = match backend {
+            "voyage" => "voyage-4-nano (~250MB)",
+            _ => "embeddinggemma-q4 (~190MB)",
+        };
+        println!("Index this repo now? First run downloads {model} and embeds all source.");
+        print!("  Index now? [y/N] ");
+        io::stdout().flush().ok();
+        let resp = read_line()?;
+        resp.eq_ignore_ascii_case("y")
+    };
+
+    if !do_index {
+        println!("→ Skipped. Run `uteke index` when ready.");
+        println!();
+        return Ok(());
+    }
+
+    // 3. Shell out to the installed binary so the project config (with the
+    //    backend we just wrote) is loaded fresh and streaming works.
+    println!("Indexing… (downloads model on first use, please wait)");
+    let exe = std::env::current_exe().map_err(|e| format!("cannot find uteke binary: {e}"))?;
+    let status = std::process::Command::new(exe)
+        .arg("index")
+        .current_dir(&init.root)
+        .status()
+        .map_err(|e| format!("failed to run `uteke index`: {e}"))?;
+    if !status.success() {
+        println!("⚠ Indexing exited with {status}. Run `uteke index` manually to retry.");
+    }
+    println!();
+    Ok(())
+}
 
 /// Print a centered banner box around the given title.
 fn print_banner(title: &str) {
@@ -300,6 +391,50 @@ fn prompt_namespace() -> Result<String, String> {
     }
 }
 
+/// Prompt the user to select a local embedding model. Both options are
+/// offline ONNX models downloaded to `~/.uteke/models/` on first use. When
+/// `coding_mode` is set, voyage (code-friendly) is the default.
+fn prompt_embedding_backend(coding_mode: bool) -> Result<&'static str, String> {
+    println!("Local embedding model (offline, downloaded on first use):");
+    if coding_mode {
+        println!("  1) voyage-4-nano     — 2048d, code-friendly, open-weight (~250MB) [default]");
+        println!("  2) embeddinggemma-q4 — 768d, general purpose (~190MB)");
+        print!("\n  Select [1-2]: ");
+        io::stdout().flush().ok();
+        let resp = read_line()?;
+        match resp.trim() {
+            "2" | "gemma" | "embeddinggemma" => Ok("onnx"),
+            _ => Ok("voyage"),
+        }
+    } else {
+        println!("  1) embeddinggemma-q4 — 768d, general purpose (~190MB) [default]");
+        println!("  2) voyage-4-nano     — 2048d, code-friendly, open-weight (~250MB)");
+        print!("\n  Select [1-2]: ");
+        io::stdout().flush().ok();
+        let resp = read_line()?;
+        match resp.trim() {
+            "2" | "voyage" | "voyage-4-nano" => Ok("voyage"),
+            _ => Ok("onnx"),
+        }
+    }
+}
+
+/// Prompt whether uteke will be used mainly for coding (per-project store +
+/// code indexing) or general memory (global store). Coding mode triggers
+/// `.uteke/uteke.toml` project init, voyage default, and an offer to index.
+fn prompt_usage_mode() -> Result<bool, String> {
+    println!("How will you use uteke?");
+    println!("  1) General memory — global store at ~/.uteke, notes/facts across projects [default]");
+    println!("  2) Coding — per-project store (.uteke/ like .git), index source into recall");
+    print!("\n  Select [1-2]: ");
+    io::stdout().flush().ok();
+    let resp = read_line()?;
+    match resp.trim() {
+        "2" | "coding" | "code" => Ok(true),
+        _ => Ok(false),
+    }
+}
+
 /// Prompt for feature toggles. Returns vec of (name, enabled).
 fn prompt_feature_toggles() -> Result<Vec<(&'static str, bool)>, String> {
     println!("Feature toggles — toggle ON/OFF (press Enter to accept defaults):");
@@ -328,6 +463,7 @@ fn prompt_feature_toggles() -> Result<Vec<(&'static str, bool)>, String> {
 /// before overwriting. In interactive mode, the user is prompted to confirm.
 fn write_config(
     namespace: &str,
+    backend: &str,
     toggles: &[(&str, bool)],
     yes: bool,
 ) -> Result<std::path::PathBuf, String> {
@@ -373,6 +509,9 @@ fn write_config(
 [store]
 namespace = "{namespace}"
 
+[embedding]
+backend = "{backend}"
+
 [recall]
 graph_rerank_enabled = {graph_rerank}
 salience_weight = {salience_weight}
@@ -388,6 +527,7 @@ auto_aging_enabled = {auto_maint}
 enabled = {server_enabled}
 "#,
         namespace = namespace,
+        backend = backend,
         graph_rerank = graph_rerank,
         salience_weight = if salience { 0.15 } else { 0.0 },
         recency_weight = if recency { 0.15 } else { 0.0 },

--- a/crates/uteke-cli/src/ui.rs
+++ b/crates/uteke-cli/src/ui.rs
@@ -1,0 +1,461 @@
+//! `uteke ui` — a lightweight local web UI that streams live indexing progress
+//! and renders the resulting knowledge graph.
+//!
+//! Design goals mirror the rest of this repo: single Rust binary, zero npm,
+//! offline. The frontend is one self-contained HTML page (vanilla JS + a
+//! canvas force-directed graph) embedded at compile time. A background thread
+//! runs `index_tree_cb`, buffering [`IndexProgress`] events into shared state;
+//! the browser polls `/api/progress` for the live chunking feed and
+//! `/api/graph` for the node/edge data once indexing settles.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tiny_http::{Header, Response, Server};
+use uteke_core::{IndexProgress, Uteke};
+
+use crate::cli::Cli;
+use crate::config::Config;
+
+/// Embedded single-page frontend (vanilla JS canvas graph + live log).
+const INDEX_HTML: &str = include_str!("ui/index.html");
+
+/// One buffered progress line, shaped for JSON consumption by the browser.
+#[derive(Clone, serde::Serialize)]
+struct ProgressLine {
+    /// Event kind: "discovered" | "file" | "skip" | "prune" | "done" | "error".
+    kind: String,
+    /// Human-readable message.
+    msg: String,
+    /// Optional file path (file/skip events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    /// 1-based position in the discovered set (file events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<usize>,
+    /// Total discovered files (discovered/file events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total: Option<usize>,
+    /// Chunks stored for this file (file events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chunks: Option<usize>,
+}
+
+/// Shared indexing state polled by the browser.
+struct UiState {
+    /// Append-only progress log; browser polls with `?since=N`.
+    log: Mutex<Vec<ProgressLine>>,
+    /// True once the background indexing thread has finished (success or error).
+    done: AtomicBool,
+    /// Running chunk total, surfaced in the header.
+    chunks: AtomicUsize,
+    /// Namespace being served.
+    namespace: String,
+    /// The shared store, reused for graph queries after indexing.
+    uteke: Arc<Mutex<Uteke>>,
+}
+
+impl UiState {
+    fn push(&self, line: ProgressLine) {
+        if let Ok(mut log) = self.log.lock() {
+            log.push(line);
+        }
+    }
+}
+
+/// Entry point for `uteke ui`. Opens the (project-scoped) store, kicks off a
+/// background index, and serves the UI until Ctrl-C.
+pub(crate) fn run(
+    cli: &Cli,
+    path: Option<&str>,
+    port: u16,
+    force: bool,
+    no_index: bool,
+    no_open: bool,
+) -> Result<(), String> {
+    let config = Config::load();
+
+    // Resolve the repo root + store path the same way the main store-open path
+    // does, so the UI serves the project store when run inside a repo.
+    let root: PathBuf = match path {
+        Some(p) => PathBuf::from(p),
+        None => crate::config::find_project_root()
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or_else(|| "cannot determine project root".to_string())?,
+    };
+
+    let store_path = cli
+        .store
+        .as_deref()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| Config::expand_tilde(&config.store.path));
+
+    let namespace = crate::resolve_namespace(cli, &config);
+
+    let uteke = Uteke::open_with_embedding_and_graph(
+        &store_path,
+        &config.embedding.backend,
+        uteke_core::EmbeddingSettings {
+            api_key: config.embedding.api_key.clone(),
+            base_url: config.embedding.base_url.clone(),
+            endpoint_path: config.embedding.endpoint_path.clone(),
+            model: config.embedding.model.clone(),
+            dims: config.embedding.dims,
+        },
+        uteke_core::TierConfig {
+            hot_days: config.tier.hot_days as i64,
+            warm_days: config.tier.warm_days as i64,
+            hot_boost: config.tier.hot_boost,
+        },
+        uteke_core::RecallConfig {
+            min_score: config.recall.min_score as f32,
+        },
+        uteke_core::GraphRerankConfig {
+            density_weight: config.recall.graph_density_weight,
+            authority_weight: config.recall.graph_authority_weight,
+            enabled: config.recall.graph_rerank_enabled,
+        },
+    )
+    .map_err(|e| format!("failed to open store: {e}"))?;
+
+    let uteke = Arc::new(Mutex::new(uteke));
+    let state = Arc::new(UiState {
+        log: Mutex::new(Vec::new()),
+        done: AtomicBool::new(false),
+        chunks: AtomicUsize::new(0),
+        namespace: namespace.clone(),
+        uteke: Arc::clone(&uteke),
+    });
+
+    // Kick off indexing in the background unless suppressed.
+    if no_index {
+        state.push(ProgressLine {
+            kind: "done".into(),
+            msg: "Serving existing graph (no re-index)".into(),
+            path: None,
+            index: None,
+            total: None,
+            chunks: None,
+        });
+        state.done.store(true, Ordering::SeqCst);
+    } else {
+        spawn_indexer(Arc::clone(&state), Arc::clone(&uteke), root, namespace, force);
+    }
+
+    // Bind the HTTP server.
+    let addr = format!("127.0.0.1:{port}");
+    let server = Server::http(&addr).map_err(|e| format!("failed to bind {addr}: {e}"))?;
+    let url = format!("http://{addr}");
+    println!("uteke ui serving at {url}  (Ctrl-C to stop)");
+    if !no_open {
+        open_browser(&url);
+    }
+
+    for req in server.incoming_requests() {
+        let resp = handle(&state, req.url());
+        if let Err(e) = req.respond(resp) {
+            tracing::warn!("ui respond failed: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Spawn the background indexing thread. Streams [`IndexProgress`] into the
+/// shared log so the browser can render live chunking progress.
+fn spawn_indexer(
+    state: Arc<UiState>,
+    uteke: Arc<Mutex<Uteke>>,
+    root: PathBuf,
+    namespace: String,
+    force: bool,
+) {
+    std::thread::spawn(move || {
+        // Hold the lock for the whole index — the graph endpoint will contend
+        // briefly, but indexing is the point of this screen.
+        let guard = match uteke.lock() {
+            Ok(g) => g,
+            Err(_) => {
+                state.push(err_line("store lock poisoned"));
+                state.done.store(true, Ordering::SeqCst);
+                return;
+            }
+        };
+
+        let st = Arc::clone(&state);
+        let result = guard.index_tree_cb(&namespace, &root, force, false, |ev| match ev {
+            IndexProgress::Discovered { files } => st.push(ProgressLine {
+                kind: "discovered".into(),
+                msg: format!("Discovered {files} source file(s)"),
+                path: None,
+                index: None,
+                total: Some(files),
+                chunks: None,
+            }),
+            IndexProgress::FileStarted { .. } => {
+                // The browser renders motion from FileIndexed/FileSkipped; a
+                // started event per file would just double the log volume.
+            }
+            IndexProgress::FileIndexed { path, chunks } => {
+                st.chunks.fetch_add(chunks, Ordering::SeqCst);
+                st.push(ProgressLine {
+                    kind: "file".into(),
+                    msg: format!("{path} — {chunks} chunk(s)"),
+                    path: Some(path.to_string()),
+                    index: None,
+                    total: None,
+                    chunks: Some(chunks),
+                });
+            }
+            IndexProgress::FileSkipped { path } => st.push(ProgressLine {
+                kind: "skip".into(),
+                msg: format!("{path} — unchanged"),
+                path: Some(path.to_string()),
+                index: None,
+                total: None,
+                chunks: None,
+            }),
+            IndexProgress::Pruned { files } => {
+                if files > 0 {
+                    st.push(ProgressLine {
+                        kind: "prune".into(),
+                        msg: format!("Pruned {files} deleted file(s)"),
+                        path: None,
+                        index: None,
+                        total: None,
+                        chunks: None,
+                    });
+                }
+            }
+        });
+
+        match result {
+            Ok(summary) => state.push(ProgressLine {
+                kind: "done".into(),
+                msg: format!(
+                    "Indexed {} file(s), {} chunk(s); {} unchanged; {} pruned",
+                    summary.indexed, summary.chunks, summary.skipped, summary.pruned
+                ),
+                path: None,
+                index: None,
+                total: None,
+                chunks: Some(summary.chunks),
+            }),
+            Err(e) => state.push(err_line(&format!("index failed: {e}"))),
+        }
+        state.done.store(true, Ordering::SeqCst);
+    });
+}
+
+fn err_line(msg: &str) -> ProgressLine {
+    ProgressLine {
+        kind: "error".into(),
+        msg: msg.to_string(),
+        path: None,
+        index: None,
+        total: None,
+        chunks: None,
+    }
+}
+
+/// Route a single request. Only three endpoints: the page, the progress feed,
+/// and the graph data.
+fn handle(state: &UiState, url: &str) -> Response<Cursor<Vec<u8>>> {
+    let (path, query) = url.split_once('?').unwrap_or((url, ""));
+    match path {
+        "/" | "/index.html" => html_response(INDEX_HTML),
+        "/api/progress" => progress_response(state, query),
+        "/api/graph" => graph_response(state),
+        _ => Response::from_string("not found").with_status_code(404),
+    }
+}
+
+/// `GET /api/progress?since=N` → `{ lines: [...], done, chunks, next }`.
+fn progress_response(state: &UiState, query: &str) -> Response<Cursor<Vec<u8>>> {
+    let since = query
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("since="))
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    let log = state.log.lock().expect("log lock");
+    let total = log.len();
+    let slice: Vec<ProgressLine> = if since < total {
+        log[since..].to_vec()
+    } else {
+        Vec::new()
+    };
+    drop(log);
+
+    let body = serde_json::json!({
+        "lines": slice,
+        "next": total,
+        "done": state.done.load(Ordering::SeqCst),
+        "chunks": state.chunks.load(Ordering::SeqCst),
+        "namespace": state.namespace,
+    });
+    json_response(&body)
+}
+
+/// `GET /api/graph` → a graph synthesized from `code`-tagged memories.
+///
+/// Code chunks are stored as flat memories (not knowledge-graph nodes), so we
+/// build a structural view here: one node per file, one per symbol, and a
+/// `contains` edge from each file to its symbols. This is what "see the code
+/// graph" means for an indexed repo — the existing entity graph
+/// (`graph_data`) stays available for user-authored relationships.
+fn graph_response(state: &UiState) -> Response<Cursor<Vec<u8>>> {
+    let uteke = match state.uteke.lock() {
+        Ok(g) => g,
+        Err(_) => return json_error("store lock poisoned"),
+    };
+    match build_code_graph(&uteke, &state.namespace) {
+        Ok(data) => json_response(&data),
+        Err(e) => json_error(&format!("graph error: {e}")),
+    }
+}
+
+/// A lightweight node/edge payload for the frontend canvas.
+#[derive(serde::Serialize)]
+struct UiNode {
+    id: String,
+    label: String,
+    entity_type: String,
+    properties: serde_json::Value,
+}
+
+#[derive(serde::Serialize)]
+struct UiEdge {
+    source_id: String,
+    target_id: String,
+    relation: String,
+}
+
+#[derive(serde::Serialize)]
+struct UiGraph {
+    nodes: Vec<UiNode>,
+    edges: Vec<UiEdge>,
+}
+
+/// Walk all `code` memories in the namespace and fold them into a file/symbol
+/// graph. Files become container nodes; each chunk becomes a symbol node with
+/// a `contains` edge from its file.
+fn build_code_graph(uteke: &Uteke, namespace: &str) -> Result<UiGraph, uteke_core::Error> {
+    use std::collections::HashSet;
+
+    let mut nodes: Vec<UiNode> = Vec::new();
+    let mut edges: Vec<UiEdge> = Vec::new();
+    let mut seen_files: HashSet<String> = HashSet::new();
+
+    // Page through code memories so large repos don't allocate one giant Vec.
+    let mut offset = 0usize;
+    let page = 500usize;
+    loop {
+        let batch = uteke.list(Some("code"), page, offset, Some(namespace))?;
+        if batch.is_empty() {
+            break;
+        }
+        for m in &batch {
+            let meta = &m.metadata;
+            let file = meta
+                .get("file")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(unknown)");
+            let sym_name = meta
+                .get("symbol_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let sym_type = meta
+                .get("symbol_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("chunk");
+            let line_start = meta.get("line_start").and_then(|v| v.as_u64());
+            let line_end = meta.get("line_end").and_then(|v| v.as_u64());
+
+            let file_id = format!("file:{file}");
+            if seen_files.insert(file_id.clone()) {
+                let short = file.rsplit('/').next().unwrap_or(file);
+                nodes.push(UiNode {
+                    id: file_id.clone(),
+                    label: short.to_string(),
+                    entity_type: "file".into(),
+                    properties: serde_json::json!({ "file": file }),
+                });
+            }
+
+            // Symbol node keyed by memory id (stable, unique per chunk).
+            let label = if sym_name.is_empty() {
+                sym_type.to_string()
+            } else {
+                sym_name.to_string()
+            };
+            nodes.push(UiNode {
+                id: m.id.clone(),
+                label,
+                entity_type: sym_type.to_string(),
+                properties: serde_json::json!({
+                    "file": file,
+                    "symbol_type": sym_type,
+                    "symbol_name": sym_name,
+                    "line_start": line_start,
+                    "line_end": line_end,
+                }),
+            });
+            edges.push(UiEdge {
+                source_id: file_id,
+                target_id: m.id.clone(),
+                relation: "contains".into(),
+            });
+        }
+        if batch.len() < page {
+            break;
+        }
+        offset += page;
+    }
+
+    Ok(UiGraph { nodes, edges })
+}
+
+fn html_response(body: &str) -> Response<Cursor<Vec<u8>>> {
+    let header = Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+        .expect("valid header");
+    Response::from_string(body).with_header(header)
+}
+
+fn json_response<T: serde::Serialize>(body: &T) -> Response<Cursor<Vec<u8>>> {
+    let s = serde_json::to_string(body).unwrap_or_else(|_| "{}".to_string());
+    let header =
+        Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).expect("valid header");
+    Response::from_string(s).with_header(header)
+}
+
+fn json_error(msg: &str) -> Response<Cursor<Vec<u8>>> {
+    let s = serde_json::json!({ "error": msg }).to_string();
+    let header =
+        Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).expect("valid header");
+    Response::from_string(s)
+        .with_status_code(500)
+        .with_header(header)
+}
+
+/// Best-effort browser launch; failure is non-fatal (URL is already printed).
+fn open_browser(url: &str) {
+    #[cfg(target_os = "linux")]
+    let cmd = "xdg-open";
+    #[cfg(target_os = "macos")]
+    let cmd = "open";
+    #[cfg(target_os = "windows")]
+    let cmd = "explorer";
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    let cmd = "";
+
+    if cmd.is_empty() {
+        return;
+    }
+    let _ = std::process::Command::new(cmd)
+        .arg(url)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}

--- a/crates/uteke-cli/src/ui/index.html
+++ b/crates/uteke-cli/src/ui/index.html
@@ -1,0 +1,505 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>uteke · graph</title>
+<style>
+  :root {
+    --bg: #0d1017; --panel: #151a23; --border: #232a36; --fg: #d7dde8;
+    --muted: #7c8698; --accent: #5aa9ff; --ok: #4bd68a; --skip: #6b7686;
+    --warn: #ffcc66; --err: #ff6b6b;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    display: flex; flex-direction: column; height: 100vh; overflow: hidden;
+  }
+  header {
+    display: flex; align-items: center; gap: 16px;
+    padding: 10px 16px; border-bottom: 1px solid var(--border); background: var(--panel);
+  }
+  header .brand { font-weight: 700; color: var(--accent); letter-spacing: .5px; }
+  header .stat { color: var(--muted); }
+  header .stat b { color: var(--fg); font-weight: 600; }
+  #status-dot {
+    width: 8px; height: 8px; border-radius: 50%; background: var(--warn);
+    display: inline-block; margin-right: 6px; animation: pulse 1s infinite;
+  }
+  #status-dot.done { background: var(--ok); animation: none; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .3; } }
+  main { flex: 1; display: flex; min-height: 0; }
+  #log {
+    width: 380px; border-right: 1px solid var(--border);
+    overflow-y: auto; padding: 8px 10px; background: #0a0d13;
+  }
+  #log .line { white-space: pre-wrap; word-break: break-all; padding: 1px 0; }
+  #log .file { color: var(--ok); }
+  #log .skip { color: var(--skip); }
+  #log .discovered, #log .prune { color: var(--accent); }
+  #log .done { color: var(--ok); font-weight: 600; }
+  #log .error { color: var(--err); }
+  #graph-wrap { flex: 1; position: relative; }
+  canvas { display: block; width: 100%; height: 100%; cursor: grab; }
+  canvas:active { cursor: grabbing; }
+  #hud {
+    position: absolute; bottom: 10px; right: 12px; text-align: right;
+    color: var(--muted); pointer-events: none; font-size: 11px;
+  }
+  #labels { position: absolute; inset: 0; pointer-events: none; overflow: hidden; }
+  #labels span {
+    position: absolute; color: #aeb8c8; font-size: 11px; white-space: nowrap;
+    transform: translate(-50%, -50%); text-shadow: 0 0 4px #000, 0 0 4px #000;
+  }
+  #tooltip {
+    position: absolute; pointer-events: none; display: none;
+    background: var(--panel); border: 1px solid var(--border);
+    padding: 6px 8px; border-radius: 4px; max-width: 320px;
+    color: var(--fg); box-shadow: 0 4px 16px rgba(0,0,0,.5); z-index: 5;
+  }
+  #tooltip .t { color: var(--accent); font-weight: 600; }
+  #empty {
+    position: absolute; inset: 0; display: flex; align-items: center;
+    justify-content: center; color: var(--muted); text-align: center;
+  }
+</style>
+</head>
+<body>
+  <header>
+    <span class="brand">uteke</span>
+    <span class="stat"><span id="status-dot"></span><span id="status">indexing…</span></span>
+    <span class="stat">ns <b id="ns">–</b></span>
+    <span class="stat">chunks <b id="chunks">0</b></span>
+    <span class="stat">nodes <b id="nodes">0</b></span>
+    <span class="stat">edges <b id="edges">0</b></span>
+    <span class="stat" style="margin-left:auto">drag to orbit · scroll to zoom · right-drag to pan</span>
+  </header>
+  <main>
+    <div id="log"></div>
+    <div id="graph-wrap">
+      <canvas id="c"></canvas>
+      <div id="labels"></div>
+      <div id="hud">3D · WebGL</div>
+      <div id="tooltip"></div>
+      <div id="empty">no graph yet — indexing populates memories;<br/>3D graph appears once files are chunked</div>
+    </div>
+  </main>
+<script>
+// ══════════════════════════════════════════════════════════════════
+//  Live progress feed
+// ══════════════════════════════════════════════════════════════════
+const logEl = document.getElementById('log');
+const statusEl = document.getElementById('status');
+const dotEl = document.getElementById('status-dot');
+const nsEl = document.getElementById('ns');
+const chunksEl = document.getElementById('chunks');
+let since = 0, indexDone = false;
+
+function appendLines(lines) {
+  const atBottom = logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 4;
+  for (const l of lines) {
+    const div = document.createElement('div');
+    div.className = 'line ' + l.kind;
+    const prefix = { file: '✓ ', skip: '· ', discovered: '» ', prune: '⊘ ', done: '● ', error: '✗ ' }[l.kind] || '  ';
+    div.textContent = prefix + l.msg;
+    logEl.appendChild(div);
+  }
+  if (atBottom) logEl.scrollTop = logEl.scrollHeight;
+}
+
+async function pollProgress() {
+  try {
+    const r = await fetch('/api/progress?since=' + since);
+    const d = await r.json();
+    if (d.lines && d.lines.length) appendLines(d.lines);
+    since = d.next;
+    nsEl.textContent = d.namespace || 'default';
+    chunksEl.textContent = d.chunks || 0;
+    if (d.done && !indexDone) {
+      indexDone = true;
+      statusEl.textContent = 'ready';
+      dotEl.classList.add('done');
+      loadGraph();
+    }
+  } catch (e) {}
+  if (!indexDone) setTimeout(pollProgress, 400);
+}
+pollProgress();
+
+// ══════════════════════════════════════════════════════════════════
+//  WebGL 3D force-directed graph (zero deps)
+// ══════════════════════════════════════════════════════════════════
+const canvas = document.getElementById('c');
+const labelsEl = document.getElementById('labels');
+const tooltip = document.getElementById('tooltip');
+const emptyEl = document.getElementById('empty');
+const gl = canvas.getContext('webgl', { antialias: true, alpha: false });
+
+let nodes = [], edges = [];
+// camera: spherical orbit around a target
+const cam = { yaw: 0.6, pitch: 0.35, dist: 900, tx: 0, ty: 0, tz: 0 };
+let dragging = null, panning = false, lastX = 0, lastY = 0, hover = null;
+let simTemp = 1.0; // annealing temperature (physics "aliveness")
+
+function colorFor(type) {
+  const p = {
+    function: [0.35,0.66,1.0], method: [0.35,0.66,1.0],
+    struct: [0.29,0.84,0.54], class: [0.29,0.84,0.54],
+    impl: [0.78,0.55,1.0], trait: [0.78,0.55,1.0],
+    enum: [1.0,0.8,0.4], interface: [1.0,0.8,0.4],
+    type: [1.0,0.62,0.35], file: [0.72,0.78,0.9],
+  };
+  return p[type] || [0.49,0.52,0.6];
+}
+
+// ── shaders ────────────────────────────────────────────────────────
+function compile(type, src) {
+  const s = gl.createShader(type);
+  gl.shaderSource(s, src); gl.compileShader(s);
+  if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) throw gl.getShaderInfoLog(s);
+  return s;
+}
+function program(vs, fs) {
+  const p = gl.createProgram();
+  gl.attachShader(p, compile(gl.VERTEX_SHADER, vs));
+  gl.attachShader(p, compile(gl.FRAGMENT_SHADER, fs));
+  gl.linkProgram(p);
+  if (!gl.getProgramParameter(p, gl.LINK_STATUS)) throw gl.getProgramInfoLog(p);
+  return p;
+}
+
+// nodes: soft round glowing points, depth-shaded
+const nodeProg = program(`
+  attribute vec3 aPos;
+  attribute vec3 aColor;
+  attribute float aSize;
+  uniform mat4 uMVP;
+  uniform float uScale;
+  varying vec3 vColor;
+  varying float vDepth;
+  void main() {
+    vec4 clip = uMVP * vec4(aPos, 1.0);
+    gl_Position = clip;
+    gl_PointSize = aSize * uScale / max(clip.w, 1.0);
+    vColor = aColor;
+    vDepth = clamp(1.0 - clip.w / 2200.0, 0.15, 1.0);
+  }
+`, `
+  precision mediump float;
+  varying vec3 vColor;
+  varying float vDepth;
+  void main() {
+    vec2 d = gl_PointCoord - vec2(0.5);
+    float r = length(d);
+    if (r > 0.5) discard;
+    float core = smoothstep(0.5, 0.0, r);
+    float glow = smoothstep(0.5, 0.15, r);
+    vec3 col = vColor * vDepth;
+    float a = core * 0.9 + glow * 0.35;
+    gl_FragColor = vec4(col * (0.6 + glow * 0.8), a);
+  }
+`);
+const nPos = gl.getAttribLocation(nodeProg, 'aPos');
+const nCol = gl.getAttribLocation(nodeProg, 'aColor');
+const nSize = gl.getAttribLocation(nodeProg, 'aSize');
+const nMVP = gl.getUniformLocation(nodeProg, 'uMVP');
+const nScaleU = gl.getUniformLocation(nodeProg, 'uScale');
+
+// edges: faint depth-faded lines
+const edgeProg = program(`
+  attribute vec3 aPos;
+  uniform mat4 uMVP;
+  varying float vDepth;
+  void main() {
+    vec4 clip = uMVP * vec4(aPos, 1.0);
+    gl_Position = clip;
+    vDepth = clamp(1.0 - clip.w / 2200.0, 0.1, 1.0);
+  }
+`, `
+  precision mediump float;
+  varying float vDepth;
+  void main() { gl_FragColor = vec4(0.47, 0.52, 0.6, 0.22 * vDepth); }
+`);
+const ePos = gl.getAttribLocation(edgeProg, 'aPos');
+const eMVP = gl.getUniformLocation(edgeProg, 'uMVP');
+
+const nodeBuf = gl.createBuffer();
+const nodeColBuf = gl.createBuffer();
+const nodeSizeBuf = gl.createBuffer();
+const edgeBuf = gl.createBuffer();
+
+// ── data load ──────────────────────────────────────────────────────
+async function loadGraph() {
+  try {
+    const r = await fetch('/api/graph');
+    const d = await r.json();
+    if (d.error) return;
+    initGraph(d.nodes || [], d.edges || []);
+  } catch (e) {}
+}
+
+function initGraph(rawNodes, rawEdges) {
+  document.getElementById('nodes').textContent = rawNodes.length;
+  document.getElementById('edges').textContent = rawEdges.length;
+  emptyEl.style.display = rawNodes.length ? 'none' : 'flex';
+
+  const idx = new Map();
+  nodes = rawNodes.map(n => {
+    const type = (n.properties && n.properties.symbol_type) || n.entity_type || '';
+    const node = {
+      id: n.id, label: n.label || n.id, type, props: n.properties || {},
+      x: (Math.random()-0.5)*600, y: (Math.random()-0.5)*600, z: (Math.random()-0.5)*600,
+      vx: 0, vy: 0, vz: 0, deg: 0, col: colorFor(type),
+    };
+    idx.set(n.id, node);
+    return node;
+  });
+  edges = rawEdges
+    .map(e => ({ s: idx.get(e.source_id), t: idx.get(e.target_id) }))
+    .filter(e => e.s && e.t);
+  for (const e of edges) { e.s.deg++; e.t.deg++; }
+  simTemp = 1.0;
+}
+
+// ── 3D force simulation (one tick per frame → live physics) ─────────
+function simStep() {
+  if (nodes.length === 0 || simTemp < 0.02) return;
+  const k = 90;               // ideal edge length
+  const rep = k * k * 6;      // repulsion strength
+  const n = nodes.length;
+  for (const nd of nodes) { nd.fx = 0; nd.fy = 0; nd.fz = 0; }
+  // repulsion (O(n^2) — fine at repo scale)
+  for (let i = 0; i < n; i++) {
+    const a = nodes[i];
+    for (let j = i+1; j < n; j++) {
+      const b = nodes[j];
+      let dx = a.x-b.x, dy = a.y-b.y, dz = a.z-b.z;
+      let d2 = dx*dx+dy*dy+dz*dz || 0.01;
+      const f = rep / d2;
+      const d = Math.sqrt(d2);
+      const ux = dx/d, uy = dy/d, uz = dz/d;
+      a.fx += ux*f; a.fy += uy*f; a.fz += uz*f;
+      b.fx -= ux*f; b.fy -= uy*f; b.fz -= uz*f;
+    }
+  }
+  // spring attraction
+  for (const e of edges) {
+    let dx = e.s.x-e.t.x, dy = e.s.y-e.t.y, dz = e.s.z-e.t.z;
+    const d = Math.sqrt(dx*dx+dy*dy+dz*dz) || 0.01;
+    const f = (d - k) * 0.25;
+    const ux = dx/d, uy = dy/d, uz = dz/d;
+    e.s.fx -= ux*f; e.s.fy -= uy*f; e.s.fz -= uz*f;
+    e.t.fx += ux*f; e.t.fy += uy*f; e.t.fz += uz*f;
+  }
+  // gentle centering + integrate with damping, scaled by temperature
+  const damp = 0.86, maxV = 40 * simTemp + 2;
+  for (const nd of nodes) {
+    nd.fx -= nd.x * 0.008; nd.fy -= nd.y * 0.008; nd.fz -= nd.z * 0.008;
+    nd.vx = (nd.vx + nd.fx) * damp;
+    nd.vy = (nd.vy + nd.fy) * damp;
+    nd.vz = (nd.vz + nd.fz) * damp;
+    const sp = Math.hypot(nd.vx, nd.vy, nd.vz) || 0.01;
+    const cap = Math.min(sp, maxV) / sp;
+    nd.x += nd.vx*cap*simTemp; nd.y += nd.vy*cap*simTemp; nd.z += nd.vz*cap*simTemp;
+  }
+  simTemp *= 0.992; // anneal → settles, but stays subtly alive a while
+}
+
+// ── matrix helpers ─────────────────────────────────────────────────
+function mat4Mul(a, b) {
+  const o = new Float32Array(16);
+  for (let r=0;r<4;r++) for (let c=0;c<4;c++) {
+    o[c*4+r] = a[0*4+r]*b[c*4+0]+a[1*4+r]*b[c*4+1]+a[2*4+r]*b[c*4+2]+a[3*4+r]*b[c*4+3];
+  }
+  return o;
+}
+function perspective(fov, asp, near, far) {
+  const f = 1/Math.tan(fov/2), nf = 1/(near-far);
+  return new Float32Array([f/asp,0,0,0, 0,f,0,0, 0,0,(far+near)*nf,-1, 0,0,2*far*near*nf,0]);
+}
+function lookAt(eye, ctr, up) {
+  const z = norm(sub(eye, ctr)), x = norm(cross(up, z)), y = cross(z, x);
+  return new Float32Array([
+    x[0],y[0],z[0],0, x[1],y[1],z[1],0, x[2],y[2],z[2],0,
+    -dot(x,eye),-dot(y,eye),-dot(z,eye),1,
+  ]);
+}
+const sub=(a,b)=>[a[0]-b[0],a[1]-b[1],a[2]-b[2]];
+const cross=(a,b)=>[a[1]*b[2]-a[2]*b[1],a[2]*b[0]-a[0]*b[2],a[0]*b[1]-a[1]*b[0]];
+const dot=(a,b)=>a[0]*b[0]+a[1]*b[1]+a[2]*b[2];
+const norm=a=>{const l=Math.hypot(a[0],a[1],a[2])||1;return[a[0]/l,a[1]/l,a[2]/l];};
+
+function camEye() {
+  const cp = Math.cos(cam.pitch), sp = Math.sin(cam.pitch);
+  const cy = Math.cos(cam.yaw), sy = Math.sin(cam.yaw);
+  return [ cam.tx + cam.dist*cp*sy, cam.ty + cam.dist*sp, cam.tz + cam.dist*cp*cy ];
+}
+function mvpMatrix() {
+  const asp = canvas.width / canvas.height;
+  const proj = perspective(Math.PI/4, asp, 1, 6000);
+  const view = lookAt(camEye(), [cam.tx,cam.ty,cam.tz], [0,1,0]);
+  return mat4Mul(proj, view);
+}
+
+// ── render loop ────────────────────────────────────────────────────
+let nodeArr, colArr, sizeArr, edgeArr;
+function packBuffers() {
+  const n = nodes.length;
+  if (!nodeArr || nodeArr.length !== n*3) {
+    nodeArr = new Float32Array(n*3); colArr = new Float32Array(n*3); sizeArr = new Float32Array(n);
+  }
+  for (let i=0;i<n;i++) {
+    const nd = nodes[i];
+    nodeArr[i*3]=nd.x; nodeArr[i*3+1]=nd.y; nodeArr[i*3+2]=nd.z;
+    colArr[i*3]=nd.col[0]; colArr[i*3+1]=nd.col[1]; colArr[i*3+2]=nd.col[2];
+    sizeArr[i]= Math.min(6 + nd.deg*1.5, 22) * (nd===hover?1.6:1);
+  }
+  if (!edgeArr || edgeArr.length !== edges.length*6) edgeArr = new Float32Array(edges.length*6);
+  for (let i=0;i<edges.length;i++) {
+    const e = edges[i];
+    edgeArr[i*6]=e.s.x; edgeArr[i*6+1]=e.s.y; edgeArr[i*6+2]=e.s.z;
+    edgeArr[i*6+3]=e.t.x; edgeArr[i*6+4]=e.t.y; edgeArr[i*6+5]=e.t.z;
+  }
+}
+
+function render() {
+  const mvp = mvpMatrix();
+  gl.viewport(0,0,canvas.width,canvas.height);
+  gl.clearColor(0.051,0.063,0.09,1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.enable(gl.BLEND);
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE); // additive glow
+
+  if (nodes.length) {
+    packBuffers();
+    // edges
+    gl.useProgram(edgeProg);
+    gl.uniformMatrix4fv(eMVP, false, mvp);
+    gl.bindBuffer(gl.ARRAY_BUFFER, edgeBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, edgeArr, gl.DYNAMIC_DRAW);
+    gl.enableVertexAttribArray(ePos);
+    gl.vertexAttribPointer(ePos, 3, gl.FLOAT, false, 0, 0);
+    gl.drawArrays(gl.LINES, 0, edges.length*2);
+    // nodes
+    gl.useProgram(nodeProg);
+    gl.uniformMatrix4fv(nMVP, false, mvp);
+    gl.uniform1f(nScaleU, canvas.height * 0.9);
+    gl.bindBuffer(gl.ARRAY_BUFFER, nodeBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, nodeArr, gl.DYNAMIC_DRAW);
+    gl.enableVertexAttribArray(nPos); gl.vertexAttribPointer(nPos,3,gl.FLOAT,false,0,0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, nodeColBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, colArr, gl.DYNAMIC_DRAW);
+    gl.enableVertexAttribArray(nCol); gl.vertexAttribPointer(nCol,3,gl.FLOAT,false,0,0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, nodeSizeBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, sizeArr, gl.DYNAMIC_DRAW);
+    gl.enableVertexAttribArray(nSize); gl.vertexAttribPointer(nSize,1,gl.FLOAT,false,0,0);
+    gl.drawArrays(gl.POINTS, 0, nodes.length);
+    updateLabels(mvp);
+  }
+}
+
+// HTML labels projected over the GL canvas (crisp text, only near nodes)
+function project(mvp, x, y, z) {
+  const cx = mvp[0]*x+mvp[4]*y+mvp[8]*z+mvp[12];
+  const cy = mvp[1]*x+mvp[5]*y+mvp[9]*z+mvp[13];
+  const cw = mvp[3]*x+mvp[7]*y+mvp[11]*z+mvp[15];
+  if (cw <= 0) return null;
+  return { x: (cx/cw*0.5+0.5)*canvas.clientWidth, y: (-cy/cw*0.5+0.5)*canvas.clientHeight, w: cw };
+}
+let labelPool = [];
+function updateLabels(mvp) {
+  // show labels for hovered node + high-degree hubs to avoid clutter
+  const show = nodes.filter(n => n === hover || n.deg >= 3);
+  while (labelPool.length < show.length) {
+    const s = document.createElement('span'); labelsEl.appendChild(s); labelPool.push(s);
+  }
+  for (let i=0;i<labelPool.length;i++) {
+    const el = labelPool[i];
+    if (i >= show.length) { el.style.display='none'; continue; }
+    const nd = show[i];
+    const p = project(mvp, nd.x, nd.y, nd.z);
+    if (!p) { el.style.display='none'; continue; }
+    el.style.display='block'; el.textContent = nd.label;
+    el.style.left = p.x+'px'; el.style.top = (p.y - 12)+'px';
+    el.style.opacity = nd===hover ? 1 : Math.max(0.25, 1 - p.w/2200);
+  }
+}
+
+function frame() { simStep(); render(); requestAnimationFrame(frame); }
+
+// ── interaction ────────────────────────────────────────────────────
+function resize() {
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
+}
+window.addEventListener('resize', resize);
+
+// pick nearest node to the ray (screen-space proximity via projection)
+function pick(mx, my) {
+  const mvp = mvpMatrix();
+  let best = null, bd = 18 * devicePixelRatio;
+  for (const nd of nodes) {
+    const p = project(mvp, nd.x, nd.y, nd.z);
+    if (!p) continue;
+    const sx = p.x * devicePixelRatio, sy = p.y * devicePixelRatio;
+    const d = Math.hypot(sx-mx, sy-my);
+    if (d < bd) { bd = d; best = nd; }
+  }
+  return best;
+}
+
+canvas.addEventListener('mousedown', e => {
+  lastX = e.clientX; lastY = e.clientY;
+  if (e.button === 2) { panning = true; }
+  else {
+    const mx = e.offsetX*devicePixelRatio, my = e.offsetY*devicePixelRatio;
+    const n = pick(mx, my);
+    if (n) { dragging = n; simTemp = Math.max(simTemp, 0.5); } // grab node, reheat
+    else { dragging = null; }
+  }
+});
+canvas.addEventListener('contextmenu', e => e.preventDefault());
+window.addEventListener('mousemove', e => {
+  const dx = e.clientX - lastX, dy = e.clientY - lastY;
+  lastX = e.clientX; lastY = e.clientY;
+  if (dragging) {
+    // move node on a plane facing the camera
+    const s = cam.dist / (canvas.height*0.9);
+    const cy = Math.cos(cam.yaw), sy = Math.sin(cam.yaw);
+    dragging.x += (dx*cy)*s; dragging.z += (-dx*sy)*s; dragging.y -= dy*s;
+    dragging.vx=dragging.vy=dragging.vz=0; simTemp = Math.max(simTemp, 0.4);
+  } else if (panning) {
+    const s = cam.dist / (canvas.height*0.9);
+    const cy = Math.cos(cam.yaw), sy = Math.sin(cam.yaw);
+    cam.tx -= (dx*cy)*s; cam.tz -= (-dx*sy)*s; cam.ty += dy*s;
+  } else if (e.buttons & 1) {
+    cam.yaw -= dx*0.007;
+    cam.pitch = Math.max(-1.5, Math.min(1.5, cam.pitch + dy*0.007));
+  } else {
+    // hover pick
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX-rect.left)*devicePixelRatio, my = (e.clientY-rect.top)*devicePixelRatio;
+    const n = pick(mx, my);
+    if (n !== hover) hover = n;
+    if (n) {
+      const loc = n.props.file ? `${n.props.file}${n.props.line_start?':'+n.props.line_start:''}` : '';
+      tooltip.style.display='block';
+      tooltip.style.left=(e.clientX-rect.left+14)+'px';
+      tooltip.style.top=(e.clientY-rect.top+14)+'px';
+      tooltip.innerHTML = `<span class="t">${n.type||'node'}</span> ${n.label}` + (loc?`<br/>${loc}`:'');
+    } else tooltip.style.display='none';
+  }
+});
+window.addEventListener('mouseup', () => { dragging=null; panning=false; });
+canvas.addEventListener('wheel', e => {
+  e.preventDefault();
+  cam.dist = Math.max(120, Math.min(4000, cam.dist * (e.deltaY<0?0.9:1.1)));
+}, { passive: false });
+
+resize();
+requestAnimationFrame(frame);
+</script>
+</body>
+</html>

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -12,7 +12,18 @@ readme = "../../README.md"
 
 [features]
 default = ["onnx"]
-onnx = ["dep:ort", "dep:ndarray", "dep:tokenizers", "dep:sha2"]
+onnx = ["dep:ort", "dep:ndarray", "dep:tokenizers"]
+treesitter = [
+    "dep:tree-sitter",
+    "dep:tree-sitter-rust",
+    "dep:tree-sitter-go",
+    "dep:tree-sitter-python",
+    "dep:tree-sitter-typescript",
+    "dep:tree-sitter-javascript",
+    "dep:tree-sitter-java",
+    "dep:tree-sitter-c",
+    "dep:tree-sitter-cpp",
+]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -30,7 +41,19 @@ fs2 = "0.4"
 ort = { version = "2.0.0-rc.12", features = ["download-binaries"], optional = true }
 ndarray = { version = "0.17", optional = true }
 tokenizers = { version = "0.23", optional = true }
-sha2 = { version = "0.11", optional = true }
+sha2 = { version = "0.11" }
+
+# Tree-sitter AST chunking (gated behind `treesitter` feature). The `unsafe`
+# code lives inside the grammar crates; consumer code here stays safe.
+tree-sitter = { version = "0.25", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
+tree-sitter-go = { version = "0.25", optional = true }
+tree-sitter-python = { version = "0.25", optional = true }
+tree-sitter-typescript = { version = "0.23", optional = true }
+tree-sitter-javascript = { version = "0.25", optional = true }
+tree-sitter-java = { version = "0.23", optional = true }
+tree-sitter-c = { version = "0.24", optional = true }
+tree-sitter-cpp = { version = "0.23", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/uteke-core/src/chunker.rs
+++ b/crates/uteke-core/src/chunker.rs
@@ -18,6 +18,10 @@ pub struct CodeChunk {
     pub symbol_type: String,
     /// Symbol name (function/class/struct name).
     pub symbol_name: String,
+    /// 1-based line number where this chunk starts in the source file.
+    pub line_start: usize,
+    /// 1-based line number where this chunk ends (inclusive).
+    pub line_end: usize,
 }
 
 /// A text chunk from markdown/prose splitting (#405).
@@ -292,9 +296,27 @@ pub fn detect_language(filename: &str) -> &str {
 
 /// Chunk source code by semantic boundaries.
 ///
-/// Detects function, struct, class, impl, and interface definitions.
-/// Falls back to line-based splitting if no patterns match.
+/// When the `treesitter` feature is enabled, tries precise AST chunking first
+/// and falls back to the regex chunker on parse failure or unsupported
+/// languages. Detects function, struct, class, impl, and interface
+/// definitions.
 pub fn chunk_code(content: &str, language: &str) -> Vec<CodeChunk> {
+    #[cfg(feature = "treesitter")]
+    {
+        // AST path: Some(non-empty) = use it; Some(empty) = parsed but no
+        // defs (fall through to regex, which yields a whole-file chunk);
+        // None = no grammar / parse error (fall through to regex).
+        if let Some(chunks) = crate::chunker_ts::chunk_code_ts(content, language) {
+            if !chunks.is_empty() {
+                return chunks;
+            }
+        }
+    }
+    chunk_code_regex(content, language)
+}
+
+/// Regex-based chunker (the pre-tree-sitter implementation, always available).
+fn chunk_code_regex(content: &str, language: &str) -> Vec<CodeChunk> {
     match language {
         "rust" => chunk_rust(content),
         "go" => chunk_go(content),
@@ -306,8 +328,16 @@ pub fn chunk_code(content: &str, language: &str) -> Vec<CodeChunk> {
             language: language.to_string(),
             symbol_type: "file".to_string(),
             symbol_name: "full".to_string(),
+            line_start: 1,
+            line_end: whole_file_line_end(content),
         }],
     }
+}
+
+/// Line count for a whole-file chunk (1-based inclusive end).
+/// Empty content spans a single (empty) line.
+fn whole_file_line_end(content: &str) -> usize {
+    content.lines().count().max(1)
 }
 
 /// Extract import/use statements from source code.
@@ -362,9 +392,13 @@ fn chunk_python(content: &str) -> Vec<CodeChunk> {
     let mut current_name = String::new();
     let mut current_type = String::new();
     let mut current_lines: Vec<&str> = Vec::new();
+    let mut current_start: usize = 0;
+    let mut last_line: usize = 0;
     let mut in_block = false;
 
-    for line in content.lines() {
+    for (idx, line) in content.lines().enumerate() {
+        let line_no = idx + 1; // 1-based
+        last_line = line_no;
         let trimmed = line.trim();
 
         // Detect new definitions
@@ -401,11 +435,14 @@ fn chunk_python(content: &str) -> Vec<CodeChunk> {
                     language: "python".to_string(),
                     symbol_type: current_type,
                     symbol_name: current_name,
+                    line_start: current_start,
+                    line_end: line_no - 1,
                 });
             }
             current_name = new_name;
             current_type = new_type;
             current_lines = vec![line];
+            current_start = line_no;
             in_block = true;
         } else if in_block {
             current_lines.push(line);
@@ -419,6 +456,8 @@ fn chunk_python(content: &str) -> Vec<CodeChunk> {
             language: "python".to_string(),
             symbol_type: current_type,
             symbol_name: current_name,
+            line_start: current_start,
+            line_end: last_line,
         });
     }
 
@@ -429,6 +468,8 @@ fn chunk_python(content: &str) -> Vec<CodeChunk> {
             language: "python".to_string(),
             symbol_type: "file".to_string(),
             symbol_name: "full".to_string(),
+            line_start: 1,
+            line_end: whole_file_line_end(content),
         });
     }
 
@@ -462,6 +503,8 @@ fn chunk_typescript(content: &str) -> Vec<CodeChunk> {
             language: "typescript".to_string(),
             symbol_type: "file".to_string(),
             symbol_name: "full".to_string(),
+            line_start: 1,
+            line_end: whole_file_line_end(content),
         });
     }
 
@@ -515,7 +558,7 @@ fn chunk_by_patterns(
                 }
 
                 // Find the body by matching braces
-                let body = match extract_block(&lines, i, open, close) {
+                let (body, span) = match extract_block(&lines, i, open, close) {
                     Some(b) => b,
                     None => continue,
                 };
@@ -525,6 +568,8 @@ fn chunk_by_patterns(
                     language: language.to_string(),
                     symbol_type: sym_type.to_string(),
                     symbol_name: name,
+                    line_start: i + 1,        // 1-based
+                    line_end: i + span,       // start line + span-1
                 });
                 break; // Don't match same line twice
             }
@@ -537,6 +582,8 @@ fn chunk_by_patterns(
             language: language.to_string(),
             symbol_type: "file".to_string(),
             symbol_name: "full".to_string(),
+            line_start: 1,
+            line_end: whole_file_line_end(content),
         });
     }
 
@@ -544,8 +591,9 @@ fn chunk_by_patterns(
 }
 
 /// Extract a brace-delimited block starting from `start_line`.
-/// Returns the full text from the definition line to the closing brace.
-fn extract_block(lines: &[&str], start: usize, open: char, close: char) -> Option<String> {
+/// Returns `(text, line_span)` from the definition line to the closing brace,
+/// where `line_span` is the number of lines the block covers (>= 1).
+fn extract_block(lines: &[&str], start: usize, open: char, close: char) -> Option<(String, usize)> {
     let mut depth = 0i32;
     let mut found_open = false;
     let mut block_lines: Vec<&str> = Vec::new();
@@ -563,14 +611,16 @@ fn extract_block(lines: &[&str], start: usize, open: char, close: char) -> Optio
         }
 
         if found_open && depth <= 0 {
-            return Some(block_lines.join("\n"));
+            let span = block_lines.len();
+            return Some((block_lines.join("\n"), span));
         }
     }
 
     // If no braces found but we have content, return a few lines
     if !block_lines.is_empty() && !found_open {
         let end = (start + 5).min(lines.len());
-        return Some(lines[start..end].join("\n"));
+        let span = end - start;
+        return Some((lines[start..end].join("\n"), span.max(1)));
     }
 
     None
@@ -606,6 +656,28 @@ fn world(x: i32) -> i32 {
         assert_eq!(chunks[0].symbol_type, "function");
         assert_eq!(chunks[0].symbol_name, "hello");
         assert_eq!(chunks[1].symbol_name, "world");
+        // Line 1 is empty (raw string leading newline); `fn hello` starts line 2.
+        assert_eq!(chunks[0].line_start, 2);
+        assert_eq!(chunks[0].line_end, 4);
+        assert_eq!(chunks[1].line_start, 6);
+        assert_eq!(chunks[1].line_end, 8);
+    }
+
+    #[test]
+    fn test_chunk_line_numbers_map_to_source() {
+        // Reconstruct a chunk's source region from line_start/line_end and
+        // confirm it matches the original file lines (Cursor-style file:line recall).
+        let code = "fn a() {\n    1\n}\nfn b() {\n    2\n}\n";
+        let chunks = chunk_code(code, "rust");
+        assert_eq!(chunks.len(), 2);
+        let src_lines: Vec<&str> = code.lines().collect();
+        for c in &chunks {
+            assert!(c.line_start >= 1 && c.line_end >= c.line_start);
+            let region = src_lines[c.line_start - 1..c.line_end].join("\n");
+            assert_eq!(region, c.content);
+        }
+        assert_eq!(chunks[0].line_start, 1);
+        assert_eq!(chunks[1].line_start, 4);
     }
 
     #[test]

--- a/crates/uteke-core/src/chunker_ts.rs
+++ b/crates/uteke-core/src/chunker_ts.rs
@@ -1,0 +1,390 @@
+//! Tree-sitter AST-based code chunking (gated behind the `treesitter` feature).
+//!
+//! Replaces the regex chunker with precise AST boundaries. Each supported
+//! language declares which top-level node kinds are "chunkable" (functions,
+//! structs, classes, impls, etc.) and how to read the symbol name from the
+//! node. Byte spans are converted to 1-based inclusive line numbers.
+//!
+//! The `unsafe` code lives inside the vendored grammar crates; the code here
+//! is entirely safe and honors the workspace `unsafe_code = "forbid"` lint.
+//!
+//! When the AST walk yields no chunks (parse error, unsupported construct),
+//! the caller falls back to the regex chunker in [`crate::chunker`].
+
+use crate::chunker::CodeChunk;
+use tree_sitter::{Node, Parser};
+
+/// A mapping from a tree-sitter node kind to a chunk symbol type, plus the
+/// grammar field name that holds the symbol's identifier.
+struct NodeSpec {
+    /// Tree-sitter node `kind()` to treat as a chunk boundary.
+    kind: &'static str,
+    /// Symbol type recorded on the produced [`CodeChunk`].
+    symbol_type: &'static str,
+    /// Field name for the identifier child (e.g. "name"). Empty = search the
+    /// first `identifier`/`type_identifier` descendant.
+    name_field: &'static str,
+}
+
+/// Language-specific chunking rules.
+struct LangSpec {
+    language: &'static str,
+    /// Node kinds that form chunk boundaries. Order matters only for docs.
+    nodes: &'static [NodeSpec],
+}
+
+/// Resolve the tree-sitter [`tree_sitter::Language`] and chunking spec for a
+/// uteke language name. Returns `None` when tree-sitter has no grammar wired
+/// for the language (caller falls back to the regex chunker).
+fn lang_for(language: &str) -> Option<(tree_sitter::Language, LangSpec)> {
+    let spec = match language {
+        "rust" => (
+            tree_sitter_rust::LANGUAGE.into(),
+            LangSpec {
+                language: "rust",
+                nodes: &[
+                    NodeSpec { kind: "function_item", symbol_type: "function", name_field: "name" },
+                    NodeSpec { kind: "struct_item", symbol_type: "struct", name_field: "name" },
+                    NodeSpec { kind: "enum_item", symbol_type: "enum", name_field: "name" },
+                    NodeSpec { kind: "trait_item", symbol_type: "trait", name_field: "name" },
+                    NodeSpec { kind: "impl_item", symbol_type: "impl", name_field: "type" },
+                    NodeSpec { kind: "mod_item", symbol_type: "module", name_field: "name" },
+                    NodeSpec { kind: "macro_definition", symbol_type: "macro", name_field: "name" },
+                    NodeSpec { kind: "const_item", symbol_type: "const", name_field: "name" },
+                    NodeSpec { kind: "static_item", symbol_type: "static", name_field: "name" },
+                    NodeSpec { kind: "type_item", symbol_type: "type", name_field: "name" },
+                ],
+            },
+        ),
+        "go" => (
+            tree_sitter_go::LANGUAGE.into(),
+            LangSpec {
+                language: "go",
+                nodes: &[
+                    NodeSpec { kind: "function_declaration", symbol_type: "function", name_field: "name" },
+                    NodeSpec { kind: "method_declaration", symbol_type: "method", name_field: "name" },
+                    NodeSpec { kind: "type_declaration", symbol_type: "type", name_field: "" },
+                ],
+            },
+        ),
+        "python" => (
+            tree_sitter_python::LANGUAGE.into(),
+            LangSpec {
+                language: "python",
+                nodes: &[
+                    NodeSpec { kind: "function_definition", symbol_type: "function", name_field: "name" },
+                    NodeSpec { kind: "class_definition", symbol_type: "class", name_field: "name" },
+                    NodeSpec { kind: "decorated_definition", symbol_type: "function", name_field: "" },
+                ],
+            },
+        ),
+        "typescript" => (
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            LangSpec {
+                language: "typescript",
+                nodes: TS_JS_NODES,
+            },
+        ),
+        "javascript" => (
+            tree_sitter_javascript::LANGUAGE.into(),
+            LangSpec {
+                language: "javascript",
+                nodes: TS_JS_NODES,
+            },
+        ),
+        "java" => (
+            tree_sitter_java::LANGUAGE.into(),
+            LangSpec {
+                language: "java",
+                nodes: &[
+                    NodeSpec { kind: "class_declaration", symbol_type: "class", name_field: "name" },
+                    NodeSpec { kind: "interface_declaration", symbol_type: "interface", name_field: "name" },
+                    NodeSpec { kind: "enum_declaration", symbol_type: "enum", name_field: "name" },
+                    NodeSpec { kind: "record_declaration", symbol_type: "record", name_field: "name" },
+                    NodeSpec { kind: "method_declaration", symbol_type: "method", name_field: "name" },
+                ],
+            },
+        ),
+        "c" => (
+            tree_sitter_c::LANGUAGE.into(),
+            LangSpec {
+                language: "c",
+                nodes: &[
+                    NodeSpec { kind: "function_definition", symbol_type: "function", name_field: "" },
+                    NodeSpec { kind: "struct_specifier", symbol_type: "struct", name_field: "name" },
+                    NodeSpec { kind: "enum_specifier", symbol_type: "enum", name_field: "name" },
+                    NodeSpec { kind: "union_specifier", symbol_type: "union", name_field: "name" },
+                ],
+            },
+        ),
+        "cpp" => (
+            tree_sitter_cpp::LANGUAGE.into(),
+            LangSpec {
+                language: "cpp",
+                nodes: &[
+                    NodeSpec { kind: "function_definition", symbol_type: "function", name_field: "" },
+                    NodeSpec { kind: "class_specifier", symbol_type: "class", name_field: "name" },
+                    NodeSpec { kind: "struct_specifier", symbol_type: "struct", name_field: "name" },
+                    NodeSpec { kind: "enum_specifier", symbol_type: "enum", name_field: "name" },
+                    NodeSpec { kind: "namespace_definition", symbol_type: "namespace", name_field: "name" },
+                ],
+            },
+        ),
+        _ => return None,
+    };
+    Some(spec)
+}
+
+/// Shared node set for TypeScript and JavaScript (same grammar shapes).
+const TS_JS_NODES: &[NodeSpec] = &[
+    NodeSpec { kind: "function_declaration", symbol_type: "function", name_field: "name" },
+    NodeSpec { kind: "generator_function_declaration", symbol_type: "function", name_field: "name" },
+    NodeSpec { kind: "class_declaration", symbol_type: "class", name_field: "name" },
+    NodeSpec { kind: "interface_declaration", symbol_type: "interface", name_field: "name" },
+    NodeSpec { kind: "type_alias_declaration", symbol_type: "type", name_field: "name" },
+    NodeSpec { kind: "enum_declaration", symbol_type: "enum", name_field: "name" },
+    // `export function foo` / `export class Bar` wrap the decl in export_statement.
+    NodeSpec { kind: "export_statement", symbol_type: "export", name_field: "" },
+    // `const foo = () => {}` — lexical bindings holding a function/arrow.
+    NodeSpec { kind: "lexical_declaration", symbol_type: "function", name_field: "" },
+];
+
+/// Chunk source code using tree-sitter. Returns `None` if the language has no
+/// grammar or parsing fails, so the caller can fall back to the regex chunker.
+/// Returns `Some(vec![])` only when the file parses but has no top-level
+/// definitions (caller may then store the whole file).
+pub fn chunk_code_ts(content: &str, language: &str) -> Option<Vec<CodeChunk>> {
+    let (ts_lang, spec) = lang_for(language)?;
+    let mut parser = Parser::new();
+    parser.set_language(&ts_lang).ok()?;
+    let tree = parser.parse(content, None)?;
+    let root = tree.root_node();
+    let src = content.as_bytes();
+
+    let mut chunks = Vec::new();
+    let mut cursor = root.walk();
+    // Walk only top-level children of the root: chunks are file-level defs.
+    for child in root.children(&mut cursor) {
+        collect_chunk(child, &spec, src, content, &mut chunks);
+    }
+
+    if chunks.is_empty() {
+        // Parsed fine but nothing chunkable — let the caller decide.
+        return Some(vec![]);
+    }
+    Some(chunks)
+}
+
+/// Produce a chunk for `node` if its kind is chunkable under `spec`. For
+/// wrapper kinds (`export_statement`, `decorated_definition`,
+/// `lexical_declaration`) the inner declaration is used for the symbol name
+/// but the wrapper's full span is kept as content.
+fn collect_chunk(
+    node: Node,
+    spec: &LangSpec,
+    src: &[u8],
+    content: &str,
+    out: &mut Vec<CodeChunk>,
+) {
+    let Some(nodespec) = spec.nodes.iter().find(|n| n.kind == node.kind()) else {
+        return;
+    };
+
+    // Resolve the symbol name.
+    let name = resolve_name(node, nodespec, src).unwrap_or_else(|| "anonymous".to_string());
+
+    // For wrapper nodes, refine the symbol type from the inner declaration.
+    let symbol_type = refine_symbol_type(node, nodespec, spec);
+
+    let start_byte = node.start_byte();
+    let end_byte = node.end_byte();
+    let text = &content[start_byte..end_byte];
+
+    // Tree-sitter rows are 0-based; convert to 1-based inclusive lines.
+    let line_start = node.start_position().row + 1;
+    let line_end = node.end_position().row + 1;
+
+    out.push(CodeChunk {
+        content: text.to_string(),
+        language: spec.language.to_string(),
+        symbol_type: symbol_type.to_string(),
+        symbol_name: name,
+        line_start,
+        line_end,
+    });
+
+    // Do not recurse into a captured chunk — methods stay part of their
+    // enclosing type/impl, matching the regex chunker's file-level behavior.
+    let _ = src;
+}
+
+/// Read the identifier for `node` per its [`NodeSpec`]. Falls back to the
+/// first identifier-like descendant when `name_field` is empty or absent.
+fn resolve_name(node: Node, nodespec: &NodeSpec, src: &[u8]) -> Option<String> {
+    if !nodespec.name_field.is_empty() {
+        if let Some(name_node) = node.child_by_field_name(nodespec.name_field) {
+            return node_text(name_node, src);
+        }
+    }
+    // Fallback: first identifier-ish descendant.
+    first_identifier(node, src)
+}
+
+/// Refine the symbol type for wrapper nodes by inspecting the inner decl.
+fn refine_symbol_type<'a>(node: Node, nodespec: &'a NodeSpec, spec: &'a LangSpec) -> &'a str {
+    match node.kind() {
+        "export_statement" | "decorated_definition" | "lexical_declaration" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if let Some(inner) = spec.nodes.iter().find(|n| n.kind == child.kind()) {
+                    if inner.kind != node.kind() {
+                        return inner.symbol_type;
+                    }
+                }
+            }
+            nodespec.symbol_type
+        }
+        _ => nodespec.symbol_type,
+    }
+}
+
+/// Extract UTF-8 text for a node from the source bytes.
+fn node_text(node: Node, src: &[u8]) -> Option<String> {
+    node.utf8_text(src).ok().map(|s| s.to_string())
+}
+
+/// Depth-first search for the first identifier-like node and return its text.
+fn first_identifier(node: Node, src: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let k = child.kind();
+        if k == "identifier"
+            || k == "type_identifier"
+            || k == "field_identifier"
+            || k == "property_identifier"
+        {
+            return node_text(child, src);
+        }
+        if let Some(found) = first_identifier(child, src) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_functions_and_structs_with_line_numbers() {
+        let src = "\
+use std::io;
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+impl Point {
+    fn origin() -> Self {
+        Point { x: 0, y: 0 }
+    }
+}
+";
+        let chunks = chunk_code_ts(src, "rust").expect("grammar present");
+        let names: Vec<_> = chunks.iter().map(|c| c.symbol_name.as_str()).collect();
+        assert!(names.contains(&"Point"), "names={names:?}");
+        assert!(names.contains(&"add"), "names={names:?}");
+
+        let point = chunks.iter().find(|c| c.symbol_name == "Point" && c.symbol_type == "struct").unwrap();
+        assert_eq!(point.line_start, 3);
+        assert_eq!(point.line_end, 6);
+
+        let add = chunks.iter().find(|c| c.symbol_name == "add").unwrap();
+        assert_eq!(add.symbol_type, "function");
+        assert_eq!(add.line_start, 8);
+        assert_eq!(add.line_end, 10);
+
+        // impl is captured at file level; its method stays inside it.
+        let imp = chunks.iter().find(|c| c.symbol_type == "impl").unwrap();
+        assert_eq!(imp.symbol_name, "Point");
+        assert!(imp.content.contains("fn origin"));
+    }
+
+    #[test]
+    fn python_class_and_function() {
+        let src = "\
+import os
+
+def top():
+    return 1
+
+class Widget:
+    def __init__(self):
+        self.n = 0
+";
+        let chunks = chunk_code_ts(src, "python").expect("grammar present");
+        let top = chunks.iter().find(|c| c.symbol_name == "top").unwrap();
+        assert_eq!(top.symbol_type, "function");
+        assert_eq!(top.line_start, 3);
+        let widget = chunks.iter().find(|c| c.symbol_name == "Widget").unwrap();
+        assert_eq!(widget.symbol_type, "class");
+        assert!(widget.content.contains("__init__"));
+    }
+
+    #[test]
+    fn typescript_export_and_arrow() {
+        let src = "\
+export function greet(name: string): string {
+    return `hi ${name}`;
+}
+
+const double = (n: number) => n * 2;
+
+interface Shape {
+    area(): number;
+}
+";
+        let chunks = chunk_code_ts(src, "typescript").expect("grammar present");
+        let names: Vec<_> = chunks.iter().map(|c| c.symbol_name.as_str()).collect();
+        assert!(names.contains(&"greet"), "names={names:?}");
+        assert!(names.contains(&"double"), "names={names:?}");
+        assert!(names.contains(&"Shape"), "names={names:?}");
+    }
+
+    #[test]
+    fn go_functions_and_types() {
+        let src = "\
+package main
+
+func main() {
+    println(\"hi\")
+}
+
+type Server struct {
+    port int
+}
+";
+        let chunks = chunk_code_ts(src, "go").expect("grammar present");
+        let names: Vec<_> = chunks.iter().map(|c| c.symbol_name.as_str()).collect();
+        assert!(names.contains(&"main"), "names={names:?}");
+        assert!(names.contains(&"Server"), "names={names:?}");
+    }
+
+    #[test]
+    fn unsupported_language_returns_none() {
+        assert!(chunk_code_ts("x = 1", "cobol").is_none());
+    }
+
+    #[test]
+    fn empty_defs_returns_some_empty() {
+        // Valid Rust with no top-level defs -> Some(empty) so caller falls back.
+        let chunks = chunk_code_ts("// just a comment\n", "rust").unwrap();
+        assert!(chunks.is_empty());
+    }
+}

--- a/crates/uteke-core/src/code_index.rs
+++ b/crates/uteke-core/src/code_index.rs
@@ -1,0 +1,510 @@
+//! Code indexing operations — turn source files into recallable memories.
+//!
+//! A source file is chunked by [`crate::chunker::chunk_code`] into semantic
+//! units (functions, structs, classes, ...). Each chunk is stored as a memory
+//! carrying location metadata so recall can point back to `file:line`.
+//!
+//! Incremental re-index is content-hash driven: [`IndexOutcome::Skipped`] is
+//! returned when a file's hash matches the tracked `indexed_files` record, so
+//! unchanged files are never re-embedded.
+
+use crate::chunker::{chunk_code, detect_language};
+use crate::memory::IndexedFile;
+use crate::Error;
+
+/// Result of indexing a single file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexOutcome {
+    /// File content unchanged since last index — no work done.
+    Skipped,
+    /// File indexed: number of chunks stored.
+    Indexed { chunks: usize },
+}
+
+/// Aggregate result of indexing a directory tree or file.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct IndexSummary {
+    /// Files (re)indexed this run.
+    pub indexed: usize,
+    /// Files skipped because content was unchanged.
+    pub skipped: usize,
+    /// Total chunks stored this run.
+    pub chunks: usize,
+    /// Files pruned (deleted on disk, chunks removed).
+    pub pruned: usize,
+}
+
+/// Live progress events emitted during [`crate::Uteke::index_tree_cb`].
+///
+/// Chunking (tree-sitter) is fast; embedding each chunk dominates runtime.
+/// These events let a CLI stream per-file progress instead of blocking on a
+/// single summary line.
+#[derive(Debug, Clone)]
+pub enum IndexProgress<'a> {
+    /// Emitted once after the walk, before any embedding work. `files` is the
+    /// count of candidate source files discovered (post language/exclude
+    /// filter).
+    Discovered { files: usize },
+    /// A file is about to be chunked + embedded (the slow step).
+    FileStarted { path: &'a str, index: usize, total: usize },
+    /// A file finished embedding: `chunks` stored.
+    FileIndexed { path: &'a str, chunks: usize },
+    /// A file was skipped (content hash unchanged).
+    FileSkipped { path: &'a str },
+    /// Pruning deleted-on-disk files completed.
+    Pruned { files: usize },
+}
+
+/// Directory names always skipped during a walk.
+pub const DEFAULT_EXCLUDED_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    ".uteke",
+    "target",
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    "vendor",
+    ".idea",
+    ".vscode",
+];
+
+/// Max file size to index (bytes). Larger files are skipped.
+pub const MAX_INDEX_FILE_SIZE: u64 = 1_000_000;
+
+/// Compute a hex content hash for indexing purposes.
+pub fn content_hash(content: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+impl crate::Uteke {
+    /// Index a single source file into the given namespace.
+    ///
+    /// - `rel_path`: repo-relative path stored in metadata (forward-slash form).
+    /// - `content`: full file contents.
+    /// - `language`: optional language override; when `None` it is detected
+    ///   from `rel_path`'s extension.
+    /// - `mtime`: file modification time (unix seconds) for the tracking record.
+    /// - `force`: when true, re-index even if the content hash is unchanged.
+    ///
+    /// Prunes any previously-indexed chunks for this file before storing the
+    /// new ones, so the index always reflects current file content.
+    pub fn index_source_file(
+        &self,
+        namespace: &str,
+        rel_path: &str,
+        content: &str,
+        language: Option<&str>,
+        mtime: i64,
+        force: bool,
+    ) -> Result<IndexOutcome, Error> {
+        let hash = content_hash(content);
+
+        // Skip unchanged files unless forced.
+        if !force {
+            if let Some(prev) = self.store.indexed_file_hash(namespace, rel_path)? {
+                if prev == hash {
+                    return Ok(IndexOutcome::Skipped);
+                }
+            }
+        }
+
+        // Remove stale chunks for this file (full replace).
+        let stale = self
+            .store
+            .memory_ids_by_indexed_file(namespace, rel_path)?;
+        for id in &stale {
+            self.forget(id)?;
+        }
+
+        let lang = language
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| detect_language(rel_path).to_string());
+        let chunks = chunk_code(content, &lang);
+
+        let mut stored = 0usize;
+        for chunk in &chunks {
+            let metadata = serde_json::json!({
+                "source_type": "code",
+                "file": rel_path,
+                "language": chunk.language,
+                "symbol_name": chunk.symbol_name,
+                "symbol_type": chunk.symbol_type,
+                "line_start": chunk.line_start,
+                "line_end": chunk.line_end,
+            });
+            // Prefix the stored content with a compact location header so the
+            // embedding text and recall snippet both carry the symbol context.
+            let body = format!(
+                "{} {} [{}:{}-{}]\n{}",
+                chunk.symbol_type,
+                chunk.symbol_name,
+                rel_path,
+                chunk.line_start,
+                chunk.line_end,
+                chunk.content
+            );
+            // `code` tag makes filtered recall/prune easy; store as a reference
+            // type since these are code artifacts, not user assertions.
+            self.remember_typed(&body, &["code"], Some(metadata), Some(namespace), "reference")?;
+            stored += 1;
+        }
+
+        self.store.upsert_indexed_file(
+            namespace,
+            &IndexedFile {
+                path: rel_path.to_string(),
+                content_hash: hash,
+                mtime,
+                chunk_count: stored as i64,
+            },
+        )?;
+
+        Ok(IndexOutcome::Indexed { chunks: stored })
+    }
+
+    /// Prune index records + chunk memories for files that no longer exist.
+    ///
+    /// `present` is the set of repo-relative paths currently on disk. Any
+    /// tracked file not in `present` has its chunks forgotten and its tracking
+    /// record removed. Returns the number of files pruned.
+    pub fn prune_deleted_files(
+        &self,
+        namespace: &str,
+        present: &std::collections::HashSet<String>,
+    ) -> Result<usize, Error> {
+        let tracked = self.store.list_indexed_files(namespace)?;
+        let mut pruned = 0usize;
+        for f in &tracked {
+            if present.contains(&f.path) {
+                continue;
+            }
+            let ids = self.store.memory_ids_by_indexed_file(namespace, &f.path)?;
+            for id in &ids {
+                self.forget(id)?;
+            }
+            self.store.delete_indexed_file(namespace, &f.path)?;
+            pruned += 1;
+        }
+        Ok(pruned)
+    }
+
+    /// Index a directory tree (or single file) into `namespace`.
+    ///
+    /// Walks `root` skipping [`DEFAULT_EXCLUDED_DIRS`] and hidden dirs, indexes
+    /// each file whose extension maps to a known language, prunes chunks for
+    /// files that disappeared, and returns an [`IndexSummary`]. `rel_base` is
+    /// the directory that repo-relative metadata paths are computed against
+    /// (usually `root` itself, or its parent for a single file).
+    ///
+    /// When `dry_run` is true, no memories are written and no pruning occurs;
+    /// the summary's `indexed` counts files that *would* be indexed.
+    pub fn index_tree(
+        &self,
+        namespace: &str,
+        root: &std::path::Path,
+        force: bool,
+        dry_run: bool,
+    ) -> Result<IndexSummary, Error> {
+        self.index_tree_cb(namespace, root, force, dry_run, |_| {})
+    }
+
+    /// Like [`Self::index_tree`] but streams [`IndexProgress`] events to `cb`.
+    ///
+    /// The callback fires: once with `Discovered` after the walk, then
+    /// `FileStarted`/`FileIndexed`/`FileSkipped` per file, and finally
+    /// `Pruned`. This lets callers render live progress — cheap to ignore
+    /// (`index_tree` passes a no-op closure).
+    pub fn index_tree_cb(
+        &self,
+        namespace: &str,
+        root: &std::path::Path,
+        force: bool,
+        dry_run: bool,
+        mut cb: impl FnMut(IndexProgress<'_>),
+    ) -> Result<IndexSummary, Error> {
+        use std::collections::HashSet;
+
+        let rel_base = if root.is_file() {
+            root.parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+        } else {
+            root.to_path_buf()
+        };
+
+        let mut files = Vec::new();
+        if root.is_file() {
+            files.push(root.to_path_buf());
+        } else {
+            collect_files(root, &mut files);
+        }
+
+        // Pre-filter to indexable (known-language) files so the discovered
+        // count and per-file index/total reflect real work.
+        let candidates: Vec<(std::path::PathBuf, String)> = files
+            .into_iter()
+            .filter_map(|f| {
+                let rel = rel_path(&rel_base, &f);
+                let lang = detect_language(&rel);
+                if lang == "text" {
+                    None
+                } else {
+                    Some((f, rel))
+                }
+            })
+            .collect();
+
+        cb(IndexProgress::Discovered {
+            files: candidates.len(),
+        });
+
+        let mut summary = IndexSummary::default();
+        let mut present: HashSet<String> = HashSet::new();
+        let total = candidates.len();
+
+        for (idx, (file, rel)) in candidates.iter().enumerate() {
+            let lang = detect_language(rel);
+            present.insert(rel.clone());
+
+            let meta = match std::fs::metadata(file) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!("skip {}: {e}", file.display());
+                    continue;
+                }
+            };
+            if meta.len() > MAX_INDEX_FILE_SIZE {
+                tracing::warn!("skip {} ({} bytes > limit)", file.display(), meta.len());
+                continue;
+            }
+            let content = match std::fs::read_to_string(file) {
+                Ok(c) => c,
+                Err(_) => continue, // binary / non-utf8
+            };
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+
+            if dry_run {
+                summary.indexed += 1;
+                continue;
+            }
+
+            cb(IndexProgress::FileStarted {
+                path: rel,
+                index: idx + 1,
+                total,
+            });
+
+            match self.index_source_file(namespace, rel, &content, Some(lang), mtime, force)? {
+                IndexOutcome::Indexed { chunks } => {
+                    summary.indexed += 1;
+                    summary.chunks += chunks;
+                    cb(IndexProgress::FileIndexed { path: rel, chunks });
+                }
+                IndexOutcome::Skipped => {
+                    summary.skipped += 1;
+                    cb(IndexProgress::FileSkipped { path: rel });
+                }
+            }
+        }
+
+        if !dry_run {
+            summary.pruned = self.prune_deleted_files(namespace, &present)?;
+            cb(IndexProgress::Pruned {
+                files: summary.pruned,
+            });
+        }
+
+        Ok(summary)
+    }
+
+    /// Report code-index status for a namespace: number of tracked files and
+    /// the sum of their chunk counts.
+    pub fn code_index_status(&self, namespace: &str) -> Result<(usize, usize), Error> {
+        let files = self.store.list_indexed_files(namespace)?;
+        let chunks: i64 = files.iter().map(|f| f.chunk_count).sum();
+        Ok((files.len(), chunks as usize))
+    }
+}
+
+/// Compute a forward-slash repo-relative path.
+fn rel_path(base: &std::path::Path, file: &std::path::Path) -> String {
+    let rel = file.strip_prefix(base).unwrap_or(file);
+    rel.to_string_lossy().replace('\\', "/")
+}
+
+/// Recursively collect files, skipping excluded/hidden directories.
+fn collect_files(dir: &std::path::Path, acc: &mut Vec<std::path::PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!("cannot read {}: {e}", dir.display());
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if DEFAULT_EXCLUDED_DIRS.contains(&name.as_ref()) || name.starts_with('.') {
+                continue;
+            }
+            collect_files(&path, acc);
+        } else if path.is_file() {
+            acc.push(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_uteke() -> crate::Uteke {
+        // In-memory store, no-op embedder path is fine for indexing logic.
+        crate::Uteke::open(":memory:").unwrap()
+    }
+
+    #[test]
+    fn hash_is_stable_and_content_sensitive() {
+        assert_eq!(content_hash("abc"), content_hash("abc"));
+        assert_ne!(content_hash("abc"), content_hash("abd"));
+    }
+
+    #[test]
+    fn index_then_skip_unchanged() {
+        let u = tmp_uteke();
+        let code = "fn a() {\n    1\n}\n";
+        let r1 = u
+            .index_source_file("repo", "src/a.rs", code, None, 100, false)
+            .unwrap();
+        assert!(matches!(r1, IndexOutcome::Indexed { chunks } if chunks >= 1));
+
+        // Same content → skipped.
+        let r2 = u
+            .index_source_file("repo", "src/a.rs", code, None, 100, false)
+            .unwrap();
+        assert_eq!(r2, IndexOutcome::Skipped);
+
+        // force → re-indexed.
+        let r3 = u
+            .index_source_file("repo", "src/a.rs", code, None, 100, true)
+            .unwrap();
+        assert!(matches!(r3, IndexOutcome::Indexed { .. }));
+    }
+
+    #[test]
+    fn reindex_replaces_stale_chunks() {
+        let u = tmp_uteke();
+        u.index_source_file("repo", "src/a.rs", "fn a() {\n    1\n}\n", None, 1, false)
+            .unwrap();
+        let before = u.store.memory_ids_by_indexed_file("repo", "src/a.rs").unwrap();
+        assert_eq!(before.len(), 1);
+
+        // Change content → two functions now.
+        u.index_source_file(
+            "repo",
+            "src/a.rs",
+            "fn a() {\n    1\n}\nfn b() {\n    2\n}\n",
+            None,
+            2,
+            false,
+        )
+        .unwrap();
+        let after = u.store.memory_ids_by_indexed_file("repo", "src/a.rs").unwrap();
+        assert_eq!(after.len(), 2);
+        // Old ids fully replaced.
+        assert!(before.iter().all(|id| !after.contains(id)));
+    }
+
+    #[test]
+    fn index_tree_walks_and_excludes() {
+        let u = tmp_uteke();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("target")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
+        std::fs::write(root.join("src/b.py"), "def b():\n    pass\n").unwrap();
+        std::fs::write(root.join("README.md"), "# doc\n").unwrap(); // text -> skipped
+        std::fs::write(root.join("target/junk.rs"), "fn junk() {}\n").unwrap(); // excluded dir
+
+        let s = u.index_tree("repo", root, false, false).unwrap();
+        assert_eq!(s.indexed, 2, "a.rs + b.py, README skipped, target excluded");
+        assert!(s.chunks >= 2);
+
+        // Re-run: unchanged -> all skipped.
+        let s2 = u.index_tree("repo", root, false, false).unwrap();
+        assert_eq!(s2.skipped, 2);
+        assert_eq!(s2.indexed, 0);
+
+        // target/junk.rs must not have been indexed.
+        assert_eq!(
+            u.store
+                .memory_ids_by_indexed_file("repo", "target/junk.rs")
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn index_tree_dry_run_writes_nothing() {
+        let u = tmp_uteke();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/a.rs"), "fn a() {}\n").unwrap();
+
+        let s = u.index_tree("repo", tmp.path(), false, true).unwrap();
+        assert_eq!(s.indexed, 1);
+        assert_eq!(s.chunks, 0);
+        assert_eq!(
+            u.store.memory_ids_by_indexed_file("repo", "src/a.rs").unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn prune_removes_deleted_files() {
+        let u = tmp_uteke();
+        u.index_source_file("repo", "src/a.rs", "fn a() {}\n", None, 1, false)
+            .unwrap();
+        u.index_source_file("repo", "src/b.rs", "fn b() {}\n", None, 1, false)
+            .unwrap();
+
+        let mut present = std::collections::HashSet::new();
+        present.insert("src/a.rs".to_string());
+
+        let pruned = u.prune_deleted_files("repo", &present).unwrap();
+        assert_eq!(pruned, 1);
+        assert_eq!(
+            u.store.memory_ids_by_indexed_file("repo", "src/b.rs").unwrap().len(),
+            0
+        );
+        assert_eq!(
+            u.store.memory_ids_by_indexed_file("repo", "src/a.rs").unwrap().len(),
+            1
+        );
+    }
+}

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -387,11 +387,18 @@ impl Store {
             .map_err(|e| Error::db("begin batch edge tx", e))?;
         let mut inserted = 0usize;
         for (target_id, edge_type) in edges {
+            // Guard against ghost endpoints: the usearch index can transiently
+            // hold ids that are not in `memories` (orphaned vectors after a
+            // failed forget/save, cross-run desync). Inserting such an edge
+            // trips the FK constraint and aborts the whole batch. Insert only
+            // when BOTH endpoints exist so a stale target is skipped, not fatal.
             let changed = tx
                 .execute(
                     "INSERT OR IGNORE INTO memory_edges
                         (source_id, target_id, edge_type, created_at)
-                     VALUES (?1, ?2, ?3, ?4)",
+                     SELECT ?1, ?2, ?3, ?4
+                     WHERE EXISTS (SELECT 1 FROM memories WHERE id = ?1)
+                       AND EXISTS (SELECT 1 FROM memories WHERE id = ?2)",
                     params![source_id, target_id, edge_type, now],
                 )
                 .map_err(|e| Error::db("batch insert memory edge", e))?;
@@ -403,7 +410,9 @@ impl Store {
                     tx.execute(
                         "INSERT OR IGNORE INTO memory_edges
                             (source_id, target_id, edge_type, created_at)
-                         VALUES (?1, ?2, ?3, ?4)",
+                         SELECT ?1, ?2, ?3, ?4
+                         WHERE EXISTS (SELECT 1 FROM memories WHERE id = ?1)
+                           AND EXISTS (SELECT 1 FROM memories WHERE id = ?2)",
                         params![target_id, source_id, backlink_type, now],
                     )
                     .map_err(|e| Error::db("batch ensure backlink", e))?;
@@ -1343,7 +1352,7 @@ mod tests {
     fn migration_dispatcher_reaches_v8() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 15, "fresh store must reach CURRENT_SCHEMA_VERSION=15");
+        assert_eq!(v, 16, "fresh store must reach CURRENT_SCHEMA_VERSION=16");
 
         // memory_edges table must exist and be queryable after migration.
         let n = store.count_memory_edges().unwrap();

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -19,6 +19,85 @@ const MAX_SEQ_LEN: usize = 2048;
 
 const HF_REPO: &str = "onnx-community/embeddinggemma-300m-ONNX";
 
+/// How to turn ONNX outputs into a single embedding vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Pooling {
+    /// Model emits a pre-pooled sentence embedding at `outputs[1]`
+    /// (EmbeddingGemma). Use it directly.
+    PrePooledOutput1,
+    /// Model emits only `last_hidden_state` at `outputs[0]`; mean-pool over
+    /// the sequence using the attention mask (Qwen3-style, e.g. voyage-4-nano).
+    MeanPoolOutput0,
+}
+
+/// Descriptor for a downloadable ONNX embedding model.
+#[derive(Debug, Clone)]
+pub struct ModelSpec {
+    /// Local directory name under `~/.uteke/models/`.
+    pub dir_name: &'static str,
+    /// Hugging Face repo id.
+    pub hf_repo: &'static str,
+    /// Embedding dimension.
+    pub dims: usize,
+    /// Max input sequence length (tokens).
+    pub max_seq_len: usize,
+    /// Output pooling strategy.
+    pub pooling: Pooling,
+    /// (filename, sha256) checksums for model.onnx, model.onnx_data, tokenizer.json.
+    pub checksums: &'static [(&'static str, &'static str)],
+}
+
+/// EmbeddingGemma Q4 (768d) — the default local model.
+pub const EMBEDDINGGEMMA_Q4: ModelSpec = ModelSpec {
+    dir_name: MODEL_DIR_NAME,
+    hf_repo: HF_REPO,
+    dims: MODEL_DIMS,
+    max_seq_len: MAX_SEQ_LEN,
+    pooling: Pooling::PrePooledOutput1,
+    checksums: MODEL_CHECKSUMS,
+};
+
+/// Voyage-4-nano Q4 (2048d, qwen3) — open-weight, code-friendly local model.
+///
+/// The ONNX export emits `last_hidden_state (…, 2048)` and a pre-pooled
+/// `pooler_output (…, 2048)` at index 1, so it uses the same pooling path as
+/// EmbeddingGemma. Native dim is 2048 (config.json's 1024 is the stale base
+/// hidden size before the embedding projection).
+pub const VOYAGE_4_NANO_Q4: ModelSpec = ModelSpec {
+    dir_name: "voyage-4-nano-q4",
+    hf_repo: "onnx-community/voyage-4-nano-ONNX",
+    dims: 2048,
+    max_seq_len: 32_000,
+    pooling: Pooling::PrePooledOutput1,
+    checksums: VOYAGE_4_NANO_CHECKSUMS,
+};
+
+/// SHA256 checksums for voyage-4-nano Q4 ONNX files.
+const VOYAGE_4_NANO_CHECKSUMS: &[(&str, &str)] = &[
+    (
+        "model_q4.onnx",
+        "2a2f390055b2ab4f17e9e57ee8a8f948f905ea33e9111af0b297c9d8d372b99a",
+    ),
+    (
+        "model_q4.onnx_data",
+        "38e29a9146c9f94bacee268002d453d146fb21805826b0dd26074e2f0e886abf",
+    ),
+    (
+        "tokenizer.json",
+        "c40c3736449ad0f4084a187dfe16f6850b2a2933dfe041394f850608b2890140",
+    ),
+];
+
+/// Resolve a model spec by name. Accepts the config `model` value.
+/// Recognized: "embeddinggemma-q4" (default), "voyage-4-nano".
+#[allow(dead_code)]
+pub fn model_spec_for(name: &str) -> ModelSpec {
+    match name {
+        "voyage" | "voyage-4-nano" | "voyage-4-nano-q4" => VOYAGE_4_NANO_Q4,
+        _ => EMBEDDINGGEMMA_Q4,
+    }
+}
+
 /// Expected SHA256 checksums for model files.
 /// Pin these to prevent corrupted/tampered downloads from causing cryptic ONNX failures.
 const MODEL_CHECKSUMS: &[(&str, &str)] = &[
@@ -43,12 +122,20 @@ const MODEL_CHECKSUMS: &[(&str, &str)] = &[
 pub struct OnnxEmbedder {
     session: Mutex<ort::session::Session>,
     tokenizer: Mutex<tokenizers::Tokenizer>,
+    spec: ModelSpec,
 }
 
 impl OnnxEmbedder {
-    /// Create a new embedding engine. Downloads model if not cached.
+    /// Create the default embedding engine (EmbeddingGemma Q4).
+    /// Downloads model if not cached.
     pub fn new() -> Result<Self, Error> {
-        let model_dir = Self::model_dir()?;
+        Self::with_spec(EMBEDDINGGEMMA_Q4)
+    }
+
+    /// Create an embedding engine for a specific model spec.
+    /// Downloads model files if not cached.
+    pub fn with_spec(spec: ModelSpec) -> Result<Self, Error> {
+        let model_dir = Self::model_dir_for(&spec)?;
         std::fs::create_dir_all(&model_dir)
             .map_err(|e| Error::embed("create model directory", e))?;
 
@@ -74,19 +161,19 @@ impl OnnxEmbedder {
         let needs_download =
             !model_path.exists() || !model_data_path.exists() || !tokenizer_path.exists();
         if needs_download {
-            eprintln!("Downloading embedding model (first run)...");
+            eprintln!("Downloading embedding model '{}' (first run)...", spec.dir_name);
         }
         if !model_path.exists() {
-            download_hf_file(HF_REPO, "onnx/model_q4.onnx", &model_path)?;
-            verify_checksum(&model_path, "model_q4.onnx")?;
+            download_hf_file(spec.hf_repo, "onnx/model_q4.onnx", &model_path)?;
+            verify_checksum_with(&model_path, "model_q4.onnx", spec.checksums)?;
         }
         if !model_data_path.exists() {
-            download_hf_file(HF_REPO, "onnx/model_q4.onnx_data", &model_data_path)?;
-            verify_checksum(&model_data_path, "model_q4.onnx_data")?;
+            download_hf_file(spec.hf_repo, "onnx/model_q4.onnx_data", &model_data_path)?;
+            verify_checksum_with(&model_data_path, "model_q4.onnx_data", spec.checksums)?;
         }
         if !tokenizer_path.exists() {
-            download_hf_file(HF_REPO, "tokenizer.json", &tokenizer_path)?;
-            verify_checksum(&tokenizer_path, "tokenizer.json")?;
+            download_hf_file(spec.hf_repo, "tokenizer.json", &tokenizer_path)?;
+            verify_checksum_with(&tokenizer_path, "tokenizer.json", spec.checksums)?;
         }
 
         // Load ONNX session
@@ -101,10 +188,11 @@ impl OnnxEmbedder {
         Ok(Self {
             session: Mutex::new(session),
             tokenizer: Mutex::new(tokenizer),
+            spec,
         })
     }
 
-    /// Embed a text string, returning a 768-dimensional f32 vector.
+    /// Embed a text string, returning a spec-dimensional f32 vector.
     ///
     /// Takes `&self` — the tokenizer mutex is locked internally.
     pub fn embed(&self, text: &str) -> Result<Vec<f32>, Error> {
@@ -122,7 +210,7 @@ impl OnnxEmbedder {
         let attention_mask = encoding.get_attention_mask();
 
         // Truncate to max sequence length
-        let seq_len = input_ids.len().min(MAX_SEQ_LEN);
+        let seq_len = input_ids.len().min(self.spec.max_seq_len);
 
         // Prepare input arrays as i64
         let input_ids_i64: Vec<i64> = input_ids[..seq_len].iter().map(|&v| v as i64).collect();
@@ -140,13 +228,10 @@ impl OnnxEmbedder {
 
         let attention_mask_tensor = ort::value::Tensor::<i64>::from_array((
             vec![1i64, seq_len as i64],
-            attention_mask_i64.into_boxed_slice(),
+            attention_mask_i64.clone().into_boxed_slice(),
         ))
         .map_err(|e| Error::embed("create attention_mask tensor", e))?;
 
-        // Run ONNX inference — EmbeddingGemma has 2 outputs:
-        //   output[0] = last_hidden_state (1, seq_len, 768)
-        //   output[1] = sentence_embedding (1, 768) — already mean-pooled
         let mut session = self
             .session
             .lock()
@@ -155,14 +240,25 @@ impl OnnxEmbedder {
             .run(ort::inputs![input_ids_tensor, attention_mask_tensor])
             .map_err(|e| Error::embed("ONNX inference", e))?;
 
-        // Use output[1] (sentence_embedding) — already pooled by the model
-        let sentence_emb = &outputs[1];
-
-        let emb_view = sentence_emb
-            .try_extract_tensor::<f32>()
-            .map_err(|e| Error::embed("extract sentence embedding", e))?;
-
-        let mut embedding: Vec<f32> = emb_view.1.to_vec();
+        let mut embedding: Vec<f32> = match self.spec.pooling {
+            Pooling::PrePooledOutput1 => {
+                // outputs[1] = sentence_embedding (1, dims) — already pooled.
+                let sentence_emb = &outputs[1];
+                let emb_view = sentence_emb
+                    .try_extract_tensor::<f32>()
+                    .map_err(|e| Error::embed("extract sentence embedding", e))?;
+                emb_view.1.to_vec()
+            }
+            Pooling::MeanPoolOutput0 => {
+                // outputs[0] = last_hidden_state (1, seq_len, hidden). Mean-pool
+                // over non-masked tokens.
+                let hidden = &outputs[0];
+                let (shape, data) = hidden
+                    .try_extract_tensor::<f32>()
+                    .map_err(|e| Error::embed("extract last_hidden_state", e))?;
+                mean_pool(shape, data, &attention_mask_i64, self.spec.dims)?
+            }
+        };
 
         // L2 normalize
         let norm = embedding.iter().map(|v| v * v).sum::<f32>().sqrt();
@@ -176,13 +272,57 @@ impl OnnxEmbedder {
     }
 
     /// Get the embedding dimension (associated function for backward compat).
+    /// Returns the default model's dims.
     pub fn dims() -> usize {
         MODEL_DIMS
     }
 
-    fn model_dir() -> Result<PathBuf, Error> {
-        crate::uteke_home().map(|p| p.join("models").join(MODEL_DIR_NAME))
+    fn model_dir_for(spec: &ModelSpec) -> Result<PathBuf, Error> {
+        crate::uteke_home().map(|p| p.join("models").join(spec.dir_name))
     }
+}
+
+/// Mean-pool a `last_hidden_state` tensor `(1, seq_len, hidden)` over tokens
+/// whose attention mask is non-zero. Returns a `hidden`-length vector.
+fn mean_pool(
+    shape: &[i64],
+    data: &[f32],
+    attention_mask: &[i64],
+    expected_dims: usize,
+) -> Result<Vec<f32>, Error> {
+    // shape = [batch=1, seq_len, hidden]
+    if shape.len() != 3 {
+        return Err(Error::embed_msg(format!(
+            "unexpected last_hidden_state rank {} (expected 3)",
+            shape.len()
+        )));
+    }
+    let seq_len = shape[1] as usize;
+    let hidden = shape[2] as usize;
+    if hidden != expected_dims {
+        return Err(Error::embed_msg(format!(
+            "model hidden size {hidden} != expected dims {expected_dims}"
+        )));
+    }
+    let mut acc = vec![0f32; hidden];
+    let mut count = 0f32;
+    for t in 0..seq_len {
+        let masked = attention_mask.get(t).copied().unwrap_or(1) != 0;
+        if !masked {
+            continue;
+        }
+        let base = t * hidden;
+        for h in 0..hidden {
+            acc[h] += data[base + h];
+        }
+        count += 1.0;
+    }
+    if count > 0.0 {
+        for v in acc.iter_mut() {
+            *v /= count;
+        }
+    }
+    Ok(acc)
 }
 
 impl Embedder for OnnxEmbedder {
@@ -192,15 +332,15 @@ impl Embedder for OnnxEmbedder {
     }
 
     fn dims(&self) -> usize {
-        MODEL_DIMS
+        self.spec.dims
     }
 
     fn max_seq_len(&self) -> usize {
-        MAX_SEQ_LEN
+        self.spec.max_seq_len
     }
 
     fn name(&self) -> &str {
-        "embeddinggemma-q4"
+        self.spec.dir_name
     }
 }
 
@@ -374,8 +514,18 @@ fn human_bytes(bytes: u64) -> String {
 }
 
 /// Verify SHA256 checksum of a downloaded model file.
+#[allow(dead_code)]
 fn verify_checksum(path: &std::path::Path, filename: &str) -> Result<(), Error> {
-    let expected = MODEL_CHECKSUMS
+    verify_checksum_with(path, filename, MODEL_CHECKSUMS)
+}
+
+/// Verify a downloaded file against a supplied checksum table.
+fn verify_checksum_with(
+    path: &std::path::Path,
+    filename: &str,
+    checksums: &[(&str, &str)],
+) -> Result<(), Error> {
+    let expected = checksums
         .iter()
         .find(|(name, _)| name == &filename)
         .map(|(_, hash)| *hash)
@@ -410,5 +560,53 @@ fn set_owner_only_permissions(path: &std::path::Path) {
         if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
             tracing::warn!("Failed to set permissions on {}: {e}", path.display());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_spec_for_resolves_voyage_and_default() {
+        assert_eq!(model_spec_for("voyage-4-nano").dir_name, "voyage-4-nano-q4");
+        assert_eq!(model_spec_for("voyage").dir_name, "voyage-4-nano-q4");
+        assert_eq!(model_spec_for("anything-else").dir_name, MODEL_DIR_NAME);
+        assert_eq!(model_spec_for("").dir_name, MODEL_DIR_NAME);
+    }
+
+    #[test]
+    fn voyage_spec_is_2048d_prepooled() {
+        assert_eq!(VOYAGE_4_NANO_Q4.dims, 2048);
+        assert_eq!(VOYAGE_4_NANO_Q4.pooling, Pooling::PrePooledOutput1);
+        assert_eq!(VOYAGE_4_NANO_Q4.max_seq_len, 32_000);
+    }
+
+    #[test]
+    fn mean_pool_averages_unmasked_tokens() {
+        // shape (1, 2, 2), tokens: [1,2] and [3,4], both unmasked -> mean [2,3]
+        let shape = [1i64, 2, 2];
+        let data = [1.0f32, 2.0, 3.0, 4.0];
+        let mask = [1i64, 1];
+        let out = mean_pool(&shape, &data, &mask, 2).unwrap();
+        assert_eq!(out, vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn mean_pool_skips_masked_tokens() {
+        // second token masked -> mean = first token [1,2]
+        let shape = [1i64, 2, 2];
+        let data = [1.0f32, 2.0, 100.0, 100.0];
+        let mask = [1i64, 0];
+        let out = mean_pool(&shape, &data, &mask, 2).unwrap();
+        assert_eq!(out, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn mean_pool_rejects_dim_mismatch() {
+        let shape = [1i64, 1, 3];
+        let data = [1.0f32, 2.0, 3.0];
+        let mask = [1i64];
+        assert!(mean_pool(&shape, &data, &mask, 2).is_err());
     }
 }

--- a/crates/uteke-core/src/embed/openai.rs
+++ b/crates/uteke-core/src/embed/openai.rs
@@ -95,11 +95,10 @@ impl OpenAiEmbedder {
     }
 }
 
-impl Embedder for OpenAiEmbedder {
-    fn embed(&self, text: &str) -> Result<Vec<f32>, Error> {
-        // OpenAI rejects empty input with 400; send a single space so the
-        // call is always valid (matches ONNX backend's non-empty contract).
-        let input = if text.is_empty() { " " } else { text };
+impl OpenAiEmbedder {
+    /// Single embedding request for pre-truncated `input`. The retry/shrink
+    /// loop lives in [`Embedder::embed`].
+    fn embed_once(&self, input: &str) -> Result<Vec<f32>, Error> {
         // Include `dimensions` when explicitly configured. This keeps the
         // API response size in sync with the configured index dims
         // (CodeCora finding #146) for models that support the field.
@@ -145,6 +144,58 @@ impl Embedder for OpenAiEmbedder {
             .map(|d| d.embedding)
             .ok_or_else(|| Error::generic("OpenAI response had no embedding data"))
     }
+}
+
+/// Conservative char budget for a given token limit. Code is denser than
+/// prose (short identifiers, punctuation), so we use ~3.5 chars/token and
+/// leave headroom below the hard limit.
+fn char_budget_for(max_tokens: usize) -> usize {
+    (max_tokens.saturating_mul(7) / 2).max(512)
+}
+
+/// Truncate on a UTF-8 char boundary to at most `max` chars.
+fn truncate_chars(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+impl Embedder for OpenAiEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, Error> {
+        // OpenAI rejects empty input with 400; send a single space so the
+        // call is always valid (matches ONNX backend's non-empty contract).
+        let base = if text.is_empty() { " " } else { text };
+
+        // Guard against the model's 8192-token context limit. We have no
+        // tokenizer here, so cap by chars with a conservative code-safe ratio
+        // (~3.5 chars/token; code is denser than prose) and, if the API still
+        // reports a context-length 400, halve and retry a few times. Long AST
+        // chunks (whole functions/files) otherwise fail outright — local
+        // backends tolerated them, OpenAI does not.
+        let mut budget = char_budget_for(MAX_SEQ_LEN);
+        let mut input = truncate_chars(base, budget);
+        loop {
+            match self.embed_once(input) {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    let msg = e.to_string();
+                    let is_ctx_len = msg.contains("maximum context length")
+                        || msg.contains("'input'");
+                    if is_ctx_len && budget > 512 {
+                        budget /= 2;
+                        input = truncate_chars(base, budget);
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
 
     fn dims(&self) -> usize {
         self.dims
@@ -172,6 +223,30 @@ struct EmbeddingData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_chars_respects_utf8_boundary() {
+        // Multi-byte chars must not be split mid-sequence.
+        let s = "aéééé"; // 'a' + 4x 2-byte chars
+        let t = truncate_chars(s, 4);
+        assert!(s.starts_with(t));
+        assert!(t.len() <= 4);
+        // Valid UTF-8 by construction (would panic otherwise).
+        assert!(t.chars().count() >= 1);
+    }
+
+    #[test]
+    fn truncate_chars_noop_when_short() {
+        assert_eq!(truncate_chars("hello", 100), "hello");
+    }
+
+    #[test]
+    fn char_budget_below_hard_limit_but_generous() {
+        let b = char_budget_for(MAX_SEQ_LEN);
+        assert!(b >= 512);
+        // ~3.5 chars/token → well above the token count, well within reason.
+        assert!(b > MAX_SEQ_LEN);
+    }
 
     #[test]
     fn rejects_empty_api_key() {

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -10,6 +10,10 @@
 //! ```
 
 pub mod chunker;
+#[cfg(feature = "treesitter")]
+pub mod chunker_ts;
+mod code_index;
+pub use code_index::{content_hash, IndexOutcome, IndexProgress, IndexSummary};
 mod consolidate;
 pub mod dream;
 mod edges;
@@ -50,8 +54,8 @@ pub use memory::types::{
 };
 pub use memory::{
     documents::{Document, DocumentChunk, DocumentSearchResult, DocumentSummary},
-    DocumentEntry, DocumentSection, Room, RoomDocument, RoomMemory, RoomStats, RoomSummary,
-    TimeRange, TopicCluster,
+    DocumentEntry, DocumentSection, IndexedFile, Room, RoomDocument, RoomMemory, RoomStats,
+    RoomSummary, TimeRange, TopicCluster,
 };
 pub use orphans::{compute_orphan_score, OrphanMemory, DEFAULT_ORPHAN_THRESHOLD};
 pub use salience_recency::{
@@ -478,9 +482,14 @@ impl Uteke {
                         cfg.dims
                     }
                 }
+                #[cfg(feature = "onnx")]
+                "voyage" => {
+                    // Local voyage-4-nano ONNX: dims fixed by the model spec.
+                    crate::embed::engine::VOYAGE_4_NANO_Q4.dims
+                }
                 other => {
                     return Err(Error::Validation(format!(
-                        "Unknown embedding backend: '{other}'. Supported: onnx, openai, ollama."
+                        "Unknown embedding backend: '{other}'. Supported: onnx, openai, ollama, voyage."
                     )));
                 }
             },
@@ -633,9 +642,16 @@ impl Uteke {
                     };
                     Box::new(crate::embed::OllamaEmbedder::new(&base_url, &model, dims)?)
                 }
+                #[cfg(feature = "onnx")]
+                "voyage" => {
+                    // Local, open-weight voyage-4-nano via ONNX (offline).
+                    Box::new(crate::embed::OnnxEmbedder::with_spec(
+                        crate::embed::engine::VOYAGE_4_NANO_Q4,
+                    )?)
+                }
                 other => {
                     return Err(Error::Validation(format!(
-                        "Unknown embedding backend: '{other}'. Supported: onnx, openai, ollama."
+                        "Unknown embedding backend: '{other}'. Supported: onnx, openai, ollama, voyage."
                     )));
                 }
             };

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -158,6 +158,33 @@ impl super::Store {
         Ok(deleted > 0)
     }
 
+    /// Return IDs of code-index memories whose `metadata.file` equals `file`
+    /// within a namespace. Used by the code indexer to replace/prune the
+    /// chunks that belong to a given source file.
+    pub fn memory_ids_by_indexed_file(
+        &self,
+        namespace: &str,
+        file: &str,
+    ) -> Result<Vec<String>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id FROM memories \
+                 WHERE namespace = ?1 \
+                   AND json_extract(metadata, '$.source_type') = 'code' \
+                   AND json_extract(metadata, '$.file') = ?2",
+            )
+            .map_err(|e| Error::db("prepare memory_ids_by_indexed_file", e))?;
+        let rows = stmt
+            .query_map(params![namespace, file], |row| row.get::<_, String>(0))
+            .map_err(|e| Error::db("query memory_ids_by_indexed_file", e))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| Error::db("read indexed memory id", e))?);
+        }
+        Ok(out)
+    }
+
     /// Update an existing memory.
     ///
     /// Note: Only updates content, embedding, tags, metadata, updated_at, and namespace.
@@ -812,6 +839,6 @@ mod content_type_tests {
         let store = super::super::store::Store::open(":memory:").unwrap();
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
-        assert_eq!(version, 15); // v15 = room_documents junction (#689); v14 = FTS5 memory_type column (#662); v13 = global docs no namespace (#614); v12 = hierarchical docs (#438); v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
+        assert_eq!(version, 16); // v16 = indexed_files (code indexer); v15 = room_documents junction (#689); v14 = FTS5 memory_type column (#662); v13 = global docs no namespace (#614); v12 = hierarchical docs (#438); v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
     }
 }

--- a/crates/uteke-core/src/memory/indexed_files.rs
+++ b/crates/uteke-core/src/memory/indexed_files.rs
@@ -1,0 +1,191 @@
+//! Indexed-file tracking for the code indexer (DB-per-repo).
+//!
+//! The `indexed_files` table records the content hash and mtime of each
+//! source file that `uteke index` has processed, keyed by `(namespace, path)`.
+//! This lets re-index runs:
+//!   - skip files whose content hash is unchanged (no re-embed), and
+//!   - prune memories for files that no longer exist on disk.
+
+use crate::Error;
+use rusqlite::{params, OptionalExtension};
+
+/// A tracked source file record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedFile {
+    /// Repo-relative path (forward-slash normalized).
+    pub path: String,
+    /// Content hash (hex) at the time of indexing.
+    pub content_hash: String,
+    /// File mtime (unix seconds) at the time of indexing.
+    pub mtime: i64,
+    /// Number of chunks/memories produced from this file.
+    pub chunk_count: i64,
+}
+
+impl super::Store {
+    /// Look up the recorded content hash for a file in a namespace.
+    /// Returns `None` if the file has never been indexed.
+    pub fn indexed_file_hash(
+        &self,
+        namespace: &str,
+        path: &str,
+    ) -> Result<Option<String>, Error> {
+        self.conn
+            .query_row(
+                "SELECT content_hash FROM indexed_files WHERE namespace = ?1 AND path = ?2",
+                params![namespace, path],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("query indexed_file hash", e))
+    }
+
+    /// Upsert a file's index record.
+    pub fn upsert_indexed_file(
+        &self,
+        namespace: &str,
+        file: &IndexedFile,
+    ) -> Result<(), Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "INSERT INTO indexed_files (namespace, path, content_hash, mtime, chunk_count, indexed_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT(namespace, path) DO UPDATE SET \
+                     content_hash = excluded.content_hash, \
+                     mtime        = excluded.mtime, \
+                     chunk_count  = excluded.chunk_count, \
+                     indexed_at   = excluded.indexed_at",
+                params![
+                    namespace,
+                    file.path,
+                    file.content_hash,
+                    file.mtime,
+                    file.chunk_count,
+                    now
+                ],
+            )
+            .map_err(|e| Error::db("upsert indexed_file", e))?;
+        Ok(())
+    }
+
+    /// Return every tracked file path for a namespace.
+    pub fn list_indexed_files(&self, namespace: &str) -> Result<Vec<IndexedFile>, Error> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT path, content_hash, mtime, chunk_count \
+                 FROM indexed_files WHERE namespace = ?1 ORDER BY path",
+            )
+            .map_err(|e| Error::db("prepare list_indexed_files", e))?;
+        let rows = stmt
+            .query_map(params![namespace], |row| {
+                Ok(IndexedFile {
+                    path: row.get(0)?,
+                    content_hash: row.get(1)?,
+                    mtime: row.get(2)?,
+                    chunk_count: row.get(3)?,
+                })
+            })
+            .map_err(|e| Error::db("query list_indexed_files", e))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| Error::db("read indexed_file row", e))?);
+        }
+        Ok(out)
+    }
+
+    /// Delete a file's index record (used when a file is removed from disk).
+    pub fn delete_indexed_file(&self, namespace: &str, path: &str) -> Result<(), Error> {
+        self.conn
+            .execute(
+                "DELETE FROM indexed_files WHERE namespace = ?1 AND path = ?2",
+                params![namespace, path],
+            )
+            .map_err(|e| Error::db("delete indexed_file", e))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::store::Store;
+
+    fn mem_store() -> Store {
+        Store::open(":memory:").unwrap()
+    }
+
+    #[test]
+    fn upsert_and_lookup_hash() {
+        let store = mem_store();
+        assert_eq!(store.indexed_file_hash("default", "src/a.rs").unwrap(), None);
+
+        let f = IndexedFile {
+            path: "src/a.rs".to_string(),
+            content_hash: "abc123".to_string(),
+            mtime: 42,
+            chunk_count: 3,
+        };
+        store.upsert_indexed_file("default", &f).unwrap();
+        assert_eq!(
+            store.indexed_file_hash("default", "src/a.rs").unwrap(),
+            Some("abc123".to_string())
+        );
+
+        // Upsert with new hash overwrites.
+        let f2 = IndexedFile {
+            content_hash: "def456".to_string(),
+            ..f.clone()
+        };
+        store.upsert_indexed_file("default", &f2).unwrap();
+        assert_eq!(
+            store.indexed_file_hash("default", "src/a.rs").unwrap(),
+            Some("def456".to_string())
+        );
+    }
+
+    #[test]
+    fn list_and_delete() {
+        let store = mem_store();
+        for p in ["src/a.rs", "src/b.rs"] {
+            store
+                .upsert_indexed_file(
+                    "default",
+                    &IndexedFile {
+                        path: p.to_string(),
+                        content_hash: "h".to_string(),
+                        mtime: 0,
+                        chunk_count: 1,
+                    },
+                )
+                .unwrap();
+        }
+        let listed = store.list_indexed_files("default").unwrap();
+        assert_eq!(listed.len(), 2);
+
+        store.delete_indexed_file("default", "src/a.rs").unwrap();
+        let listed = store.list_indexed_files("default").unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].path, "src/b.rs");
+    }
+
+    #[test]
+    fn namespace_isolation() {
+        let store = mem_store();
+        store
+            .upsert_indexed_file(
+                "repo-a",
+                &IndexedFile {
+                    path: "x.rs".to_string(),
+                    content_hash: "1".to_string(),
+                    mtime: 0,
+                    chunk_count: 1,
+                },
+            )
+            .unwrap();
+        assert_eq!(store.indexed_file_hash("repo-b", "x.rs").unwrap(), None);
+        assert_eq!(store.list_indexed_files("repo-b").unwrap().len(), 0);
+        assert_eq!(store.list_indexed_files("repo-a").unwrap().len(), 1);
+    }
+}

--- a/crates/uteke-core/src/memory/mod.rs
+++ b/crates/uteke-core/src/memory/mod.rs
@@ -5,6 +5,7 @@ pub mod bulk;
 pub mod crud;
 pub mod documents;
 pub mod fts5;
+pub mod indexed_files;
 pub mod rooms;
 pub mod schema;
 pub mod store;
@@ -16,6 +17,7 @@ pub use rooms::{
     DocumentEntry, DocumentSection, Room, RoomDocument, RoomMemory, RoomStats, RoomSummary,
     TimeRange, TopicCluster,
 };
+pub use indexed_files::IndexedFile;
 pub use store::Store;
 pub use types::{
     Memory, RecallStrategy, SearchResult, SearchResultType, SearchType, StoreStats,

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -374,6 +374,8 @@ impl super::Store {
                 14 => self.migrate_v13_to_v14()?,
                 // v15: room_documents junction table (#689)
                 15 => self.migrate_v14_to_v15()?,
+                // v16: indexed_files table (code indexer, DB-per-repo)
+                16 => self.migrate_v15_to_v16()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -992,6 +994,33 @@ impl super::Store {
             .map_err(|e| Error::db("create room_documents table", e))?;
 
         tracing::info!("Migration v14 to v15 complete: room_documents table created");
+        Ok(())
+    }
+
+    /// v16: indexed_files table for the code indexer (DB-per-repo).
+    ///
+    /// Tracks content hash + mtime per source file so `uteke index` can skip
+    /// unchanged files and prune memories for deleted files. Table is also in
+    /// the SCHEMA constant for fresh stores; this migration upgrades existing
+    /// v15 stores. No backfill — tracking starts from first index run.
+    fn migrate_v15_to_v16(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v15 to v16: indexed_files table");
+        self.conn
+            .execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS indexed_files (
+                    namespace    TEXT NOT NULL DEFAULT 'default',
+                    path         TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    mtime        INTEGER NOT NULL DEFAULT 0,
+                    chunk_count  INTEGER NOT NULL DEFAULT 0,
+                    indexed_at   TEXT NOT NULL,
+                    PRIMARY KEY (namespace, path)
+                );
+                CREATE INDEX IF NOT EXISTS idx_indexed_files_ns ON indexed_files(namespace);
+                "#,
+            )
+            .map_err(|e| Error::db("schema migration v15 to v16", e))?;
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -161,6 +161,20 @@ CREATE TABLE IF NOT EXISTS room_documents (
 );
 CREATE INDEX IF NOT EXISTS idx_room_documents_room ON room_documents(room_id);
 CREATE INDEX IF NOT EXISTS idx_room_documents_slug ON room_documents(doc_slug);
+
+-- v16: Code indexer file tracking (DB-per-repo). Records the content hash and
+-- mtime of each indexed source file so re-index can skip unchanged files and
+-- prune memories for files that were deleted. Keyed by (namespace, path).
+CREATE TABLE IF NOT EXISTS indexed_files (
+    namespace   TEXT NOT NULL DEFAULT 'default',
+    path        TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    mtime       INTEGER NOT NULL DEFAULT 0,
+    chunk_count INTEGER NOT NULL DEFAULT 0,
+    indexed_at  TEXT NOT NULL,
+    PRIMARY KEY (namespace, path)
+);
+CREATE INDEX IF NOT EXISTS idx_indexed_files_ns ON indexed_files(namespace);
 "#;
 
 /// Indexes that depend on migration-added columns.
@@ -173,7 +187,7 @@ pub(super) const SCHEMA_INDEXES: &[&str] = &[
 ];
 
 /// Current schema version. Increment when adding migrations.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 15;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 16;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -1788,7 +1802,7 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(version, 15, "schema_version should be 15 after migration");
+        assert_eq!(version, 16, "schema_version should be 16 after migration");
 
         // 7. Verify hierarchy columns now exist (in documents table).
         let cols = ["parent_id", "path", "depth", "sort_order", "has_children"];

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -296,7 +296,7 @@ mod tests {
     fn migration_dispatcher_reaches_v9() {
         let store = Store::open(":memory:").unwrap();
         let v = store.schema_version().unwrap();
-        assert_eq!(v, 15, "fresh store must reach CURRENT_SCHEMA_VERSION=15");
+        assert_eq!(v, 16, "fresh store must reach CURRENT_SCHEMA_VERSION=16");
         // timeline_events table must exist.
         let m = mem();
         store.insert(&m).unwrap();

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.9.0", features = ["onnx", "treesitter"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -170,6 +170,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_tags_delete(),
                 tool_pin(),
                 tool_unpin(),
+                tool_index(),
+                tool_index_status(),
             ]
         })),
 
@@ -213,6 +215,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_tags_delete" => exec_tags_delete(uteke, &arguments)?,
                 "uteke_pin" => exec_pin(uteke, &arguments)?,
                 "uteke_unpin" => exec_unpin(uteke, &arguments)?,
+                "uteke_index" => exec_index(uteke, &arguments)?,
+                "uteke_index_status" => exec_index_status(uteke, &arguments)?,
                 _ => return Err(format!("Unknown tool: {tool_name}")),
             };
 
@@ -660,6 +664,35 @@ fn tool_unpin() -> Value {
                 "id": { "type": "string", "description": "The memory ID (UUID)" }
             },
             "required": ["id"]
+        }
+    })
+}
+
+fn tool_index() -> Value {
+    serde_json::json!({
+        "name": "uteke_index",
+        "description": "Index source code in a directory into recallable memories. Walks the tree (skipping VCS/build dirs), chunks each file by symbol (function/struct/class), and stores chunks with file:line metadata. Incremental: unchanged files (by content hash) are skipped; deleted files are pruned. Recall the results with uteke_recall — code results carry file, line_start, line_end, symbol_name, and symbol_type in metadata.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Directory or file to index. Defaults to the current working directory." },
+                "namespace": { "type": "string", "description": "Namespace to index into (default: 'default')" },
+                "force": { "type": "boolean", "description": "Re-index all files even if unchanged (default: false)" },
+                "dry_run": { "type": "boolean", "description": "Report what would be indexed without writing (default: false)" }
+            }
+        }
+    })
+}
+
+fn tool_index_status() -> Value {
+    serde_json::json!({
+        "name": "uteke_index_status",
+        "description": "Report the code index status for a namespace: number of tracked source files and total indexed chunks.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "namespace": { "type": "string", "description": "Namespace to report (default: 'default')" }
+            }
         }
     })
 }
@@ -1738,4 +1771,57 @@ fn exec_unpin(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         }),
         Err(e) => Err(format!("Failed: {e}")),
     }
+}
+
+fn exec_index(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let ns = args["namespace"].as_str().unwrap_or("default");
+    let force = args["force"].as_bool().unwrap_or(false);
+    let dry_run = args["dry_run"].as_bool().unwrap_or(false);
+
+    let root = match args["path"].as_str() {
+        Some(p) => std::path::PathBuf::from(p),
+        None => std::env::current_dir().map_err(|e| format!("cannot resolve cwd: {e}"))?,
+    };
+    if !root.exists() {
+        return Err(format!("Path does not exist: {}", root.display()));
+    }
+
+    let s = uteke
+        .index_tree(ns, &root, force, dry_run)
+        .map_err(|e| format!("index failed: {e}"))?;
+
+    let text = if dry_run {
+        format!(
+            "Dry run: would index {} file(s) under {} (namespace: {ns})",
+            s.indexed,
+            root.display()
+        )
+    } else {
+        format!(
+            "Indexed {} file(s), {} chunk(s); {} unchanged; {} pruned (namespace: {ns})",
+            s.indexed, s.chunks, s.skipped, s.pruned
+        )
+    };
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_index_status(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let ns = args["namespace"].as_str().unwrap_or("default");
+    let (files, chunks) = uteke
+        .code_index_status(ns)
+        .map_err(|e| format!("Failed: {e}"))?;
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("Code index (namespace {ns}): {files} file(s), {chunks} chunk(s)"),
+        }],
+        is_error: false,
+    })
 }

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -27,10 +27,11 @@ fn main() {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
 
-    // Open uteke store
-    let store_path = dirs::home_dir()
-        .map(|h| h.join(".uteke"))
-        .expect("Cannot determine home directory");
+    // Open uteke store. Prefer a repo-local store when the MCP server is
+    // launched inside a project that ran `uteke init --project`: walk up from
+    // cwd for `.uteke/uteke.toml` and use that repo-local `.uteke` directory.
+    // Otherwise fall back to the global `~/.uteke` store.
+    let store_path = resolve_store_path();
 
     let uteke = match Uteke::open(&store_path) {
         Ok(u) => u,
@@ -61,4 +62,31 @@ fn main() {
             let _ = stdout.flush();
         }
     }
+}
+
+/// Resolve the store directory for the MCP server.
+///
+/// Walks up from the current directory looking for a repo-local
+/// `.uteke/uteke.toml` (written by `uteke init --project`). When found, the
+/// repo-local `.uteke` directory is used so the MCP server shares the same
+/// per-project code index the CLI writes. Falls back to the global
+/// `~/.uteke` store otherwise. `UTEKE_HOME` still overrides via `Uteke::open`.
+fn resolve_store_path() -> std::path::PathBuf {
+    if std::env::var_os("UTEKE_HOME").is_none() {
+        if let Ok(cwd) = std::env::current_dir() {
+            let mut dir: Option<&std::path::Path> = Some(cwd.as_path());
+            while let Some(d) = dir {
+                if d.join(".uteke").join("uteke.toml").is_file() {
+                    return d.join(".uteke");
+                }
+                if d.join(".git").exists() {
+                    break; // repo root without a project store -> use global
+                }
+                dir = d.parent();
+            }
+        }
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".uteke"))
+        .expect("Cannot determine home directory")
 }


### PR DESCRIPTION
Closes codecoradev/uteke#758

Implements both asks from #758: **(1)** an optional large-context local model, and **(2)** a project-scoped "walking mode" that lets a coding agent navigate a codebase file-to-file with precise `file:line` provenance instead of fragmented summaries.

---

## Before → After

| Dimension | Before (`develop`) | After (this PR) |
|---|---|---|
| **Embedding model** | EmbeddingGemma-300M only (768d, ~2k ctx) | EmbeddingGemma **or** Voyage-4-Nano (2048d, **32k ctx**) — local ONNX, selectable in config |
| **Store scoping** | Single global store (`~/.uteke`) | **DB-per-repo**: project `.uteke/` auto-scoped by cwd; global store still used outside repos |
| **Code awareness** | Prose/markdown memories only | **Code indexing**: source tree → chunked memories with `file:line`, incremental via content hash |
| **Chunking** | Regex heuristics | **tree-sitter AST** (rust/go/py/ts/js/java/c/cpp) with regex fallback |
| **Recall on code** | Summary fragments, no location | Exact symbol + `file:line`, jump-to-definition ready |
| **Onboarding** | General memory only | Coding-vs-general **usage-mode** prompt; coding defaults to Voyage + per-project store |
| **Visibility** | CLI text only | **`uteke ui`**: single-binary local web UI — live chunking feed + zero-dep **WebGL 3D** code graph |
| **Config** | Global file | **Layered**: CLI args > project `.uteke/uteke.toml` > global > defaults |
| **MCP** | memory tools | + `uteke_index` / `uteke_index_status` for agents |
| **Agent flow** | recall summaries | walk file-to-file, build a persistent project "mental map" |

### Recall, before vs after (same repo)
**Before** — no code in the store; a query like *"how does treesitter AST chunking work"* returns nothing actionable.
**After** — top hits are the exact functions, correctly ranked, each with `file:line`:
```
1. (1.000) function collect_chunk   [crates/uteke-core/src/chunker_ts.rs:182-219]
2. (0.984) function chunk_code_ts   [crates/uteke-core/src/chunker_ts.rs:156-176]
3. (0.968) function chunk_code      [crates/uteke-core/src/chunker.rs:303-316]
```

---

## What's in it

**Embedding (`#758` part 1)**
- Multi-model ONNX engine; Voyage-4-Nano (qwen3, q4, dim 2048, pre-pooled) as a local, offline alternative to Gemma — no cloud API.
- Hardened the OpenAI embedder against the 8192-token limit (char budget + shrink-and-retry).

**Walking mode (`#758` part 2)**
- `code_index` engine: walks a tree, chunks each file, stores chunks as recallable memories with `file:line`.
- tree-sitter AST grammars with regex fallback; `unsafe` stays isolated in grammar crates (`unsafe_code = "forbid"` in consumer code).
- Incremental: `indexed_files` table + content hashing; only changed files re-embed; deleted files pruned.
- DB-per-repo isolation via layered config, auto-scoped by cwd.

**Surface area**
- CLI: `uteke init --project`, streaming `uteke index [PATH]`, `uteke index --status`, coding-vs-general onboarding.
- `uteke ui`: single Rust binary, embedded HTML, zero npm/offline; live `IndexProgress` feed + WebGL 3D force-directed graph (orbit/zoom/pan, depth-shaded glow nodes, hover to `file:line`).
- MCP: `uteke_index`, `uteke_index_status`.

## Verification
- Build green with `--features treesitter`.
- Tests: **uteke-core 394** (treesitter), **uteke-cli 55** — all passing.
- End-to-end recall verified on this repo (see table above).

## Notes for reviewers
- Schema migration **v15 -> v16** adds `indexed_files` (idempotent, existing DBs auto-migrate).
- Per-repo store DB/index artifacts are gitignored; the small `.uteke/uteke.toml` project config is intended to travel with the repo.
- Voyage scores compress into ~0.96-1.0 (qwen3 anisotropy) — ranking is correct, but absolute scores aren't a usable threshold. Per-backend dedup tuning is a sensible follow-up.
- Both features are additive; default behavior (Gemma, global store, prose memories) is unchanged unless coding mode is selected.
