### PR TITLE
docs: fix hermes integration examples, add valid memory types & API notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Docs
+- **Hermes integration docs updated** — Fixed incorrect `room_remember` example (was using `remember` with `room_id` which is not supported by `/remember` endpoint). Added `room_document` action. Added "Valid Memory Types" section. Added "HTTP API Notes" section documenting POST-with-body pattern and known issues (#784, #785, #786).
+
 ## [0.10.1] — 2026-07-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -88,13 +88,15 @@ Rooms enable multi-agent collaborative memory — multiple agents share a room a
 
 ```python
 # Create a shared room
-uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 uteke(action="room_create", room_id="sprint-planning", title="Sprint Planning")
 
-# Add a memory to a room (use remember with room_id)
-uteke(action="remember", content="Deploy at 3pm", room_id="sprint-planning", namespace="team")
+# Add a memory to a room (with author attribution)
+uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 
-# Recall from a room
+# Add a reference document to a room
+uteke(action="room_document", room_id="sprint-planning", content="Architecture spec: ...", title="Arch Spec")
+
+# Recall from a room (semantic search — query is required)
 uteke(action="room_recall", room_id="sprint-planning", content="deploy deadline")
 
 # List all rooms (cross-namespace)
@@ -208,16 +210,67 @@ hermes mcp add uteke --command uteke-mcp
 | `remember` | Store a new memory |
 | `recall` | Semantic search |
 | `search` | Keyword search |
-| `list` | List memories |
+| `list` | List memories (with namespace filter) |
 | `forget` | Delete memory |
-| `stats` | Store statistics |
-| `room_remember` | Store memory in a room with author |
+| `stats` | Namespace or global statistics |
+| `room_remember` | Store memory in a room with author attribution |
+| `room_document` | Store a reference document in a room |
 | `room_create` | Create a room |
-| `room_recall` | Recall from a room |
-| `room_list` | List all rooms |
-| `room_summary` | Room topic summary |
-| `room_stats` | Room statistics |
-| `room_delete` | Delete a room |
+| `room_recall` | Semantic search within a room (requires `query`) |
+| `room_list` | List all rooms (cross-namespace) |
+| `room_summary` | Room topic summary with clusters and highlights |
+| `room_stats` | Room statistics (memory count, participants) |
+| `room_delete` | Delete a room (memories preserved) |
+| `namespace_list` | List all namespaces |
+| `namespace_stats` | Statistics for a specific namespace |
+| `tags_list` | List all tags |
+| `tags_rename` | Rename a tag across all memories |
+| `tags_delete` | Delete a tag from all memories |
+| `consolidate` | Merge similar memories (with threshold) |
+| `aging` | Aging cleanup of old memories |
+| `import` | Import memories from JSON |
+| `importance` | Recompute importance scores |
+| `doctor` | Health check (alias for `/health`) |
+
+## Valid Memory Types
+
+When using `remember`, `room_remember`, or `room_document`, the `type` parameter accepts these values:
+
+| Type | Description |
+|------|-------------|
+| `fact` | A factual statement or observation |
+| `procedure` | A how-to, process, or workflow |
+| `preference` | A user or system preference |
+| `decision` | A decision that was made |
+| `context` | Background context for a topic |
+| `note` | A general note |
+| `insight` | An insight or conclusion |
+| `reference` | A reference document (default for `room_document`) |
+| `event` | A time-based event |
+
+> **Warning:** Using an invalid type (e.g., `document`) causes HTTP 500. Use `reference` instead of `document`.
+
+## HTTP API Notes
+
+The uteke HTTP server (`uteke-serve`) uses **exact path matching** — query parameters are NOT part of the route. This means:
+
+```bash
+# ✅ Correct — POST with JSON body
+curl -X POST http://127.0.0.1:8767/stats \
+  -H 'Content-Type: application/json' \
+  -d '{"namespace": "cto"}'
+
+# ❌ Wrong — GET with query params returns 404
+curl http://127.0.0.1:8767/stats?namespace=cto
+```
+
+**All endpoints that accept parameters use POST with JSON body**, not GET with query strings.
+
+### Known Issues
+
+- **#784** — `room/stats` counts deprecated memories (inflated counts vs `room/summary`)
+- **#785** — `room/recall` requires `query` parameter (cannot list all memories in a room)
+- **#786** — Full HTTP API reference documentation is pending
 
 ## Memory-Provider for Other Agents
 
@@ -262,8 +315,9 @@ This installs uteke as the agent's default memory provider — relevant memories
 
 ## How It Works (uteke-tool)
 
-- **Remember**: POST to `/remember` — content is embedded (EmbeddingGemma Q4, 768d) and stored in SQLite + HNSW vector index
+- **Remember**: POST to `/remember` — content is embedded (EmbeddingGemma Q4, 768d) and stored in SQLite + HNSW vector index. Supports `type` param (see [Valid Memory Types](#valid-memory-types))
 - **Recall**: POST to `/recall` — semantic search via hybrid RRF (vector + FTS5), returns ranked results
+- **Room Remember**: POST to `/room/remember` — stores memory and links to room in a single call. **Requires** `room_id` (not `room`). Use `type="reference"` for documents (not `document` — causes 500)
 - **Rooms**: Cross-namespace collaboration spaces — rooms span namespaces, enabling multi-agent coordination
 - **MCP**: JSON-RPC over stdio or HTTP — standard MCP protocol for AI agent integration
 


### PR DESCRIPTION
## Summary

Fix incorrect documentation in `docs/integrations/hermes.md` discovered during a full uteke-tool plugin audit (14 plugin bugs fixed in #783).

## Changes

### 1. Fixed `room_remember` example (breaking doc bug)

The docs showed:
```python
# ❌ Wrong — /remember does NOT support room_id
uteke(action="remember", content="Deploy at 3pm", room_id="sprint-planning", namespace="team")
```

This was misleading — the `/remember` endpoint silently ignores `room_id`. The correct way is `room_remember`:
```python
# ✅ Correct — /room/remember with room_id
uteke(action="room_remember", room_id="sprint-planning", content="...", author="agent1")
```

### 2. Added `room_document` action

Was missing from examples. Uses `type="reference"` (not `document` — which causes HTTP 500).

### 3. Added "Valid Memory Types" section

Documents all 9 valid types: `fact, procedure, preference, decision, context, note, insight, reference, event`. Warns that invalid types (e.g., `document`) cause HTTP 500.

### 4. Added "HTTP API Notes" section

Documents the POST-with-JSON-body pattern (GET with query params returns 404 due to exact path matching). This was the root cause of 12/14 plugin bugs in #783.

### 5. Expanded Available Actions table

14 → 24 actions documented, including `namespace_list`, `tags_list`, `consolidate`, `aging`, `import`, `importance`, `doctor`, etc.

## Related Issues

- #783 (closed) — uteke-tool plugin endpoint mismatches (14 bugs fixed)
- #784 — room/stats counts deprecated memories
- #785 — room/recall requires query param
- #786 — Full HTTP API reference missing
