### PR TITLE
Release v0.10.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --workspace
 
+  docs-check:
+    name: API Docs Fresh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -p docgen
+      - name: Verify docs are up-to-date
+        run: |
+          if ! git diff --quiet docs/api-reference.md; then
+            echo "::error::docs/api-reference.md is stale. Run 'cargo run -p docgen' and commit the result."
+            git diff --stat docs/api-reference.md
+            exit 1
+          fi
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ORT_VERSION: "1.24.4"
 
 jobs:
   verify-main:
@@ -41,6 +42,64 @@ jobs:
             echo "Merge develop → main via PR before tagging."
             exit 1
           fi
+
+  build-ort-legacy:
+    name: Build legacy ORT (SSE4.2, no AVX2)
+    needs: [verify-main]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout onnxruntime source
+        uses: actions/checkout@v7
+        with:
+          repository: microsoft/onnxruntime
+          ref: v${{ env.ORT_VERSION }}
+          path: onnxruntime-src
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential python3
+
+      - name: Cache legacy ORT build
+        id: cache-ort
+        uses: actions/cache@v4
+        with:
+          path: onnxruntime-build/lib/libonnxruntime.so*
+          key: ort-legacy-sse42-${{ env.ORT_VERSION }}-v1
+
+      - name: Build ONNX Runtime (SSE4.2 only)
+        if: steps.cache-ort.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p onnxruntime-build
+          cmake -S onnxruntime-src/cmake -B onnxruntime-build \
+            -Donnxruntime_BUILD_SHARED_LIB=ON \
+            -Donnxruntime_BUILD_UNIT_TESTS=OFF \
+            -Donnxruntime_ENABLE_PYTHON=OFF \
+            -Donnxruntime_ENABLE_CPUINFO=OFF \
+            -Donnxruntime_USE_AVX=OFF \
+            -Donnxruntime_USE_AVX2=OFF \
+            -Donnxruntime_USE_AVX512=OFF \
+            -Donnxruntime_BUILD_BENCHMARKS=OFF \
+            -Donnxruntime_BUILD_OBJC=OFF \
+            -Donnxruntime_BUILD_CSHARP=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=onnxruntime-install
+
+          cmake --build onnxruntime-build --config Release --parallel $(nproc)
+
+      - name: Package legacy ORT
+        run: |
+          mkdir -p ort-legacy
+          cp onnxruntime-build/lib/libonnxruntime.so* ort-legacy/ || true
+          # Also look for the sonamed lib
+          find onnxruntime-build -name 'libonnxruntime.so*' -type f -exec cp {} ort-legacy/ \;
+          ls -lh ort-legacy/
+
+      - name: Upload legacy ORT artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ort-legacy-linux-x64
+          path: ort-legacy/
 
   build-release:
     name: Build ${{ matrix.target }}
@@ -78,6 +137,43 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Download prebuilt ORT shared library
+        shell: bash
+        run: |
+          ORT_VER="${ORT_VERSION}"
+          case "${{ runner.os }}" in
+            Linux)
+              if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
+                ORT_PKG="onnxruntime-linux-x64-${ORT_VER}.tgz"
+              else
+                ORT_PKG="onnxruntime-linux-aarch64-${ORT_VER}.tgz"
+              fi
+              curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" | tar xz
+              mkdir -p ort-lib
+              # Copy actual .so files AND symlinks (needed for dlopen)
+              find onnxruntime-*/lib -name 'libonnxruntime.so*' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+              find onnxruntime-*/lib -name 'libonnxruntime_providers_shared.so*' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+              echo "ORT_LIB_DIR=ort-lib" >> $GITHUB_ENV
+              ;;
+            macOS)
+              ORT_PKG="onnxruntime-osx-arm64-${ORT_VER}.tgz"
+              curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" | tar xz
+              mkdir -p ort-lib
+              find onnxruntime-*/lib -name 'libonnxruntime*.dylib' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+              echo "ORT_LIB_DIR=ort-lib" >> $GITHUB_ENV
+              ;;
+            Windows)
+              ORT_PKG="onnxruntime-win-x64-${ORT_VER}.zip"
+              curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" -o ort.zip
+              mkdir -p ort-lib
+              unzip -j ort.zip 'onnxruntime-win-x64-*/lib/*.dll' -d ort-lib/ 2>/dev/null || true
+              unzip -j ort.zip 'onnxruntime-win-x64-*/lib/*.lib' -d ort-lib/ 2>/dev/null || true
+              echo "ORT_LIB_DIR=ort-lib" >> $GITHUB_ENV
+              ;;
+          esac
+          echo "Downloaded ORT libraries:"
+          ls -lh "${ORT_LIB_DIR:-ort-lib}/" || true
+
       - name: Build release binaries
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli -p uteke-server -p uteke-mcp
 
@@ -100,25 +196,98 @@ jobs:
           cp target/${{ matrix.target }}/release/uteke release/uteke
           cp target/${{ matrix.target }}/release/uteke-serve release/uteke-serve
           cp target/${{ matrix.target }}/release/uteke-mcp release/uteke-mcp
+          # Include ORT shared library
+          if [ -d "${ORT_LIB_DIR}" ]; then
+            cp -r "${ORT_LIB_DIR}"/* release/
+            echo "✅ ORT libraries included in package"
+          else
+            echo "⚠️ No ORT libraries found"
+          fi
           cd release
-          tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke uteke-serve uteke-mcp
+          tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" *
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           mkdir release
-          cp target/${{ matrix.target }}/release/uteke.exe release/uteke.exe
-          cp target/${{ matrix.target }}/release/uteke-serve.exe release/uteke-serve.exe
-          cp target/${{ matrix.target }}/release/uteke-mcp.exe release/uteke-mcp.exe
+          Copy-Item "target/${{ matrix.target }}/release/uteke.exe" release/
+          Copy-Item "target/${{ matrix.target }}/release/uteke-serve.exe" release/
+          Copy-Item "target/${{ matrix.target }}/release/uteke-mcp.exe" release/
+          # Include ORT DLLs
+          if (Test-Path $env:ORT_LIB_DIR) {
+            Copy-Item "$env:ORT_LIB_DIR/*" release/
+            Write-Host "✅ ORT libraries included in package"
+          } else {
+            Write-Host "⚠️ No ORT libraries found"
+          }
           cd release
-          7z a "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" uteke.exe uteke-serve.exe uteke-mcp.exe
+          7z a "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}" *
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}
           path: release/${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}
+
+  build-ort-legacy-windows:
+    name: Build legacy ORT Windows (SSE4.2, no AVX2)
+    needs: [verify-main]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout onnxruntime source
+        uses: actions/checkout@v7
+        with:
+          repository: microsoft/onnxruntime
+          ref: v${{ env.ORT_VERSION }}
+          path: onnxruntime-src
+
+      - name: Setup MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Cache legacy ORT build
+        id: cache-ort
+        uses: actions/cache@v4
+        with:
+          path: onnxruntime-build/Release/onnxruntime.dll
+          key: ort-legacy-win-sse42-${{ env.ORT_VERSION }}-v1
+
+      - name: Build ONNX Runtime (SSE4.2 only)
+        if: steps.cache-ort.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          mkdir onnxruntime-build
+          cmake -S onnxruntime-src\cmake -B onnxruntime-build ^
+            -Donnxruntime_BUILD_SHARED_LIB=ON ^
+            -Donnxruntime_BUILD_UNIT_TESTS=OFF ^
+            -Donnxruntime_ENABLE_PYTHON=OFF ^
+            -Donnxruntime_ENABLE_CPUINFO=OFF ^
+            -Donnxruntime_USE_AVX=OFF ^
+            -Donnxruntime_USE_AVX2=OFF ^
+            -Donnxruntime_USE_AVX512=OFF ^
+            -Donnxruntime_BUILD_BENCHMARKS=OFF ^
+            -Donnxruntime_BUILD_OBJC=OFF ^
+            -Donnxruntime_BUILD_CSHARP=OFF ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_INSTALL_PREFIX=onnxruntime-install
+          cmake --build onnxruntime-build --config Release --parallel %NUMBER_OF_PROCESSORS%
+
+      - name: Package legacy ORT
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ort-legacy
+          Copy-Item "onnxruntime-build\Release\onnxruntime*.dll" ort-legacy/ -ErrorAction SilentlyContinue
+          if (-not (Test-Path "ort-legacy\onnxruntime.dll")) {
+            # Try x64 output dir
+            Copy-Item "onnxruntime-build\x64\Release\onnxruntime*.dll" ort-legacy/ -ErrorAction SilentlyContinue
+          }
+          Get-ChildItem ort-legacy/ | Format-Table Name, Length
+
+      - name: Upload legacy ORT artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ort-legacy-windows-x64
+          path: ort-legacy/
 
   publish-crates:
     name: Publish to crates.io
@@ -145,15 +314,112 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-server --allow-dirty
         continue-on-error: true
 
+  package-legacy:
+    name: Package Linux x64 legacy bundle
+    needs: [build-release, build-ort-legacy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Download standard Linux x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uteke-x86_64-unknown-linux-gnu-${{ steps.version.outputs.VERSION }}
+          path: standard-artifact
+
+      - name: Download legacy ORT artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ort-legacy-linux-x64
+          path: ort-legacy
+
+      - name: Create legacy bundle
+        run: |
+          mkdir -p legacy-release
+          tar xzf standard-artifact/uteke-x86_64-unknown-linux-gnu-${{ steps.version.outputs.VERSION }}.tar.gz -C legacy-release/
+          # Replace standard ORT with legacy ORT in ort-legacy/ subdirectory
+          mkdir -p legacy-release/ort-legacy
+          cp ort-legacy/libonnxruntime.so* legacy-release/ort-legacy/
+          # Verify
+          echo "Standard ORT libs:"
+          ls -lh legacy-release/libonnxruntime.so* 2>/dev/null || echo "  (none at root)"
+          echo "Legacy ORT libs:"
+          ls -lh legacy-release/ort-legacy/
+          echo ""
+          echo "Full bundle contents:"
+          ls -lh legacy-release/
+          cd legacy-release
+          tar czf "uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}.tar.gz" *
+
+      - name: Upload legacy artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}
+          path: legacy-release/uteke-x86_64-unknown-linux-gnu-legacy-${{ steps.version.outputs.VERSION }}.tar.gz
+
+  package-legacy-windows:
+    name: Package Windows x64 legacy bundle
+    needs: [build-release, build-ort-legacy-windows]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Download standard Windows x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uteke-x86_64-pc-windows-msvc-${{ steps.version.outputs.VERSION }}
+          path: standard-artifact
+
+      - name: Download legacy ORT artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ort-legacy-windows-x64
+          path: ort-legacy
+
+      - name: Create legacy bundle
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path legacy-release
+          Expand-Archive "standard-artifact\uteke-x86_64-pc-windows-msvc-${{ steps.version.outputs.VERSION }}.zip" -DestinationPath legacy-release -Force
+          # Add legacy ORT DLLs in ort-legacy subdirectory
+          New-Item -ItemType Directory -Force -Path legacy-release\ort-legacy
+          Copy-Item "ort-legacy\*.dll" legacy-release\ort-legacy\ -ErrorAction SilentlyContinue
+          Write-Host "Standard ORT libs:"
+          Get-ChildItem legacy-release\onnxruntime*.dll -ErrorAction SilentlyContinue
+          Write-Host "Legacy ORT libs:"
+          Get-ChildItem legacy-release\ort-legacy\
+          Write-Host "`nFull bundle contents:"
+          Get-ChildItem legacy-release\
+          7z a "uteke-x86_64-pc-windows-msvc-legacy-${{ steps.version.outputs.VERSION }}.zip" legacy-release\*
+
+      - name: Upload legacy artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: uteke-x86_64-pc-windows-msvc-legacy-${{ steps.version.outputs.VERSION }}
+          path: uteke-x86_64-pc-windows-msvc-legacy-${{ steps.version.outputs.VERSION }}.zip
+
   release:
     name: Create GitHub Release
-    needs: [build-release]
+    needs: [build-release, package-legacy, package-legacy-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -169,10 +435,6 @@ jobs:
           cd release-artifacts
           sha256sum * > checksums-sha256.txt
           cat checksums-sha256.txt
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Extract changelog for this version
         id: changelog
@@ -193,14 +455,17 @@ jobs:
           echo "" >> release-notes.md
           cat changelog-body.md >> release-notes.md
           echo "" >> release-notes.md
-          printf '### 📦 Binaries\n\nEach archive contains **three binaries**:\n- `uteke` — CLI tool\n- `uteke-serve` — HTTP server daemon\n- `uteke-mcp` — MCP server (stdio + HTTP)\n\n' >> release-notes.md
-          printf '| Platform | File |\n|----------|------|\n' >> release-notes.md
-          printf '| Linux (x86_64) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\n' "${VER}" >> release-notes.md
-          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\n\n' "${VER}" >> release-notes.md
-          printf '### 🚀 Quick Start\n\n```bash\n# Quick install (Linux / macOS)\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Pin a specific version\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\n\n# Store a memory\nuteke remember "Important context" --tags project\n\n# Recall by meaning\nuteke recall "what was that context?"\n\n# Start server for fast AI agent access\nuteke-serve --port 8767\n```\n\n' >> release-notes.md
-          printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\n' >> release-notes.md
+          printf '### 📦 Binaries\\n\\nEach archive contains **three binaries** + **ONNX Runtime shared library**:\\n- `uteke` — CLI tool\\n- `uteke-serve` — HTTP server daemon\\n- `uteke-mcp` — MCP server (stdio + HTTP)\\n- `libonnxruntime.so*` / `libonnxruntime*.dylib` / `onnxruntime*.dll` — ONNX Runtime\\n\\n' >> release-notes.md
+          printf '| Platform | File |\\n|----------|------|\\n' >> release-notes.md
+          printf '| Linux (x86_64, AVX2) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| Linux (x86_64, legacy) | `uteke-x86_64-unknown-linux-gnu-legacy-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
+          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\\n' "${VER}" >> release-notes.md
+          printf '| Windows (x86_64, legacy) | `uteke-x86_64-pc-windows-msvc-legacy-%s.zip` |\\n\\n' "${VER}" >> release-notes.md
+          printf '### 🖥️ Legacy Bundles (Linux + Windows)\\n\\nThe **legacy** bundles include a SSE4.2-only ONNX Runtime sidecar (`ort-legacy/`). Use these on older CPUs without AVX2 support (e.g., Intel Celeron J4125/N4020) to avoid SIGILL crashes.\\n\\n' >> release-notes.md
+          printf '### 🚀 Quick Start\\n\\n```bash\\n# Quick install (Linux / macOS)\\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Pin a specific version\\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Store a memory\\nuteke remember "Important context" --tags project\\n\\n# Recall by meaning\\nuteke recall "what was that context?"\\n\\n# Start server for fast AI agent access\\nuteke-serve --port 8767\\n```\\n\\n' >> release-notes.md
+          printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\\n' >> release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -264,16 +529,28 @@ jobs:
             echo "Available files:" && find . -type f | head -20
             exit 1
           fi
-          tar xzf "$AMD64" -C ../binaries
-          mv ../binaries/uteke ../binaries/uteke-amd64
-          mv ../binaries/uteke-serve ../binaries/uteke-serve-amd64
-          mv ../binaries/uteke-mcp ../binaries/uteke-mcp-amd64
-          tar xzf "$ARM64" -C ../binaries
-          mv ../binaries/uteke ../binaries/uteke-arm64
-          mv ../binaries/uteke-serve ../binaries/uteke-serve-arm64
-          mv ../binaries/uteke-mcp ../binaries/uteke-mcp-arm64
-          chmod +x ../binaries/*
-          ls -lh ../binaries/
+          # Extract amd64 → rename binaries, keep .so in amd64 subfolder
+          mkdir -p binaries-amd64
+          tar xzf "$AMD64" -C binaries-amd64
+          mv binaries-amd64/uteke binaries/uteke-amd64
+          mv binaries-amd64/uteke-serve binaries/uteke-serve-amd64
+          mv binaries-amd64/uteke-mcp binaries/uteke-mcp-amd64
+          # Keep ORT .so files in arch-specific subfolder for Dockerfile
+          mkdir -p binaries/ort-amd64
+          cp binaries-amd64/libonnxruntime*.so* binaries/ort-amd64/ 2>/dev/null || true
+          # Extract arm64 → same pattern
+          mkdir -p binaries-arm64
+          tar xzf "$ARM64" -C binaries-arm64
+          mv binaries-arm64/uteke binaries/uteke-arm64
+          mv binaries-arm64/uteke-serve binaries/uteke-serve-arm64
+          mv binaries-arm64/uteke-mcp binaries/uteke-mcp-arm64
+          mkdir -p binaries/ort-arm64
+          cp binaries-arm64/libonnxruntime*.so* binaries/ort-arm64/ 2>/dev/null || true
+          chmod +x binaries/uteke-* binaries/uteke-serve-* binaries/uteke-mcp-*
+          echo "=== Docker context ==="
+          ls -lh binaries/
+          ls -lh binaries/ort-amd64/ 2>/dev/null || true
+          ls -lh binaries/ort-arm64/ 2>/dev/null || true
 
       - name: Docker meta
         id: meta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Fixed
+- **SIGILL on CPUs without AVX2 (#709)** — Runtime CPU feature detection now dynamically selects between AVX2 and SSE4.2 ONNX Runtime shared libraries. CI builds a legacy SSE4.2-only ORT sidecar for both Linux and Windows. Use the `*-legacy*` release bundles on older CPUs (e.g., Intel Celeron J4125/N4020).
+- **`POST /room/remember` returned 500 for invalid memory types (#789)** — Validation errors now correctly return HTTP 400 instead of 500.
+
+### Changed
+- **ORT loading switched from `download-binaries` to `load-dynamic`** — ORT shared library is now loaded at runtime via `dlopen`/`LoadLibrary` instead of being statically linked. Release bundles now include the ORT `.so`/`.dylib`/`.dll` as sidecar files.
+
 ### Docs
 - **Hermes integration docs updated** — Fixed incorrect `room_remember` example (was using `remember` with `room_id` which is not supported by `/remember` endpoint). Added `room_document` action. Added "Valid Memory Types" section. Added "HTTP API Notes" section documenting POST-with-body pattern and known issues (#784, #785, #786).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Docs
+- **Hermes integration docs updated** — Fixed incorrect `room_remember` example (was using `remember` with `room_id` which is not supported by `/remember` endpoint). Added `room_document` action. Added "Valid Memory Types" section. Added "HTTP API Notes" section documenting POST-with-body pattern and known issues (#784, #785, #786).
+
 ## [0.10.1] — 2026-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
-## [Unreleased]
+## [0.10.2] — 2026-07-28
 
 ### Fixed
 - **SIGILL on CPUs without AVX2 (#709)** — Runtime CPU feature detection now dynamically selects between AVX2 and SSE4.2 ONNX Runtime shared libraries. CI builds a legacy SSE4.2-only ORT sidecar for both Linux and Windows. Use the `*-legacy*` release bundles on older CPUs (e.g., Intel Celeron J4125/N4020).
 - **`POST /room/remember` returned 500 for invalid memory types (#789)** — Validation errors now correctly return HTTP 400 instead of 500.
+- **Room operations counted deprecated memories (#784)** — `room_stats()`, `recall_room()`, and `get_room_memory_ids()` now filter `deprecated = 0`. Previously caused 76% stat inflation (620 vs 148 active).
+- **`POST /room/recall` required query parameter (#785)** — `query` is now `Option<String>` with `#[serde(default)]`. Empty/missing query falls back to chronological recall instead of returning 400.
+- **`DELETE /forget` rejected short ID prefixes (#794)** — `list` and `room_recall` display 8-char ID prefixes, but `forget` required full UUIDs. Now resolves short prefixes via SQL `LIKE` with ambiguous-match detection (400 if >1 match).
 
 ### Changed
 - **ORT loading switched from `download-binaries` to `load-dynamic`** — ORT shared library is now loaded at runtime via `dlopen`/`LoadLibrary` instead of being statically linked. Release bundles now include the ORT `.so`/`.dylib`/`.dll` as sidecar files.
+
+### Added
+- **Auto-generated API reference docs (#786)** — New `crates/docgen` binary reads route registry + `schemars::JsonSchema` derives to generate `docs/api-reference.md`. CI `docs-check` job fails if docs are stale. Feature-gated behind `docgen` flag — zero runtime overhead.
+
+### Security
+- **Bump quinn-proto 0.11.14 → 0.11.15 (GHSA-4w2j-m93h-cj5j)** — Dependency patch for HTTP/3 stream injection vulnerability.
 
 ### Docs
 - **Hermes integration docs updated** — Fixed incorrect `room_remember` example (was using `remember` with `room_id` which is not supported by `/remember` endpoint). Added `room_document` action. Added "Valid Memory Types" section. Added "HTTP API Notes" section documenting POST-with-body pattern and known issues (#784, #785, #786).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,12 +164,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -330,16 +318,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -548,16 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
 ]
 
 [[package]]
@@ -771,21 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,12 +908,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -1297,6 +1244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,12 +1314,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lzma-rust2"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1452,23 +1403,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1609,49 +1543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,11 +1554,11 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading",
  "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
 ]
 
 [[package]]
@@ -1675,11 +1566,6 @@ name = "ort-sys"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
-dependencies = [
- "hmac-sha256",
- "lzma-rust2",
- "ureq",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1709,15 +1595,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -2132,15 +2009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,29 +2019,6 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2343,17 +2188,6 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2851,36 +2685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64 0.22.1",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pki-types",
- "socks",
- "ureq-proto",
- "utf8-zero",
- "webpki-root-certs",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,12 +2789,6 @@ dependencies = [
  "uteke-mcp",
  "uuid",
 ]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3173,15 +2971,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "dirs",
  "serde",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -457,7 +457,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -475,7 +475,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -505,7 +505,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -555,7 +555,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -630,8 +630,25 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "docgen"
+version = "0.1.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "uteke-core",
+ "uteke-server",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1402,7 +1419,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1660,7 +1677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1832,6 +1849,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2009,6 +2046,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,7 +2115,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2112,7 +2185,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2256,6 +2329,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,7 +2356,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2325,7 +2409,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2579,7 +2663,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2778,6 +2862,7 @@ version = "0.10.1"
 dependencies = [
  "chrono",
  "ctrlc",
+ "schemars",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2906,7 +2991,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3046,7 +3131,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3057,7 +3142,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3214,7 +3299,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3230,7 +3315,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3307,7 +3392,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3328,7 +3413,7 @@ checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3348,7 +3433,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3388,7 +3473,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/uteke-cli",
     "crates/uteke-server",
     "crates/uteke-mcp",
+    "crates/docgen",
 ]
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-# Copy CI-downloaded binaries (preferred).
+# Copy CI-downloaded binaries + ORT shared libs (arch-specific subfolder).
 COPY binaries/ ./
+
+# Select arch-specific binaries and ORT libraries
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
       mv uteke-arm64 uteke && mv uteke-serve-arm64 uteke-serve && mv uteke-mcp-arm64 uteke-mcp && \
-      rm -f uteke-amd64 uteke-serve-amd64 uteke-mcp-amd64; \
+      rm -f uteke-amd64 uteke-serve-amd64 uteke-mcp-amd64 && \
+      if [ -d ort-arm64 ]; then cp ort-arm64/* . ; fi && \
+      rm -rf ort-amd64 ort-arm64; \
     else \
       mv uteke-amd64 uteke && mv uteke-serve-amd64 uteke-serve && mv uteke-mcp-amd64 uteke-mcp && \
-      rm -f uteke-arm64 uteke-serve-arm64 uteke-mcp-arm64; \
+      rm -f uteke-arm64 uteke-serve-arm64 uteke-mcp-arm64 && \
+      if [ -d ort-amd64 ]; then cp ort-amd64/* . ; fi && \
+      rm -rf ort-amd64 ort-arm64; \
     fi && \
     chmod +x uteke uteke-serve uteke-mcp
 
@@ -39,6 +45,12 @@ RUN groupadd --system --gid 1000 uteke && \
 COPY --from=builder /build/uteke /usr/local/bin/uteke
 COPY --from=builder /build/uteke-serve /usr/local/bin/uteke-serve
 COPY --from=builder /build/uteke-mcp /usr/local/bin/uteke-mcp
+
+# Copy ORT shared libraries (needed since we use load-dynamic, not download-binaries).
+# These are placed in /usr/local/lib where ldconfig will find them.
+COPY --from=builder /build/libonnxruntime*.so* /usr/local/lib/
+COPY --from=builder /build/libonnxruntime_providers_shared.so* /usr/local/lib/
+RUN ldconfig
 
 # Copy entrypoint script (handles lazy model download on first run)
 COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh |
 Pin a specific version with `UTEKE_VERSION`:
 
 ```bash
-UTEKE_VERSION=v0.0.7 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.10.2 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ### Windows Setup
@@ -114,7 +114,7 @@ Model cached at:
 ## Verify Installation
 
 ```bash
-uteke --version        # Should show "uteke 0.0.2"
+uteke --version        # Should show "uteke 0.10.2"
 uteke stats            # Should show store statistics
 
 # Quick smoke test

--- a/README.id.md
+++ b/README.id.md
@@ -83,7 +83,7 @@ Wizard-nya akan:
 2. **Tanya** AI agent apa yang kamu pakai (Hermes, Claude, Cursor, Pi, OpenCode)
 3. **Pilih** mode integrasi — manual tool calls vs automatic memory-provider
 4. **Toggle** fitur on/off (Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode)
-5. **Tulis** `~/.uteke/uteke.toml` dengan pilihan kamu
+5. **Tulis** `~/.codecora/uteke/uteke.toml` dengan pilihan kamu
 6. **Install** file integrasi agent otomatis (`uteke init`)
 7. **Tunjukkan** semua command uteke, dikelompokkan per kategori
 
@@ -274,7 +274,7 @@ Bisa. Uteke punya MCP server yang langsung pakai dengan Claude Code, Cursor, dan
 <details>
 <summary><strong>Sudah production-ready?</strong></summary>
 
-Uteke sekarang v0.7.2 dengan 206 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
+Uteke sekarang v0.10.2 dengan 431 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
 </details>
 
 ---
@@ -283,7 +283,7 @@ Uteke sekarang v0.7.2 dengan 206 test, CI/CD di setiap commit, dan benchmark har
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (206 test)
+cargo test --workspace         # Test (431 test)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.7.3 with 206 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
+Uteke is at v0.10.2 with 431 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
 </details>
 
 ---
@@ -290,7 +290,7 @@ Uteke is at v0.7.3 with 206 tests, CI/CD on every commit, and benchmark harness.
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (206 tests)
+cargo test --workspace         # Test (431 tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/crates/docgen/Cargo.toml
+++ b/crates/docgen/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "docgen"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+description = "Auto-generates api-reference.md from uteke-server route registry and type schemas"
+
+[[bin]]
+name = "generate-api-docs"
+path = "src/main.rs"
+
+[dependencies]
+uteke-server = { path = "../uteke-server", features = ["docgen"] }
+uteke-core = { path = "../uteke-core" }
+schemars = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/docgen/src/main.rs
+++ b/crates/docgen/src/main.rs
@@ -1,0 +1,310 @@
+//! Auto-generates `docs/api-reference.md` from the route registry and type schemas.
+//!
+//! Usage: `cargo run -p docgen`
+//!
+//! This binary depends on `uteke-server` with the `docgen` feature enabled,
+//! giving it access to the route registry and JSON schemas for all request types.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use schemars::schema_for;
+use serde_json::Value;
+
+use uteke_server::api_registry::ENDPOINTS;
+
+fn main() {
+    let out = Path::new("docs/api-reference.md");
+    let content = generate();
+    fs::create_dir_all(out.parent().unwrap()).ok();
+    fs::write(out, &content).expect("Failed to write api-reference.md");
+    println!("✅ Generated {} ({} bytes)", out.display(), content.len());
+}
+
+fn generate() -> String {
+    let mut md = String::new();
+
+    // Header
+    md.push_str("# HTTP API Reference\n\n");
+    md.push_str(
+        "Auto-generated from `uteke-server` route registry and type schemas. \
+                 Do not edit manually — run `cargo run -p docgen` to regenerate.\n\n",
+    );
+    md.push_str("**Base URL**: `http://localhost:8767` (default)\n\n");
+    md.push_str("**Auth**: Set `--auth-token <TOKEN>` to require `Authorization: Bearer <TOKEN>` header.\n\n");
+
+    // Group endpoints by category
+    let mut groups: BTreeMap<&str, Vec<&uteke_server::api_registry::Endpoint>> = BTreeMap::new();
+    for ep in ENDPOINTS {
+        let category = categorize(ep.path);
+        groups.entry(category).or_default().push(ep);
+    }
+
+    for (category, endpoints) in &groups {
+        md.push_str(&format!("## {}\n\n", category));
+        for ep in endpoints {
+            md.push_str(&render_endpoint(ep));
+        }
+        md.push('\n');
+    }
+
+    // Schemas section
+    md.push_str("## Request/Response Schemas\n\n");
+    md.push_str("Detailed field definitions for each request type.\n\n");
+
+    let mut schema_types: BTreeMap<&str, Value> = BTreeMap::new();
+    collect_schemas(&mut schema_types);
+
+    for (name, schema) in &schema_types {
+        md.push_str(&format!("### `{}`\n\n", name));
+        md.push_str(&render_schema(schema));
+        md.push('\n');
+    }
+
+    md
+}
+
+fn categorize(path: &str) -> &'static str {
+    if path == "/health" {
+        return "🔴 Health & Info";
+    }
+    if path.starts_with("/room/") || path.starts_with("/doc/room/") {
+        return "🟢 Rooms";
+    }
+    if path.starts_with("/doc/") {
+        return "🔵 Documents";
+    }
+    if path.starts_with("/memory/") {
+        return "🟣 Memory Management";
+    }
+    if path == "/remember"
+        || path == "/recall"
+        || path == "/search"
+        || path == "/list"
+        || path == "/forget"
+        || path == "/recent"
+    {
+        return "🟡 Core Memory";
+    }
+    if path.starts_with("/graph/") || path.starts_with("/edges") || path == "/timeline" {
+        return "🟠 Graph";
+    }
+    if path.starts_with("/tag") {
+        return "🏷️ Tags";
+    }
+    if path == "/pin" || path == "/unpin" {
+        return "📌 Pin (Legacy)";
+    }
+    if path.starts_with("/import") || path.starts_with("/export") {
+        return "📦 Import/Export";
+    }
+    if path.starts_with("/prune")
+        || path.starts_with("/consolidate")
+        || path.starts_with("/aging")
+        || path.starts_with("/importance")
+        || path.starts_with("/orphans")
+        || path.starts_with("/extract")
+        || path.starts_with("/rebuild")
+    {
+        return "🔧 Maintenance";
+    }
+    if path == "/context" || path == "/dream" || path == "/mcp" {
+        return "🤖 AI Integration";
+    }
+    "📝 Other"
+}
+
+fn render_endpoint(ep: &uteke_server::api_registry::Endpoint) -> String {
+    let mut s = String::new();
+
+    // Method badge
+    let badge = match ep.method {
+        "GET" => "🟢 `GET`",
+        "POST" => "🟡 `POST`",
+        "PUT" => "🔵 `PUT`",
+        "DELETE" => "🔴 `DELETE`",
+        _ => ep.method,
+    };
+
+    s.push_str(&format!("#### {} `{}`\n\n", badge, ep.path));
+    s.push_str(&format!("{}\n\n", ep.description));
+
+    if ep.excludes_deprecated {
+        s.push_str("*Excludes deprecated memories from results.*\n\n");
+    }
+
+    if let Some(req_type) = ep.request_type {
+        if req_type == "serde_json::Value" {
+            s.push_str("**Request body**: JSON object (see handler source for fields)\n\n");
+        } else {
+            s.push_str(&format!(
+                "**Request body**: [`{}`](#{})\n\n",
+                req_type,
+                req_type.to_lowercase().replace('_', "-")
+            ));
+        }
+    }
+
+    if let Some(resp_type) = ep.response_type {
+        s.push_str(&format!(
+            "**Response**: [`{}`](#{})\n\n",
+            resp_type,
+            resp_type.to_lowercase().replace('_', "-")
+        ));
+    }
+
+    if !ep.issues.is_empty() {
+        let issues: Vec<String> = ep.issues.iter().map(|i| format!("`{}`", i)).collect();
+        s.push_str(&format!("*Related: {}*\n\n", issues.join(", ")));
+    }
+
+    s
+}
+
+fn render_schema(schema: &Value) -> String {
+    let mut s = String::new();
+
+    if let Some(desc) = schema.get("description") {
+        s.push_str(&format!("{}\n\n", desc.as_str().unwrap_or("")));
+    }
+
+    if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+        let required: Vec<&str> = schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+
+        s.push_str("| Field | Type | Required | Description |\n");
+        s.push_str("|-------|------|----------|-------------|\n");
+
+        // Sort fields for consistent output
+        let mut sorted_props: Vec<_> = props.iter().collect();
+        sorted_props.sort_by_key(|(k, _)| *k);
+
+        for (name, prop) in sorted_props {
+            let ty = json_type_name(prop);
+            let req = if required.contains(&name.as_str()) {
+                "Yes"
+            } else {
+                "No"
+            };
+            let desc = prop
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            s.push_str(&format!("| `{}` | {} | {} | {} |\n", name, ty, req, desc));
+        }
+        s.push('\n');
+    }
+
+    s
+}
+
+fn json_type_name(prop: &Value) -> String {
+    // Check for enum (oneOf)
+    if prop.get("oneOf").is_some() {
+        return "enum".to_string();
+    }
+
+    // Check for array
+    if let Some(ty) = prop.get("type").and_then(|v| v.as_str()) {
+        if ty == "array" {
+            if let Some(items) = prop.get("items") {
+                let inner = json_type_name(items);
+                return format!("`{}`[]", inner);
+            }
+            return "array".to_string();
+        }
+        return format!("`{}`", ty);
+    }
+
+    // Check for $ref
+    if let Some(ref_path) = prop.get("$ref").and_then(|v| v.as_str()) {
+        // Extract type name from #/definitions/TypeName
+        if let Some(name) = ref_path.strip_prefix("#/definitions/") {
+            let anchor = name.to_lowercase().replace('_', "-");
+            return format!("[`{}`](#{})", name, anchor);
+        }
+    }
+
+    // Check for anyOf (Option<T>)
+    if let Some(any_of) = prop.get("anyOf").and_then(|v| v.as_array()) {
+        let types: Vec<String> = any_of.iter().map(json_type_name).collect();
+        return types.join(" | ");
+    }
+
+    "any".to_string()
+}
+
+/// Collect JSON schemas for all named request/response types.
+fn collect_schemas(schemas: &mut BTreeMap<&'static str, Value>) {
+    // Note: schemars::schema_for! generates schema at compile time.
+    // We use a match on type names to generate each schema individually.
+    // Only types with #[derive(JsonSchema)] (via docgen feature) work here.
+    macro_rules! add_schema {
+        ($name:literal, $ty:ty) => {
+            schemas.insert($name, serde_json::to_value(&schema_for!($ty)).unwrap());
+        };
+    }
+
+    // Core types
+    add_schema!("RememberRequest", uteke_server::types::RememberRequest);
+    add_schema!("RecallRequest", uteke_server::types::RecallRequest);
+    add_schema!("SearchRequest", uteke_server::types::SearchRequest);
+    add_schema!("ListParams", uteke_server::types::ListParams);
+    add_schema!(
+        "MemoryUpdateRequest",
+        uteke_server::types::MemoryUpdateRequest
+    );
+    add_schema!("MemoryPinRequest", uteke_server::types::MemoryPinRequest);
+    add_schema!(
+        "MemoryImportanceRequest",
+        uteke_server::types::MemoryImportanceRequest
+    );
+    add_schema!(
+        "MemoryFeedbackRequest",
+        uteke_server::types::MemoryFeedbackRequest
+    );
+
+    // Room types
+    add_schema!("RoomRecallRequest", uteke_server::types::RoomRecallRequest);
+    add_schema!(
+        "RoomRememberRequest",
+        uteke_server::types::RoomRememberRequest
+    );
+
+    // Document types
+    add_schema!("DocCreateRequest", uteke_server::types::DocCreateRequest);
+    add_schema!("DocGetRequest", uteke_server::types::DocGetRequest);
+    add_schema!("DocMoveRequest", uteke_server::types::DocMoveRequest);
+
+    // Tags
+    add_schema!("TagRenameRequest", uteke_server::types::TagRenameRequest);
+    add_schema!("TagDeleteRequest", uteke_server::types::TagDeleteRequest);
+
+    // Pin
+    add_schema!("PinRequest", uteke_server::types::PinRequest);
+
+    // Graph
+    add_schema!("GraphEdgeRequest", uteke_server::types::GraphEdgeRequest);
+
+    // Import/Export
+    add_schema!("ImportRequest", uteke_server::types::ImportRequest);
+
+    // Maintenance
+    add_schema!("PruneRequest", uteke_server::types::PruneRequest);
+    add_schema!(
+        "ConsolidateRequest",
+        uteke_server::types::ConsolidateRequest
+    );
+    add_schema!("AgingRequest", uteke_server::types::AgingRequest);
+    add_schema!("ImportanceRequest", uteke_server::types::ImportanceRequest);
+    add_schema!("OrphansRequest", uteke_server::types::OrphansRequest);
+    add_schema!("ExtractRequest", uteke_server::types::ExtractRequest);
+
+    // Response types
+    add_schema!("HealthResponse", uteke_server::types::HealthResponse);
+    add_schema!("ErrorResponse", uteke_server::types::ErrorResponse);
+}

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -27,7 +27,9 @@ tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 fs2 = "0.4"
 # ONNX-only dependencies (gated behind `onnx` feature)
-ort = { version = "2.0.0-rc.12", features = ["download-binaries"], optional = true }
+# NOTE: load-dynamic requires api-18+ to avoid pykeio/ort#547 (vitis EP compile error).
+# download-binaries is intentionally removed — ORT lib is shipped as a sidecar instead.
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic", "ndarray", "api-18"], optional = true }
 ndarray = { version = "0.17", optional = true }
 tokenizers = { version = "0.23", optional = true }
 sha2 = { version = "0.11", optional = true }

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -2,6 +2,7 @@
 
 use crate::Error;
 use crate::embed::Embedder;
+use crate::embed::ort_init;
 use sha2::{Digest, Sha256};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -48,6 +49,22 @@ pub struct OnnxEmbedder {
 impl OnnxEmbedder {
     /// Create a new embedding engine. Downloads model if not cached.
     pub fn new() -> Result<Self, Error> {
+        // ── Pre-flight: Initialize ORT environment with the correct library ──
+        // This detects AVX2 support and loads the appropriate ONNX Runtime shared
+        // library (standard AVX2 or legacy SSE4.2 sidecar). Must run before any
+        // Session is created. The once_lock ensures we only init once per process.
+        static ORT_INIT: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLock::new();
+        ORT_INIT
+            .get_or_init(|| ort_init::init_ort_environment().map(|_| ()))
+            .as_ref()
+            .map_err(|e| {
+                Error::embed_msg(format!(
+                    "ONNX Runtime initialization failed: {e}. \
+                 CPU may lack required SIMD support. Use the 'legacy' bundle \
+                 (includes SSE4.2 ORT) or set ORT_LIB_PATH."
+                ))
+            })?;
+
         let model_dir = Self::model_dir()?;
         std::fs::create_dir_all(&model_dir)
             .map_err(|e| Error::embed("create model directory", e))?;

--- a/crates/uteke-core/src/embed/mod.rs
+++ b/crates/uteke-core/src/embed/mod.rs
@@ -6,6 +6,8 @@ pub mod engine;
 pub mod fallback;
 pub mod ollama;
 pub mod openai;
+#[cfg(feature = "onnx")]
+pub mod ort_init;
 
 pub use embed_trait::Embedder;
 #[cfg(feature = "onnx")]

--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -1,0 +1,253 @@
+//! Runtime CPU feature detection and ORT library resolution.
+//!
+//! Solves SIGILL (Exit Code 132) on CPUs without AVX2 (e.g., Celeron J4125/N4020)
+//! by dynamically selecting the correct ONNX Runtime shared library at startup.
+//!
+//! Resolution order:
+//! 1. `ORT_LIB_PATH` env var — explicit override (for testing / custom setups).
+//! 2. If AVX2 is detected → `./libonnxruntime.so` (AVX2 build, ships in standard bundle).
+//! 3. If AVX2 is NOT detected → `./ort-legacy/libonnxruntime.so` (SSE4.2 build, sidecar).
+//! 4. System lib paths: `/usr/local/lib`, `/usr/lib`, `/lib` (Docker / package installs).
+//! 5. If no library found → return error (caller can fall back to non-ORT embedder).
+
+use std::path::PathBuf;
+
+/// Name of the legacy ORT sidecar directory (placed next to the binary).
+const LEGACY_ORT_DIR: &str = "ort-legacy";
+
+/// ORT shared library filename per platform.
+#[cfg(target_os = "linux")]
+const ORT_LIB_NAME: &str = "libonnxruntime.so";
+#[cfg(target_os = "macos")]
+const ORT_LIB_NAME: &str = "libonnxruntime.dylib";
+#[cfg(target_os = "windows")]
+const ORT_LIB_NAME: &str = "onnxruntime.dll";
+
+/// Result of CPU feature detection and ORT library resolution.
+pub struct OrtLibInfo {
+    /// Path to the resolved ORT shared library.
+    pub lib_path: PathBuf,
+    /// Whether AVX2 was detected on this CPU.
+    pub has_avx2: bool,
+}
+
+impl std::fmt::Debug for OrtLibInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OrtLibInfo")
+            .field("lib_path", &self.lib_path)
+            .field("has_avx2", &self.has_avx2)
+            .finish()
+    }
+}
+
+/// Detect whether the current CPU supports AVX2.
+///
+/// Returns `false` on non-x86_64 architectures (ARM, etc.) since those
+/// don't use AVX2 at all — the standard ORT build will work fine.
+#[inline]
+pub fn has_avx2() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: `is_x86_feature_detected!` is a compile-time macro that
+        // generates a `cpuid` instruction. It is safe to call at any time.
+        std::is_x86_feature_detected!("avx2")
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        // Non-x86_64 (ARM, RISC-V, etc.) — no AVX2 concept.
+        // Use the standard library; the x86-specific SIGILL issue doesn't apply.
+        true
+    }
+}
+
+/// Resolve the path to the ONNX Runtime shared library.
+///
+/// Search order:
+/// 1. `ORT_LIB_PATH` environment variable (explicit override).
+/// 2. AVX2 detected → `<exe_dir>/libonnxruntime.so` (standard bundle).
+/// 3. No AVX2 → `<exe_dir>/ort-legacy/libonnxruntime.so` (legacy sidecar).
+///
+/// # Errors
+///
+/// Returns a descriptive error if no ORT library can be found.
+pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
+    // 1. Explicit env var override
+    if let Ok(env_path) = std::env::var("ORT_LIB_PATH") {
+        let path = PathBuf::from(&env_path);
+        if path.exists() {
+            tracing::info!(
+                "ORT: using explicit library path from ORT_LIB_PATH: {}",
+                path.display()
+            );
+            return Ok(OrtLibInfo {
+                lib_path: path,
+                has_avx2: has_avx2(),
+            });
+        }
+        return Err(format!(
+            "ORT_LIB_PATH set to '{}' but file does not exist",
+            env_path
+        ));
+    }
+
+    let exe_dir = exe_dir()?;
+    let avx2 = has_avx2();
+
+    if avx2 {
+        // 2. AVX2 CPU → use standard library next to binary
+        let standard_path = exe_dir.join(ORT_LIB_NAME);
+        if standard_path.exists() {
+            tracing::info!(
+                "ORT: AVX2 detected, using standard library: {}",
+                standard_path.display()
+            );
+            return Ok(OrtLibInfo {
+                lib_path: standard_path,
+                has_avx2: true,
+            });
+        }
+        // Standard lib not found — this is fine during development (cargo run)
+        // The error will be caught when ort::init_from() is called.
+        tracing::warn!(
+            "ORT: AVX2 detected but no standard library found at {}. \
+             If running from source, set ORT_LIB_PATH or build with download-binaries.",
+            standard_path.display()
+        );
+        return Err(format!(
+            "AVX2 detected but ONNX Runtime library not found at '{}'. \
+             Set ORT_LIB_PATH or use the standard release bundle.",
+            standard_path.display()
+        ));
+    }
+
+    // 3. No AVX2 → look for legacy sidecar
+    let legacy_path = exe_dir.join(LEGACY_ORT_DIR).join(ORT_LIB_NAME);
+    if legacy_path.exists() {
+        tracing::info!(
+            "ORT: No AVX2 detected, using legacy (SSE4.2) library: {}",
+            legacy_path.display()
+        );
+        return Ok(OrtLibInfo {
+            lib_path: legacy_path,
+            has_avx2: false,
+        });
+    }
+
+    // 4. Docker/system fallback: check standard system library paths.
+    // In Docker containers, binaries are in /usr/local/bin/ but .so is in /usr/local/lib/.
+    // On Windows, system paths are not applicable (DLLs are loaded from exe dir or PATH).
+    #[cfg(unix)]
+    {
+        let system_paths: &[&str] = &["/usr/local/lib", "/usr/lib", "/lib"];
+        for dir in system_paths {
+            let system_path = std::path::Path::new(dir).join(ORT_LIB_NAME);
+            if system_path.exists() {
+                tracing::info!("ORT: Using system library at {}", system_path.display());
+                return Ok(OrtLibInfo {
+                    lib_path: system_path,
+                    has_avx2: avx2,
+                });
+            }
+        }
+    }
+
+    Err(format!(
+        "CPU lacks AVX2 and legacy ORT library not found at '{}'. \
+         Use the 'legacy' release bundle which includes the ort-legacy/ sidecar.",
+        legacy_path.display()
+    ))
+}
+
+/// Get the directory containing the running executable.
+fn exe_dir() -> Result<PathBuf, String> {
+    let exe =
+        std::env::current_exe().map_err(|e| format!("failed to determine executable path: {e}"))?;
+    exe.parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "executable path has no parent directory".into())
+}
+
+/// Initialize the ORT environment using the resolved library path.
+///
+/// This must be called **once** before any `ort::Session` is created.
+/// Returns the `OrtLibInfo` on success so callers can log which variant is in use.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - No suitable ORT library can be found (`resolve_ort_lib` failure).
+/// - The library fails to load (`ort::init_from` failure, e.g. version mismatch).
+pub fn init_ort_environment() -> Result<OrtLibInfo, String> {
+    let info = resolve_ort_lib()?;
+
+    ort::init_from(&info.lib_path)
+        .map_err(|e| {
+            format!(
+                "Failed to load ONNX Runtime from '{}': {e}. \
+             Ensure the library version matches ort crate 2.0.0-rc.12.",
+                info.lib_path.display()
+            )
+        })?
+        .commit();
+
+    tracing::info!(
+        "ORT environment initialized successfully (AVX2={})",
+        info.has_avx2
+    );
+
+    Ok(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_avx2_returns_bool() {
+        // Just verify it doesn't panic — the actual value depends on the test machine.
+        let _avx2 = has_avx2();
+    }
+
+    #[test]
+    fn resolve_ort_lib_prefers_env_var() {
+        // Create a temp file to use as fake ORT lib
+        let tmp = std::env::temp_dir().join("test_ort_lib_resolve.so");
+        std::fs::write(&tmp, b"fake").unwrap();
+
+        // SAFETY: set_var/remove_var in test code is safe — no concurrent access.
+        unsafe {
+            std::env::set_var("ORT_LIB_PATH", &tmp);
+        }
+        let result = resolve_ort_lib();
+        unsafe {
+            std::env::remove_var("ORT_LIB_PATH");
+        }
+
+        // Cleanup
+        std::fs::remove_file(&tmp).ok();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().lib_path, tmp);
+    }
+
+    #[test]
+    fn resolve_ort_lib_errors_on_missing_env_var_path() {
+        // SAFETY: set_var/remove_var in test code is safe — no concurrent access.
+        unsafe {
+            std::env::set_var("ORT_LIB_PATH", "/nonexistent/path/libonnxruntime.so");
+        }
+        let result = resolve_ort_lib();
+        unsafe {
+            std::env::remove_var("ORT_LIB_PATH");
+        }
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn exe_dir_returns_parent() {
+        let dir = exe_dir().unwrap();
+        assert!(dir.exists(), "exe dir should exist: {}", dir.display());
+    }
+}

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -125,6 +125,37 @@ impl super::Store {
         Ok(result)
     }
 
+    /// Resolve a short ID (prefix) to a full memory ID.
+    ///
+    /// `list` and `room_recall` display only the first 8 chars of each UUID.
+    /// This method resolves that prefix back to the full ID so `forget` can
+    /// accept what `list` shows (#794).
+    ///
+    /// Returns `Ok(Some(id))` if exactly one match, `Ok(None)` if zero,
+    /// or `Err` if multiple matches (ambiguous prefix).
+    pub fn resolve_id_prefix(&self, prefix: &str) -> Result<Option<String>, Error> {
+        let pattern = format!("{prefix}%");
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE id LIKE ?1")
+            .map_err(|e| Error::db("Failed to prepare statement for resolve_id_prefix", e))?;
+
+        let ids: Vec<String> = stmt
+            .query_map(params![pattern], |row| row.get(0))
+            .map_err(|e| Error::db("Failed to query id prefix", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        match ids.len() {
+            0 => Ok(None),
+            1 => Ok(Some(ids[0].clone())),
+            _ => Err(Error::Validation(format!(
+                "Ambiguous ID prefix '{prefix}' — matches {} memories. Use a longer prefix.",
+                ids.len()
+            ))),
+        }
+    }
+
     /// Get a memory by its ID, only if it belongs to `namespace`.
     ///
     /// Used by edge auto-wiring (#346) to enforce namespace isolation on

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -225,6 +225,9 @@ impl super::Store {
     }
 
     /// Get statistics about a room.
+    ///
+    /// Only counts active (non-deprecated) memories — matches the behavior of
+    /// `recall_room` and `room_summary` which also filter `deprecated = 0` (#784).
     pub fn room_stats(&self, room_id: &str) -> Result<Option<RoomStats>, Error> {
         let room = match self.get_room(room_id)? {
             Some(r) => r,
@@ -234,16 +237,22 @@ impl super::Store {
         let memory_count: usize =
             self.conn
                 .query_row(
-                    "SELECT COUNT(DISTINCT memory_id) FROM room_memories WHERE room_id = ?1",
+                    "SELECT COUNT(DISTINCT rm.memory_id) FROM room_memories rm \
+                     INNER JOIN memories m ON rm.memory_id = m.id \
+                     WHERE rm.room_id = ?1 AND m.deprecated = 0",
                     params![room_id],
                     |row| row.get::<_, i64>(0),
                 )
                 .map_err(|e| Error::db("room memory count", e))? as usize;
 
-        // Get distinct authors as participants
+        // Get distinct authors as participants (only for active memories)
         let mut stmt = self
             .conn
-            .prepare("SELECT DISTINCT author FROM room_memories WHERE room_id = ?1 ORDER BY author")
+            .prepare(
+                "SELECT DISTINCT rm.author FROM room_memories rm \
+                 INNER JOIN memories m ON rm.memory_id = m.id \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0 ORDER BY rm.author",
+            )
             .map_err(|e| Error::db("room participants", e))?;
         let participants: Vec<String> = stmt
             .query_map(params![room_id], |row| row.get(0))
@@ -254,7 +263,9 @@ impl super::Store {
         let last_activity: Option<String> = self
             .conn
             .query_row(
-                "SELECT MAX(joined_at) FROM room_memories WHERE room_id = ?1",
+                "SELECT MAX(rm.joined_at) FROM room_memories rm \
+                 INNER JOIN memories m ON rm.memory_id = m.id \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0",
                 params![room_id],
                 |row| row.get(0),
             )
@@ -303,6 +314,7 @@ impl super::Store {
 
     /// Recall all memories linked to a room, sorted by time.
     /// Cross-namespace: returns memories from ALL namespaces that contributed to the room.
+    /// Only returns active (non-deprecated) memories (#784).
     pub fn recall_room(
         &self,
         room_id: &str,
@@ -319,7 +331,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 AND rm.author = ?2 \
+                 WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC \
                  LIMIT ?3"
             }
@@ -330,7 +342,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 AND rm.author = ?2 \
+                 WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC"
             }
             (None, false) => {
@@ -340,7 +352,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC \
                  LIMIT ?2"
             }
@@ -351,7 +363,7 @@ impl super::Store {
                  m.slug, m.source, m.source_type \
                  FROM memories m \
                  INNER JOIN room_memories rm ON m.id = rm.memory_id \
-                 WHERE rm.room_id = ?1 \
+                 WHERE rm.room_id = ?1 AND m.deprecated = 0 \
                  ORDER BY rm.joined_at ASC"
             }
         };
@@ -413,14 +425,23 @@ impl super::Store {
     /// Get memory IDs linked to a room.
     /// Returns just the IDs — much cheaper than full recall when only
     /// filtering is needed.
+    /// Only returns IDs of active (non-deprecated) memories (#784).
     pub fn get_room_memory_ids(
         &self,
         room_id: &str,
         author: Option<&str>,
     ) -> Result<Vec<String>, Error> {
         let sql = match author {
-            Some(_) => "SELECT memory_id FROM room_memories WHERE room_id = ?1 AND author = ?2",
-            None => "SELECT memory_id FROM room_memories WHERE room_id = ?1",
+            Some(_) => {
+                "SELECT rm.memory_id FROM room_memories rm \
+                          INNER JOIN memories m ON rm.memory_id = m.id \
+                          WHERE rm.room_id = ?1 AND rm.author = ?2 AND m.deprecated = 0"
+            }
+            None => {
+                "SELECT rm.memory_id FROM room_memories rm \
+                     INNER JOIN memories m ON rm.memory_id = m.id \
+                     WHERE rm.room_id = ?1 AND m.deprecated = 0"
+            }
         };
 
         let mut stmt = self
@@ -1314,6 +1335,50 @@ mod tests {
     }
 
     #[test]
+    fn recall_room_excludes_deprecated_memories() {
+        let store = Store::open(":memory:").unwrap();
+        store.create_room("dep-recall", None, "default").unwrap();
+
+        let m1 = make_test_memory("mem-rd1", "active memory", &[]);
+        let mut m2 = make_test_memory("mem-rd2", "deprecated memory", &[]);
+        m2.deprecated = true;
+        store.insert(&m1).unwrap();
+        store.insert(&m2).unwrap();
+        store
+            .link_memory_to_room("dep-recall", "mem-rd1", "alice", "participant")
+            .unwrap();
+        store
+            .link_memory_to_room("dep-recall", "mem-rd2", "bob", "participant")
+            .unwrap();
+
+        let mems = store.recall_room("dep-recall", None, 0).unwrap();
+        assert_eq!(mems.len(), 1, "deprecated memory should be excluded");
+        assert_eq!(mems[0].id, "mem-rd1");
+    }
+
+    #[test]
+    fn get_room_memory_ids_excludes_deprecated() {
+        let store = Store::open(":memory:").unwrap();
+        store.create_room("dep-ids", None, "default").unwrap();
+
+        let m1 = make_test_memory("mem-gid1", "active", &[]);
+        let mut m2 = make_test_memory("mem-gid2", "deprecated", &[]);
+        m2.deprecated = true;
+        store.insert(&m1).unwrap();
+        store.insert(&m2).unwrap();
+        store
+            .link_memory_to_room("dep-ids", "mem-gid1", "alice", "participant")
+            .unwrap();
+        store
+            .link_memory_to_room("dep-ids", "mem-gid2", "alice", "participant")
+            .unwrap();
+
+        let ids = store.get_room_memory_ids("dep-ids", None).unwrap();
+        assert_eq!(ids.len(), 1, "deprecated memory ID should be excluded");
+        assert_eq!(ids[0], "mem-gid1");
+    }
+
+    #[test]
     fn get_room_memory_ids_with_author() {
         let store = Store::open(":memory:").unwrap();
         store.create_room("ids-auth", None, "default").unwrap();
@@ -1385,6 +1450,35 @@ mod tests {
         let store = Store::open(":memory:").unwrap();
         let stats = store.room_stats("nope").unwrap();
         assert!(stats.is_none());
+    }
+
+    #[test]
+    fn room_stats_excludes_deprecated_memories() {
+        let store = Store::open(":memory:").unwrap();
+        store
+            .create_room("dep-stats", Some("Deprecated Stats"), "default")
+            .unwrap();
+
+        let m1 = make_test_memory("mem-d1", "active", &[]);
+        let mut m2 = make_test_memory("mem-d2", "deprecated", &[]);
+        m2.deprecated = true;
+        store.insert(&m1).unwrap();
+        store.insert(&m2).unwrap();
+        store
+            .link_memory_to_room("dep-stats", "mem-d1", "alice", "participant")
+            .unwrap();
+        store
+            .link_memory_to_room("dep-stats", "mem-d2", "bob", "participant")
+            .unwrap();
+
+        let stats = store.room_stats("dep-stats").unwrap().unwrap();
+        assert_eq!(stats.memory_count, 1, "deprecated memory should not count");
+        assert_eq!(
+            stats.participant_count, 1,
+            "only alice (author of active memory) should appear"
+        );
+        assert!(stats.participants.contains(&"alice".to_string()));
+        assert!(!stats.participants.contains(&"bob".to_string()));
     }
 
     // ── room_summary ────────────────────────────────────────────

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1109,6 +1109,14 @@ impl crate::Uteke {
         self.store.get_by_id(id)
     }
 
+    /// Resolve a short ID prefix (first 8 chars) to a full memory ID (#794).
+    ///
+    /// Returns `Ok(Some(id))` for exact match, `Ok(None)` if not found,
+    /// or `Err(Validation)` if ambiguous.
+    pub fn resolve_id_prefix(&self, prefix: &str) -> Result<Option<String>, Error> {
+        self.store.resolve_id_prefix(prefix)
+    }
+
     /// Update an existing memory with partial fields (#659).
     ///
     /// Only provided fields are changed. If `content` is changed, the

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -9,6 +9,13 @@ description = "HTTP server for uteke — persistent warm memory for AI agents"
 keywords = ["server", "memory", "ai", "http", "embedding"]
 categories = ["web-programming::http-server", "development-tools"]
 
+[features]
+docgen = ["dep:schemars"]
+
+[lib]
+name = "uteke_server"
+path = "src/lib.rs"
+
 [[bin]]
 name = "uteke-serve"
 path = "src/main.rs"
@@ -18,6 +25,7 @@ uteke-core = { path = "../uteke-core", version = "0.10.0", features = ["onnx"] }
 uteke-mcp = { path = "../uteke-mcp", version = "0.10.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+schemars = { version = "1", optional = true }
 toml = "1"
 tiny_http = "0.12"
 tracing = "0.1"

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -1,0 +1,585 @@
+//! API route registry — single source of truth for endpoint metadata.
+//!
+//! Used by `crates/docgen` to auto-generate `docs/api-reference.md`.
+//!
+//! Every endpoint exposed by `uteke-serve` should be listed here.
+//! If a handler exists but isn't registered here, the CI doc-generation
+//! step will fail (count mismatch).
+
+#![allow(dead_code)]
+
+#[cfg(feature = "docgen")]
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// Metadata for a single API endpoint.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "docgen", derive(JsonSchema))]
+pub struct Endpoint {
+    /// HTTP method (GET, POST, PUT, DELETE).
+    pub method: &'static str,
+    /// URL path (e.g., "/remember").
+    pub path: &'static str,
+    /// Short description of what the endpoint does.
+    pub description: &'static str,
+    /// Name of the request body type, if any (e.g., "RememberRequest").
+    /// Null for GET endpoints or endpoints with no body.
+    pub request_type: Option<&'static str>,
+    /// Name of the primary response type, if structured (e.g., "Memory").
+    pub response_type: Option<&'static str>,
+    /// Whether the endpoint filters out deprecated memories.
+    pub excludes_deprecated: bool,
+    /// Related issue numbers for context.
+    pub issues: &'static [&'static str],
+}
+
+/// Complete API route registry.
+/// This must be kept in sync with `handlers.rs`.
+pub const ENDPOINTS: &[Endpoint] = &[
+    // ── Health & Info ────────────────────────────────────────────────────
+    Endpoint {
+        method: "GET",
+        path: "/health",
+        description: "Health check — returns server status and version",
+        request_type: None,
+        response_type: Some("HealthResponse"),
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/namespaces",
+        description: "List all namespaces in the memory store",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/stats",
+        description: "Get memory statistics (count, etc.) for a namespace. Accepts `?namespace=X` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/stats",
+        description: "Get memory statistics via POST body. Accepts `{\"namespace\": \"...\"}`.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#786"],
+    },
+    // ── Core Memory Operations ───────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/remember",
+        description: "Store a new memory. Accepts content, tags, namespace, type, metadata.",
+        request_type: Some("RememberRequest"),
+        response_type: Some("Memory"),
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/recall",
+        description: "Semantic search — recall memories by meaning. Returns ranked results.",
+        request_type: Some("RecallRequest"),
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/search",
+        description: "Keyword search — find memories by matching words in content/tags.",
+        request_type: Some("SearchRequest"),
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/list",
+        description: "List memories with optional filters (namespace, tags, sort, limit, offset).",
+        request_type: Some("ListParams"),
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+    Endpoint {
+        method: "DELETE",
+        path: "/forget",
+        description: "Deprecate a memory by ID. Returns 404 if ID doesn't exist.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/memory",
+        description: "Get a single memory by ID. Accepts `?id=...` query param.",
+        request_type: None,
+        response_type: Some("Memory"),
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "PUT",
+        path: "/memory",
+        description: "Update an existing memory's content and/or metadata.",
+        request_type: Some("MemoryUpdateRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/memory/pin",
+        description: "Pin a memory so it won't be removed by aging/cleanup operations.",
+        request_type: Some("MemoryPinRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/memory/importance",
+        description: "Get or set the importance score of a memory.",
+        request_type: Some("MemoryImportanceRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/memory/feedback",
+        description: "Submit positive/negative feedback on a memory for ranking signals.",
+        request_type: Some("MemoryFeedbackRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/memory/doc-refs",
+        description: "Get documents that reference a specific memory.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Tags ─────────────────────────────────────────────────────────────
+    Endpoint {
+        method: "GET",
+        path: "/tags",
+        description: "List all tags in a namespace. Accepts `?namespace=X` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/tags/rename",
+        description: "Rename a tag across all memories.",
+        request_type: Some("TagRenameRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/tags/delete",
+        description: "Delete a tag from all memories.",
+        request_type: Some("TagDeleteRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Pin/Unpin (legacy) ─────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/pin",
+        description: "Pin a memory by ID (legacy — prefer /memory/pin).",
+        request_type: Some("PinRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/unpin",
+        description: "Unpin a memory by ID (legacy — prefer /memory/pin with pin=false).",
+        request_type: Some("PinRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Rooms ────────────────────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/room/create",
+        description: "Create a new memory room. Accepts `{\"name\": \"...\"}`.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/remember",
+        description: "Store a memory linked to a room. Accepts room_id, content, tags, type, author.",
+        request_type: Some("RoomRememberRequest"),
+        response_type: Some("Memory"),
+        excludes_deprecated: false,
+        issues: &["#789"],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/recall",
+        description: "Semantic search within a room. Empty query returns all memories chronologically.",
+        request_type: Some("RoomRecallRequest"),
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &["#785"],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/summary",
+        description: "Get room summary with memory clusters and statistics.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/summary-document",
+        description: "Get room summary focused on document-type memories.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/room/list",
+        description: "List all rooms.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/stats",
+        description: "Get memory count for a room. Includes deprecated memories (known discrepancy vs /room/summary).",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#784"],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/room/memories",
+        description: "List all memories in a room (chronological). Accepts `?room_id=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+    Endpoint {
+        method: "DELETE",
+        path: "/room/delete",
+        description: "Delete a room and all its memories. Accepts `?room_id=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Room Documents ──────────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/room/document",
+        description: "Store a reference document in a room (large content >500 chars).",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/document/list",
+        description: "List documents in a room.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "PUT",
+        path: "/room/document/add",
+        description: "Add a reference to an existing document in a room.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "DELETE",
+        path: "/room/document/remove",
+        description: "Remove a document reference from a room.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/doc/room/list",
+        description: "List rooms that reference a specific document.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Documents ───────────────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/doc/create",
+        description: "Create a new document with slug, title, content, tags.",
+        request_type: Some("DocCreateRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/doc/get",
+        description: "Get a document by slug.",
+        request_type: Some("DocGetRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/doc/move",
+        description: "Move a document to a different parent.",
+        request_type: Some("DocMoveRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "DELETE",
+        path: "/doc/delete",
+        description: "Delete a document by slug or ID.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/doc/mem-refs",
+        description: "Get memories that reference a specific document.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Graph ───────────────────────────────────────────────────────────
+    Endpoint {
+        method: "GET",
+        path: "/graph",
+        description: "Get graph edges for a memory. Accepts `?id=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/graph/edge",
+        description: "Add a directed edge between two memories.",
+        request_type: Some("GraphEdgeRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "DELETE",
+        path: "/graph/edge",
+        description: "Remove an edge between two memories. Accepts `?from=...&to=...` query params.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/edges",
+        description: "List edges for a memory (alias for /graph). Accepts `?id=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Timeline ─────────────────────────────────────────────────────────
+    Endpoint {
+        method: "GET",
+        path: "/timeline",
+        description: "Get timeline of memory events for a memory. Accepts `?id=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Import/Export ────────────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/import",
+        description: "Import memories from a JSON array.",
+        request_type: Some("ImportRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/export",
+        description: "Export all memories as JSON. Accepts `?namespace=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Maintenance ──────────────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/prune",
+        description: "Remove orphaned memories (no room, no graph edges).",
+        request_type: Some("PruneRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/consolidate",
+        description: "Merge similar/duplicate memories automatically.",
+        request_type: Some("ConsolidateRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/aging",
+        description: "Run aging cleanup — deprioritize or remove old/stale memories.",
+        request_type: Some("AgingRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/importance",
+        description: "Recompute importance scores for all memories.",
+        request_type: Some("ImportanceRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/orphans",
+        description: "List orphaned memories (not in any room, no edges).",
+        request_type: Some("OrphansRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/extract",
+        description: "Extract entities and relationships from memory content.",
+        request_type: Some("ExtractRequest"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/rebuild-backlinks",
+        description: "Rebuild backlink indices for memory graph.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Context / Dream / MCP ───────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/context",
+        description: "Get context window for a query (for LLM prompt enrichment).",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/dream",
+        description: "Generate new memories/insights from existing memory corpus.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/mcp",
+        description: "MCP (Model Context Protocol) bridge endpoint for AI agent tool calls.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &[],
+    },
+    // ── Recent ───────────────────────────────────────────────────────────
+    Endpoint {
+        method: "GET",
+        path: "/recent",
+        description: "Get recently added memories. Accepts `?limit=N&namespace=X` query params.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: true,
+        issues: &[],
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoints_count_matches_handlers() {
+        // This test enforces that the registry stays in sync with handlers.rs.
+        // If you add/remove a handler, update ENDPOINTS above.
+        // Current count: derived from handlers.rs route matches.
+        assert!(!ENDPOINTS.is_empty(), "Endpoint registry must not be empty");
+        // Spot-check: we should have at least the core endpoints
+        let paths: Vec<&str> = ENDPOINTS.iter().map(|e| e.path).collect();
+        assert!(paths.contains(&"/health"), "Missing /health");
+        assert!(paths.contains(&"/remember"), "Missing /remember");
+        assert!(paths.contains(&"/recall"), "Missing /recall");
+        assert!(paths.contains(&"/room/remember"), "Missing /room/remember");
+        assert!(paths.contains(&"/room/recall"), "Missing /room/recall");
+    }
+}

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -431,17 +431,36 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 .collect();
 
             if let Some(id) = params.get("id") {
-                // Validate UUID format
-                if uuid::Uuid::parse_str(id).is_err() {
-                    return ctx.error_response_for(req, 400, format!("Invalid UUID format: {id}"));
-                }
+                // Accept full UUID or short ID prefix (#794).
+                // `list` and `room_recall` display only 8-char prefixes, so
+                // `forget` must resolve them back to full UUIDs.
+                let resolved_id = if uuid::Uuid::parse_str(id).is_ok() {
+                    id.clone()
+                } else {
+                    match uteke.resolve_id_prefix(id) {
+                        Ok(Some(full)) => full,
+                        Ok(None) => {
+                            return ctx.error_response_for(
+                                req,
+                                404,
+                                format!("Memory not found: {id}"),
+                            );
+                        }
+                        Err(e) => {
+                            error!("Resolve error: {e}");
+                            return ctx.error_response_for(req, 400, e.to_string());
+                        }
+                    }
+                };
                 // Check existence before deleting (#762) — forget() silently
                 // returns Ok(()) even when the ID doesn't exist.
-                if uteke.get_by_id(id).ok().flatten().is_none() {
+                if uteke.get_by_id(&resolved_id).ok().flatten().is_none() {
                     return ctx.error_response_for(req, 404, format!("Memory not found: {id}"));
                 }
-                match uteke.forget(id) {
-                    Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"forgotten": id})),
+                match uteke.forget(&resolved_id) {
+                    Ok(()) => {
+                        ctx.ok_response_for(req, &serde_json::json!({"forgotten": resolved_id}))
+                    }
                     Err(e) => {
                         error!("Internal error: {e}");
                         ctx.error_response_for(req, 500, "Internal server error")

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -1065,7 +1065,11 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         ),
                         Err(e) => {
                             error!("room/remember error: {e}");
-                            ctx.error_response_for(req, 500, "Internal server error")
+                            let status = match e {
+                                uteke_core::Error::Validation(_) => 400,
+                                _ => 500,
+                            };
+                            ctx.error_response_for(req, status, e.to_string())
                         }
                     }
                 }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -960,33 +960,43 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
-        // ── Room Recall (semantic — requires non-empty query) ─────────────
+        // ── Room Recall (semantic with optional fallback to chronological) ──
         (Method::Post, "/room/recall") => match read_body::<RoomRecallRequest>(req.as_reader()) {
             Ok(req_data) => {
-                if req_data.query.trim().is_empty() {
-                    return ctx.error_response_for(
-                        req,
-                        400,
-                        "Empty query is not allowed. Use GET /room/memories for chronological listing.",
+                let query = req_data.query.as_deref().unwrap_or("").trim();
+                if query.is_empty() {
+                    // No query provided — fall back to chronological recall (#785)
+                    match uteke.recall_room(
+                        &req_data.room_id,
+                        req_data.author.as_deref(),
+                        req_data.limit,
+                    ) {
+                        Ok(memories) => ctx.ok_response_for(req, &memories),
+                        Err(e) => {
+                            error!("Internal error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
+                    }
+                } else {
+                    // Semantic recall with query
+                    let min_score = req_data.min_score.unwrap_or(
+                        ctx.recall_config
+                            .as_ref()
+                            .and_then(|r| r.min_score)
+                            .unwrap_or(DEFAULT_MIN_SCORE as f64) as f32,
                     );
-                }
-                let min_score = req_data.min_score.unwrap_or(
-                    ctx.recall_config
-                        .as_ref()
-                        .and_then(|r| r.min_score)
-                        .unwrap_or(DEFAULT_MIN_SCORE as f64) as f32,
-                );
-                match uteke.recall_room_semantic(
-                    &req_data.room_id,
-                    &req_data.query,
-                    req_data.limit,
-                    req_data.author.as_deref(),
-                    min_score,
-                ) {
-                    Ok(results) => ctx.ok_response_for(req, &results),
-                    Err(e) => {
-                        error!("Internal error: {e}");
-                        ctx.error_response_for(req, 500, "Internal server error")
+                    match uteke.recall_room_semantic(
+                        &req_data.room_id,
+                        query,
+                        req_data.limit,
+                        req_data.author.as_deref(),
+                        min_score,
+                    ) {
+                        Ok(results) => ctx.ok_response_for(req, &results),
+                        Err(e) => {
+                            error!("Internal error: {e}");
+                            ctx.error_response_for(req, 500, "Internal server error")
+                        }
                     }
                 }
             }

--- a/crates/uteke-server/src/lib.rs
+++ b/crates/uteke-server/src/lib.rs
@@ -1,0 +1,10 @@
+//! Uteke HTTP Server library exports.
+//!
+//! The binary (`uteke-serve`) lives in `main.rs`.
+//! This lib exists so that `crates/docgen` can access request/response types
+//! and the API route registry for documentation generation.
+
+#[cfg(feature = "docgen")]
+pub mod api_registry;
+
+pub mod types;

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -141,7 +141,9 @@ fn main() {
                 println!(
                     "  GET  /room/memories       → ?room_id=<id>[&author=&limit=] → chronological memories"
                 );
-                println!("  POST /room/recall          → {{ room_id, query }} → ranked memories");
+                println!(
+                    "  POST /room/recall          → {{ room_id, query? }} → ranked memories (query optional, falls back to chronological)"
+                );
                 println!("  POST /room/summary         → {{ room_id }} → {{ summary }}");
                 println!("  POST /room/document        → {{ room_id }} → {{ document }}");
                 println!("  POST /room/stats           → {{ room_id }} → room stats");

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -3,6 +3,8 @@
 //! Keeps the embedding model loaded in RAM for <50ms recall.
 //! Usage: `uteke-serve [--port 8767] [--host 127.0.0.1] [--auth-token <TOKEN>]`
 
+#[cfg(feature = "docgen")]
+mod api_registry;
 mod context;
 mod handlers;
 mod types;

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -291,7 +291,10 @@ pub fn default_doc_limit() -> usize {
 #[derive(Deserialize)]
 pub struct RoomRecallRequest {
     pub room_id: String,
-    pub query: String,
+    /// Semantic search query. When `None` or empty, falls back to
+    /// chronological recall (equivalent to `GET /room/memories`) (#785).
+    #[serde(default)]
+    pub query: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: usize,
     #[serde(default)]

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -7,6 +7,7 @@ use tiny_http::Header;
 
 // ── Document Types ──────────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct DocCreateRequest {
     pub slug: String,
@@ -18,12 +19,14 @@ pub struct DocCreateRequest {
     pub parent: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct DocGetRequest {
     pub id: Option<String>,
     pub slug: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct DocListParams {
     #[serde(default = "default_doc_limit")]
@@ -34,6 +37,7 @@ pub struct DocListParams {
     pub parent: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct DocSearchRequest {
     pub query: String,
@@ -43,6 +47,7 @@ pub struct DocSearchRequest {
     pub mode: String,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct DocMoveRequest {
     pub id: Option<String>,
@@ -51,6 +56,7 @@ pub struct DocMoveRequest {
     pub new_parent: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct DocUpdateRequest {
     pub id: Option<String>,
@@ -164,6 +170,7 @@ pub fn to_v1_flat(result: &uteke_core::memory::types::UnifiedSearchResult) -> se
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct RememberRequest {
     pub content: String,
@@ -197,6 +204,7 @@ pub struct RememberRequest {
     pub source_type: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct RecallRequest {
     pub query: String,
@@ -231,6 +239,7 @@ pub struct RecallRequest {
     pub enrich: bool,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct SearchRequest {
     pub query: String,
@@ -242,6 +251,7 @@ pub struct SearchRequest {
     pub namespace: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct ListParams {
     #[serde(default)]
@@ -257,6 +267,7 @@ pub struct ListParams {
     pub at: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Serialize)]
 pub struct HealthResponse {
     pub status: &'static str,
@@ -273,6 +284,7 @@ pub struct HealthResponse {
     pub api_latest: Option<&'static str>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Serialize)]
 pub struct ErrorResponse {
     pub error: String,
@@ -288,6 +300,7 @@ pub fn default_limit() -> usize {
 pub fn default_doc_limit() -> usize {
     1000
 }
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct RoomRecallRequest {
     pub room_id: String,
@@ -386,6 +399,7 @@ pub fn ns(ns: &Option<String>) -> Option<&str> {
 
 // ── Config Types (shared across modules) ─────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(serde::Deserialize, Default, Clone)]
 pub struct RecallFileSection {
     /// Minimum cosine similarity score for recall results.
@@ -405,6 +419,7 @@ pub const DEFAULT_MIN_SCORE: f32 = 0.0;
 
 // ── Tag Management Types ─────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct TagRenameRequest {
     pub old: String,
@@ -413,6 +428,7 @@ pub struct TagRenameRequest {
     pub new: String,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct TagDeleteRequest {
     pub tag: String,
@@ -422,6 +438,7 @@ pub struct TagDeleteRequest {
 
 // ── Memory Update Types (#659) ─────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct MemoryUpdateRequest {
     /// UUID of the memory to update (required).
@@ -448,6 +465,7 @@ pub struct MemoryUpdateRequest {
 
 // ── Pin Types ─────────────────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct PinRequest {
     pub id: String,
@@ -455,12 +473,14 @@ pub struct PinRequest {
 
 // ── Memory Mutation Types (#660) ───────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct MemoryPinRequest {
     pub id: String,
     pub pinned: bool,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct MemoryImportanceRequest {
     pub id: String,
@@ -468,6 +488,7 @@ pub struct MemoryImportanceRequest {
 }
 
 /// Request for memory feedback / trust scoring (#718).
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct MemoryFeedbackRequest {
     pub id: String,
@@ -477,6 +498,7 @@ pub struct MemoryFeedbackRequest {
 
 // ── Graph Types ────────────────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct GraphEdgeRequest {
     pub source: String,
@@ -489,6 +511,7 @@ pub struct GraphEdgeRequest {
 
 // ── Extract Types ──────────────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct ExtractRequest {
     pub content: String,
@@ -508,6 +531,7 @@ pub struct ExtractRequest {
 
 // ── Import Types ──────────────────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct ImportRequest {
     /// JSONL content to import.
@@ -521,6 +545,7 @@ pub struct ImportRequest {
 
 // ── Room Remember Types (#762) ────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct RoomRememberRequest {
     pub room_id: String,
@@ -540,6 +565,7 @@ pub struct RoomRememberRequest {
 
 // ── Maintenance Types (#607) ──────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct PruneRequest {
     #[serde(default = "default_prune_ttl")]
@@ -554,6 +580,7 @@ fn default_prune_ttl() -> u32 {
     30
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct ConsolidateRequest {
     #[serde(default = "default_consolidate_threshold")]
@@ -568,6 +595,7 @@ fn default_consolidate_threshold() -> f32 {
     0.9
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct AgingRequest {
     #[serde(default = "default_aging_action")]
@@ -590,6 +618,7 @@ fn default_aging_action() -> String {
 
 // ── Monitoring Types (#608) ──────────────────────────────────────────────
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct ImportanceRequest {
     #[serde(default)]
@@ -597,6 +626,7 @@ pub struct ImportanceRequest {
     pub namespace: Option<String>,
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct OrphansRequest {
     #[serde(default = "default_orphan_threshold")]
@@ -611,6 +641,7 @@ fn default_orphan_threshold() -> f64 {
     0.3
 }
 
+#[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
 pub struct RebuildBacklinksRequest {
     #[serde(default)]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -40,6 +40,7 @@ export default createConfig({
       text: 'Reference',
       items: [
         { text: 'CLI Reference', link: '/cli-reference' },
+        { text: 'HTTP API Reference', link: '/api-reference' },
         { text: 'Comparison', link: '/comparison' },
         { text: 'Architecture', link: '/architecture' },
         { text: 'Hermes Integration', link: '/integrations/hermes' },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,692 +1,659 @@
----
-title: HTTP API Reference
----
-
 # HTTP API Reference
 
-Complete reference for all uteke-server HTTP endpoints. Version **0.10.1**.
+Auto-generated from `uteke-server` route registry and type schemas. Do not edit manually — run `cargo run -p docgen` to regenerate.
 
-All endpoints accept and return JSON (`Content-Type: application/json`). POST/PUT/DELETE bodies are JSON; GET endpoints use query parameters.
+**Base URL**: `http://localhost:8767` (default)
 
-## Base URL
+**Auth**: Set `--auth-token <TOKEN>` to require `Authorization: Bearer <TOKEN>` header.
 
-```
-http://localhost:8767
-```
+## 🏷️ Tags
 
-Default port is `8767`. Override with `--port` flag or `UTEKE_PORT` env var.
+#### 🟢 `GET` `/tags`
 
-## API Versioning
+List all tags in a namespace. Accepts `?namespace=X` query param.
 
-All routes support optional `/api/v1` or `/api/v2` prefix for version negotiation ([#737](https://github.com/codecoradev/uteke/issues/737)):
-
-| Version | Format | Description |
-|---------|--------|-------------|
-| `v1` | Flat recall results | v0.7.x compatible (`[{id, content, score, ...}]`) |
-| `v2` | Wrapped `UnifiedSearchResult` | v0.8.x+ (unified search with metadata) |
-| *(none)* | Latest (`v2`) | Unversioned routes alias to latest |
-
-```bash
-# Versioned
-POST /api/v2/recall
-# Unversioned (aliases to v2)
-POST /recall
-```
-
----
-
-## Health & Stats
-
-### GET /health
-
-Server health check. Returns version, memory count, and supported API versions.
-
-**Response:**
-```json
-{
-  "status": "ok",
-  "version": "0.10.1",
-  "memories": 148,
-  "namespaces": 3,
-  "api_versions": ["v1", "v2"],
-  "api_latest": "v2"
-}
-```
-
-### GET /stats
-
-Global statistics (namespaces, memory counts, tag counts).
-
-**Response:**
-```json
-{
-  "namespaces": ["default", "cto", "cmo"],
-  "total_memories": 148,
-  "by_namespace": { "default": 50, "cto": 80, "cmo": 18 }
-}
-```
-
-### POST /stats
-
-Statistics for a specific namespace.
-
-**Request:**
-```json
-{ "namespace": "default" }
-```
-
----
-
-## Memory Operations
-
-### POST /remember
-
-Store a new memory with automatic embedding generation.
-
-**Request:**
-```json
-{
-  "content": "Uteke uses SQLite + ONNX embeddings",
-  "tags": ["architecture", "uteke"],
-  "namespace": "default",
-  "type": "fact",
-  "entity": "uteke",
-  "category": "architecture",
-  "metadata": { "project": "uteke" },
-  "source": "docs",
-  "source_type": "user",
-  "valid_from": "2026-01-01T00:00:00Z",
-  "valid_until": null,
-  "detect_contradiction": false
-}
-```
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `content` | string | ✅ | — | Memory content text |
-| `tags` | string[] | ❌ | `[]` | Tags for filtering |
-| `namespace` | string | ❌ | `default` | Namespace isolation |
-| `type` | string | ❌ | `null` | Memory type (fact, procedure, preference, decision, etc.) |
-| `entity` | string | ❌ | `null` | Entity name (stored as metadata) |
-| `category` | string | ❌ | `null` | Category (stored as metadata) |
-| `metadata` | object | ❌ | `null` | Extra key-value pairs |
-| `source` | string | ❌ | `null` | Source provenance |
-| `source_type` | string | ❌ | `user` | Source type |
-| `valid_from` | string | ❌ | `null` | RFC3339 timestamp |
-| `valid_until` | string | ❌ | `null` | RFC3339 timestamp |
-| `detect_contradiction` | bool | ❌ | `false` | Check for contradictions |
-
-### POST /recall
-
-Semantic recall — search memories by meaning using embeddings.
-
-**Request:**
-```json
-{
-  "query": "how does uteke store data",
-  "limit": 5,
-  "tags": [],
-  "namespace": "default",
-  "entity": null,
-  "category": null,
-  "min_score": 0.0,
-  "strict": false,
-  "at": null,
-  "search_type": "all",
-  "enrich": false
-}
-```
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `query` | string | ✅ | — | Semantic search query |
-| `limit` | int | ❌ | `5` | Max results |
-| `tags` | string[] | ❌ | `[]` | Filter by tags |
-| `namespace` | string | ❌ | `null` | Namespace filter |
-| `entity` | string | ❌ | `null` | Filter by entity metadata |
-| `category` | string | ❌ | `null` | Filter by category metadata |
-| `min_score` | float | ❌ | `0.0` | Minimum similarity score |
-| `strict` | bool | ❌ | `false` | Use strict threshold (0.5) |
-| `at` | string | ❌ | `null` | Time-travel: RFC3339 timestamp |
-| `search_type` | string | ❌ | `all` | `all`, `memory`, or `doc` |
-| `enrich` | bool | ❌ | `false` | Enrich with cross-entity links |
-
-### POST /search
-
-Fast keyword/FTS search (non-semantic).
-
-**Request:**
-```json
-{
-  "query": "sqlite",
-  "limit": 10,
-  "tags": [],
-  "namespace": "default"
-}
-```
-
-### POST /list
-
-List memories with pagination and optional tag filter.
-
-**Request:**
-```json
-{
-  "tag": "architecture",
-  "limit": 5,
-  "offset": 0,
-  "namespace": "default",
-  "at": null
-}
-```
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `tag` | string | ❌ | `null` | Filter by tag |
-| `limit` | int | ❌ | `5` | Page size |
-| `offset` | int | ❌ | `0` | Pagination offset |
-| `namespace` | string | ❌ | `null` | Namespace filter |
-| `at` | string | ❌ | `null` | Time-travel timestamp |
-
-### DELETE /forget
-
-Delete a memory by ID.
-
-**Query params:** `?id=<uuid>`
-
-```bash
-DELETE /forget?id=550e8400-e29b-41d4-a716-446655440000
-```
-
-### GET /memory
-
-Get a single memory by ID.
-
-**Query params:** `?id=<uuid>`
-
-### PUT /memory
-
-Update a memory ([#659](https://github.com/codecoradev/uteke/issues/659)). Triggers embedding regeneration if content changes.
-
-**Request:**
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "content": "updated content",
-  "tags": ["new-tag"],
-  "metadata": { "key": "value" },
-  "importance": 0.8,
-  "pinned": true,
-  "memory_type": "decision"
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | string | ✅ | Memory UUID |
-| `content` | string | ❌ | New content (triggers re-embedding) |
-| `tags` | string[] | ❌ | Replace tags |
-| `metadata` | object | ❌ | Replace metadata |
-| `importance` | float | ❌ | Importance score (0.0–1.0) |
-| `pinned` | bool | ❌ | Pinned state |
-| `memory_type` | string | ❌ | Memory type |
-
-### POST /memory/pin
-
-Set pinned state on a memory ([#660](https://github.com/codecoradev/uteke/issues/660)).
-
-**Request:**
-```json
-{ "id": "550e8400-...", "pinned": true }
-```
-
-### POST /memory/importance
-
-Set importance score on a memory.
-
-**Request:**
-```json
-{ "id": "550e8400-...", "importance": 0.9 }
-```
-
-### POST /memory/feedback
-
-Submit feedback for trust scoring ([#718](https://github.com/codecoradev/uteke/issues/718)).
-
-**Request:**
-```json
-{ "id": "550e8400-...", "feedback": "helpful" }
-```
-
-`feedback` must be `"helpful"` or `"unhelpful"`.
-
-### POST /memory/doc-refs
-
-Get document references linked to a memory ([#689](https://github.com/codecoradev/uteke/issues/689)).
-
-**Request:**
-```json
-{ "memory_id": "550e8400-..." }
-```
-
----
-
-## Pin Operations
-
-### POST /pin
-
-Pin a memory by ID.
-
-**Request:**
-```json
-{ "id": "550e8400-..." }
-```
-
-### POST /unpin
-
-Unpin a memory by ID.
-
-**Request:**
-```json
-{ "id": "550e8400-..." }
-```
-
----
-
-## Namespace & Tags
-
-### GET /namespaces
-
-List all namespaces.
-
-**Query params:** `?memory_count=true` (include memory counts per namespace)
-
-### GET /tags
-
-List all tags with usage counts.
-
-**Query params:** `?namespace=<name>`
-
-### POST /tags/rename
+#### 🟡 `POST` `/tags/rename`
 
 Rename a tag across all memories.
 
-**Request:**
-```json
-{ "old": "arch", "new": "architecture", "namespace": "default" }
-```
+**Request body**: [`TagRenameRequest`](#tagrenamerequest)
 
-### POST /tags/delete
+#### 🟡 `POST` `/tags/delete`
 
 Delete a tag from all memories.
 
-**Request:**
-```json
-{ "tag": "deprecated", "namespace": "default" }
-```
+**Request body**: [`TagDeleteRequest`](#tagdeleterequest)
 
----
 
-## Recent & Graph
+## 📌 Pin (Legacy)
 
-### GET /recent
+#### 🟡 `POST` `/pin`
 
-Get recently accessed memories.
+Pin a memory by ID (legacy — prefer /memory/pin).
 
-**Query params:** `?limit=10&namespace=default`
+**Request body**: [`PinRequest`](#pinrequest)
 
-### GET /graph
+#### 🟡 `POST` `/unpin`
 
-Get relationship graph for an entity.
+Unpin a memory by ID (legacy — prefer /memory/pin with pin=false).
 
-**Query params:** `?entity=<name>&depth=3`
+**Request body**: [`PinRequest`](#pinrequest)
 
-### POST /graph/edge
 
-Create a relationship edge between entities.
+## 📝 Other
 
-**Request:**
-```json
-{
-  "source": "uteke",
-  "target": "sqlite",
-  "edge_type": "uses",
-  "weight": 1.0
-}
-```
+#### 🟢 `GET` `/namespaces`
 
-### DELETE /graph/edge
+List all namespaces in the memory store
 
-Delete a relationship edge.
+#### 🟢 `GET` `/stats`
 
-**Query params:** `?source=<name>&target=<name>&edge_type=<type>`
+Get memory statistics (count, etc.) for a namespace. Accepts `?namespace=X` query param.
 
----
+#### 🟡 `POST` `/stats`
 
-## Rooms
+Get memory statistics via POST body. Accepts `{"namespace": "..."}`.
 
-Rooms are collaborative memory spaces for multi-agent discussions.
+**Request body**: JSON object (see handler source for fields)
 
-### POST /room/create
+*Related: `#786`*
 
-Create a new room.
+#### 🟢 `GET` `/memory`
 
-**Request:**
-```json
-{ "room_id": "project-discussion", "title": "Project Discussion", "namespace": "default" }
-```
+Get a single memory by ID. Accepts `?id=...` query param.
 
-### POST /room/remember
+**Response**: [`Memory`](#memory)
 
-Store a memory and link it to a room.
+#### 🔵 `PUT` `/memory`
 
-**Request:**
-```json
-{
-  "room_id": "project-discussion",
-  "content": "Decision: use SQLite for storage",
-  "author": "cto",
-  "tags": ["decision"],
-  "role": "lead"
-}
-```
+Update an existing memory's content and/or metadata.
 
-### GET /room/memories
+**Request body**: [`MemoryUpdateRequest`](#memoryupdaterequest)
 
-List memories in a room (chronological order).
+#### 🟢 `GET` `/graph`
 
-**Query params:** `?room_id=<id>&author=<name>&limit=10`
+Get graph edges for a memory. Accepts `?id=...` query param.
 
-### POST /room/recall
 
-Semantic recall within a room. Query is **optional** — when omitted or empty, falls back to chronological recall ([#785](https://github.com/codecoradev/uteke/issues/785)).
+## 📦 Import/Export
 
-**Request (semantic — with query):**
-```json
-{
-  "room_id": "project-discussion",
-  "query": "database decision",
-  "limit": 5,
-  "author": null,
-  "min_score": 0.0
-}
-```
+#### 🟡 `POST` `/import`
 
-**Request (chronological fallback — no query):**
-```json
-{
-  "room_id": "project-discussion",
-  "limit": 10,
-  "author": "cto"
-}
-```
+Import memories from a JSON array.
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `room_id` | string | ✅ | — | Room identifier |
-| `query` | string | ❌ | `null` | Semantic query. When empty/absent, falls back to chronological |
-| `limit` | int | ❌ | `5` | Max results |
-| `author` | string | ❌ | `null` | Filter by author |
-| `min_score` | float | ❌ | `0.0` | Minimum similarity (semantic mode only) |
+**Request body**: [`ImportRequest`](#importrequest)
 
-### POST /room/stats
+#### 🟢 `GET` `/export`
 
-Get room statistics (memory count, participant count, participants list, last activity). Excludes deprecated memories ([#784](https://github.com/codecoradev/uteke/issues/784)).
+Export all memories as JSON. Accepts `?namespace=...` query param.
 
-**Request:**
-```json
-{ "room_id": "project-discussion" }
-```
+#### 🟡 `POST` `/importance`
 
-**Response:**
-```json
-{
-  "memory_count": 12,
-  "participant_count": 3,
-  "participants": ["cto", "cmo", "coo"],
-  "last_activity": "2026-07-27T10:30:00Z"
-}
-```
+Recompute importance scores for all memories.
 
-### POST /room/summary
+**Request body**: [`ImportanceRequest`](#importancerequest)
 
-Get or generate a room summary.
 
-**Request:**
-```json
-{ "room_id": "project-discussion" }
-```
+## 🔧 Maintenance
 
-### POST /room/summary-document
+#### 🟡 `POST` `/prune`
 
-Get the summary document for a room.
+Remove orphaned memories (no room, no graph edges).
 
-**Request:**
-```json
-{ "room_id": "project-discussion" }
-```
+**Request body**: [`PruneRequest`](#prunerequest)
 
-### POST /room/document
+#### 🟡 `POST` `/consolidate`
 
-Get the document associated with a room.
+Merge similar/duplicate memories automatically.
 
-**Request:**
-```json
-{ "room_id": "project-discussion" }
-```
+**Request body**: [`ConsolidateRequest`](#consolidaterequest)
 
-### POST /room/document/list
+#### 🟡 `POST` `/aging`
 
-List documents linked to a room.
+Run aging cleanup — deprioritize or remove old/stale memories.
 
-**Request:**
-```json
-{ "room_id": "project-discussion" }
-```
+**Request body**: [`AgingRequest`](#agingrequest)
 
-### PUT /room/document/add
+#### 🟡 `POST` `/orphans`
 
-Link a document to a room.
+List orphaned memories (not in any room, no edges).
 
-**Request:**
-```json
-{ "room_id": "project-discussion", "doc_id": "doc-uuid" }
-```
+**Request body**: [`OrphansRequest`](#orphansrequest)
 
-### DELETE /room/document/remove
+#### 🟡 `POST` `/extract`
 
-Unlink a document from a room.
+Extract entities and relationships from memory content.
 
-**Query params:** `?room_id=<id>&doc_id=<uuid>`
+**Request body**: [`ExtractRequest`](#extractrequest)
 
-### POST /doc/room/list
+#### 🟡 `POST` `/rebuild-backlinks`
 
-List rooms linked to a document.
+Rebuild backlink indices for memory graph.
 
-**Request:**
-```json
-{ "doc_id": "doc-uuid" }
-```
 
-### GET /room/list
+## 🔴 Health & Info
+
+#### 🟢 `GET` `/health`
+
+Health check — returns server status and version
+
+**Response**: [`HealthResponse`](#healthresponse)
+
+
+## 🔵 Documents
+
+#### 🟡 `POST` `/doc/create`
+
+Create a new document with slug, title, content, tags.
+
+**Request body**: [`DocCreateRequest`](#doccreaterequest)
+
+#### 🟡 `POST` `/doc/get`
+
+Get a document by slug.
+
+**Request body**: [`DocGetRequest`](#docgetrequest)
+
+#### 🟡 `POST` `/doc/move`
+
+Move a document to a different parent.
+
+**Request body**: [`DocMoveRequest`](#docmoverequest)
+
+#### 🔴 `DELETE` `/doc/delete`
+
+Delete a document by slug or ID.
+
+#### 🟡 `POST` `/doc/mem-refs`
+
+Get memories that reference a specific document.
+
+**Request body**: JSON object (see handler source for fields)
+
+
+## 🟠 Graph
+
+#### 🟡 `POST` `/graph/edge`
+
+Add a directed edge between two memories.
+
+**Request body**: [`GraphEdgeRequest`](#graphedgerequest)
+
+#### 🔴 `DELETE` `/graph/edge`
+
+Remove an edge between two memories. Accepts `?from=...&to=...` query params.
+
+#### 🟢 `GET` `/edges`
+
+List edges for a memory (alias for /graph). Accepts `?id=...` query param.
+
+#### 🟢 `GET` `/timeline`
+
+Get timeline of memory events for a memory. Accepts `?id=...` query param.
+
+
+## 🟡 Core Memory
+
+#### 🟡 `POST` `/remember`
+
+Store a new memory. Accepts content, tags, namespace, type, metadata.
+
+**Request body**: [`RememberRequest`](#rememberrequest)
+
+**Response**: [`Memory`](#memory)
+
+#### 🟡 `POST` `/recall`
+
+Semantic search — recall memories by meaning. Returns ranked results.
+
+*Excludes deprecated memories from results.*
+
+**Request body**: [`RecallRequest`](#recallrequest)
+
+#### 🟡 `POST` `/search`
+
+Keyword search — find memories by matching words in content/tags.
+
+*Excludes deprecated memories from results.*
+
+**Request body**: [`SearchRequest`](#searchrequest)
+
+#### 🟡 `POST` `/list`
+
+List memories with optional filters (namespace, tags, sort, limit, offset).
+
+*Excludes deprecated memories from results.*
+
+**Request body**: [`ListParams`](#listparams)
+
+#### 🔴 `DELETE` `/forget`
+
+Deprecate a memory by ID. Returns 404 if ID doesn't exist.
+
+#### 🟢 `GET` `/recent`
+
+Get recently added memories. Accepts `?limit=N&namespace=X` query params.
+
+*Excludes deprecated memories from results.*
+
+
+## 🟢 Rooms
+
+#### 🟡 `POST` `/room/create`
+
+Create a new memory room. Accepts `{"name": "..."}`.
+
+**Request body**: JSON object (see handler source for fields)
+
+#### 🟡 `POST` `/room/remember`
+
+Store a memory linked to a room. Accepts room_id, content, tags, type, author.
+
+**Request body**: [`RoomRememberRequest`](#roomrememberrequest)
+
+**Response**: [`Memory`](#memory)
+
+*Related: `#789`*
+
+#### 🟡 `POST` `/room/recall`
+
+Semantic search within a room. Empty query returns all memories chronologically.
+
+*Excludes deprecated memories from results.*
+
+**Request body**: [`RoomRecallRequest`](#roomrecallrequest)
+
+*Related: `#785`*
+
+#### 🟡 `POST` `/room/summary`
+
+Get room summary with memory clusters and statistics.
+
+*Excludes deprecated memories from results.*
+
+**Request body**: JSON object (see handler source for fields)
+
+#### 🟡 `POST` `/room/summary-document`
+
+Get room summary focused on document-type memories.
+
+*Excludes deprecated memories from results.*
+
+**Request body**: JSON object (see handler source for fields)
+
+#### 🟢 `GET` `/room/list`
 
 List all rooms.
 
-**Query params:** `?namespace=<name>`
+#### 🟡 `POST` `/room/stats`
 
-### DELETE /room/delete
+Get memory count for a room. Includes deprecated memories (known discrepancy vs /room/summary).
 
-Delete a room. Cascades `room_memories` links (memories themselves survive).
+**Request body**: JSON object (see handler source for fields)
 
-**Query params:** `?room_id=<id>`
+*Related: `#784`*
 
----
+#### 🟢 `GET` `/room/memories`
 
-## Documents
+List all memories in a room (chronological). Accepts `?room_id=...` query param.
 
-Documents are structured content with hierarchical parent-child relationships.
+*Excludes deprecated memories from results.*
 
-### POST /doc/create
+#### 🔴 `DELETE` `/room/delete`
 
-Create a new document.
+Delete a room and all its memories. Accepts `?room_id=...` query param.
 
-**Request:**
-```json
-{
-  "slug": "architecture-overview",
-  "title": "Architecture Overview",
-  "content": "# Architecture\n\n...",
-  "tags": ["architecture"],
-  "parent": null
-}
-```
+#### 🟡 `POST` `/room/document`
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `slug` | string | ✅ | — | URL-safe identifier |
-| `title` | string | ❌ | `null` | Display title |
-| `content` | string | ✅ | — | Document content (markdown) |
-| `tags` | string[] | ❌ | `[]` | Tags |
-| `parent` | string | ❌ | `null` | Parent doc slug (for hierarchy) |
+Store a reference document in a room (large content >500 chars).
 
-### POST /doc/get
+**Request body**: JSON object (see handler source for fields)
 
-Get a document by ID or slug.
+#### 🟡 `POST` `/room/document/list`
 
-**Request:**
-```json
-{ "id": "uuid-or-null", "slug": "architecture-overview" }
-```
+List documents in a room.
 
-Provide either `id` or `slug`.
+**Request body**: JSON object (see handler source for fields)
 
-### POST /doc/update
+#### 🔵 `PUT` `/room/document/add`
 
-Update a document.
+Add a reference to an existing document in a room.
 
-**Request:**
-```json
-{
-  "id": null,
-  "slug": "architecture-overview",
-  "title": "Updated Title",
-  "content": "updated content",
-  "tags": ["architecture", "updated"],
-  "metadata": null
-}
-```
+**Request body**: JSON object (see handler source for fields)
 
-### POST /doc/list
+#### 🔴 `DELETE` `/room/document/remove`
 
-List documents.
+Remove a document reference from a room.
 
-**Request:**
-```json
-{ "limit": 1000, "roots_only": false, "parent": null }
-```
+**Request body**: JSON object (see handler source for fields)
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `limit` | int | `1000` | Max results (high default for full tree) |
-| `roots_only` | bool | `false` | Only top-level docs (no parent) |
-| `parent` | string | `null` | Filter by parent slug |
+#### 🟡 `POST` `/doc/room/list`
 
-### POST /doc/search
+List rooms that reference a specific document.
 
-Search documents.
+**Request body**: JSON object (see handler source for fields)
 
-**Request:**
-```json
-{ "query": "storage", "limit": 5, "mode": "hybrid" }
-```
 
-`mode`: `hybrid` (default), `fts`, or `semantic`.
+## 🟣 Memory Management
 
-### POST /doc/move
+#### 🟡 `POST` `/memory/pin`
 
-Move a document to a new parent.
+Pin a memory so it won't be removed by aging/cleanup operations.
 
-**Request:**
-```json
-{ "id": null, "slug": "child-doc", "new_parent": "new-parent-slug" }
-```
+**Request body**: [`MemoryPinRequest`](#memorypinrequest)
 
-### DELETE /doc/delete
+#### 🟡 `POST` `/memory/importance`
 
-Delete a document.
+Get or set the importance score of a memory.
 
-**Query params:** `?id=<uuid>` or `?slug=<slug>`
+**Request body**: [`MemoryImportanceRequest`](#memoryimportancerequest)
 
-### POST /doc/mem-refs
+#### 🟡 `POST` `/memory/feedback`
 
-Get memory references linked to a document ([#689](https://github.com/codecoradev/uteke/issues/689)).
+Submit positive/negative feedback on a memory for ranking signals.
 
-**Request:**
-```json
-{ "doc_id": "doc-uuid" }
-```
+**Request body**: [`MemoryFeedbackRequest`](#memoryfeedbackrequest)
 
----
+#### 🟡 `POST` `/memory/doc-refs`
 
-## Advanced
+Get documents that reference a specific memory.
 
-### POST /context
+**Request body**: JSON object (see handler source for fields)
 
-Get contextual memories for a given input.
 
-**Request:** Arbitrary JSON object.
+## 🤖 AI Integration
 
-### POST /dream
+#### 🟡 `POST` `/context`
 
-Trigger dream/consolidation process.
+Get context window for a query (for LLM prompt enrichment).
 
-**Request:** Arbitrary JSON object.
+**Request body**: JSON object (see handler source for fields)
 
-### POST /mcp
+#### 🟡 `POST` `/dream`
 
-MCP (Model Context Protocol) JSON-RPC endpoint. See [MCP Server docs](/mcp) for details.
+Generate new memories/insights from existing memory corpus.
 
----
+**Request body**: JSON object (see handler source for fields)
 
-## Error Responses
+#### 🟡 `POST` `/mcp`
 
-All errors return HTTP 4xx/5xx with a JSON error body:
+MCP (Model Context Protocol) bridge endpoint for AI agent tool calls.
 
-```json
-{ "error": "Description of what went wrong" }
-```
+**Request body**: JSON object (see handler source for fields)
 
-| Status | Meaning |
-|--------|---------|
-| 400 | Bad request — invalid JSON, missing required field, validation error |
-| 401 | Unauthorized — missing or invalid API key |
-| 404 | Not found — resource doesn't exist |
-| 413 | Payload too large — exceeds `MAX_PAYLOAD_SIZE` |
-| 500 | Internal server error — unexpected failure |
 
----
+## Request/Response Schemas
 
-## Authentication
+Detailed field definitions for each request type.
 
-If `UTEKE_API_KEY` is set, all endpoints require an `Authorization: Bearer <key>` header. When unset, the server runs in open mode (no auth).
+### `AgingRequest`
 
-```bash
-# With auth
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8767/stats
-```
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | `string` | No |  |
+| `dry_run` | `boolean` | No |  |
+| `max_access_count` | any | No | Max access count threshold for preview/cleanup (default: 1). |
+| `namespace` | any | No |  |
+| `older_than_days` | any | No | Days threshold for preview/cleanup (default: warm_days from config, fallback 90). |
 
----
 
-## CORS
+### `ConsolidateRequest`
 
-All responses include CORS headers (`Access-Control-Allow-Origin: *`) for browser-based clients. Preflight `OPTIONS` requests are handled automatically.
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dry_run` | `boolean` | No |  |
+| `namespace` | any | No |  |
+| `threshold` | `number` | No |  |
 
----
 
-## See Also
+### `DocCreateRequest`
 
-- [CLI Reference](/cli-reference) — uteke CLI commands
-- [Configuration](/configuration) — server configuration options
-- [Rooms](/rooms) — room feature guide
-- [MCP Server](/mcp) — MCP protocol integration
-- [TLS & Reverse Proxy](/tls) — production deployment
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | `string` | Yes |  |
+| `parent` | any | No |  |
+| `slug` | `string` | Yes |  |
+| `tags` | ``string``[] | No |  |
+| `title` | any | No |  |
+
+
+### `DocGetRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | any | No |  |
+| `slug` | any | No |  |
+
+
+### `DocMoveRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | any | No |  |
+| `new_parent` | any | No |  |
+| `slug` | any | No |  |
+
+
+### `ErrorResponse`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `error` | `string` | Yes |  |
+
+
+### `ExtractRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | `string` | Yes |  |
+| `max_facts` | any | No | Override max facts per document. |
+| `model` | any | No | Override extraction model (else config default). |
+| `namespace` | any | No |  |
+| `tags` | ``string``[] | No |  |
+| `type` | any | No |  |
+
+
+### `GraphEdgeRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `edge_type` | any | No |  |
+| `source` | `string` | Yes |  |
+| `target` | `string` | Yes |  |
+| `weight` | any | No |  |
+
+
+### `HealthResponse`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_latest` | any | No | Latest API version (#737). |
+| `api_versions` | any | No | Supported API versions (#737). |
+| `memories` | `integer` | Yes |  |
+| `namespaces` | `integer` | Yes |  |
+| `status` | `string` | Yes |  |
+| `version` | `string` | Yes | Server version (uteke-server crate version), so HTTP clients can gate
+features on the actual server capability rather than a local CLI probe. |
+
+
+### `ImportRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | `string` | Yes | JSONL content to import. |
+| `namespace` | any | No |  |
+| `tags` | ``string``[] | No |  |
+
+
+### `ImportanceRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `namespace` | any | No |  |
+
+
+### `ListParams`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `at` | any | No | Time-travel: list memories that existed at this RFC3339 timestamp. |
+| `limit` | `integer` | No |  |
+| `namespace` | any | No |  |
+| `offset` | `integer` | No |  |
+| `tag` | any | No |  |
+
+
+### `MemoryFeedbackRequest`
+
+Request for memory feedback / trust scoring (#718).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `feedback` | `string` | Yes | "helpful" or "unhelpful" |
+| `id` | `string` | Yes |  |
+
+
+### `MemoryImportanceRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes |  |
+| `importance` | `number` | Yes |  |
+
+
+### `MemoryPinRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes |  |
+| `pinned` | `boolean` | Yes |  |
+
+
+### `MemoryUpdateRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | any | No | New content. Triggers embedding regeneration. |
+| `id` | `string` | Yes | UUID of the memory to update (required). |
+| `importance` | any | No | Set importance score (0.0–1.0). |
+| `memory_type` | any | No | Set memory type (fact, procedure, preference, decision, context, note, insight, reference, event). |
+| `metadata` | any | No | Replace metadata entirely with this object. |
+| `pinned` | any | No | Set pinned state. |
+| `tags` | any | No | Replace tags entirely with this list. |
+
+
+### `OrphansRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `limit` | `integer` | No |  |
+| `namespace` | any | No |  |
+| `threshold` | `number` | No |  |
+
+
+### `PinRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes |  |
+
+
+### `PruneRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dry_run` | `boolean` | No |  |
+| `namespace` | any | No |  |
+| `ttl_days` | `integer` | No |  |
+
+
+### `RecallRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `at` | any | No | Time-travel: query memories that existed at this RFC3339 timestamp. |
+| `category` | any | No | Filter by category metadata. |
+| `enrich` | `boolean` | No | Enrich results with cross-entity links (doc↔memory) (#689).
+When true, populates `linked_doc_slugs` on memory results and
+`linked_memory_ids` on document results. |
+| `entity` | any | No | Filter by entity metadata. |
+| `limit` | `integer` | No |  |
+| `min_score` | any | No | Minimum similarity score. Results below are filtered. |
+| `namespace` | any | No |  |
+| `query` | `string` | Yes |  |
+| `search_type` | any | No | Search type filter: "all" (default, unified), "memory", or "doc" (#531). |
+| `strict` | `boolean` | No | Use strict threshold (defaults to 0.5 if min_score not set). |
+| `tags` | ``string``[] | No |  |
+
+
+### `RememberRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | any | No | Category — stored as metadata key "category". |
+| `content` | `string` | Yes |  |
+| `detect_contradiction` | `boolean` | No |  |
+| `entity` | any | No | Entity name — stored as metadata key "entity". |
+| `metadata` | any | No | Extra metadata key=value pairs, merged into the metadata map.
+Accepts an object (e.g. {"project": "uteke"}). |
+| `namespace` | any | No |  |
+| `source` | any | No | Source provenance — set via set_source() after storage. |
+| `source_type` | any | No | Source type (defaults to "user"). |
+| `tags` | ``string``[] | No |  |
+| `type` | any | No |  |
+| `valid_from` | any | No |  |
+| `valid_until` | any | No |  |
+
+
+### `RoomRecallRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `author` | any | No |  |
+| `limit` | `integer` | No |  |
+| `min_score` | any | No |  |
+| `query` | any | No | Semantic search query. When `None` or empty, falls back to
+chronological recall (equivalent to `GET /room/memories`) (#785). |
+| `room_id` | `string` | Yes |  |
+
+
+### `RoomRememberRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `author` | any | No | Author — stored as participant role in room link. |
+| `content` | `string` | Yes |  |
+| `metadata` | any | No |  |
+| `namespace` | any | No |  |
+| `room_id` | `string` | Yes |  |
+| `tags` | ``string``[] | No |  |
+| `type` | any | No |  |
+
+
+### `SearchRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `limit` | `integer` | No |  |
+| `namespace` | any | No |  |
+| `query` | `string` | Yes |  |
+| `tags` | ``string``[] | No |  |
+
+
+### `TagDeleteRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `namespace` | any | No |  |
+| `tag` | `string` | Yes |  |
+
+
+### `TagRenameRequest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `namespace` | any | No |  |
+| `new` | `string` | Yes |  |
+| `old` | `string` | Yes |  |
+
+

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,692 @@
+---
+title: HTTP API Reference
+---
+
+# HTTP API Reference
+
+Complete reference for all uteke-server HTTP endpoints. Version **0.10.1**.
+
+All endpoints accept and return JSON (`Content-Type: application/json`). POST/PUT/DELETE bodies are JSON; GET endpoints use query parameters.
+
+## Base URL
+
+```
+http://localhost:8767
+```
+
+Default port is `8767`. Override with `--port` flag or `UTEKE_PORT` env var.
+
+## API Versioning
+
+All routes support optional `/api/v1` or `/api/v2` prefix for version negotiation ([#737](https://github.com/codecoradev/uteke/issues/737)):
+
+| Version | Format | Description |
+|---------|--------|-------------|
+| `v1` | Flat recall results | v0.7.x compatible (`[{id, content, score, ...}]`) |
+| `v2` | Wrapped `UnifiedSearchResult` | v0.8.x+ (unified search with metadata) |
+| *(none)* | Latest (`v2`) | Unversioned routes alias to latest |
+
+```bash
+# Versioned
+POST /api/v2/recall
+# Unversioned (aliases to v2)
+POST /recall
+```
+
+---
+
+## Health & Stats
+
+### GET /health
+
+Server health check. Returns version, memory count, and supported API versions.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "version": "0.10.1",
+  "memories": 148,
+  "namespaces": 3,
+  "api_versions": ["v1", "v2"],
+  "api_latest": "v2"
+}
+```
+
+### GET /stats
+
+Global statistics (namespaces, memory counts, tag counts).
+
+**Response:**
+```json
+{
+  "namespaces": ["default", "cto", "cmo"],
+  "total_memories": 148,
+  "by_namespace": { "default": 50, "cto": 80, "cmo": 18 }
+}
+```
+
+### POST /stats
+
+Statistics for a specific namespace.
+
+**Request:**
+```json
+{ "namespace": "default" }
+```
+
+---
+
+## Memory Operations
+
+### POST /remember
+
+Store a new memory with automatic embedding generation.
+
+**Request:**
+```json
+{
+  "content": "Uteke uses SQLite + ONNX embeddings",
+  "tags": ["architecture", "uteke"],
+  "namespace": "default",
+  "type": "fact",
+  "entity": "uteke",
+  "category": "architecture",
+  "metadata": { "project": "uteke" },
+  "source": "docs",
+  "source_type": "user",
+  "valid_from": "2026-01-01T00:00:00Z",
+  "valid_until": null,
+  "detect_contradiction": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `content` | string | ✅ | — | Memory content text |
+| `tags` | string[] | ❌ | `[]` | Tags for filtering |
+| `namespace` | string | ❌ | `default` | Namespace isolation |
+| `type` | string | ❌ | `null` | Memory type (fact, procedure, preference, decision, etc.) |
+| `entity` | string | ❌ | `null` | Entity name (stored as metadata) |
+| `category` | string | ❌ | `null` | Category (stored as metadata) |
+| `metadata` | object | ❌ | `null` | Extra key-value pairs |
+| `source` | string | ❌ | `null` | Source provenance |
+| `source_type` | string | ❌ | `user` | Source type |
+| `valid_from` | string | ❌ | `null` | RFC3339 timestamp |
+| `valid_until` | string | ❌ | `null` | RFC3339 timestamp |
+| `detect_contradiction` | bool | ❌ | `false` | Check for contradictions |
+
+### POST /recall
+
+Semantic recall — search memories by meaning using embeddings.
+
+**Request:**
+```json
+{
+  "query": "how does uteke store data",
+  "limit": 5,
+  "tags": [],
+  "namespace": "default",
+  "entity": null,
+  "category": null,
+  "min_score": 0.0,
+  "strict": false,
+  "at": null,
+  "search_type": "all",
+  "enrich": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Semantic search query |
+| `limit` | int | ❌ | `5` | Max results |
+| `tags` | string[] | ❌ | `[]` | Filter by tags |
+| `namespace` | string | ❌ | `null` | Namespace filter |
+| `entity` | string | ❌ | `null` | Filter by entity metadata |
+| `category` | string | ❌ | `null` | Filter by category metadata |
+| `min_score` | float | ❌ | `0.0` | Minimum similarity score |
+| `strict` | bool | ❌ | `false` | Use strict threshold (0.5) |
+| `at` | string | ❌ | `null` | Time-travel: RFC3339 timestamp |
+| `search_type` | string | ❌ | `all` | `all`, `memory`, or `doc` |
+| `enrich` | bool | ❌ | `false` | Enrich with cross-entity links |
+
+### POST /search
+
+Fast keyword/FTS search (non-semantic).
+
+**Request:**
+```json
+{
+  "query": "sqlite",
+  "limit": 10,
+  "tags": [],
+  "namespace": "default"
+}
+```
+
+### POST /list
+
+List memories with pagination and optional tag filter.
+
+**Request:**
+```json
+{
+  "tag": "architecture",
+  "limit": 5,
+  "offset": 0,
+  "namespace": "default",
+  "at": null
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `tag` | string | ❌ | `null` | Filter by tag |
+| `limit` | int | ❌ | `5` | Page size |
+| `offset` | int | ❌ | `0` | Pagination offset |
+| `namespace` | string | ❌ | `null` | Namespace filter |
+| `at` | string | ❌ | `null` | Time-travel timestamp |
+
+### DELETE /forget
+
+Delete a memory by ID.
+
+**Query params:** `?id=<uuid>`
+
+```bash
+DELETE /forget?id=550e8400-e29b-41d4-a716-446655440000
+```
+
+### GET /memory
+
+Get a single memory by ID.
+
+**Query params:** `?id=<uuid>`
+
+### PUT /memory
+
+Update a memory ([#659](https://github.com/codecoradev/uteke/issues/659)). Triggers embedding regeneration if content changes.
+
+**Request:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "content": "updated content",
+  "tags": ["new-tag"],
+  "metadata": { "key": "value" },
+  "importance": 0.8,
+  "pinned": true,
+  "memory_type": "decision"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Memory UUID |
+| `content` | string | ❌ | New content (triggers re-embedding) |
+| `tags` | string[] | ❌ | Replace tags |
+| `metadata` | object | ❌ | Replace metadata |
+| `importance` | float | ❌ | Importance score (0.0–1.0) |
+| `pinned` | bool | ❌ | Pinned state |
+| `memory_type` | string | ❌ | Memory type |
+
+### POST /memory/pin
+
+Set pinned state on a memory ([#660](https://github.com/codecoradev/uteke/issues/660)).
+
+**Request:**
+```json
+{ "id": "550e8400-...", "pinned": true }
+```
+
+### POST /memory/importance
+
+Set importance score on a memory.
+
+**Request:**
+```json
+{ "id": "550e8400-...", "importance": 0.9 }
+```
+
+### POST /memory/feedback
+
+Submit feedback for trust scoring ([#718](https://github.com/codecoradev/uteke/issues/718)).
+
+**Request:**
+```json
+{ "id": "550e8400-...", "feedback": "helpful" }
+```
+
+`feedback` must be `"helpful"` or `"unhelpful"`.
+
+### POST /memory/doc-refs
+
+Get document references linked to a memory ([#689](https://github.com/codecoradev/uteke/issues/689)).
+
+**Request:**
+```json
+{ "memory_id": "550e8400-..." }
+```
+
+---
+
+## Pin Operations
+
+### POST /pin
+
+Pin a memory by ID.
+
+**Request:**
+```json
+{ "id": "550e8400-..." }
+```
+
+### POST /unpin
+
+Unpin a memory by ID.
+
+**Request:**
+```json
+{ "id": "550e8400-..." }
+```
+
+---
+
+## Namespace & Tags
+
+### GET /namespaces
+
+List all namespaces.
+
+**Query params:** `?memory_count=true` (include memory counts per namespace)
+
+### GET /tags
+
+List all tags with usage counts.
+
+**Query params:** `?namespace=<name>`
+
+### POST /tags/rename
+
+Rename a tag across all memories.
+
+**Request:**
+```json
+{ "old": "arch", "new": "architecture", "namespace": "default" }
+```
+
+### POST /tags/delete
+
+Delete a tag from all memories.
+
+**Request:**
+```json
+{ "tag": "deprecated", "namespace": "default" }
+```
+
+---
+
+## Recent & Graph
+
+### GET /recent
+
+Get recently accessed memories.
+
+**Query params:** `?limit=10&namespace=default`
+
+### GET /graph
+
+Get relationship graph for an entity.
+
+**Query params:** `?entity=<name>&depth=3`
+
+### POST /graph/edge
+
+Create a relationship edge between entities.
+
+**Request:**
+```json
+{
+  "source": "uteke",
+  "target": "sqlite",
+  "edge_type": "uses",
+  "weight": 1.0
+}
+```
+
+### DELETE /graph/edge
+
+Delete a relationship edge.
+
+**Query params:** `?source=<name>&target=<name>&edge_type=<type>`
+
+---
+
+## Rooms
+
+Rooms are collaborative memory spaces for multi-agent discussions.
+
+### POST /room/create
+
+Create a new room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion", "title": "Project Discussion", "namespace": "default" }
+```
+
+### POST /room/remember
+
+Store a memory and link it to a room.
+
+**Request:**
+```json
+{
+  "room_id": "project-discussion",
+  "content": "Decision: use SQLite for storage",
+  "author": "cto",
+  "tags": ["decision"],
+  "role": "lead"
+}
+```
+
+### GET /room/memories
+
+List memories in a room (chronological order).
+
+**Query params:** `?room_id=<id>&author=<name>&limit=10`
+
+### POST /room/recall
+
+Semantic recall within a room. Query is **optional** — when omitted or empty, falls back to chronological recall ([#785](https://github.com/codecoradev/uteke/issues/785)).
+
+**Request (semantic — with query):**
+```json
+{
+  "room_id": "project-discussion",
+  "query": "database decision",
+  "limit": 5,
+  "author": null,
+  "min_score": 0.0
+}
+```
+
+**Request (chronological fallback — no query):**
+```json
+{
+  "room_id": "project-discussion",
+  "limit": 10,
+  "author": "cto"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `room_id` | string | ✅ | — | Room identifier |
+| `query` | string | ❌ | `null` | Semantic query. When empty/absent, falls back to chronological |
+| `limit` | int | ❌ | `5` | Max results |
+| `author` | string | ❌ | `null` | Filter by author |
+| `min_score` | float | ❌ | `0.0` | Minimum similarity (semantic mode only) |
+
+### POST /room/stats
+
+Get room statistics (memory count, participant count, participants list, last activity). Excludes deprecated memories ([#784](https://github.com/codecoradev/uteke/issues/784)).
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+**Response:**
+```json
+{
+  "memory_count": 12,
+  "participant_count": 3,
+  "participants": ["cto", "cmo", "coo"],
+  "last_activity": "2026-07-27T10:30:00Z"
+}
+```
+
+### POST /room/summary
+
+Get or generate a room summary.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### POST /room/summary-document
+
+Get the summary document for a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### POST /room/document
+
+Get the document associated with a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### POST /room/document/list
+
+List documents linked to a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion" }
+```
+
+### PUT /room/document/add
+
+Link a document to a room.
+
+**Request:**
+```json
+{ "room_id": "project-discussion", "doc_id": "doc-uuid" }
+```
+
+### DELETE /room/document/remove
+
+Unlink a document from a room.
+
+**Query params:** `?room_id=<id>&doc_id=<uuid>`
+
+### POST /doc/room/list
+
+List rooms linked to a document.
+
+**Request:**
+```json
+{ "doc_id": "doc-uuid" }
+```
+
+### GET /room/list
+
+List all rooms.
+
+**Query params:** `?namespace=<name>`
+
+### DELETE /room/delete
+
+Delete a room. Cascades `room_memories` links (memories themselves survive).
+
+**Query params:** `?room_id=<id>`
+
+---
+
+## Documents
+
+Documents are structured content with hierarchical parent-child relationships.
+
+### POST /doc/create
+
+Create a new document.
+
+**Request:**
+```json
+{
+  "slug": "architecture-overview",
+  "title": "Architecture Overview",
+  "content": "# Architecture\n\n...",
+  "tags": ["architecture"],
+  "parent": null
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `slug` | string | ✅ | — | URL-safe identifier |
+| `title` | string | ❌ | `null` | Display title |
+| `content` | string | ✅ | — | Document content (markdown) |
+| `tags` | string[] | ❌ | `[]` | Tags |
+| `parent` | string | ❌ | `null` | Parent doc slug (for hierarchy) |
+
+### POST /doc/get
+
+Get a document by ID or slug.
+
+**Request:**
+```json
+{ "id": "uuid-or-null", "slug": "architecture-overview" }
+```
+
+Provide either `id` or `slug`.
+
+### POST /doc/update
+
+Update a document.
+
+**Request:**
+```json
+{
+  "id": null,
+  "slug": "architecture-overview",
+  "title": "Updated Title",
+  "content": "updated content",
+  "tags": ["architecture", "updated"],
+  "metadata": null
+}
+```
+
+### POST /doc/list
+
+List documents.
+
+**Request:**
+```json
+{ "limit": 1000, "roots_only": false, "parent": null }
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | int | `1000` | Max results (high default for full tree) |
+| `roots_only` | bool | `false` | Only top-level docs (no parent) |
+| `parent` | string | `null` | Filter by parent slug |
+
+### POST /doc/search
+
+Search documents.
+
+**Request:**
+```json
+{ "query": "storage", "limit": 5, "mode": "hybrid" }
+```
+
+`mode`: `hybrid` (default), `fts`, or `semantic`.
+
+### POST /doc/move
+
+Move a document to a new parent.
+
+**Request:**
+```json
+{ "id": null, "slug": "child-doc", "new_parent": "new-parent-slug" }
+```
+
+### DELETE /doc/delete
+
+Delete a document.
+
+**Query params:** `?id=<uuid>` or `?slug=<slug>`
+
+### POST /doc/mem-refs
+
+Get memory references linked to a document ([#689](https://github.com/codecoradev/uteke/issues/689)).
+
+**Request:**
+```json
+{ "doc_id": "doc-uuid" }
+```
+
+---
+
+## Advanced
+
+### POST /context
+
+Get contextual memories for a given input.
+
+**Request:** Arbitrary JSON object.
+
+### POST /dream
+
+Trigger dream/consolidation process.
+
+**Request:** Arbitrary JSON object.
+
+### POST /mcp
+
+MCP (Model Context Protocol) JSON-RPC endpoint. See [MCP Server docs](/mcp) for details.
+
+---
+
+## Error Responses
+
+All errors return HTTP 4xx/5xx with a JSON error body:
+
+```json
+{ "error": "Description of what went wrong" }
+```
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Bad request — invalid JSON, missing required field, validation error |
+| 401 | Unauthorized — missing or invalid API key |
+| 404 | Not found — resource doesn't exist |
+| 413 | Payload too large — exceeds `MAX_PAYLOAD_SIZE` |
+| 500 | Internal server error — unexpected failure |
+
+---
+
+## Authentication
+
+If `UTEKE_API_KEY` is set, all endpoints require an `Authorization: Bearer <key>` header. When unset, the server runs in open mode (no auth).
+
+```bash
+# With auth
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8767/stats
+```
+
+---
+
+## CORS
+
+All responses include CORS headers (`Access-Control-Allow-Origin: *`) for browser-based clients. Preflight `OPTIONS` requests are handled automatically.
+
+---
+
+## See Also
+
+- [CLI Reference](/cli-reference) — uteke CLI commands
+- [Configuration](/configuration) — server configuration options
+- [Rooms](/rooms) — room feature guide
+- [MCP Server](/mcp) — MCP protocol integration
+- [TLS & Reverse Proxy](/tls) — production deployment

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -88,13 +88,15 @@ Rooms enable multi-agent collaborative memory — multiple agents share a room a
 
 ```python
 # Create a shared room
-uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 uteke(action="room_create", room_id="sprint-planning", title="Sprint Planning")
 
-# Add a memory to a room (use remember with room_id)
-uteke(action="remember", content="Deploy at 3pm", room_id="sprint-planning", namespace="team")
+# Add a memory to a room (with author attribution)
+uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 
-# Recall from a room
+# Add a reference document to a room
+uteke(action="room_document", room_id="sprint-planning", content="Architecture spec: ...", title="Arch Spec")
+
+# Recall from a room (semantic search — query is required)
 uteke(action="room_recall", room_id="sprint-planning", content="deploy deadline")
 
 # List all rooms (cross-namespace)
@@ -208,16 +210,67 @@ hermes mcp add uteke --command uteke-mcp
 | `remember` | Store a new memory |
 | `recall` | Semantic search |
 | `search` | Keyword search |
-| `list` | List memories |
+| `list` | List memories (with namespace filter) |
 | `forget` | Delete memory |
-| `stats` | Store statistics |
-| `room_remember` | Store memory in a room with author |
+| `stats` | Namespace or global statistics |
+| `room_remember` | Store memory in a room with author attribution |
+| `room_document` | Store a reference document in a room |
 | `room_create` | Create a room |
-| `room_recall` | Recall from a room |
-| `room_list` | List all rooms |
-| `room_summary` | Room topic summary |
-| `room_stats` | Room statistics |
-| `room_delete` | Delete a room |
+| `room_recall` | Semantic search within a room (requires `query`) |
+| `room_list` | List all rooms (cross-namespace) |
+| `room_summary` | Room topic summary with clusters and highlights |
+| `room_stats` | Room statistics (memory count, participants) |
+| `room_delete` | Delete a room (memories preserved) |
+| `namespace_list` | List all namespaces |
+| `namespace_stats` | Statistics for a specific namespace |
+| `tags_list` | List all tags |
+| `tags_rename` | Rename a tag across all memories |
+| `tags_delete` | Delete a tag from all memories |
+| `consolidate` | Merge similar memories (with threshold) |
+| `aging` | Aging cleanup of old memories |
+| `import` | Import memories from JSON |
+| `importance` | Recompute importance scores |
+| `doctor` | Health check (alias for `/health`) |
+
+## Valid Memory Types
+
+When using `remember`, `room_remember`, or `room_document`, the `type` parameter accepts these values:
+
+| Type | Description |
+|------|-------------|
+| `fact` | A factual statement or observation |
+| `procedure` | A how-to, process, or workflow |
+| `preference` | A user or system preference |
+| `decision` | A decision that was made |
+| `context` | Background context for a topic |
+| `note` | A general note |
+| `insight` | An insight or conclusion |
+| `reference` | A reference document (default for `room_document`) |
+| `event` | A time-based event |
+
+> **Warning:** Using an invalid type (e.g., `document`) causes HTTP 500. Use `reference` instead of `document`.
+
+## HTTP API Notes
+
+The uteke HTTP server (`uteke-serve`) uses **exact path matching** — query parameters are NOT part of the route. This means:
+
+```bash
+# ✅ Correct — POST with JSON body
+curl -X POST http://127.0.0.1:8767/stats \
+  -H 'Content-Type: application/json' \
+  -d '{"namespace": "cto"}'
+
+# ❌ Wrong — GET with query params returns 404
+curl http://127.0.0.1:8767/stats?namespace=cto
+```
+
+**All endpoints that accept parameters use POST with JSON body**, not GET with query strings.
+
+### Known Issues
+
+- **#784** — `room/stats` counts deprecated memories (inflated counts vs `room/summary`)
+- **#785** — `room/recall` requires `query` parameter (cannot list all memories in a room)
+- **#786** — Full HTTP API reference documentation is pending
 
 ## Memory-Provider for Other Agents
 
@@ -262,8 +315,9 @@ This installs uteke as the agent's default memory provider — relevant memories
 
 ## How It Works (uteke-tool)
 
-- **Remember**: POST to `/remember` — content is embedded (EmbeddingGemma Q4, 768d) and stored in SQLite + HNSW vector index
+- **Remember**: POST to `/remember` — content is embedded (EmbeddingGemma Q4, 768d) and stored in SQLite + HNSW vector index. Supports `type` param (see [Valid Memory Types](#valid-memory-types))
 - **Recall**: POST to `/recall` — semantic search via hybrid RRF (vector + FTS5), returns ranked results
+- **Room Remember**: POST to `/room/remember` — stores memory and links to room in a single call. **Requires** `room_id` (not `room`). Use `type="reference"` for documents (not `document` — causes 500)
 - **Rooms**: Cross-namespace collaboration spaces — rooms span namespaces, enabling multi-agent coordination
 - **MCP**: JSON-RPC over stdio or HTTP — standard MCP protocol for AI agent integration
 


### PR DESCRIPTION
## Release v0.10.2

Merge develop → main for v0.10.2 release tagging.

### Changes since v0.10.1

**Fixed**
- #709 — Runtime ORT dispatch (AVX2/SSE4.2) + legacy Windows builds
- #789 — Validation error → 400 (was 500)
- #784 — Room operations exclude deprecated memories (76% stat inflation fix)
- #785 — POST /room/recall query now optional
- #794 — DELETE /forget accepts short ID prefixes

**Added**
- #786 — Auto-generated API reference docs via schemars + docgen binary

**Security**
- quinn-proto 0.11.14 → 0.11.15 (GHSA-4w2j-m93h-cj5j)

**Docs**
- Hermes integration examples fixed
- README/INSTALL version refs updated
- CHANGELOG complete for v0.10.2

### Issues closed this release
- #709, #789, #784, #785, #794, #793, #791, #786

Full changelog: https://github.com/codecoradev/uteke/blob/develop/CHANGELOG.md