### PR TITLE
chore: v0.10.2 pre-release — version bump + docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
-## [Unreleased]
+## [0.10.2] — 2026-07-28
 
 ### Fixed
 - **SIGILL on CPUs without AVX2 (#709)** — Runtime CPU feature detection now dynamically selects between AVX2 and SSE4.2 ONNX Runtime shared libraries. CI builds a legacy SSE4.2-only ORT sidecar for both Linux and Windows. Use the `*-legacy*` release bundles on older CPUs (e.g., Intel Celeron J4125/N4020).
 - **`POST /room/remember` returned 500 for invalid memory types (#789)** — Validation errors now correctly return HTTP 400 instead of 500.
+- **Room operations counted deprecated memories (#784)** — `room_stats()`, `recall_room()`, and `get_room_memory_ids()` now filter `deprecated = 0`. Previously caused 76% stat inflation (620 vs 148 active).
+- **`POST /room/recall` required query parameter (#785)** — `query` is now `Option<String>` with `#[serde(default)]`. Empty/missing query falls back to chronological recall instead of returning 400.
+- **`DELETE /forget` rejected short ID prefixes (#794)** — `list` and `room_recall` display 8-char ID prefixes, but `forget` required full UUIDs. Now resolves short prefixes via SQL `LIKE` with ambiguous-match detection (400 if >1 match).
 
 ### Changed
 - **ORT loading switched from `download-binaries` to `load-dynamic`** — ORT shared library is now loaded at runtime via `dlopen`/`LoadLibrary` instead of being statically linked. Release bundles now include the ORT `.so`/`.dylib`/`.dll` as sidecar files.
+
+### Added
+- **Auto-generated API reference docs (#786)** — New `crates/docgen` binary reads route registry + `schemars::JsonSchema` derives to generate `docs/api-reference.md`. CI `docs-check` job fails if docs are stale. Feature-gated behind `docgen` flag — zero runtime overhead.
+
+### Security
+- **Bump quinn-proto 0.11.14 → 0.11.15 (GHSA-4w2j-m93h-cj5j)** — Dependency patch for HTTP/3 stream injection vulnerability.
 
 ### Docs
 - **Hermes integration docs updated** — Fixed incorrect `room_remember` example (was using `remember` with `room_id` which is not supported by `/remember` endpoint). Added `room_document` action. Added "Valid Memory Types" section. Added "HTTP API Notes" section documenting POST-with-body pattern and known issues (#784, #785, #786).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "dirs",
  "serde",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh |
 Pin a specific version with `UTEKE_VERSION`:
 
 ```bash
-UTEKE_VERSION=v0.0.7 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.10.2 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ### Windows Setup
@@ -114,7 +114,7 @@ Model cached at:
 ## Verify Installation
 
 ```bash
-uteke --version        # Should show "uteke 0.0.2"
+uteke --version        # Should show "uteke 0.10.2"
 uteke stats            # Should show store statistics
 
 # Quick smoke test

--- a/README.id.md
+++ b/README.id.md
@@ -83,7 +83,7 @@ Wizard-nya akan:
 2. **Tanya** AI agent apa yang kamu pakai (Hermes, Claude, Cursor, Pi, OpenCode)
 3. **Pilih** mode integrasi — manual tool calls vs automatic memory-provider
 4. **Toggle** fitur on/off (Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode)
-5. **Tulis** `~/.uteke/uteke.toml` dengan pilihan kamu
+5. **Tulis** `~/.codecora/uteke/uteke.toml` dengan pilihan kamu
 6. **Install** file integrasi agent otomatis (`uteke init`)
 7. **Tunjukkan** semua command uteke, dikelompokkan per kategori
 
@@ -274,7 +274,7 @@ Bisa. Uteke punya MCP server yang langsung pakai dengan Claude Code, Cursor, dan
 <details>
 <summary><strong>Sudah production-ready?</strong></summary>
 
-Uteke sekarang v0.7.2 dengan 206 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
+Uteke sekarang v0.10.2 dengan 431 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
 </details>
 
 ---
@@ -283,7 +283,7 @@ Uteke sekarang v0.7.2 dengan 206 test, CI/CD di setiap commit, dan benchmark har
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (206 test)
+cargo test --workspace         # Test (431 test)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.7.3 with 206 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
+Uteke is at v0.10.2 with 431 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
 </details>
 
 ---
@@ -290,7 +290,7 @@ Uteke is at v0.7.3 with 206 tests, CI/CD on every commit, and benchmark harness.
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (206 tests)
+cargo test --workspace         # Test (431 tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```


### PR DESCRIPTION
## Summary

Pre-release housekeeping for v0.10.2. All changes since v0.10.1 are now documented.

### Changes

| File | What | Why |
|------|------|-----|
| `Cargo.toml` | Version 0.10.1 → 0.10.2 | Release bump |
| `CHANGELOG.md` | Promote [Unreleased] → [0.10.2], add 5 missing entries | Complete release notes |
| `README.md` | v0.7.3 → v0.10.2, tests 206 → 431 | Stale since v0.7.x |
| `README.id.md` | v0.7.2 → v0.10.2, tests 206 → 431, ~/.uteke path fix | Stale since v0.7.x |
| `INSTALL.md` | Version examples 0.0.2/0.0.7 → 0.10.2 | Stale since v0.0.x |
| `Cargo.lock` | Auto-updated | Version bump |

### CHANGELOG additions (not in [Unreleased] before)

- **Fixed**: Room operations counted deprecated memories (#784)
- **Fixed**: POST /room/recall query now optional (#785)
- **Fixed**: DELETE /forget accepts short ID prefixes (#794)
- **Added**: Auto-generated API reference docs via schemars (#786)
- **Security**: quinn-proto 0.11.14 → 0.11.15 (GHSA-4w2j-m93h-cj5j)

### Validation

- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace (431 passed)
- [x] docs/api-reference.md regenerated with new version

### No code changes — docs + version only.