### PR TITLE
fix(ort): force /MD runtime for Windows legacy ORT build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: onnxruntime-build/Release/onnxruntime.dll
-          key: ort-legacy-win-sse42-${{ env.ORT_VERSION }}-v1
+          key: ort-legacy-win-sse42-${{ env.ORT_VERSION }}-v2
 
       - name: Build ONNX Runtime (SSE4.2 only)
         if: steps.cache-ort.outputs.cache-hit != 'true'
@@ -270,6 +270,7 @@ jobs:
             -Donnxruntime_BUILD_CSHARP=OFF ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_INSTALL_PREFIX=onnxruntime-install ^
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL ^
             "-DCMAKE_CXX_FLAGS=/wd4875"
           cmake --build onnxruntime-build --config Release --parallel %NUMBER_OF_PROCESSORS%
 


### PR DESCRIPTION
## Problem

Windows legacy ORT build (SSE4.2, no AVX2) fails with MSVC linker errors:

- `LNK2038: RuntimeLibrary mismatch: MT_StaticRelease vs MD_DynamicRelease`
- `LNK2005: multiply defined symbols` (`libcpmt.lib` vs `msvcprt.lib`)
- `LNK1169: one or more multiply defined symbols found` (fatal)

Root cause: ONNX Runtime's CMake build compiles protobuf with `/MT` (static CRT) while onnxruntime.dll itself uses `/MD` (dynamic CRT).

## Fix

1. Add `-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL` to force `/MD` across all dependencies
2. Bump cache key `v1→v2` to invalidate cached build without the flag

## Impact

- Unblocks v0.10.2 GitHub Release (blocked by this failed job)
- Only affects `build-legacy-ort-windows` job — Linux/macOS/job builds unchanged

## Test

CI will rebuild ORT from source on Windows runner. If LNK2038/LNK1169 are gone, the build succeeds and produces `onnxruntime.dll`.