### PR TITLE
fix: accept short ID prefix in DELETE /forget (#794)

### DIFF
--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -125,6 +125,37 @@ impl super::Store {
         Ok(result)
     }
 
+    /// Resolve a short ID (prefix) to a full memory ID.
+    ///
+    /// `list` and `room_recall` display only the first 8 chars of each UUID.
+    /// This method resolves that prefix back to the full ID so `forget` can
+    /// accept what `list` shows (#794).
+    ///
+    /// Returns `Ok(Some(id))` if exactly one match, `Ok(None)` if zero,
+    /// or `Err` if multiple matches (ambiguous prefix).
+    pub fn resolve_id_prefix(&self, prefix: &str) -> Result<Option<String>, Error> {
+        let pattern = format!("{prefix}%");
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE id LIKE ?1")
+            .map_err(|e| Error::db("Failed to prepare statement for resolve_id_prefix", e))?;
+
+        let ids: Vec<String> = stmt
+            .query_map(params![pattern], |row| row.get(0))
+            .map_err(|e| Error::db("Failed to query id prefix", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        match ids.len() {
+            0 => Ok(None),
+            1 => Ok(Some(ids[0].clone())),
+            _ => Err(Error::Validation(format!(
+                "Ambiguous ID prefix '{prefix}' — matches {} memories. Use a longer prefix.",
+                ids.len()
+            ))),
+        }
+    }
+
     /// Get a memory by its ID, only if it belongs to `namespace`.
     ///
     /// Used by edge auto-wiring (#346) to enforce namespace isolation on

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1109,6 +1109,14 @@ impl crate::Uteke {
         self.store.get_by_id(id)
     }
 
+    /// Resolve a short ID prefix (first 8 chars) to a full memory ID (#794).
+    ///
+    /// Returns `Ok(Some(id))` for exact match, `Ok(None)` if not found,
+    /// or `Err(Validation)` if ambiguous.
+    pub fn resolve_id_prefix(&self, prefix: &str) -> Result<Option<String>, Error> {
+        self.store.resolve_id_prefix(prefix)
+    }
+
     /// Update an existing memory with partial fields (#659).
     ///
     /// Only provided fields are changed. If `content` is changed, the

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -431,17 +431,36 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 .collect();
 
             if let Some(id) = params.get("id") {
-                // Validate UUID format
-                if uuid::Uuid::parse_str(id).is_err() {
-                    return ctx.error_response_for(req, 400, format!("Invalid UUID format: {id}"));
-                }
+                // Accept full UUID or short ID prefix (#794).
+                // `list` and `room_recall` display only 8-char prefixes, so
+                // `forget` must resolve them back to full UUIDs.
+                let resolved_id = if uuid::Uuid::parse_str(id).is_ok() {
+                    id.clone()
+                } else {
+                    match uteke.resolve_id_prefix(id) {
+                        Ok(Some(full)) => full,
+                        Ok(None) => {
+                            return ctx.error_response_for(
+                                req,
+                                404,
+                                format!("Memory not found: {id}"),
+                            );
+                        }
+                        Err(e) => {
+                            error!("Resolve error: {e}");
+                            return ctx.error_response_for(req, 400, e.to_string());
+                        }
+                    }
+                };
                 // Check existence before deleting (#762) — forget() silently
                 // returns Ok(()) even when the ID doesn't exist.
-                if uteke.get_by_id(id).ok().flatten().is_none() {
+                if uteke.get_by_id(&resolved_id).ok().flatten().is_none() {
                     return ctx.error_response_for(req, 404, format!("Memory not found: {id}"));
                 }
-                match uteke.forget(id) {
-                    Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"forgotten": id})),
+                match uteke.forget(&resolved_id) {
+                    Ok(()) => {
+                        ctx.ok_response_for(req, &serde_json::json!({"forgotten": resolved_id}))
+                    }
                     Err(e) => {
                         error!("Internal error: {e}");
                         ctx.error_response_for(req, 500, "Internal server error")


### PR DESCRIPTION
## Summary

Closes #794

 and  display only the first 8 chars of each UUID, but `DELETE /forget?id=` required a full UUID — making it impossible to delete memories directly from CLI output.

## Fix

- **`resolve_id_prefix()`** — new method in `uteke-core` (crud + operations) that resolves a short ID prefix to the full UUID via SQL `LIKE`
- **Handler logic**: try full UUID first → fallback to prefix resolution → 404 if not found, 400 if ambiguous
- **Ambiguous handling**: if prefix matches >1 memory, returns 400 with count (e.g. "Ambiguous ID prefix — matches 3 memories")

## Files changed

| File | Change |
|------|--------|
| `crates/uteke-core/src/memory/crud.rs` | +`resolve_id_prefix()` |
| `crates/uteke-core/src/operations.rs` | Expose `resolve_id_prefix()` |
| `crates/uteke-server/src/handlers.rs` | Handler accepts short ID via prefix resolution |

## Verification

- [x] `cargo check --workspace --all-targets` ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✅
- [x] `cargo test --workspace` ✅
- [x] `cargo fmt --all -- --check` ✅
- [x] Cora code review ✅