### PR TITLE
fix: isolate test_uteke_home_with_env from parallel env var pollution

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -2022,10 +2022,14 @@ mod tests {
 
     #[test]
     fn test_uteke_home_with_env() {
-        // Save originals to prevent test pollution across parallel test threads.
+        // Isolate from parallel tests: use a unique temp HOME and set UTEKE_HOME.
+        let tmp = std::env::temp_dir().join("uteke_test_home_env");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
         let orig_uteke = std::env::var("UTEKE_HOME").ok();
         let orig_home = std::env::var("HOME").ok();
         unsafe {
+            std::env::set_var("HOME", &tmp);
             std::env::set_var("UTEKE_HOME", "/tmp/custom_home");
         }
         let home = uteke_home().unwrap_or_else(|_| PathBuf::from("/tmp/.codecora/uteke"));
@@ -2039,6 +2043,7 @@ mod tests {
         if let Some(ref v) = orig_home {
             unsafe { std::env::set_var("HOME", v) };
         }
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

CI test `test_uteke_home_with_env` fails intermittently on GitHub Actions runners.

**Root cause:** Race condition between two parallel test threads:

| Thread A (`test_uteke_home_with_env`) | Thread B (`test_uteke_home_default_no_migration`) |
|---|---|
| `set_var("UTEKE_HOME", "/tmp/custom_home")` | `set_var("HOME", "/tmp/uteke_test_home_default")` |
| | `remove_var("UTEKE_HOME")` ← **clobbers Thread A's set** |
| `uteke_home()` reads `UTEKE_HOME` → **gone** | |
| Falls back to `dirs::home_dir().join(".codecora/uteke")` | |
| Gets `/tmp/uteke_test_home_default/.codecora/uteke` instead of `/tmp/custom_home` | |
| **Assertion fails** | |

## Fix

Also set `HOME` to a unique temp dir in `test_uteke_home_with_env`, matching the isolation pattern already used by `test_uteke_home_default_no_migration`. This way even if `UTEKE_HOME` gets clobbered, the fallback path is still predictable and isolated.

## Testing

- [x] Cora review passed (no issues)
- [ ] CI green on this PR