### PR TITLE
fix(ort): force /MD + /NODEFAULTLIB for Windows ORT build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: onnxruntime-build/Release/onnxruntime.dll
-          key: ort-legacy-win-sse42-${{ env.ORT_VERSION }}-v2
+          key: ort-legacy-win-sse42-${{ env.ORT_VERSION }}-v3
 
       - name: Build ONNX Runtime (SSE4.2 only)
         if: steps.cache-ort.outputs.cache-hit != 'true'
@@ -271,7 +271,9 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_INSTALL_PREFIX=onnxruntime-install ^
             -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL ^
-            "-DCMAKE_CXX_FLAGS=/wd4875"
+            "-DCMAKE_CXX_FLAGS=/MD /wd4875" ^
+            "-DCMAKE_C_FLAGS=/MD" ^
+            "-DCMAKE_SHARED_LINKER_FLAGS=/NODEFAULTLIB:LIBCMT;LIBCPMT"
           cmake --build onnxruntime-build --config Release --parallel %NUMBER_OF_PROCESSORS%
 
       - name: Package legacy ORT


### PR DESCRIPTION
v2 attempt. CMAKE_MSVC_RUNTIME_LIBRARY alone was insufficient — protobuf submodule still compiled with /MT.

Changes:
1. Add /MD to CMAKE_CXX_FLAGS and CMAKE_C_FLAGS (explicit compiler flag)
2. Add /NODEFAULTLIB:LIBCMT;LIBCPMT to CMAKE_SHARED_LINKER_FLAGS (prevent static CRT linkage)
3. Bump cache key v2→v3