### PR TITLE
fix: runtime ORT dispatch for non-AVX2 CPUs + validation error mapping (#709, #789)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,65 @@ jobs:
           name: ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}
           path: release/${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}
 
+  build-ort-legacy-windows:
+    name: Build legacy ORT Windows (SSE4.2, no AVX2)
+    needs: [verify-main]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout onnxruntime source
+        uses: actions/checkout@v7
+        with:
+          repository: microsoft/onnxruntime
+          ref: v${{ env.ORT_VERSION }}
+          path: onnxruntime-src
+
+      - name: Setup MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Cache legacy ORT build
+        id: cache-ort
+        uses: actions/cache@v4
+        with:
+          path: onnxruntime-build/Release/onnxruntime.dll
+          key: ort-legacy-win-sse42-${{ env.ORT_VERSION }}-v1
+
+      - name: Build ONNX Runtime (SSE4.2 only)
+        if: steps.cache-ort.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          mkdir onnxruntime-build
+          cmake -S onnxruntime-src\cmake -B onnxruntime-build ^
+            -Donnxruntime_BUILD_SHARED_LIB=ON ^
+            -Donnxruntime_BUILD_UNIT_TESTS=OFF ^
+            -Donnxruntime_ENABLE_PYTHON=OFF ^
+            -Donnxruntime_ENABLE_CPUINFO=OFF ^
+            -Donnxruntime_USE_AVX=OFF ^
+            -Donnxruntime_USE_AVX2=OFF ^
+            -Donnxruntime_USE_AVX512=OFF ^
+            -Donnxruntime_BUILD_BENCHMARKS=OFF ^
+            -Donnxruntime_BUILD_OBJC=OFF ^
+            -Donnxruntime_BUILD_CSHARP=OFF ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_INSTALL_PREFIX=onnxruntime-install
+          cmake --build onnxruntime-build --config Release --parallel %NUMBER_OF_PROCESSORS%
+
+      - name: Package legacy ORT
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ort-legacy
+          Copy-Item "onnxruntime-build\Release\onnxruntime*.dll" ort-legacy/ -ErrorAction SilentlyContinue
+          if (-not (Test-Path "ort-legacy\onnxruntime.dll")) {
+            # Try x64 output dir
+            Copy-Item "onnxruntime-build\x64\Release\onnxruntime*.dll" ort-legacy/ -ErrorAction SilentlyContinue
+          }
+          Get-ChildItem ort-legacy/ | Format-Table Name, Length
+
+      - name: Upload legacy ORT artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ort-legacy-windows-x64
+          path: ort-legacy/
+
   publish-crates:
     name: Publish to crates.io
     needs: [verify-main]
@@ -302,9 +361,55 @@ jobs:
           name: uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}
           path: legacy-release/uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}.tar.gz
 
+  package-legacy-windows:
+    name: Package Windows x64 legacy bundle
+    needs: [build-release, build-ort-legacy-windows]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Download standard Windows x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uteke-x86_64-pc-windows-msvc-${{ steps.version.outputs.VERSION }}
+          path: standard-artifact
+
+      - name: Download legacy ORT artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ort-legacy-windows-x64
+          path: ort-legacy
+
+      - name: Create legacy bundle
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path legacy-release
+          Expand-Archive "standard-artifact\uteke-x86_64-pc-windows-msvc-${{ steps.version.outputs.VERSION }}.zip" -DestinationPath legacy-release -Force
+          # Add legacy ORT DLLs in ort-legacy subdirectory
+          New-Item -ItemType Directory -Force -Path legacy-release\ort-legacy
+          Copy-Item "ort-legacy\*.dll" legacy-release\ort-legacy\ -ErrorAction SilentlyContinue
+          Write-Host "Standard ORT libs:"
+          Get-ChildItem legacy-release\onnxruntime*.dll -ErrorAction SilentlyContinue
+          Write-Host "Legacy ORT libs:"
+          Get-ChildItem legacy-release\ort-legacy\
+          Write-Host "`nFull bundle contents:"
+          Get-ChildItem legacy-release\
+          7z a "uteke-x86_64-pc-windows-msvc-legacy-${{ steps.version.outputs.VERSION }}.zip" legacy-release\*
+
+      - name: Upload legacy artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: uteke-x86_64-pc-windows-msvc-legacy-${{ steps.version.outputs.VERSION }}
+          path: uteke-x86_64-pc-windows-msvc-legacy-${{ steps.version.outputs.VERSION }}.zip
+
   release:
     name: Create GitHub Release
-    needs: [build-release, package-legacy]
+    needs: [build-release, package-legacy, package-legacy-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -356,8 +461,9 @@ jobs:
           printf '| Linux (x86_64, legacy) | `uteke-x86_64-unknown-linux-gnu-legacy-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
           printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
           printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
-          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\\n\\n' "${VER}" >> release-notes.md
-          printf '### 🖥️ Linux Legacy Bundle\\n\\nThe **legacy** bundle includes a SSE4.2-only ONNX Runtime sidecar (`ort-legacy/`). Use this on older CPUs without AVX2 support (e.g., Intel Celeron J4125/N4020) to avoid SIGILL crashes.\\n\\n' >> release-notes.md
+          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\\n' "${VER}" >> release-notes.md
+          printf '| Windows (x86_64, legacy) | `uteke-x86_64-pc-windows-msvc-legacy-%s.zip` |\\n\\n' "${VER}" >> release-notes.md
+          printf '### 🖥️ Legacy Bundles (Linux + Windows)\\n\\nThe **legacy** bundles include a SSE4.2-only ONNX Runtime sidecar (`ort-legacy/`). Use these on older CPUs without AVX2 support (e.g., Intel Celeron J4125/N4020) to avoid SIGILL crashes.\\n\\n' >> release-notes.md
           printf '### 🚀 Quick Start\\n\\n```bash\\n# Quick install (Linux / macOS)\\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Pin a specific version\\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Store a memory\\nuteke remember "Important context" --tags project\\n\\n# Recall by meaning\\nuteke recall "what was that context?"\\n\\n# Start server for fast AI agent access\\nuteke-serve --port 8767\\n```\\n\\n' >> release-notes.md
           printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\\n' >> release-notes.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ORT_VERSION: "1.24.4"
 
 jobs:
   verify-main:
@@ -41,6 +42,64 @@ jobs:
             echo "Merge develop → main via PR before tagging."
             exit 1
           fi
+
+  build-ort-legacy:
+    name: Build legacy ORT (SSE4.2, no AVX2)
+    needs: [verify-main]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout onnxruntime source
+        uses: actions/checkout@v7
+        with:
+          repository: microsoft/onnxruntime
+          ref: v${{ env.ORT_VERSION }}
+          path: onnxruntime-src
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential python3
+
+      - name: Cache legacy ORT build
+        id: cache-ort
+        uses: actions/cache@v4
+        with:
+          path: onnxruntime-build/lib/libonnxruntime.so*
+          key: ort-legacy-sse42-${{ env.ORT_VERSION }}-v1
+
+      - name: Build ONNX Runtime (SSE4.2 only)
+        if: steps.cache-ort.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p onnxruntime-build
+          cmake -S onnxruntime-src/cmake -B onnxruntime-build \
+            -Donnxruntime_BUILD_SHARED_LIB=ON \
+            -Donnxruntime_BUILD_UNIT_TESTS=OFF \
+            -Donnxruntime_ENABLE_PYTHON=OFF \
+            -Donnxruntime_ENABLE_CPUINFO=OFF \
+            -Donnxruntime_USE_AVX=OFF \
+            -Donnxruntime_USE_AVX2=OFF \
+            -Donnxruntime_USE_AVX512=OFF \
+            -Donnxruntime_BUILD_BENCHMARKS=OFF \
+            -Donnxruntime_BUILD_OBJC=OFF \
+            -Donnxruntime_BUILD_CSHARP=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=onnxruntime-install
+
+          cmake --build onnxruntime-build --config Release --parallel $(nproc)
+
+      - name: Package legacy ORT
+        run: |
+          mkdir -p ort-legacy
+          cp onnxruntime-build/lib/libonnxruntime.so* ort-legacy/ || true
+          # Also look for the sonamed lib
+          find onnxruntime-build -name 'libonnxruntime.so*' -type f -exec cp {} ort-legacy/ \;
+          ls -lh ort-legacy/
+
+      - name: Upload legacy ORT artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ort-legacy-linux-x64
+          path: ort-legacy/
 
   build-release:
     name: Build ${{ matrix.target }}
@@ -78,6 +137,43 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Download prebuilt ORT shared library
+        shell: bash
+        run: |
+          ORT_VER="${ORT_VERSION}"
+          case "${{ runner.os }}" in
+            Linux)
+              if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
+                ORT_PKG="onnxruntime-linux-x64-${ORT_VER}.tgz"
+              else
+                ORT_PKG="onnxruntime-linux-aarch64-${ORT_VER}.tgz"
+              fi
+              curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" | tar xz
+              mkdir -p ort-lib
+              # Copy actual .so files AND symlinks (needed for dlopen)
+              find onnxruntime-*/lib -name 'libonnxruntime.so*' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+              find onnxruntime-*/lib -name 'libonnxruntime_providers_shared.so*' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+              echo "ORT_LIB_DIR=ort-lib" >> $GITHUB_ENV
+              ;;
+            macOS)
+              ORT_PKG="onnxruntime-osx-arm64-${ORT_VER}.tgz"
+              curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" | tar xz
+              mkdir -p ort-lib
+              find onnxruntime-*/lib -name 'libonnxruntime*.dylib' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+              echo "ORT_LIB_DIR=ort-lib" >> $GITHUB_ENV
+              ;;
+            Windows)
+              ORT_PKG="onnxruntime-win-x64-${ORT_VER}.zip"
+              curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" -o ort.zip
+              mkdir -p ort-lib
+              unzip -j ort.zip 'onnxruntime-win-x64-*/lib/*.dll' -d ort-lib/ 2>/dev/null || true
+              unzip -j ort.zip 'onnxruntime-win-x64-*/lib/*.lib' -d ort-lib/ 2>/dev/null || true
+              echo "ORT_LIB_DIR=ort-lib" >> $GITHUB_ENV
+              ;;
+          esac
+          echo "Downloaded ORT libraries:"
+          ls -lh "${ORT_LIB_DIR:-ort-lib}/" || true
+
       - name: Build release binaries
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli -p uteke-server -p uteke-mcp
 
@@ -100,19 +196,33 @@ jobs:
           cp target/${{ matrix.target }}/release/uteke release/uteke
           cp target/${{ matrix.target }}/release/uteke-serve release/uteke-serve
           cp target/${{ matrix.target }}/release/uteke-mcp release/uteke-mcp
+          # Include ORT shared library
+          if [ -d "${ORT_LIB_DIR}" ]; then
+            cp -r "${ORT_LIB_DIR}"/* release/
+            echo "✅ ORT libraries included in package"
+          else
+            echo "⚠️ No ORT libraries found"
+          fi
           cd release
-          tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke uteke-serve uteke-mcp
+          tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" *
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           mkdir release
-          cp target/${{ matrix.target }}/release/uteke.exe release/uteke.exe
-          cp target/${{ matrix.target }}/release/uteke-serve.exe release/uteke-serve.exe
-          cp target/${{ matrix.target }}/release/uteke-mcp.exe release/uteke-mcp.exe
+          Copy-Item "target/${{ matrix.target }}/release/uteke.exe" release/
+          Copy-Item "target/${{ matrix.target }}/release/uteke-serve.exe" release/
+          Copy-Item "target/${{ matrix.target }}/release/uteke-mcp.exe" release/
+          # Include ORT DLLs
+          if (Test-Path $env:ORT_LIB_DIR) {
+            Copy-Item "$env:ORT_LIB_DIR/*" release/
+            Write-Host "✅ ORT libraries included in package"
+          } else {
+            Write-Host "⚠️ No ORT libraries found"
+          }
           cd release
-          7z a "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke.exe uteke-serve.exe uteke-mcp.exe
+          7z a "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" *
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -145,15 +255,66 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-server --allow-dirty
         continue-on-error: true
 
+  package-legacy:
+    name: Package Linux x64 legacy bundle
+    needs: [build-release, build-ort-legacy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Download standard Linux x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uteke-x86_64-unknown-linux-gnu-${{ steps.version.outputs.VERSION }}
+          path: standard-artifact
+
+      - name: Download legacy ORT artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ort-legacy-linux-x64
+          path: ort-legacy
+
+      - name: Create legacy bundle
+        run: |
+          mkdir -p legacy-release
+          tar xzf standard-artifact/uteke-x86_64-unknown-linux-gnu-${{ steps.version.outputs.VERSION }}.tar.gz -C legacy-release/
+          # Replace standard ORT with legacy ORT in ort-legacy/ subdirectory
+          mkdir -p legacy-release/ort-legacy
+          cp ort-legacy/libonnxruntime.so* legacy-release/ort-legacy/
+          # Verify
+          echo "Standard ORT libs:"
+          ls -lh legacy-release/libonnxruntime.so* 2>/dev/null || echo "  (none at root)"
+          echo "Legacy ORT libs:"
+          ls -lh legacy-release/ort-legacy/
+          echo ""
+          echo "Full bundle contents:"
+          ls -lh legacy-release/
+          cd legacy-release
+          tar czf "uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}.tar.gz" *
+
+      - name: Upload legacy artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}
+          path: legacy-release/uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}.tar.gz
+
   release:
     name: Create GitHub Release
-    needs: [build-release]
+    needs: [build-release, package-legacy]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -169,10 +330,6 @@ jobs:
           cd release-artifacts
           sha256sum * > checksums-sha256.txt
           cat checksums-sha256.txt
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Extract changelog for this version
         id: changelog
@@ -193,14 +350,16 @@ jobs:
           echo "" >> release-notes.md
           cat changelog-body.md >> release-notes.md
           echo "" >> release-notes.md
-          printf '### 📦 Binaries\n\nEach archive contains **three binaries**:\n- `uteke` — CLI tool\n- `uteke-serve` — HTTP server daemon\n- `uteke-mcp` — MCP server (stdio + HTTP)\n\n' >> release-notes.md
-          printf '| Platform | File |\n|----------|------|\n' >> release-notes.md
-          printf '| Linux (x86_64) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\n\n' "${VER}" >> release-notes.md
-          printf '### 🚀 Quick Start\n\n```bash\n# Quick install (Linux / macOS)\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Pin a specific version\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Store a memory\nuteke remember "Important context" --tags project\n\n# Recall by meaning\nuteke recall "what was that context?"\n\n# Start server for fast AI agent access\nuteke-serve --port 8767\n```\n\n' >> release-notes.md
-          printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\n' >> release-notes.md
+          printf '### 📦 Binaries\\n\\nEach archive contains **three binaries** + **ONNX Runtime shared library**:\\n- `uteke` — CLI tool\\n- `uteke-serve` — HTTP server daemon\\n- `uteke-mcp` — MCP server (stdio + HTTP)\\n- `libonnxruntime.so*` / `libonnxruntime*.dylib` / `onnxruntime*.dll` — ONNX Runtime\\n\\n' >> release-notes.md
+          printf '| Platform | File |\\n|----------|------|\\n' >> release-notes.md
+          printf '| Linux (x86_64, AVX2) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| Linux (x86_64, legacy) | `uteke-x86_64-unknown-linux-gnu-legacy-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\\n\\n' "${VER}" >> release-notes.md
+          printf '### 🖥️ Linux Legacy Bundle\\n\\nThe **legacy** bundle includes a SSE4.2-only ONNX Runtime sidecar (`ort-legacy/`). Use this on older CPUs without AVX2 support (e.g., Intel Celeron J4125/N4020) to avoid SIGILL crashes.\\n\\n' >> release-notes.md
+          printf '### 🚀 Quick Start\\n\\n```bash\\n# Quick install (Linux / macOS)\\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Pin a specific version\\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Store a memory\\nuteke remember "Important context" --tags project\\n\\n# Recall by meaning\\nuteke recall "what was that context?"\\n\\n# Start server for fast AI agent access\\nuteke-serve --port 8767\\n```\\n\\n' >> release-notes.md
+          printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\\n' >> release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -264,16 +423,28 @@ jobs:
             echo "Available files:" && find . -type f | head -20
             exit 1
           fi
-          tar xzf "$AMD64" -C ../binaries
-          mv ../binaries/uteke ../binaries/uteke-amd64
-          mv ../binaries/uteke-serve ../binaries/uteke-serve-amd64
-          mv ../binaries/uteke-mcp ../binaries/uteke-mcp-amd64
-          tar xzf "$ARM64" -C ../binaries
-          mv ../binaries/uteke ../binaries/uteke-arm64
-          mv ../binaries/uteke-serve ../binaries/uteke-serve-arm64
-          mv ../binaries/uteke-mcp ../binaries/uteke-mcp-arm64
-          chmod +x ../binaries/*
-          ls -lh ../binaries/
+          # Extract amd64 → rename binaries, keep .so in amd64 subfolder
+          mkdir -p binaries-amd64
+          tar xzf "$AMD64" -C binaries-amd64
+          mv binaries-amd64/uteke binaries/uteke-amd64
+          mv binaries-amd64/uteke-serve binaries/uteke-serve-amd64
+          mv binaries-amd64/uteke-mcp binaries/uteke-mcp-amd64
+          # Keep ORT .so files in arch-specific subfolder for Dockerfile
+          mkdir -p binaries/ort-amd64
+          cp binaries-amd64/libonnxruntime*.so* binaries/ort-amd64/ 2>/dev/null || true
+          # Extract arm64 → same pattern
+          mkdir -p binaries-arm64
+          tar xzf "$ARM64" -C binaries-arm64
+          mv binaries-arm64/uteke binaries/uteke-arm64
+          mv binaries-arm64/uteke-serve binaries/uteke-serve-arm64
+          mv binaries-arm64/uteke-mcp binaries/uteke-mcp-arm64
+          mkdir -p binaries/ort-arm64
+          cp binaries-arm64/libonnxruntime*.so* binaries/ort-arm64/ 2>/dev/null || true
+          chmod +x binaries/uteke-* binaries/uteke-serve-* binaries/uteke-mcp-*
+          echo "=== Docker context ==="
+          ls -lh binaries/
+          ls -lh binaries/ort-amd64/ 2>/dev/null || true
+          ls -lh binaries/ort-arm64/ 2>/dev/null || true
 
       - name: Docker meta
         id: meta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Fixed
+- **SIGILL on CPUs without AVX2 (#709)** — Runtime CPU feature detection now dynamically selects between AVX2 and SSE4.2 ONNX Runtime shared libraries. CI builds a legacy SSE4.2-only ORT sidecar for both Linux and Windows. Use the `*-legacy*` release bundles on older CPUs (e.g., Intel Celeron J4125/N4020).
+- **`POST /room/remember` returned 500 for invalid memory types (#789)** — Validation errors now correctly return HTTP 400 instead of 500.
+
+### Changed
+- **ORT loading switched from `download-binaries` to `load-dynamic`** — ORT shared library is now loaded at runtime via `dlopen`/`LoadLibrary` instead of being statically linked. Release bundles now include the ORT `.so`/`.dylib`/`.dll` as sidecar files.
+
 ### Docs
 - **Hermes integration docs updated** — Fixed incorrect `room_remember` example (was using `remember` with `room_id` which is not supported by `/remember` endpoint). Added `room_document` action. Added "Valid Memory Types" section. Added "HTTP API Notes" section documenting POST-with-body pattern and known issues (#784, #785, #786).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,12 +164,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -330,16 +318,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -548,16 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
 ]
 
 [[package]]
@@ -771,21 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,12 +908,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -1297,6 +1244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,12 +1314,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lzma-rust2"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1452,23 +1403,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1609,49 +1543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,11 +1554,11 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading",
  "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
 ]
 
 [[package]]
@@ -1675,11 +1566,6 @@ name = "ort-sys"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
-dependencies = [
- "hmac-sha256",
- "lzma-rust2",
- "ureq",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1709,15 +1595,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -2132,15 +2009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,29 +2019,6 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2343,17 +2188,6 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2851,36 +2685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64 0.22.1",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pki-types",
- "socks",
- "ureq-proto",
- "utf8-zero",
- "webpki-root-certs",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,12 +2789,6 @@ dependencies = [
  "uteke-mcp",
  "uuid",
 ]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3173,15 +2971,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-# Copy CI-downloaded binaries (preferred).
+# Copy CI-downloaded binaries + ORT shared libs (arch-specific subfolder).
 COPY binaries/ ./
+
+# Select arch-specific binaries and ORT libraries
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
       mv uteke-arm64 uteke && mv uteke-serve-arm64 uteke-serve && mv uteke-mcp-arm64 uteke-mcp && \
-      rm -f uteke-amd64 uteke-serve-amd64 uteke-mcp-amd64; \
+      rm -f uteke-amd64 uteke-serve-amd64 uteke-mcp-amd64 && \
+      if [ -d ort-arm64 ]; then cp ort-arm64/* . ; fi && \
+      rm -rf ort-amd64 ort-arm64; \
     else \
       mv uteke-amd64 uteke && mv uteke-serve-amd64 uteke-serve && mv uteke-mcp-amd64 uteke-mcp && \
-      rm -f uteke-arm64 uteke-serve-arm64 uteke-mcp-arm64; \
+      rm -f uteke-arm64 uteke-serve-arm64 uteke-mcp-arm64 && \
+      if [ -d ort-amd64 ]; then cp ort-amd64/* . ; fi && \
+      rm -rf ort-amd64 ort-arm64; \
     fi && \
     chmod +x uteke uteke-serve uteke-mcp
 
@@ -39,6 +45,12 @@ RUN groupadd --system --gid 1000 uteke && \
 COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
 COPY --from=builder /build/uteke-mcp /usr/local/bin/uteke-mcp
+
+# Copy ORT shared libraries (needed since we use load-dynamic, not download-binaries).
+# These are placed in /usr/local/lib where ldconfig will find them.
+COPY --from=builder /build/libonnxruntime*.so* /usr/local/lib/
+COPY --from=builder /build/libonnxruntime_providers_shared.so* /usr/local/lib/
+RUN ldconfig
 
 # Copy entrypoint script (handles lazy model download on first run)
 COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -27,7 +27,9 @@ tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 fs2 = "0.4"
 # ONNX-only dependencies (gated behind `onnx` feature)
-ort = { version = "2.0.0-rc.12", features = ["download-binaries"], optional = true }
+# NOTE: load-dynamic requires api-18+ to avoid pykeio/ort#547 (vitis EP compile error).
+# download-binaries is intentionally removed — ORT lib is shipped as a sidecar instead.
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic", "ndarray", "api-18"], optional = true }
 ndarray = { version = "0.17", optional = true }
 tokenizers = { version = "0.23", optional = true }
 sha2 = { version = "0.11", optional = true }

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -2,6 +2,7 @@
 
 use crate::Error;
 use crate::embed::Embedder;
+use crate::embed::ort_init;
 use sha2::{Digest, Sha256};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -48,6 +49,22 @@ pub struct OnnxEmbedder {
 impl OnnxEmbedder {
     /// Create a new embedding engine. Downloads model if not cached.
     pub fn new() -> Result<Self, Error> {
+        // ── Pre-flight: Initialize ORT environment with the correct library ──
+        // This detects AVX2 support and loads the appropriate ONNX Runtime shared
+        // library (standard AVX2 or legacy SSE4.2 sidecar). Must run before any
+        // Session is created. The once_lock ensures we only init once per process.
+        static ORT_INIT: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLock::new();
+        ORT_INIT
+            .get_or_init(|| {
+                ort_init::init_ort_environment().map(|_| ())
+            })
+            .as_ref()
+            .map_err(|e| Error::embed_msg(format!(
+                "ONNX Runtime initialization failed: {e}. \
+                 CPU may lack required SIMD support. Use the 'legacy' bundle \
+                 (includes SSE4.2 ORT) or set ORT_LIB_PATH."
+            )))?;
+
         let model_dir = Self::model_dir()?;
         std::fs::create_dir_all(&model_dir)
             .map_err(|e| Error::embed("create model directory", e))?;

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -55,15 +55,15 @@ impl OnnxEmbedder {
         // Session is created. The once_lock ensures we only init once per process.
         static ORT_INIT: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLock::new();
         ORT_INIT
-            .get_or_init(|| {
-                ort_init::init_ort_environment().map(|_| ())
-            })
+            .get_or_init(|| ort_init::init_ort_environment().map(|_| ()))
             .as_ref()
-            .map_err(|e| Error::embed_msg(format!(
-                "ONNX Runtime initialization failed: {e}. \
+            .map_err(|e| {
+                Error::embed_msg(format!(
+                    "ONNX Runtime initialization failed: {e}. \
                  CPU may lack required SIMD support. Use the 'legacy' bundle \
                  (includes SSE4.2 ORT) or set ORT_LIB_PATH."
-            )))?;
+                ))
+            })?;
 
         let model_dir = Self::model_dir()?;
         std::fs::create_dir_all(&model_dir)

--- a/crates/uteke-core/src/embed/mod.rs
+++ b/crates/uteke-core/src/embed/mod.rs
@@ -6,6 +6,8 @@ pub mod engine;
 pub mod fallback;
 pub mod ollama;
 pub mod openai;
+#[cfg(feature = "onnx")]
+pub mod ort_init;
 
 pub use embed_trait::Embedder;
 #[cfg(feature = "onnx")]

--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -1,0 +1,232 @@
+//! Runtime CPU feature detection and ORT library resolution.
+//!
+//! Solves SIGILL (Exit Code 132) on CPUs without AVX2 (e.g., Celeron J4125/N4020)
+//! by dynamically selecting the correct ONNX Runtime shared library at startup.
+//!
+//! Resolution order:
+//! 1. `ORT_LIB_PATH` env var — explicit override (for testing / custom setups).
+//! 2. If AVX2 is detected → `./libonnxruntime.so` (AVX2 build, ships in standard bundle).
+//! 3. If AVX2 is NOT detected → `./ort-legacy/libonnxruntime.so` (SSE4.2 build, sidecar).
+//! 4. If no library found → return error (caller can fall back to non-ORT embedder).
+
+use std::path::PathBuf;
+
+/// Name of the legacy ORT sidecar directory (placed next to the binary).
+const LEGACY_ORT_DIR: &str = "ort-legacy";
+
+/// ORT shared library filename per platform.
+#[cfg(target_os = "linux")]
+const ORT_LIB_NAME: &str = "libonnxruntime.so";
+#[cfg(target_os = "macos")]
+const ORT_LIB_NAME: &str = "libonnxruntime.dylib";
+#[cfg(target_os = "windows")]
+const ORT_LIB_NAME: &str = "onnxruntime.dll";
+
+/// Result of CPU feature detection and ORT library resolution.
+pub struct OrtLibInfo {
+    /// Path to the resolved ORT shared library.
+    pub lib_path: PathBuf,
+    /// Whether AVX2 was detected on this CPU.
+    pub has_avx2: bool,
+}
+
+impl std::fmt::Debug for OrtLibInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OrtLibInfo")
+            .field("lib_path", &self.lib_path)
+            .field("has_avx2", &self.has_avx2)
+            .finish()
+    }
+}
+
+/// Detect whether the current CPU supports AVX2.
+///
+/// Returns `false` on non-x86_64 architectures (ARM, etc.) since those
+/// don't use AVX2 at all — the standard ORT build will work fine.
+#[inline]
+pub fn has_avx2() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: `is_x86_feature_detected!` is a compile-time macro that
+        // generates a `cpuid` instruction. It is safe to call at any time.
+        std::is_x86_feature_detected!("avx2")
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        // Non-x86_64 (ARM, RISC-V, etc.) — no AVX2 concept.
+        // Use the standard library; the x86-specific SIGILL issue doesn't apply.
+        true
+    }
+}
+
+/// Resolve the path to the ONNX Runtime shared library.
+///
+/// Search order:
+/// 1. `ORT_LIB_PATH` environment variable (explicit override).
+/// 2. AVX2 detected → `<exe_dir>/libonnxruntime.so` (standard bundle).
+/// 3. No AVX2 → `<exe_dir>/ort-legacy/libonnxruntime.so` (legacy sidecar).
+///
+/// # Errors
+///
+/// Returns a descriptive error if no ORT library can be found.
+pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
+    // 1. Explicit env var override
+    if let Ok(env_path) = std::env::var("ORT_LIB_PATH") {
+        let path = PathBuf::from(&env_path);
+        if path.exists() {
+            tracing::info!(
+                "ORT: using explicit library path from ORT_LIB_PATH: {}",
+                path.display()
+            );
+            return Ok(OrtLibInfo {
+                lib_path: path,
+                has_avx2: has_avx2(),
+            });
+        }
+        return Err(format!(
+            "ORT_LIB_PATH set to '{}' but file does not exist",
+            env_path
+        ));
+    }
+
+    let exe_dir = exe_dir()?;
+    let avx2 = has_avx2();
+
+    if avx2 {
+        // 2. AVX2 CPU → use standard library next to binary
+        let standard_path = exe_dir.join(ORT_LIB_NAME);
+        if standard_path.exists() {
+            tracing::info!(
+                "ORT: AVX2 detected, using standard library: {}",
+                standard_path.display()
+            );
+            return Ok(OrtLibInfo {
+                lib_path: standard_path,
+                has_avx2: true,
+            });
+        }
+        // Standard lib not found — this is fine during development (cargo run)
+        // The error will be caught when ort::init_from() is called.
+        tracing::warn!(
+            "ORT: AVX2 detected but no standard library found at {}. \
+             If running from source, set ORT_LIB_PATH or build with download-binaries.",
+            standard_path.display()
+        );
+        return Err(format!(
+            "AVX2 detected but ONNX Runtime library not found at '{}'. \
+             Set ORT_LIB_PATH or use the standard release bundle.",
+            standard_path.display()
+        ));
+    }
+
+    // 3. No AVX2 → look for legacy sidecar
+    let legacy_path = exe_dir.join(LEGACY_ORT_DIR).join(ORT_LIB_NAME);
+    if legacy_path.exists() {
+        tracing::info!(
+            "ORT: No AVX2 detected, using legacy (SSE4.2) library: {}",
+            legacy_path.display()
+        );
+        return Ok(OrtLibInfo {
+            lib_path: legacy_path,
+            has_avx2: false,
+        });
+    }
+
+    Err(format!(
+        "CPU lacks AVX2 and legacy ORT library not found at '{}'. \
+         Use the 'legacy' release bundle which includes the ort-legacy/ sidecar.",
+        legacy_path.display()
+    ))
+}
+
+/// Get the directory containing the running executable.
+fn exe_dir() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("failed to determine executable path: {e}"))?;
+    exe.parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "executable path has no parent directory".into())
+}
+
+/// Initialize the ORT environment using the resolved library path.
+///
+/// This must be called **once** before any `ort::Session` is created.
+/// Returns the `OrtLibInfo` on success so callers can log which variant is in use.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - No suitable ORT library can be found (`resolve_ort_lib` failure).
+/// - The library fails to load (`ort::init_from` failure, e.g. version mismatch).
+pub fn init_ort_environment() -> Result<OrtLibInfo, String> {
+    let info = resolve_ort_lib()?;
+
+    ort::init_from(&info.lib_path)
+        .map_err(|e| format!(
+            "Failed to load ONNX Runtime from '{}': {e}. \
+             Ensure the library version matches ort crate 2.0.0-rc.12.",
+            info.lib_path.display()
+        ))?
+        .commit();
+
+    tracing::info!(
+        "ORT environment initialized successfully (AVX2={})",
+        info.has_avx2
+    );
+
+    Ok(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_avx2_returns_bool() {
+        // Just verify it doesn't panic — the actual value depends on the test machine.
+        let _avx2 = has_avx2();
+    }
+
+    #[test]
+    fn resolve_ort_lib_prefers_env_var() {
+        // Create a temp file to use as fake ORT lib
+        let tmp = std::env::temp_dir().join("test_ort_lib_resolve.so");
+        std::fs::write(&tmp, b"fake").unwrap();
+
+        // SAFETY: set_var/remove_var in test code is safe — no concurrent access.
+        unsafe {
+            std::env::set_var("ORT_LIB_PATH", &tmp);
+        }
+        let result = resolve_ort_lib();
+        unsafe {
+            std::env::remove_var("ORT_LIB_PATH");
+        }
+
+        // Cleanup
+        std::fs::remove_file(&tmp).ok();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().lib_path, tmp);
+    }
+
+    #[test]
+    fn resolve_ort_lib_errors_on_missing_env_var_path() {
+        // SAFETY: set_var/remove_var in test code is safe — no concurrent access.
+        unsafe {
+            std::env::set_var("ORT_LIB_PATH", "/nonexistent/path/libonnxruntime.so");
+        }
+        let result = resolve_ort_lib();
+        unsafe {
+            std::env::remove_var("ORT_LIB_PATH");
+        }
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn exe_dir_returns_parent() {
+        let dir = exe_dir().unwrap();
+        assert!(dir.exists(), "exe dir should exist: {}", dir.display());
+    }
+}

--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -135,22 +135,19 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
 
     // 4. Docker/system fallback: check standard system library paths.
     // In Docker containers, binaries are in /usr/local/bin/ but .so is in /usr/local/lib/.
-    let system_paths: &[&str] = &[
-        "/usr/local/lib",
-        "/usr/lib",
-        "/lib",
-    ];
-    for dir in system_paths {
-        let system_path = std::path::Path::new(dir).join(ORT_LIB_NAME);
-        if system_path.exists() {
-            tracing::info!(
-                "ORT: Using system library at {}",
-                system_path.display()
-            );
-            return Ok(OrtLibInfo {
-                lib_path: system_path,
-                has_avx2: avx2,
-            });
+    // On Windows, system paths are not applicable (DLLs are loaded from exe dir or PATH).
+    #[cfg(unix)]
+    {
+        let system_paths: &[&str] = &["/usr/local/lib", "/usr/lib", "/lib"];
+        for dir in system_paths {
+            let system_path = std::path::Path::new(dir).join(ORT_LIB_NAME);
+            if system_path.exists() {
+                tracing::info!("ORT: Using system library at {}", system_path.display());
+                return Ok(OrtLibInfo {
+                    lib_path: system_path,
+                    has_avx2: avx2,
+                });
+            }
         }
     }
 
@@ -163,8 +160,8 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
 
 /// Get the directory containing the running executable.
 fn exe_dir() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe()
-        .map_err(|e| format!("failed to determine executable path: {e}"))?;
+    let exe =
+        std::env::current_exe().map_err(|e| format!("failed to determine executable path: {e}"))?;
     exe.parent()
         .map(|p| p.to_path_buf())
         .ok_or_else(|| "executable path has no parent directory".into())
@@ -184,11 +181,13 @@ pub fn init_ort_environment() -> Result<OrtLibInfo, String> {
     let info = resolve_ort_lib()?;
 
     ort::init_from(&info.lib_path)
-        .map_err(|e| format!(
-            "Failed to load ONNX Runtime from '{}': {e}. \
+        .map_err(|e| {
+            format!(
+                "Failed to load ONNX Runtime from '{}': {e}. \
              Ensure the library version matches ort crate 2.0.0-rc.12.",
-            info.lib_path.display()
-        ))?
+                info.lib_path.display()
+            )
+        })?
         .commit();
 
     tracing::info!(

--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -7,7 +7,8 @@
 //! 1. `ORT_LIB_PATH` env var — explicit override (for testing / custom setups).
 //! 2. If AVX2 is detected → `./libonnxruntime.so` (AVX2 build, ships in standard bundle).
 //! 3. If AVX2 is NOT detected → `./ort-legacy/libonnxruntime.so` (SSE4.2 build, sidecar).
-//! 4. If no library found → return error (caller can fall back to non-ORT embedder).
+//! 4. System lib paths: `/usr/local/lib`, `/usr/lib`, `/lib` (Docker / package installs).
+//! 5. If no library found → return error (caller can fall back to non-ORT embedder).
 
 use std::path::PathBuf;
 
@@ -130,6 +131,27 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
             lib_path: legacy_path,
             has_avx2: false,
         });
+    }
+
+    // 4. Docker/system fallback: check standard system library paths.
+    // In Docker containers, binaries are in /usr/local/bin/ but .so is in /usr/local/lib/.
+    let system_paths: &[&str] = &[
+        "/usr/local/lib",
+        "/usr/lib",
+        "/lib",
+    ];
+    for dir in system_paths {
+        let system_path = std::path::Path::new(dir).join(ORT_LIB_NAME);
+        if system_path.exists() {
+            tracing::info!(
+                "ORT: Using system library at {}",
+                system_path.display()
+            );
+            return Ok(OrtLibInfo {
+                lib_path: system_path,
+                has_avx2: avx2,
+            });
+        }
     }
 
     Err(format!(

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -1065,7 +1065,11 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         ),
                         Err(e) => {
                             error!("room/remember error: {e}");
-                            ctx.error_response_for(req, 500, "Internal server error")
+                            let status = match e {
+                                uteke_core::Error::Validation(_) => 400,
+                                _ => 500,
+                            };
+                            ctx.error_response_for(req, status, e.to_string())
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes SIGILL crashes on CPUs without AVX2 (Intel Celeron J4125/N4020) and corrects HTTP error codes for invalid memory types.

### Changes

**#709 — Runtime ORT library dispatch**
- CPU feature detection at startup via `is_x86_feature_detected!("avx2")`
- Dynamic ORT loading (`load-dynamic`) instead of static `download-binaries`
- CI builds legacy SSE4.2-only ORT sidecar for **Linux + Windows**
- Release bundles now include `ort-legacy/` directory with fallback DLL
- `#[cfg(unix)]` guard on system lib paths (no-op on Windows)

**#789 — Validation error mapping**
- `POST /room/remember` returns 400 (not 500) for invalid `memory_type`
- Follows existing pattern from `/remember` handler (line 924-927)

**Issue cleanup**
- Closed #785 (already fixed — `room/recall` handles empty query)
- Closed #791 (not uteke — truncation is in Hermes MCP client layer)

### Test plan

- [x] `cargo test -p uteke-core --features onnx` — 379 passed
- [x] `cargo check -p uteke-server` — clean
- [ ] CI: verify build passes on all targets
- [ ] Manual: test on AVX2 machine (standard bundle)
- [ ] Manual: test on non-AVX2 machine (legacy bundle)

### Commits

1. `1cb1400` feat(onnx): runtime ORT library dispatch for non-AVX2 CPUs
2. `db01326` ci(release): add ORT sidecar packaging + legacy SSE4.2 build
3. `9e9d63d` fix: return 400 for Validation errors in /room/remember
4. `57ce55a` ci(release): add Windows legacy SSE4.2 ORT build
5. `54c2121` docs: update CHANGELOG