### PR TITLE
fix(ci): create binaries dir inside release-artifacts after cd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,8 +520,8 @@ jobs:
 
       - name: Extract binaries for Docker context
         run: |
-          mkdir -p binaries
           cd release-artifacts
+          mkdir -p binaries
           AMD64=$(find . -name "uteke-x86_64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
           ARM64=$(find . -name "uteke-aarch64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
           if [ -z "$AMD64" ] || [ -z "$ARM64" ]; then


### PR DESCRIPTION
## Summary
- Fix `mkdir -p binaries` running before `cd release-artifacts`, creating the directory in the workspace root instead of inside the artifact extraction directory
- All subsequent `mv` commands wrote to `release-artifacts/binaries/` while Docker context expected `binaries/` at workspace root → empty Docker build context
- **Root cause**: `download-artifact@v4` with `pattern` extracts into `release-artifacts/<artifact-name>/`, so all work must happen inside that directory

## Test plan
- [ ] Verify CI `build-release` job passes (Docker build step finds binaries)
- [ ] Verify Docker image publishes with correct multi-arch binaries

Closes #803