### PR TITLE
fix(ci): Windows legacy ORT C4875 + Docker artifact download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,8 @@ jobs:
             -Donnxruntime_BUILD_OBJC=OFF ^
             -Donnxruntime_BUILD_CSHARP=OFF ^
             -DCMAKE_BUILD_TYPE=Release ^
-            -DCMAKE_INSTALL_PREFIX=onnxruntime-install
+            -DCMAKE_INSTALL_PREFIX=onnxruntime-install ^
+            "-DCMAKE_CXX_FLAGS=/wd4875"
           cmake --build onnxruntime-build --config Release --parallel %NUMBER_OF_PROCESSORS%
 
       - name: Package legacy ORT
@@ -516,7 +517,6 @@ jobs:
         with:
           pattern: uteke-*-${{ github.ref_name }}
           path: release-artifacts
-          merge-multiple: true
 
       - name: Extract binaries for Docker context
         run: |


### PR DESCRIPTION
## Problem

Release v0.10.2 workflow failed:
1. **Windows legacy ORT build**: MSVC C4875 (non-string literal [[gsl::suppress]]) treated as error in onnxruntime source
2. **Docker image build**: `merge-multiple: true` auto-extracts artifacts, losing .tar.gz wrappers that the extraction script expects

Both are pre-existing issues in release.yml, not code regressions.

## Fix
- Add `-DCMAKE_CXX_FLAGS=/wd4875` to Windows legacy ORT cmake
- Remove `merge-multiple: true` from Docker artifact download step