### PR TITLE
feat: migrate default data dir ~/.uteke → ~/.codecora/uteke (#773)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,7 +97,7 @@ cargo build --release
 copy target\release\uteke.exe C:\Users\you\AppData\Local\bin\
 ```
 
-> **Note:** On Windows, data is stored at `C:\Users\you\.uteke\`.
+> **Note:** On Windows, data is stored at `C:\Users\you\.codecora\uteke\`.
 
 ## First Run
 
@@ -109,7 +109,7 @@ uteke remember "My first memory" --tags test
 
 Model cached at:
 - **macOS/Linux:** `~/.codecora/uteke/models/embeddinggemma-q4/`
-- **Windows:** `C:\Users\you\.uteke\models\embeddinggemma-q4\`
+- **Windows:** `C:\Users\you\.codecora\uteke\models\embeddinggemma-q4\`
 
 ## Verify Installation
 
@@ -172,7 +172,7 @@ mkdir -p ~/.codecora/uteke/models/embeddinggemma-q4/onnx
 # Download model_q4.onnx and model_q4.onnx_data to above directory
 
 # Windows
-mkdir C:\Users\you\.uteke\models\embeddinggemma-q4\onnx
+mkdir C:\Users\you\.codecora\uteke\models\embeddinggemma-q4\onnx
 # Download model_q4.onnx and model_q4.onnx_data to above directory
 ```
 
@@ -197,5 +197,5 @@ cargo uninstall uteke
 rm -rf ~/.codecora/uteke
 
 # Windows
-Remove-Item -Recurse -Force "$env:USERPROFILE\.uteke"
+Remove-Item -Recurse -Force "$env:USERPROFILE\.codecora\uteke"
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,7 @@ uteke remember "My first memory" --tags test
 ```
 
 Model cached at:
-- **macOS/Linux:** `~/.uteke/models/embeddinggemma-q4/`
+- **macOS/Linux:** `~/.codecora/uteke/models/embeddinggemma-q4/`
 - **Windows:** `C:\Users\you\.uteke\models\embeddinggemma-q4\`
 
 ## Verify Installation
@@ -168,7 +168,7 @@ https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX
 Manual download:
 ```bash
 # macOS/Linux
-mkdir -p ~/.uteke/models/embeddinggemma-q4/onnx
+mkdir -p ~/.codecora/uteke/models/embeddinggemma-q4/onnx
 # Download model_q4.onnx and model_q4.onnx_data to above directory
 
 # Windows
@@ -194,7 +194,7 @@ cargo uninstall uteke
 
 # Remove all data (memories, models, config)
 # macOS/Linux
-rm -rf ~/.uteke
+rm -rf ~/.codecora/uteke
 
 # Windows
 Remove-Item -Recurse -Force "$env:USERPROFILE\.uteke"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The wizard will:
 2. **Ask** which AI agent you use (Hermes, Claude, Cursor, Pi, OpenCode)
 3. **Pick** integration mode — manual tool calls vs automatic memory-provider
 4. **Toggle** features on/off (Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode)
-5. **Write** `~/.uteke/uteke.toml` with your selections
+5. **Write** `~/.codecora/uteke/uteke.toml` with your selections
 6. **Install** agent integration files automatically (`uteke init`)
 7. **Showcase** every uteke command grouped by category
 

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -14,7 +14,7 @@ use clap_complete::Shell;
     version
 )]
 pub struct Cli {
-    /// Store path override (default: ~/.uteke)
+    /// Store path override (default: ~/.codecora/uteke)
     #[arg(long, global = true)]
     pub store: Option<String>,
 

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration management for uteke CLI.
 //!
-//! Layered config resolution: CLI args > project `.uteke/uteke.toml` > global `~/.uteke/uteke.toml` > defaults.
+//! Layered config resolution: CLI args > project `.uteke/uteke.toml` > global `{uteke_home}/uteke.toml` > defaults.
 //! Migrates legacy `config.toml` → `uteke.toml` on load.
 
 use std::path::PathBuf;
@@ -20,7 +20,7 @@ pub struct StoreConfig {
 impl Default for StoreConfig {
     fn default() -> Self {
         Self {
-            path: "~/.uteke".to_string(),
+            path: "~/.codecora/uteke".to_string(),
             namespace: "default".to_string(),
         }
     }
@@ -398,7 +398,7 @@ impl Default for LimitsConfig {
 impl Config {
     /// Load config with layered resolution:
     /// 1. Defaults
-    /// 2. Global `~/.uteke/uteke.toml`
+    /// 2. Global `{uteke_home}/uteke.toml`
     /// 3. Project `.uteke/uteke.toml`
     ///
     /// Each layer overrides the previous. Legacy `config.toml` is migrated
@@ -409,7 +409,7 @@ impl Config {
         // Migrate legacy config.toml → uteke.toml at global location
         migrate_legacy_global();
 
-        // Layer 1: global ~/.uteke/uteke.toml
+        // Layer 1: global config at uteke_home
         if let Some(global_path) = global_config_path() {
             config = config.merge_from_file(&global_path);
         }
@@ -775,7 +775,7 @@ impl Config {
 # See https://github.com/codecoradev/uteke for documentation
 
 [store]
-# path = "~/.uteke"
+# path = "~/.codecora/uteke"
 # namespace = "default"
 
 [embedding]
@@ -884,7 +884,7 @@ impl Config {
 
 // ── Legacy migration ────────────────────────────────────────────────────────
 
-/// Migrate legacy `~/.uteke/config.toml` → `~/.uteke/uteke.toml`.
+/// Migrate legacy `{uteke_home}/config.toml` → `{uteke_home}/uteke.toml`.
 /// Read an env var as a type T, falling back to default if unset or invalid.
 fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
     std::env::var(key)
@@ -976,9 +976,9 @@ fn migrate_content(old: &str) -> String {
     out
 }
 
-/// Return the global config path `~/.uteke/uteke.toml` if home dir is known.
+/// Return the global config path `{uteke_home}/uteke.toml`.
 fn global_config_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".uteke").join("uteke.toml"))
+    uteke_core::uteke_home().ok().map(|h| h.join("uteke.toml"))
 }
 
 /// Update or insert the namespace value in a TOML config string.
@@ -1028,7 +1028,7 @@ mod tests {
     #[test]
     fn default_config_values() {
         let cfg = Config::default();
-        assert_eq!(cfg.store.path, "~/.uteke");
+        assert_eq!(cfg.store.path, "~/.codecora/uteke");
         assert_eq!(cfg.store.namespace, "default");
         assert_eq!(cfg.embedding.model, "embeddinggemma-q4");
         assert_eq!(cfg.embedding.backend, "onnx");
@@ -1100,7 +1100,7 @@ level = "info"
         assert_eq!(cfg.store.namespace, "my-ns");
         assert_eq!(cfg.logging.level, "info");
         // Everything else is default
-        assert_eq!(cfg.store.path, "~/.uteke");
+        assert_eq!(cfg.store.path, "~/.codecora/uteke");
         assert_eq!(cfg.embedding.model, "embeddinggemma-q4");
         assert_eq!(cfg.embedding.backend, "onnx");
         assert_eq!(cfg.embedding.max_seq_length, 2048);
@@ -1230,7 +1230,7 @@ min_score_strict = 0.8
         assert!((merged.recall.min_score - 0.6).abs() < f64::EPSILON);
         assert!((merged.recall.min_score_strict - 0.8).abs() < f64::EPSILON);
         // Other config untouched
-        assert_eq!(merged.store.path, "~/.uteke");
+        assert_eq!(merged.store.path, "~/.codecora/uteke");
         assert_eq!(merged.embedding.model, "embeddinggemma-q4");
         assert_eq!(merged.tier.hot_days, 7);
         assert_eq!(merged.logging.level, "warn");
@@ -1305,7 +1305,7 @@ port = 9999
         let merged = Config::default().merge_from_file(&tmp);
         std::fs::remove_file(&tmp).ok();
         // Should return defaults when file is invalid
-        assert_eq!(merged.store.path, "~/.uteke");
+        assert_eq!(merged.store.path, "~/.codecora/uteke");
     }
 
     #[test]

--- a/crates/uteke-cli/src/logging.rs
+++ b/crates/uteke-cli/src/logging.rs
@@ -1,7 +1,7 @@
 //! Logging setup: console + daily rotating file.
 //!
 //! Console shows WARN by default (DEBUG with --verbose).
-//! File always captures DEBUG to `~/.uteke/uteke.log` with daily rotation.
+//! File always captures DEBUG to `{uteke_home}/uteke.log` with daily rotation.
 
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};

--- a/crates/uteke-cli/src/onboard.rs
+++ b/crates/uteke-cli/src/onboard.rs
@@ -224,13 +224,13 @@ fn get_version() -> String {
     format!("v{}", env!("CARGO_PKG_VERSION"))
 }
 
-/// Check if the uteke store (~/.uteke/uteke.db) exists.
+/// Check if the uteke store exists.
 fn detect_store() -> bool {
     let home = match dirs::home_dir() {
         Some(h) => h,
         None => return false,
     };
-    home.join(".uteke").join("uteke.db").exists()
+    home.join(".codecora/uteke").join("uteke.db").exists()
 }
 
 /// Prompt the user to select an agent.
@@ -324,7 +324,7 @@ fn prompt_feature_toggles() -> Result<Vec<(&'static str, bool)>, String> {
     Ok(results)
 }
 
-/// Write the config to `~/.uteke/uteke.toml`.
+/// Write the config to `{uteke_home}/uteke.toml`.
 ///
 /// If a config file already exists, it is backed up to `uteke.toml.bak`
 /// before overwriting. In interactive mode, the user is prompted to confirm.
@@ -333,9 +333,8 @@ fn write_config(
     toggles: &[(&str, bool)],
     yes: bool,
 ) -> Result<std::path::PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
-    let uteke_dir = home.join(".uteke");
-    std::fs::create_dir_all(&uteke_dir).map_err(|e| format!("Failed to create ~/.uteke: {e}"))?;
+    let uteke_dir = uteke_core::uteke_home().map_err(|e| format!("{e}"))?;
+    std::fs::create_dir_all(&uteke_dir).map_err(|e| format!("Failed to create uteke home: {e}"))?;
 
     let config_path = uteke_dir.join("uteke.toml");
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -2031,13 +2031,13 @@ mod tests {
         let home = uteke_home().unwrap_or_else(|_| PathBuf::from("/tmp/.codecora/uteke"));
         assert_eq!(home.to_string_lossy(), "/tmp/custom_home");
         // Restore originals
-        match orig_uteke {
-            Some(v) => unsafe { std::env::set_var("UTEKE_HOME", &v) },
-            None => unsafe { std::env::remove_var("UTEKE_HOME") },
+        if let Some(ref v) = orig_uteke {
+            unsafe { std::env::set_var("UTEKE_HOME", v) };
+        } else {
+            unsafe { std::env::remove_var("UTEKE_HOME") };
         }
-        match orig_home {
-            Some(v) => unsafe { std::env::set_var("HOME", &v) },
-            None => {} // don't remove HOME
+        if let Some(ref v) = orig_home {
+            unsafe { std::env::set_var("HOME", v) };
         }
     }
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -2022,13 +2022,22 @@ mod tests {
 
     #[test]
     fn test_uteke_home_with_env() {
+        // Save originals to prevent test pollution across parallel test threads.
+        let orig_uteke = std::env::var("UTEKE_HOME").ok();
+        let orig_home = std::env::var("HOME").ok();
         unsafe {
             std::env::set_var("UTEKE_HOME", "/tmp/custom_home");
         }
         let home = uteke_home().unwrap_or_else(|_| PathBuf::from("/tmp/.codecora/uteke"));
         assert_eq!(home.to_string_lossy(), "/tmp/custom_home");
-        unsafe {
-            std::env::remove_var("UTEKE_HOME");
+        // Restore originals
+        match orig_uteke {
+            Some(v) => unsafe { std::env::set_var("UTEKE_HOME", &v) },
+            None => unsafe { std::env::remove_var("UTEKE_HOME") },
+        }
+        match orig_home {
+            Some(v) => unsafe { std::env::set_var("HOME", &v) },
+            None => {} // don't remove HOME
         }
     }
 
@@ -2038,6 +2047,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("uteke_test_home_default");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
+        let orig_home = std::env::var("HOME").ok();
         unsafe {
             std::env::set_var("HOME", &tmp);
             std::env::remove_var("UTEKE_HOME");
@@ -2046,8 +2056,10 @@ mod tests {
         let result = uteke_home().unwrap();
         assert_eq!(result, expected);
         // Cleanup: restore original HOME
-        unsafe {
-            std::env::remove_var("HOME");
+        if let Some(ref home) = orig_home {
+            unsafe {
+                std::env::set_var("HOME", home);
+            }
         }
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -217,9 +217,8 @@ impl Default for DreamConfig {
 /// Recursively copy a directory (std-only, no external deps).
 /// Used for cross-device migration fallback.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), Error> {
-    std::fs::create_dir_all(dst).map_err(|e| {
-        Error::generic(&format!("Failed to create {}: {e}", dst.display()))
-    })?;
+    std::fs::create_dir_all(dst)
+        .map_err(|e| Error::generic(&format!("Failed to create {}: {e}", dst.display())))?;
     for entry in std::fs::read_dir(src)
         .map_err(|e| Error::generic(&format!("Failed to read dir {}: {e}", src.display())))?
     {
@@ -229,9 +228,8 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), Error> {
         if from.is_dir() {
             copy_dir_recursive(&from, &to)?;
         } else {
-            std::fs::copy(&from, &to).map_err(|e| {
-                Error::generic(&format!("Failed to copy {}: {e}", from.display()))
-            })?;
+            std::fs::copy(&from, &to)
+                .map_err(|e| Error::generic(&format!("Failed to copy {}: {e}", from.display())))?;
         }
     }
     Ok(())
@@ -262,8 +260,9 @@ pub fn uteke_home() -> Result<PathBuf, Error> {
             );
         } else {
             if let Some(parent) = new_path.parent() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| Error::generic(&format!("Failed to create {}: {e}", parent.display())))?;
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    Error::generic(&format!("Failed to create {}: {e}", parent.display()))
+                })?;
             }
             match std::fs::rename(&old_path, &new_path) {
                 Ok(()) => {
@@ -273,10 +272,11 @@ pub fn uteke_home() -> Result<PathBuf, Error> {
                     // EXDEV — cross-device rename (home on different FS).
                     // Fallback: recursive copy + delete.
                     copy_dir_recursive(&old_path, &new_path)?;
-                    std::fs::remove_dir_all(&old_path)
-                        .map_err(|e| Error::generic(&format!(
+                    std::fs::remove_dir_all(&old_path).map_err(|e| {
+                        Error::generic(&format!(
                             "Failed to remove ~/.uteke after cross-device copy: {e}"
-                        )))?;
+                        ))
+                    })?;
                     eprintln!("Migrated ~/.uteke/ → ~/.codecora/uteke/ (cross-device copy)");
                 }
                 Err(e) => {
@@ -2054,7 +2054,10 @@ mod tests {
         let dst = tmp.join("dst");
         copy_dir_recursive(&tmp.join("src"), &dst).unwrap();
         assert!(dst.join("sub/file.txt").exists());
-        assert_eq!(std::fs::read_to_string(dst.join("sub/file.txt")).unwrap(), "hello");
+        assert_eq!(
+            std::fs::read_to_string(dst.join("sub/file.txt")).unwrap(),
+            "hello"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -2034,14 +2034,22 @@ mod tests {
 
     #[test]
     fn test_uteke_home_default_no_migration() {
-        // Without UTEKE_HOME, should return ~/.codecora/uteke (no old dir = no migration).
+        // Ensure no side effects: use a temp dir as HOME so ~/.uteke can't exist.
+        let tmp = std::env::temp_dir().join("uteke_test_home_default");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
         unsafe {
+            std::env::set_var("HOME", &tmp);
             std::env::remove_var("UTEKE_HOME");
         }
-        let home = dirs::home_dir().expect("test requires HOME");
-        let expected = home.join(".codecora/uteke");
+        let expected = tmp.join(".codecora/uteke");
         let result = uteke_home().unwrap();
         assert_eq!(result, expected);
+        // Cleanup: restore original HOME
+        unsafe {
+            std::env::remove_var("HOME");
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -4,7 +4,7 @@
 //! ```ignore
 //! use uteke_core::Uteke;
 //!
-//! let uteke = Uteke::open("~/.uteke/db.sqlite")?;
+//! let uteke = Uteke::open("~/.codecora/uteke/db.sqlite")?;
 //! let id = uteke.remember("important context", &["tag1"], None)?;
 //! let results = uteke.recall("query", 5, None, None, 0.0, None, None)?;
 //! ```
@@ -212,23 +212,81 @@ impl Default for DreamConfig {
 /// Resolve uteke data directory.
 ///
 /// Uses `UTEKE_HOME` environment variable when set, otherwise falls back to
-/// `~/.uteke`. This allows Docker containers and custom deployments to
-/// override the default storage location.
+/// `~/.codecora/uteke` (auto-migrating from legacy `~/.uteke`).
 ///
+/// Recursively copy a directory (std-only, no external deps).
+/// Used for cross-device migration fallback.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), Error> {
+    std::fs::create_dir_all(dst).map_err(|e| {
+        Error::generic(&format!("Failed to create {}: {e}", dst.display()))
+    })?;
+    for entry in std::fs::read_dir(src)
+        .map_err(|e| Error::generic(&format!("Failed to read dir {}: {e}", src.display())))?
+    {
+        let entry = entry.map_err(|e| Error::generic(&format!("Failed to read entry: {e}")))?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to).map_err(|e| {
+                Error::generic(&format!("Failed to copy {}: {e}", from.display()))
+            })?;
+        }
+    }
+    Ok(())
+}
+
 /// ```text
 /// UTEKE_HOME=/data   → /data
-/// (not set)           → ~/.uteke
+/// (not set)           → ~/.codecora/uteke  (auto-migrates from ~/.uteke)
 /// ```
 pub fn uteke_home() -> Result<PathBuf, Error> {
+    // 1. Env override (Docker, custom) — always wins, zero change.
     if let Ok(home) = std::env::var("UTEKE_HOME") {
-        Ok(PathBuf::from(home))
-    } else {
-        dirs::home_dir()
-            .ok_or_else(|| {
-                Error::generic("Cannot determine home directory. Set UTEKE_HOME or HOME.")
-            })
-            .map(|p| p.join(".uteke"))
+        return Ok(PathBuf::from(home));
     }
+
+    let home = dirs::home_dir().ok_or_else(|| {
+        Error::generic("Cannot determine home directory. Set UTEKE_HOME or HOME.")
+    })?;
+
+    let new_path = home.join(".codecora/uteke");
+    let old_path = home.join(".uteke");
+
+    // 2. Auto-migrate: if old exists and new doesn't → move.
+    if !new_path.is_dir() && old_path.is_dir() {
+        if old_path.is_symlink() {
+            eprintln!(
+                "warning: ~/.uteke is a symlink, skipping auto-migration. Set UTEKE_HOME manually."
+            );
+        } else {
+            if let Some(parent) = new_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| Error::generic(&format!("Failed to create {}: {e}", parent.display())))?;
+            }
+            match std::fs::rename(&old_path, &new_path) {
+                Ok(()) => {
+                    eprintln!("Migrated ~/.uteke/ → ~/.codecora/uteke/");
+                }
+                Err(e) if e.raw_os_error() == Some(18) => {
+                    // EXDEV — cross-device rename (home on different FS).
+                    // Fallback: recursive copy + delete.
+                    copy_dir_recursive(&old_path, &new_path)?;
+                    std::fs::remove_dir_all(&old_path)
+                        .map_err(|e| Error::generic(&format!(
+                            "Failed to remove ~/.uteke after cross-device copy: {e}"
+                        )))?;
+                    eprintln!("Migrated ~/.uteke/ → ~/.codecora/uteke/ (cross-device copy)");
+                }
+                Err(e) => {
+                    return Err(Error::generic(&format!("Failed to migrate ~/.uteke: {e}")));
+                }
+            }
+        }
+    }
+
+    Ok(new_path)
 }
 
 /// Resolved embedder configuration used by lazy backend dispatch.
@@ -1967,11 +2025,38 @@ mod tests {
         unsafe {
             std::env::set_var("UTEKE_HOME", "/tmp/custom_home");
         }
-        let home = uteke_home().unwrap_or_else(|_| PathBuf::from("/tmp/.uteke"));
+        let home = uteke_home().unwrap_or_else(|_| PathBuf::from("/tmp/.codecora/uteke"));
         assert_eq!(home.to_string_lossy(), "/tmp/custom_home");
         unsafe {
             std::env::remove_var("UTEKE_HOME");
         }
+    }
+
+    #[test]
+    fn test_uteke_home_default_no_migration() {
+        // Without UTEKE_HOME, should return ~/.codecora/uteke (no old dir = no migration).
+        unsafe {
+            std::env::remove_var("UTEKE_HOME");
+        }
+        let home = dirs::home_dir().expect("test requires HOME");
+        let expected = home.join(".codecora/uteke");
+        let result = uteke_home().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_copy_dir_recursive() {
+        let tmp = std::env::temp_dir().join("uteke_test_copy_dir");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("src/sub")).unwrap();
+        std::fs::write(tmp.join("src/sub/file.txt"), "hello").unwrap();
+
+        let dst = tmp.join("dst");
+        copy_dir_recursive(&tmp.join("src"), &dst).unwrap();
+        assert!(dst.join("sub/file.txt").exists());
+        assert_eq!(std::fs::read_to_string(dst.join("sub/file.txt")).unwrap(), "hello");
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -218,18 +218,18 @@ impl Default for DreamConfig {
 /// Used for cross-device migration fallback.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), Error> {
     std::fs::create_dir_all(dst)
-        .map_err(|e| Error::generic(&format!("Failed to create {}: {e}", dst.display())))?;
+        .map_err(|e| Error::generic(format!("Failed to create {}: {e}", dst.display())))?;
     for entry in std::fs::read_dir(src)
-        .map_err(|e| Error::generic(&format!("Failed to read dir {}: {e}", src.display())))?
+        .map_err(|e| Error::generic(format!("Failed to read dir {}: {e}", src.display())))?
     {
-        let entry = entry.map_err(|e| Error::generic(&format!("Failed to read entry: {e}")))?;
+        let entry = entry.map_err(|e| Error::generic(format!("Failed to read entry: {e}")))?;
         let from = entry.path();
         let to = dst.join(entry.file_name());
         if from.is_dir() {
             copy_dir_recursive(&from, &to)?;
         } else {
             std::fs::copy(&from, &to)
-                .map_err(|e| Error::generic(&format!("Failed to copy {}: {e}", from.display())))?;
+                .map_err(|e| Error::generic(format!("Failed to copy {}: {e}", from.display())))?;
         }
     }
     Ok(())
@@ -261,7 +261,7 @@ pub fn uteke_home() -> Result<PathBuf, Error> {
         } else {
             if let Some(parent) = new_path.parent() {
                 std::fs::create_dir_all(parent).map_err(|e| {
-                    Error::generic(&format!("Failed to create {}: {e}", parent.display()))
+                    Error::generic(format!("Failed to create {}: {e}", parent.display()))
                 })?;
             }
             match std::fs::rename(&old_path, &new_path) {
@@ -273,14 +273,14 @@ pub fn uteke_home() -> Result<PathBuf, Error> {
                     // Fallback: recursive copy + delete.
                     copy_dir_recursive(&old_path, &new_path)?;
                     std::fs::remove_dir_all(&old_path).map_err(|e| {
-                        Error::generic(&format!(
+                        Error::generic(format!(
                             "Failed to remove ~/.uteke after cross-device copy: {e}"
                         ))
                     })?;
                     eprintln!("Migrated ~/.uteke/ → ~/.codecora/uteke/ (cross-device copy)");
                 }
                 Err(e) => {
-                    return Err(Error::generic(&format!("Failed to migrate ~/.uteke: {e}")));
+                    return Err(Error::generic(format!("Failed to migrate ~/.uteke: {e}")));
                 }
             }
         }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -100,7 +100,7 @@ fn main() {
                 println!("  CLI args override config values.");
                 println!();
                 println!("Environment:");
-                println!("  UTEKE_HOME          Data directory (default: ~/.uteke)");
+                println!("  UTEKE_HOME          Data directory (default: ~/.codecora/uteke)");
                 println!("  UTEKE_AUTH_TOKEN     Bearer token (alternative to --auth-token)");
                 println!(
                     "  UTEKE_READ_ONLY_TOKEN  Read-only token (alternative to --read-only-token)"
@@ -504,7 +504,7 @@ struct ServerFileSection {
 }
 
 /// Find and parse the nearest uteke.toml, looking at:
-/// 1. $UTEKE_HOME/uteke.toml (or ~/.uteke/uteke.toml)
+/// 1. $UTEKE_HOME/uteke.toml (or ~/.codecora/uteke/uteke.toml)
 /// 2. $CWD/.uteke/uteke.toml
 fn load_uteke_toml() -> ServerFileConfig {
     let mut config = ServerFileConfig::default();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ title: Architecture
 │          │ (HNSW)   │ (virtual  │                    │
 │          │ RwLock   │   table)  │                    │
 ├──────────┴──────────┴───────────┴────────────────────┤
-│              ~/.uteke/ (local storage)               │
+│              ~/.codecora/uteke/ (local storage)               │
 │ uteke.db │ uteke_index.usearch │ embeddinggemma-q4/ │
 └─────────────────────────────────────────────────────┘
 ```
@@ -58,7 +58,7 @@ title: Architecture
 2. **`recall`** — Query is embedded → usearch finds nearest neighbors + FTS5 finds keyword matches → RRF merges both result sets → hot memories get +0.1 score boost → returns ranked results
 3. **`search`** — SQLite FTS5 keyword search (phrase match + token-OR fallback, scoped to namespace)
 4. **`forget`** — Incremental delete from usearch + SQLite (no rebuild)
-5. Everything lives in `~/.uteke/` — fully local, fully yours
+5. Everything lives in `~/.codecora/uteke/` — fully local, fully yours
 
 ## Data Flow
 
@@ -168,7 +168,7 @@ Read-heavy workload: recall/search operations far outnumber remember/forget. Mul
 
 ### Cross-Process File Lock (#543)
 
-The RwLock provides intra-process concurrency only (multiple threads within a single `uteke-serve` process). For cross-process safety (multiple `uteke-serve` instances or CLI + server sharing the same store), a file-based lock (`fs2` crate) guards the SQLite database and usearch index files. The lock is acquired on store open and held until the process exits or the store is dropped. This prevents concurrent writes from corrupting the index or database when multiple processes access the same `~/.uteke/` directory.
+The RwLock provides intra-process concurrency only (multiple threads within a single `uteke-serve` process). For cross-process safety (multiple `uteke-serve` instances or CLI + server sharing the same store), a file-based lock (`fs2` crate) guards the SQLite database and usearch index files. The lock is acquired on store open and held until the process exits or the store is dropped. This prevents concurrent writes from corrupting the index or database when multiple processes access the same `~/.codecora/uteke/` directory.
 
 ### FTS5 + Vector Hybrid via RRF
 
@@ -263,7 +263,7 @@ Benchmarked on Oracle Cloud ARM (Ampere Altra), CPU-only, no GPU.
 ## File Structure
 
 ```
-~/.uteke/
+~/.codecora/uteke/
 ├── uteke.db                    # SQLite (memories + metadata + FTS5)
 ├── uteke_index.usearch         # Persistent HNSW vector index
 ├── uteke_index.keys            # Index key mapping (atomic save)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,12 +10,12 @@ Complete reference for all uteke commands. Version **0.8.0**.
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--store <path>` | Override store location | `~/.uteke` |
+| `--store <path>` | Override store location | `~/.codecora/uteke` |
 | `--namespace <name>` | Namespace for multi-agent isolation | `default` |
 | `--json` | Output as JSON | off |
 | `--verbose` | Enable debug logging | off |
 
-Config file path is auto-resolved (`~/.uteke/uteke.toml` + `.uteke/uteke.toml`); there is no `--config` flag.
+Config file path is auto-resolved (`~/.codecora/uteke/uteke.toml` + `.uteke/uteke.toml`); there is no `--config` flag.
 
 ## uteke onboard
 
@@ -45,7 +45,7 @@ The wizard steps:
 3. **Integration mode** — manual tool vs memory-provider (auto recall + extraction)
 4. **Namespace** — for multi-agent isolation
 5. **Feature toggles** — toggle ON/OFF for: Aging, Auto-maintenance, Graph rerank, Salience boost, Recency boost, Server mode
-6. **Config write** — generates `~/.uteke/uteke.toml`
+6. **Config write** — generates `~/.codecora/uteke/uteke.toml`
 7. **Agent init** — runs `uteke init` with your selections
 8. **Feature showcase** — prints all commands grouped by category
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Uteke supports `uteke.toml` configuration with layered resolution.
 Uteke searches for config in this order. Last match wins (highest priority):
 
 1. **(built-in defaults)** — Hardcoded defaults
-2. **`~/.uteke/uteke.toml`** — Global user-level config
+2. **`~/.codecora/uteke/uteke.toml`** — Global user-level config
 3. **`.uteke/uteke.toml`** — Project-level (in current working directory)
 
 Config file path is auto-resolved (no `--config` flag). Layered merge: each file overlays the previous, with field-level granularity (only keys explicitly present override).
@@ -22,8 +22,8 @@ Config file path is auto-resolved (no `--config` flag). Layered merge: each file
 # uteke.toml
 
 [store]
-# Store location (default: ~/.uteke)
-path = "~/.uteke"
+# Store location (default: ~/.codecora/uteke)
+path = "~/.codecora/uteke"
 
 # Default namespace (default: "default")
 namespace = "default"
@@ -250,7 +250,7 @@ Resolution order (highest priority first):
 
 | Env Var | Config Equivalent | Default | Description |
 |---------|-------------------|---------|-------------|
-| `UTEKE_HOME` | — | `~/.uteke` | Data directory |
+| `UTEKE_HOME` | — | `~/.codecora/uteke` | Data directory |
 | `UTEKE_NAMESPACE` | `[store] namespace` | `default` | Default namespace (applied in CLI) |
 | `UTEKE_AUTH_TOKEN` | — | — | Server auth token (applied in server) |
 | `UTEKE_LOG_LEVEL` | `[logging] level` | `warn` | Log level (trace/debug/info/warn/error) |
@@ -292,14 +292,14 @@ If you have an older flat-format config (pre-v0.0.4), uteke auto-migrates it on 
 
 ```toml
 # Old format (auto-detected and migrated)
-path = "~/.uteke"
+path = "~/.codecora/uteke"
 default_namespace = "default"
 log_level = "info"
 
 ↓ Auto-migrated to ↓
 
 [store]
-path = "~/.uteke"
+path = "~/.codecora/uteke"
 namespace = "default"
 
 [logging]
@@ -356,10 +356,10 @@ UTEKE_NAMESPACE=agent-1 uteke recall "context"
 
 ## File Logging
 
-Logs are written to `~/.uteke/logs/uteke.log` with daily rotation:
+Logs are written to `~/.codecora/uteke/logs/uteke.log` with daily rotation:
 
 ```
-~/.uteke/logs/
+~/.codecora/uteke/logs/
 ├── uteke.log              # Current log
 ├── uteke.log.2026-05-29   # Yesterday's log
 └── uteke.log.2026-05-28   # Two days ago

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -59,6 +59,6 @@ cp -r extensions/uteke-status .pi/extensions/
 
 ## How It Works
 
-- **Stats query** — Reads `~/.uteke/uteke.db` via sqlite3 CLI for cross-namespace totals
+- **Stats query** — Reads `~/.codecora/uteke/uteke.db` via sqlite3 CLI for cross-namespace totals
 - **System prompt** — Injects uteke usage rules via `before_agent_start` event
 - **Status refresh** — Updates footer on `session_start` and `turn_end` events

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ The wizard covers:
 3. **Integration mode** — manual tool (explicit calls) vs memory-provider (auto recall + extraction)
 4. **Namespace** — for multi-agent isolation
 5. **Feature toggles** — Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode
-6. **Config write** — generates `~/.uteke/uteke.toml` with your choices
+6. **Config write** — generates `~/.codecora/uteke/uteke.toml` with your choices
 7. **Agent init** — runs `uteke init --agent <your-choice>` automatically
 8. **Feature showcase** — prints all uteke commands grouped by category
 
@@ -158,10 +158,10 @@ uteke repair
 
 ## Where is Data Stored?
 
-All data lives in `~/.uteke/`:
+All data lives in `~/.codecora/uteke/`:
 
 ```
-~/.uteke/
+~/.codecora/uteke/
 ├── uteke.db                    # SQLite (memories + metadata + FTS5)
 ├── uteke_index.usearch         # Persistent HNSW vector index
 ├── uteke_index.keys            # Index key mapping

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -351,7 +351,7 @@ Config via `~/.hermes/uteke.json` (preferred) or environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `UTEKE_BIN` | (search PATH) | Path to uteke binary |
-| `UTEKE_HOME` | (inherit) | HOME dir for uteke store (`~/.uteke`) |
+| `UTEKE_HOME` | (inherit) | HOME dir for uteke store (`~/.codecora/uteke`) |
 | `UTEKE_NAMESPACE` | (agent profile name) | Memory namespace |
 | `UTEKE_SERVER_URL` | (empty = subprocess) | uteke-serve HTTP URL |
 | `UTEKE_TOKEN` | (empty) | Auth token for uteke-serve |

--- a/docs/launch/hn-post.md
+++ b/docs/launch/hn-post.md
@@ -19,7 +19,7 @@ uteke recall "what deployment is coming up?"
 
 - **Single binary** — `curl | sh` and you're done. No Python, no server, no Docker.
 - **Zero config** — First run downloads the embedding model (~188MB ONNX). That's it.
-- **Fully offline** — No API keys. No cloud. Data lives in `~/.uteke/`. SQLite + HNSW.
+- **Fully offline** — No API keys. No cloud. Data lives in `~/.codecora/uteke/`. SQLite + HNSW.
 - **Semantic search** — Uses EmbeddingGemma Q4 (768d) for vector similarity. ONNX runtime runs locally.
 - **~30ms recall** via library, ~42ms via HTTP server. CLI cold start ~3s (model load).
 - **JSON everywhere** — Every command supports `--json` output. Perfect for scripting and agent integration.

--- a/docs/launch/twitter-thread.md
+++ b/docs/launch/twitter-thread.md
@@ -48,7 +48,7 @@ Under the hood:
 🔹 ONNX — EmbeddingGemma Q4 embeddings (768d)
 🔹 Rust — memory safe, no unsafe code
 
-Everything lives in ~/.uteke/
+Everything lives in ~/.codecora/uteke/
 
 ---
 

--- a/docs/plans/2026-06-04-readme-landing-page-gtm.md
+++ b/docs/plans/2026-06-04-readme-landing-page-gtm.md
@@ -160,7 +160,7 @@ AI agents forget everything between sessions. Uteke gives them persistent, searc
 | Team needing shared memory | Multi-user sync + collaboration | ❌ Not yet (Phase B) |
 | Enterprise needing graph RAG | Entity relationships, cross-agent knowledge | ❌ Use Mem0/Zep instead |
 
-> **Not sure?** Try it — `curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh` — uninstall is just `rm -rf ~/.uteke`.
+> **Not sure?** Try it — `curl -sSL https://raw.githubusercontent.com/ajianaz/uteke/main/install.sh | sh` — uninstall is just `rm -rf ~/.codecora/uteke`.
 ```
 
 ---

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -97,7 +97,7 @@ uteke-serve --host 0.0.0.0 --auth-token YOUR_TOKEN --cors-origin https://uteke.y
 | Variable | Purpose |
 |----------|---------|
 | `UTEKE_AUTH_TOKEN` | Bearer token for API authentication |
-| `UTEKE_HOME` | Data directory (default: `~/.uteke`) |
+| `UTEKE_HOME` | Data directory (default: `~/.codecora/uteke`) |
 
 ## Cloudflare Tunnel
 

--- a/extensions/hermes-memory-provider/__init__.py.tmpl
+++ b/extensions/hermes-memory-provider/__init__.py.tmpl
@@ -17,7 +17,7 @@ Transport:
 
 Config via $HERMES_HOME/uteke.json (preferred) or environment variables:
   UTEKE_BIN           — path to the uteke binary (default: search PATH)
-  UTEKE_HOME          — HOME dir uteke runs under (holds ~/.uteke store)
+  UTEKE_HOME          — HOME dir uteke runs under (holds ~/.codecora/uteke store)
   UTEKE_NAMESPACE     — memory namespace (default: agent profile name)
   UTEKE_SERVER_URL    — uteke-serve HTTP URL (default: http://127.0.0.1:8767)
   UTEKE_TOKEN         — auth token for uteke-serve (Bearer token)


### PR DESCRIPTION
## Summary

Migrate the default uteke data directory from `~/.uteke` to `~/.codecora/uteke` with seamless auto-migration.

## Changes

### Core (`uteke-core`)
- **`uteke_home()`** — defaults to `~/.codecora/uteke` instead of `~/.uteke`
- **Auto-migration** — on first run, detects legacy `~/.uteke` and renames it to new location
- **Cross-device fallback** — handles EXDEV error (home on different filesystem) with recursive copy + delete
- **Symlink guard** — skips migration if `~/.uteke` is a symlink (user might have custom setup)

### CLI (`uteke-cli`)
- **`global_config_path()`** — now calls `uteke_core::uteke_home()` instead of hardcoding `dirs::home_dir().join(".uteke")`
- **`StoreConfig::default()`** — updated default path string
- **`--store` help text**, onboard detect/write, logging paths — all updated

### Server (`uteke-server`)
- Help text and config resolution comments updated

### Docs & Extensions
- README, INSTALL, configuration, getting-started, tls, architecture, extensions, integrations, cli-reference, launch posts — all `~/.uteke` → `~/.codecora/uteke`
- Hermes memory provider template updated

### Intentionally Unchanged
- **CHANGELOG.md** — historical entries kept as-is (they describe what was true at release time)
- **Test input strings** in `set_namespace_in_toml` — simulate parsing old user configs with `~/.uteke`
- **Migration error messages** in `uteke_home()` — reference old path for user-facing diagnostics

Closes #773