### PR TITLE
ci: filter release artifacts to avoid Docker buildx metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,10 +316,11 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Download all artifacts
+      - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-artifacts
+          pattern: uteke-*
           merge-multiple: true
 
       - name: List artifacts


### PR DESCRIPTION
## Problem
`download-artifact` with `merge-multiple: true` but no `pattern` downloads ALL artifacts from the run, including Docker Buildx internal metadata (`*.dockerbuild` zip). This non-standard artifact causes "download failed after 5 retries".

## Fix
Add `pattern: uteke-*` to only download release binary artifacts.

## Why it worked before
Previous runs had the Windows ORT build failing, so the release job never ran. The Docker buildx artifact was always present but never downloaded by the release job until now (all builds pass).