### PR TITLE
fix(ci): keep binaries/ at workspace root for Docker context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,17 +520,16 @@ jobs:
 
       - name: Extract binaries for Docker context
         run: |
-          cd release-artifacts
-          mkdir -p binaries
-          AMD64=$(find . -name "uteke-x86_64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
-          ARM64=$(find . -name "uteke-aarch64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
+          # binaries/ MUST be at workspace root — Dockerfile copies it: COPY binaries/ ./
+          mkdir -p binaries binaries-amd64 binaries-arm64
+          AMD64=$(find release-artifacts -name "uteke-x86_64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
+          ARM64=$(find release-artifacts -name "uteke-aarch64-unknown-linux-gnu-${{ github.ref_name }}.tar.gz" | head -1)
           if [ -z "$AMD64" ] || [ -z "$ARM64" ]; then
             echo "::error::Linux binary artifacts not found"
-            echo "Available files:" && find . -type f | head -20
+            echo "Available files:" && find release-artifacts -type f | head -20
             exit 1
           fi
           # Extract amd64 → rename binaries, keep .so in amd64 subfolder
-          mkdir -p binaries-amd64
           tar xzf "$AMD64" -C binaries-amd64
           mv binaries-amd64/uteke binaries/uteke-amd64
           mv binaries-amd64/uteke-serve binaries/uteke-serve-amd64
@@ -539,7 +538,6 @@ jobs:
           mkdir -p binaries/ort-amd64
           cp binaries-amd64/libonnxruntime*.so* binaries/ort-amd64/ 2>/dev/null || true
           # Extract arm64 → same pattern
-          mkdir -p binaries-arm64
           tar xzf "$ARM64" -C binaries-arm64
           mv binaries-arm64/uteke binaries/uteke-arm64
           mv binaries-arm64/uteke-serve binaries/uteke-serve-arm64


### PR DESCRIPTION
## Problem

Docker build fails with: `/binaries: not found`

```
ERROR: failed to build: failed to solve: failed to compute cache key: 
failed to calculate checksum of ref: "/binaries": not found
```

## Root Cause

PR #806 fixed the `mkdir`/`cd` ordering, but created a **new** bug: by moving `cd release-artifacts` before `mkdir binaries`, `binaries/` ended up at `release-artifacts/binaries/` instead of workspace root.

The Dockerfile (`COPY binaries/ ./`) and Docker build context (`context: .`) both expect `binaries/` at **workspace root**, not inside `release-artifacts/`.

## Fix

Don't `cd release-artifacts`. Instead:
- `mkdir -p binaries binaries-amd64 binaries-arm64` at workspace root
- `find release-artifacts -name ...` to locate artifacts
- All paths relative to workspace root

## Test plan
- [ ] CI passes
- [ ] After merge + release: Docker build succeeds