### PR TITLE
fix: filter deprecated memories from room operations (#784, #785, #786)

### DIFF
--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -432,12 +432,16 @@ impl super::Store {
         author: Option<&str>,
     ) -> Result<Vec<String>, Error> {
         let sql = match author {
-            Some(_) => "SELECT rm.memory_id FROM room_memories rm \
+            Some(_) => {
+                "SELECT rm.memory_id FROM room_memories rm \
                           INNER JOIN memories m ON rm.memory_id = m.id \
-                          WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0",
-            None => "SELECT rm.memory_id FROM room_memories rm \
+                          WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0"
+            }
+            None => {
+                "SELECT rm.memory_id FROM room_memories rm \
                      INNER JOIN memories m ON rm.memory_id = m.id \
-                     WHERE rm.room_id = ?1 AND m.deprecated = 0",
+                     WHERE rm.room_id = ?1 AND m.deprecated = 0"
+            }
         };
 
         let mut stmt = self

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -225,6 +225,9 @@ impl super::Store {
     }
 
     /// Get statistics about a room.
+    ///
+    /// Only counts active (non-deprecated) memories — matches the behavior of
+    /// `recall_room` and `room_summary` which also filter `deprecated = 0` (#784).
     pub fn room_stats(&self, room_id: &str) -> Result<Option<RoomStats>, Error> {
         let room = match self.get_room(room_id)? {
             Some(r) => r,
@@ -234,16 +237,22 @@ impl super::Store {
         let memory_count: usize =
             self.conn
                 .query_row(
-                    "SELECT COUNT(DISTINCT memory_id) FROM room_memories WHERE room_id = ?1",
+                    "SELECT COUNT(DISTINCT rm.memory_id) FROM room_memories rm \
+                     INNER JOIN memories m ON rm.memory_id = m.id \
+                     WHERE rm.room_id = ?1 AND m.deprecated = 0",
                     params![room_id],
                     |row| row.get::<_, i64>(0),
                 )
                 .map_err(|e| Error::db("room memory count", e))? as usize;
 
-        // Get distinct authors as participants
+        // Get distinct authors as participants (only for active memories)
         let mut stmt = self
             .conn
-            .prepare("SELECT DISTINCT author FROM room_memories WHERE room_id = ?1 ORDER BY author")
+            .prepare(
+                "SELECT DISTINCT rm.author FROM room_memories rm \
+                 INNER JOIN memories m ON rm.memory_id = m.id \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0 ORDER BY rm.author",
+            )
             .map_err(|e| Error::db("room participants", e))?;
         let participants: Vec<String> = stmt
             .query_map(params![room_id], |row| row.get(0))
@@ -254,7 +263,9 @@ impl super::Store {
         let last_activity: Option<String> = self
             .conn
             .query_row(
-                "SELECT MAX(joined_at) FROM room_memories WHERE room_id = ?1",
+                "SELECT MAX(rm.joined_at) FROM room_memories rm \
+                 INNER JOIN memories m ON rm.memory_id = m.id \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0",
                 params![room_id],
                 |row| row.get(0),
             )
@@ -303,6 +314,7 @@ impl super::Store {
 
     /// Recall all memories linked to a room, sorted by time.
     /// Cross-namespace: returns memories from ALL namespaces that contributed to the room.
+    /// Only returns active (non-deprecated) memories (#784).
     pub fn recall_room(
         &self,
         room_id: &str,
@@ -319,7 +331,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 AND rm.author = ?2 \
+                 WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC \
                  LIMIT ?3"
             }
@@ -330,7 +342,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 AND rm.author = ?2 \
+                 WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC"
             }
             (None, false) => {
@@ -340,7 +352,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC \
                  LIMIT ?2"
             }
@@ -351,7 +363,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC"
             }
         };
@@ -413,14 +425,19 @@ impl super::Store {
     /// Get memory IDs linked to a room.
     /// Returns just the IDs — much cheaper than full recall when only
     /// filtering is needed.
+    /// Only returns IDs of active (non-deprecated) memories (#784).
     pub fn get_room_memory_ids(
         &self,
         room_id: &str,
         author: Option<&str>,
     ) -> Result<Vec<String>, Error> {
         let sql = match author {
-            Some(_) => "SELECT memory_id FROM room_memories WHERE room_id = ?1 AND author = ?2",
-            None => "SELECT memory_id FROM room_memories WHERE room_id = ?1",
+            Some(_) => "SELECT rm.memory_id FROM room_memories rm \
+                          INNER JOIN memories m ON rm.memory_id = m.id \
+                          WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0",
+            None => "SELECT rm.memory_id FROM room_memories rm \
+                     INNER JOIN memories m ON rm.memory_id = m.id \
+                     WHERE rm.room_id = ?1 AND m.deprecated = 0",
         };
 
         let mut stmt = self
@@ -1314,6 +1331,50 @@ mod tests {
     }
 
     #[test]
+    fn recall_room_excludes_deprecated_memories() {
+        let store = Store::open(":memory:").unwrap();
+        store.create_room("dep-recall", None, "default").unwrap();
+
+        let m1 = make_test_memory("mem-rd1", "active memory", &[]);
+        let mut m2 = make_test_memory("mem-rd2", "deprecated memory", &[]);
+        m2.deprecated = true;
+        store.insert(&m1).unwrap();
+        store.insert(&m2).unwrap();
+        store
+            .link_memory_to_room("dep-recall", "mem-rd1", "alice", "participant")
+            .unwrap();
+        store
+            .link_memory_to_room("dep-recall", "mem-rd2", "bob", "participant")
+            .unwrap();
+
+        let mems = store.recall_room("dep-recall", None, 0).unwrap();
+        assert_eq!(mems.len(), 1, "deprecated memory should be excluded");
+        assert_eq!(mems[0].id, "mem-rd1");
+    }
+
+    #[test]
+    fn get_room_memory_ids_excludes_deprecated() {
+        let store = Store::open(":memory:").unwrap();
+        store.create_room("dep-ids", None, "default").unwrap();
+
+        let m1 = make_test_memory("mem-gid1", "active", &[]);
+        let mut m2 = make_test_memory("mem-gid2", "deprecated", &[]);
+        m2.deprecated = true;
+        store.insert(&m1).unwrap();
+        store.insert(&m2).unwrap();
+        store
+            .link_memory_to_room("dep-ids", "mem-gid1", "alice", "participant")
+            .unwrap();
+        store
+            .link_memory_to_room("dep-ids", "mem-gid2", "alice", "participant")
+            .unwrap();
+
+        let ids = store.get_room_memory_ids("dep-ids", None).unwrap();
+        assert_eq!(ids.len(), 1, "deprecated memory ID should be excluded");
+        assert_eq!(ids[0], "mem-gid1");
+    }
+
+    #[test]
     fn get_room_memory_ids_with_author() {
         let store = Store::open(":memory:").unwrap();
         store.create_room("ids-auth", None, "default").unwrap();
@@ -1385,6 +1446,35 @@ mod tests {
         let store = Store::open(":memory:").unwrap();
         let stats = store.room_stats("nope").unwrap();
         assert!(stats.is_none());
+    }
+
+    #[test]
+    fn room_stats_excludes_deprecated_memories() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .create_room("dep-stats", Some("Deprecated Stats"), "default")
+            .unwrap();
+
+        let m1 = make_test_memory("mem-d1", "active", &[]);
+        let mut m2 = make_test_memory("mem-d2", "deprecated", &[]);
+        m2.deprecated = true;
+        store.insert(&m1).unwrap();
+        store.insert(&m2).unwrap();
+        store
+            .link_memory_to_room("dep-stats", "mem-d1", "alice", "participant")
+            .unwrap();
+        store
+            .link_memory_to_room("dep-stats", "mem-d2", "bob", "participant")
+            .unwrap();
+
+        let stats = store.room_stats("dep-stats").unwrap().unwrap();
+        assert_eq!(stats.memory_count, 1, "deprecated memory should not count");
+        assert_eq!(
+            stats.participant_count, 1,
+            "only alice (author of active memory) should appear"
+        );
+        assert!(stats.participants.contains(&"alice".to_string()));
+        assert!(!stats.participants.contains(&"bob".to_string()));
     }
 
     // ── room_summary ────────────────────────────────────────────

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -960,33 +960,43 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
-        // ── Room Recall (semantic — requires non-empty query) ─────────────
+        // ── Room Recall (semantic with optional fallback to chronological) ──
         (Method::Post, "/room/recall") => match read_body::<RoomRecallRequest>(req.as_reader()) {
             Ok(req_data) => {
-                if req_data.query.trim().is_empty() {
-                    return ctx.error_response_for(
-                        req,
-                        400,
-                        "Empty query is not allowed. Use GET /room/memories for chronological listing.",
+                let query = req_data.query.as_deref().unwrap_or("").trim();
+                if query.is_empty() {
+                    // No query provided — fall back to chronological recall (#785)
+                    match uteke.recall_room(
+                        &req_data.room_id,
+                        req_data.author.as_deref(),
+                        req_data.limit,
+                    ) {
+                        Ok(memories) => ctx.ok_response_for(req, &memories),
+                        Err(e) => {
+                            error!("Internal error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                } else {
+                    // Semantic recall with query
+                    let min_score = req_data.min_score.unwrap_or(
+                        ctx.recall_config
+                            .as_ref()
+                            .and_then(|r| r.min_score)
+                            .unwrap_or(DEFAULT_MIN_SCORE as f64) as f32,
                     );
-                }
-                let min_score = req_data.min_score.unwrap_or(
-                    ctx.recall_config
-                        .as_ref()
-                        .and_then(|r| r.min_score)
-                        .unwrap_or(DEFAULT_MIN_SCORE as f64) as f32,
-                );
-                match uteke.recall_room_semantic(
-                    &req_data.room_id,
-                    &req_data.query,
-                    req_data.limit,
-                    req_data.author.as_deref(),
-                    min_score,
-                ) {
-                    Ok(results) => ctx.ok_response_for(req, &results),
-                    Err(e) => {
-                        error!("Internal error: {e}");
-                        ctx.error_response_for(req, 500, "Internal server error")
+                    match uteke.recall_room_semantic(
+                        &req_data.room_id,
+                        query,
+                        req_data.limit,
+                        req_data.author.as_deref(),
+                        min_score,
+                    ) {
+                        Ok(results) => ctx.ok_response_for(req, &results),
+                        Err(e) => {
+                            error!("Internal error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
                     }
                 }
             }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
                 println!(
                     "  GET  /room/memories       → ?room_id=<id>[&author=&limit=] → chronological memories"
                 );
-                println!("  POST /room/recall          → {{ room_id, query }} → ranked memories");
+                println!("  POST /room/recall          → {{ room_id, query? }} → ranked memories (query optional, falls back to chronological)");
                 println!("  POST /room/summary         → {{ room_id }} → {{ summary }}");
                 println!("  POST /room/document        → {{ room_id }} → {{ document }}");
                 println!("  POST /room/stats           → {{ room_id }} → room stats");

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -141,7 +141,9 @@ fn main() {
                 println!(
                     "  GET  /room/memories       → ?room_id=<id>[&author=&limit=] → chronological memories"
                 );
-                println!("  POST /room/recall          → {{ room_id, query? }} → ranked memories (query optional, falls back to chronological)");
+                println!(
+                    "  POST /room/recall          → {{ room_id, query? }} → ranked memories (query optional, falls back to chronological)"
+                );
                 println!("  POST /room/summary         → {{ room_id }} → {{ summary }}");
                 println!("  POST /room/document        → {{ room_id }} → {{ document }}");
                 println!("  POST /room/stats           → {{ room_id }} → room stats");

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -291,7 +291,10 @@ pub fn default_doc_limit() -> usize {
 #[derive(Deserialize)]
 pub struct RoomRecallRequest {
     pub room_id: String,
-    pub query: String,
+    /// Semantic search query. When `None` or empty, falls back to
+    /// chronological recall (equivalent to `GET /room/memories`) (#785).
+    #[serde(default)]
+    pub query: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: usize,
     #[serde(default)]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -40,6 +40,7 @@ export default createConfig({
       text: 'Reference',
       items: [
         { text: 'CLI Reference', link: '/cli-reference' },
+        { text: 'HTTP API Reference', link: '/api-reference' },
         { text: 'Comparison', link: '/comparison' },
         { text: 'Architecture', link: '/architecture' },
         { text: 'Hermes Integration', link: '/integrations/hermes' },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,692 @@
+---
+title: HTTP API Reference
+---
+
+# HTTP API Reference
+
+Complete reference for all uteke-server HTTP endpoints. Version **0.10.1**.
+
+All endpoints accept and return JSON (`Content-Type: application/json`). POST/PUT/DELETE bodies are JSON; GET endpoints use query parameters.
+
+## Base URL
+
+```
+http://localhost:8767
+```
+
+Default port is `8767`. Override with `--port` flag or `UTEKE_PORT` env var.
+
+## API Versioning
+
+All routes support optional `/api/v1` or `/api/v2` prefix for version negotiation ([#737](https://github.com/codecoradev/uteke/issues/737)):
+
+| Version | Format | Description |
+|---------|--------|-------------|
+| `v1` | Flat recall results | v0.7.x compatible (`[{id, content, score, ...}]`) |
+| `v2` | Wrapped `UnifiedSearchResult` | v0.8.x+ (unified search with metadata) |
+| *(none)* | Latest (`v2`) | Unversioned routes alias to latest |
+
+```bash
+# Versioned
+POST /api/v2/recall
+# Unversioned (aliases to v2)
+POST /recall
+```
+
+---
+
+## Health & Stats
+
+### GET /health
+
+Server health check. Returns version, memory count, and supported API versions.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "version": "0.10.1",
+  "memories": 148,
+  "namespaces": 3,
+  "api_versions": ["v1", "v2"],
+  "api_latest": "v2"
+}
+```
+
+### GET /stats
+
+Global statistics (namespaces, memory counts, tag counts).
+
+**Response:**
+```json
+{
+  "namespaces": ["default", "cto", "cmo"],
+  "total_memories": 148,
+  "by_namespace": { "default": 50, "cto": 80, "cmo": 18 }
+}
+```
+
+### POST /stats
+
+Statistics for a specific namespace.
+
+**Request:**
+```json
+{ "namespace": "default" }
+```
+
+---
+
+## Memory Operations
+
+### POST /remember
+
+Store a new memory with automatic embedding generation.
+
+**Request:**
+```json
+{
+  "content": "Uteke uses SQLite + ONNX embeddings",
+  "tags": ["architecture", "uteke"],
+  "namespace": "default",
+  "type": "fact",
+  "entity": "uteke",
+  "category": "architecture",
+  "metadata": { "project": "uteke" },
+  "source": "docs",
+  "source_type": "user",
+  "valid_from": "2026-01-01T00:00:00Z",
+  "valid_until": null,
+  "detect_contradiction": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `content` | string | ✅ | — | Memory content text |
+| `tags` | string[] | ❌ | `[]` | Tags for filtering |
+| `namespace` | string | ❌ | `default` | Namespace isolation |
+| `type` | string | ❌ | `null` | Memory type (fact, procedure, preference, decision, etc.) |
+| `entity` | string | ❌ | `null` | Entity name (stored as metadata) |
+| `category` | string | ❌ | `null` | Category (stored as metadata) |
+| `metadata` | object | ❌ | `null` | Extra key-value pairs |
+| `source` | string | ❌ | `null` | Source provenance |
+| `source_type` | string | ❌ | `user` | Source type |
+| `valid_from` | string | ❌ | `null` | RFC3339 timestamp |
+| `valid_until` | string | ❌ | `null` | RFC3339 timestamp |
+| `detect_contradiction` | bool | ❌ | `false` | Check for contradictions |
+
+### POST /recall
+
+Semantic recall — search memories by meaning using embeddings.
+
+**Request:**
+```json
+{
+  "query": "how does uteke store data",
+  "limit": 5,
+  "tags": [],
+  "namespace": "default",
+  "entity": null,
+  "category": null,
+  "min_score": 0.0,
+  "strict": false,
+  "at": null,
+  "search_type": "all",
+  "enrich": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Semantic search query |
+| `limit` | int | ❌ | `5` | Max results |
+| `tags` | string[] | ❌ | `[]` | Filter by tags |
+| `namespace` | string | ❌ | `null` | Namespace filter |
+| `entity` | string | ❌ | `null` | Filter by entity metadata |
+| `category` | string | ❌ | `null` | Filter by category metadata |
+| `min_score` | float | ❌ | `0.0` | Minimum similarity score |
+| `strict` | bool | ❌ | `false` | Use strict threshold (0.5) |
+| `at` | string | ❌ | `null` | Time-travel: RFC3339 timestamp |
+| `search_type` | string | ❌ | `all` | `all`, `memory`, or `doc` |
+| `enrich` | bool | ❌ | `false` | Enrich with cross-entity links |
+
+### POST /search
+
+Fast keyword/FTS search (non-semantic).
+
+**Request:**
+```json
+{
+  "query": "sqlite",
+  "limit": 10,
+  "tags": [],
+  "namespace": "default"
+}
+```
+
+### POST /list
+
+List memories with pagination and optional tag filter.
+
+**Request:**
+```json
+{
+  "tag": "architecture",
+  "limit": 5,
+  "offset": 0,
+  "namespace": "default",
+  "at": null
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `tag` | string | ❌ | `null` | Filter by tag |
+| `limit` | int | ❌ | `5` | Page size |
+| `offset` | int | ❌ | `0` | Pagination offset |
+| `namespace` | string | ❌ | `null` | Namespace filter |
+| `at` | string | ❌ | `null` | Time-travel timestamp |
+
+### DELETE /forget
+
+Delete a memory by ID.
+
+**Query params:** `?id=<uuid>`
+
+```bash
+DELETE /forget?id=550e8400-e29b-41d4-a716-446655440000
+```
+
+### GET /memory
+
+Get a single memory by ID.
+
+**Query params:** `?id=<uuid>`
+
+### PUT /memory
+
+Update a memory ([#659](https://github.com/codecoradev/uteke/issues/659)). Triggers embedding regeneration if content changes.
+
+**Request:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "content": "updated content",
+  "tags": ["new-tag"],
+  "metadata": { "key": "value" },
+  "importance": 0.8,
+  "pinned": true,
+  "memory_type": "decision"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Memory UUID |
+| `content` | string | ❌ | New content (triggers re-embedding) |
+| `tags` | string[] | ❌ | Replace tags |
+| `metadata` | object | ❌ | Replace metadata |
+| `importance` | float | ❌ | Importance score (0.0–1.0) |
+| `pinned` | bool | ❌ | Pinned state |
+| `memory_type` | string | ❌ | Memory type |
+
+### POST /memory/pin
+
+Set pinned state on a memory ([#660](https://github.com/codecoradev/uteke/issues/660)).
+
+**Request:**
+```json
+{ "id": "550e8400-...", "pinned": true }
+```
+
+### POST /memory/importance
+
+Set importance score on a memory.
+
+**Request:**
+```json
+{ "id": "550e8400-...", "importance": 0.9 }
+```
+
+### POST /memory/feedback
+
+Submit feedback for trust scoring ([#718](https://github.com/codecoradev/uteke/issues/718)).
+
+**Request:**
+```json
+{ "id": "550e8400-...", "feedback": "helpful" }
+```
+
+`feedback` must be `"helpful"` or `"unhelpful"`.
+
+### POST /memory/doc-refs
+
+Get document references linked to a memory ([#689](https://github.com/codecoradev/uteke/issues/689)).
+
+**Request:**
+```json
+{ "memory_id": "550e8400-..." }
+```
+
+---
+
+## Pin Operations
+
+### POST /pin
+
+Pin a memory by ID.
+
+**Request:**
+```json
+{ "id": "550e8400-..." }
+```
+
+### POST /unpin
+
+Unpin a memory by ID.
+
+**Request:**
+```json
+{ "id": "550e8400-..." }
+```
+
+---
+
+## Namespace & Tags
+
+### GET /namespaces
+
+List all namespaces.
+
+**Query params:** `?memory_count=true` (include memory counts per namespace)
+
+### GET /tags
+
+List all tags with usage counts.
+
+**Query params:** `?namespace=<name>`
+
+### POST /tags/rename
+
+Rename a tag across all memories.
+
+**Request:**
+```json
+{ "old": "arch", "new": "architecture", "namespace": "default" }
+```
+
+### POST /tags/delete
+
+Delete a tag from all memories.
+
+**Request:**
+```json
+{ "tag": "deprecated", "namespace": "default" }
+```
+
+---
+
+## Recent & Graph
+
+### GET /recent
+
+Get recently accessed memories.
+
+**Query params:** `?limit=10&namespace=default`
+
+### GET /graph
+
+Get relationship graph for an entity.
+
+**Query params:** `?entity=<name>&depth=3`
+
+### POST /graph/edge
+
+Create a relationship edge between entities.
+
+**Request:**
+```json
+{
+  "source": "uteke",
+  "target": "sqlite",
+  "edge_type": "uses",
+  "weight": 1.0
+}
+```
+
+### DELETE /graph/edge
+
+Delete a relationship edge.
+
+**Query params:** `?source=<name>&target=<name>&edge_type=<type>`
+
+---
+
+## Rooms
+
+Rooms are collaborative memory spaces for multi-agent discussions.
+
+### POST /room/create
+
+Create a new room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion", "title": "Project Discussion", "namespace": "default" }
+```
+
+### POST /room/remember
+
+Store a memory and link it to a room.
+
+**Request:**
+```json
+{
+  "room_id": "project-discussion",
+  "content": "Decision: use SQLite for storage",
+  "author": "cto",
+  "tags": ["decision"],
+  "role": "lead"
+}
+```
+
+### GET /room/memories
+
+List memories in a room (chronological order).
+
+**Query params:** `?room_id=<id>&author=<name>&limit=10`
+
+### POST /room/recall
+
+Semantic recall within a room. Query is **optional** — when omitted or empty, falls back to chronological recall ([#785](https://github.com/codecoradev/uteke/issues/785)).
+
+**Request (semantic — with query):**
+```json
+{
+  "room_id": "project-discussion",
+  "query": "database decision",
+  "limit": 5,
+  "author": null,
+  "min_score": 0.0
+}
+```
+
+**Request (chronological fallback — no query):**
+```json
+{
+  "room_id": "project-discussion",
+  "limit": 10,
+  "author": "cto"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `room_id` | string | ✅ | — | Room identifier |
+| `query` | string | ❌ | `null` | Semantic query. When empty/absent, falls back to chronological |
+| `limit` | int | ❌ | `5` | Max results |
+| `author` | string | ❌ | `null` | Filter by author |
+| `min_score` | float | ❌ | `0.0` | Minimum similarity (semantic mode only) |
+
+### POST /room/stats
+
+Get room statistics (memory count, participant count, participants list, last activity). Excludes deprecated memories ([#784](https://github.com/codecoradev/uteke/issues/784)).
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+**Response:**
+```json
+{
+  "memory_count": 12,
+  "participant_count": 3,
+  "participants": ["cto", "cmo", "coo"],
+  "last_activity": "2026-07-27T10:30:00Z"
+}
+```
+
+### POST /room/summary
+
+Get or generate a room summary.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### POST /room/summary-document
+
+Get the summary document for a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### POST /room/document
+
+Get the document associated with a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### POST /room/document/list
+
+List documents linked to a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### PUT /room/document/add
+
+Link a document to a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion", "doc_id": "doc-uuid" }
+```
+
+### DELETE /room/document/remove
+
+Unlink a document from a room.
+
+**Query params:** `?room_id=<id>&doc_id=<uuid>`
+
+### POST /doc/room/list
+
+List rooms linked to a document.
+
+**Request:**
+```json
+{ "doc_id": "doc-uuid" }
+```
+
+### GET /room/list
+
+List all rooms.
+
+**Query params:** `?namespace=<name>`
+
+### DELETE /room/delete
+
+Delete a room. Cascades `room_memories` links (memories themselves survive).
+
+**Query params:** `?room_id=<id>`
+
+---
+
+## Documents
+
+Documents are structured content with hierarchical parent-child relationships.
+
+### POST /doc/create
+
+Create a new document.
+
+**Request:**
+```json
+{
+  "slug": "architecture-overview",
+  "title": "Architecture Overview",
+  "content": "# Architecture\n\n...",
+  "tags": ["architecture"],
+  "parent": null
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `slug` | string | ✅ | — | URL-safe identifier |
+| `title` | string | ❌ | `null` | Display title |
+| `content` | string | ✅ | — | Document content (markdown) |
+| `tags` | string[] | ❌ | `[]` | Tags |
+| `parent` | string | ❌ | `null` | Parent doc slug (for hierarchy) |
+
+### POST /doc/get
+
+Get a document by ID or slug.
+
+**Request:**
+```json
+{ "id": "uuid-or-null", "slug": "architecture-overview" }
+```
+
+Provide either `id` or `slug`.
+
+### POST /doc/update
+
+Update a document.
+
+**Request:**
+```json
+{
+  "id": null,
+  "slug": "architecture-overview",
+  "title": "Updated Title",
+  "content": "updated content",
+  "tags": ["architecture", "updated"],
+  "metadata": null
+}
+```
+
+### POST /doc/list
+
+List documents.
+
+**Request:**
+```json
+{ "limit": 1000, "roots_only": false, "parent": null }
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | int | `1000` | Max results (high default for full tree) |
+| `roots_only` | bool | `false` | Only top-level docs (no parent) |
+| `parent` | string | `null` | Filter by parent slug |
+
+### POST /doc/search
+
+Search documents.
+
+**Request:**
+```json
+{ "query": "storage", "limit": 5, "mode": "hybrid" }
+```
+
+`mode`: `hybrid` (default), `fts`, or `semantic`.
+
+### POST /doc/move
+
+Move a document to a new parent.
+
+**Request:**
+```json
+{ "id": null, "slug": "child-doc", "new_parent": "new-parent-slug" }
+```
+
+### DELETE /doc/delete
+
+Delete a document.
+
+**Query params:** `?id=<uuid>` or `?slug=<slug>`
+
+### POST /doc/mem-refs
+
+Get memory references linked to a document ([#689](https://github.com/codecoradev/uteke/issues/689)).
+
+**Request:**
+```json
+{ "doc_id": "doc-uuid" }
+```
+
+---
+
+## Advanced
+
+### POST /context
+
+Get contextual memories for a given input.
+
+**Request:** Arbitrary JSON object.
+
+### POST /dream
+
+Trigger dream/consolidation process.
+
+**Request:** Arbitrary JSON object.
+
+### POST /mcp
+
+MCP (Model Context Protocol) JSON-RPC endpoint. See [MCP Server docs](/mcp) for details.
+
+---
+
+## Error Responses
+
+All errors return HTTP 4xx/5xx with a JSON error body:
+
+```json
+{ "error": "Description of what went wrong" }
+```
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Bad request — invalid JSON, missing required field, validation error |
+| 401 | Unauthorized — missing or invalid API key |
+| 404 | Not found — resource doesn't exist |
+| 413 | Payload too large — exceeds `MAX_PAYLOAD_SIZE` |
+| 500 | Internal server error — unexpected failure |
+
+---
+
+## Authentication
+
+If `UTEKE_API_KEY` is set, all endpoints require an `Authorization: Bearer <key>` header. When unset, the server runs in open mode (no auth).
+
+```bash
+# With auth
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8767/stats
+```
+
+---
+
+## CORS
+
+All responses include CORS headers (`Access-Control-Allow-Origin: *`) for browser-based clients. Preflight `OPTIONS` requests are handled automatically.
+
+---
+
+## See Also
+
+- [CLI Reference](/cli-reference) — uteke CLI commands
+- [Configuration](/configuration) — server configuration options
+- [Rooms](/rooms) — room feature guide
+- [MCP Server](/mcp) — MCP protocol integration
+- [TLS & Reverse Proxy](/tls) — production deployment


### PR DESCRIPTION
## Summary

Fixes three issues identified via cora intelligence analysis:

### #784 — Room stats count deprecated memories (bug)
- `room_stats()`, `recall_room()`, `get_room_memory_ids()` now filter `deprecated = 0` via `INNER JOIN memories m ON rm.memory_id = m.id`
- **Impact:** Previously counted deprecated memories causing 76% stat inflation (620 vs 148 active)
- Added 3 test cases: `recall_room_excludes_deprecated_memories`, `get_room_memory_ids_excludes_deprecated`, `room_stats_excludes_deprecated_memories`

### #785 — POST /room/recall query should be optional
- `RoomRecallRequest.query` changed from `String` to `Option<String>` with `#[serde(default)]`
- Handler: when query is `None` or empty, falls back to chronological `recall_room` instead of returning `400`
- Updated help text in `main.rs`

### #786 — Missing HTTP API reference docs
- Created `docs/api-reference.md` — full HTTP API reference covering 30+ endpoints
- All request/response schemas documented with field tables
- Added to VitePress sidebar config

## Cora Intelligence Usage
- `cora index --rebuild` — 1569 symbols from 137 files
- `cora brain_search` — semantic code lookup for room operations pattern
- `cora find_impact` — blast radius analysis for `room_stats` and `recall_room`
- `cora search_symbols` — function-level lookup (tree-sitter Rust limitation: no `#[derive]` struct support)

## Test Plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — all tests pass (including 3 new tests)
- [ ] CI green on GitHub Actions

Closes #784, #785, #786