### PR TITLE
fix: expose room_remember via HTTP + forget returns 404

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -435,6 +435,11 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 if uuid::Uuid::parse_str(id).is_err() {
                     return ctx.error_response_for(req, 400, format!("Invalid UUID format: {id}"));
                 }
+                // Check existence before deleting (#762) — forget() silently
+                // returns Ok(()) even when the ID doesn't exist.
+                if uteke.get_by_id(id).ok().flatten().is_none() {
+                    return ctx.error_response_for(req, 404, format!("Memory not found: {id}"));
+                }
                 match uteke.forget(id) {
                     Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"forgotten": id})),
                     Err(e) => {
@@ -1015,6 +1020,42 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         Err(e) => {
                             let msg = format!("Failed to create room: {e}");
                             ctx.error_response_for(req, 400, &msg)
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
+        // POST /room/remember — store memory and link to room (#762)
+        (Method::Post, "/room/remember") => {
+            match read_body::<RoomRememberRequest>(req.as_reader()) {
+                Ok(req_data) => {
+                    if let Err(e) = uteke_core::validate_input(&req_data.content, &req_data.tags) {
+                        return ctx.error_response_for(req, 400, e.to_string());
+                    }
+                    let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
+                    let memory_type = req_data.r#type.as_deref().unwrap_or("fact");
+                    let author = req_data.author.as_deref().unwrap_or("user");
+                    match uteke.remember_in_room(
+                        &req_data.content,
+                        &tag_refs,
+                        req_data.metadata.clone(),
+                        ns(&req_data.namespace),
+                        memory_type,
+                        &req_data.room_id,
+                        author,
+                    ) {
+                        Ok(id) => ctx.ok_response_for(
+                            req,
+                            &serde_json::json!({
+                                "id": id,
+                                "room_id": req_data.room_id,
+                            }),
+                        ),
+                        Err(e) => {
+                            error!("room/remember error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
                         }
                     }
                 }

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -516,6 +516,25 @@ pub struct ImportRequest {
     pub tags: Vec<String>,
 }
 
+// ── Room Remember Types (#762) ────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RoomRememberRequest {
+    pub room_id: String,
+    pub content: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+    /// Author — stored as participant role in room link.
+    #[serde(default)]
+    pub author: Option<String>,
+}
+
 // ── Maintenance Types (#607) ──────────────────────────────────────────────
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Closes #762

## Summary

Two code-level bugs fixed:

### Bug A: `POST /room/remember` endpoint missing
`remember_in_room()` existed in `uteke-core` but was never exposed via HTTP. Users had no way to store a memory AND link it to a room in a single API call.

**Fix:** Added `POST /room/remember` endpoint that accepts `room_id`, `content`, `tags`, `namespace`, `type`, `metadata`, and `author`.

### Bug B: `DELETE /forget` returned 200 for non-existent IDs
`forget()` in uteke-core silently returns `Ok(())` even when the memory doesn't exist. The HTTP handler propagated this as a 200 success.

**Fix:** Check memory existence before calling `forget()`. Return 404 if not found.

### Tags investigation
The tags field handling in the code path (`handler → validate_input → remember → remember_auto_infer → remember_embed → crud::insert`) is correct. The production 500 observed during testing appears to be an infrastructure/embedder issue, not a code bug.

## Test plan
- [ ] `POST /room/remember` creates memory and links to room
- [ ] `DELETE /forget?id=<non-existent-uuid>` returns 404
- [ ] `DELETE /forget?id=<valid-uuid>` returns 200 with `{"forgotten": id}`