### PR TITLE
ci: fix release notes template heredoc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,16 +351,50 @@ jobs:
           echo "" >> release-notes.md
           cat changelog-body.md >> release-notes.md
           echo "" >> release-notes.md
-          printf '### 📦 Binaries\\n\\nEach archive contains **three binaries** + **ONNX Runtime shared library**:\\n- `uteke` — CLI tool\\n- `uteke-serve` — HTTP server daemon\\n- `uteke-mcp` — MCP server (stdio + HTTP)\\n- `libonnxruntime.so*` / `libonnxruntime*.dylib` / `onnxruntime*.dll` — ONNX Runtime\\n\\n' >> release-notes.md
-          printf '| Platform | File |\\n|----------|------|\\n' >> release-notes.md
-          printf '| Linux (x86_64, AVX2) | `uteke-x86_64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
-          printf '| Linux (x86_64, legacy) | `uteke-x86_64-unknown-linux-gnu-legacy-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
-          printf '| Linux (ARM64) | `uteke-aarch64-unknown-linux-gnu-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
-          printf '| macOS (Apple Silicon) | `uteke-aarch64-apple-darwin-%s.tar.gz` |\\n' "${VER}" >> release-notes.md
-          printf '| Windows (x86_64) | `uteke-x86_64-pc-windows-msvc-%s.zip` |\n\n' "${VER}" >> release-notes.md
-          printf '### 🖥️ Legacy Bundle (Linux)\nThe **legacy** bundle includes a SSE4.2-only ONNX Runtime sidecar (`ort-legacy/`). Use on older CPUs without AVX2 support (e.g., Intel Celeron J4125/N4020) to avoid SIGILL crashes.\n\n' >> release-notes.md
-          printf '### 🚀 Quick Start\\n\\n```bash\\n# Quick install (Linux / macOS)\\ncurl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Pin a specific version\\nUTEKE_VERSION=%s curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh\\n\\n# Store a memory\\nuteke remember "Important context" --tags project\\n\\n# Recall by meaning\\nuteke recall "what was that context?"\\n\\n# Start server for fast AI agent access\\nuteke-serve --port 8767\\n```\\n\\n' >> release-notes.md
-          printf '**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md\\n' >> release-notes.md
+          cat >> release-notes.md << RELEASEEOF
+
+          ### 📦 Downloads
+
+          Each archive contains three binaries + ONNX Runtime shared library:
+
+          | Binary | Description |
+          |--------|-------------|
+          | `uteke` | CLI tool |
+          | `uteke-serve` | HTTP server daemon |
+          | `uteke-mcp` | MCP server (stdio + HTTP) |
+          | `libonnxruntime.so*` / `libonnxruntime*.dylib` / `onnxruntime*.dll` | ONNX Runtime |
+
+          | Platform | File |
+          |----------|------|
+          | Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-${VER}.tar.gz` |
+          | Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-${VER}.tar.gz` |
+          | Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-${VER}.tar.gz` |
+          | macOS Apple Silicon | `uteke-aarch64-apple-darwin-${VER}.tar.gz` |
+          | Windows x86_64 | `uteke-x86_64-pc-windows-msvc-${VER}.zip` |
+
+          > **Legacy Bundle (Linux only)** — Includes a SSE4.2-only ORT sidecar (`ort-legacy/`) for CPUs without AVX2 (Intel Celeron J4125/N4020). Use this bundle to avoid SIGILL crashes on older hardware.
+
+          ### 🚀 Quick Start
+
+          ```bash
+          # Quick install (Linux / macOS)
+          curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+
+          # Pin a specific version
+          UTEKE_VERSION=${VER} curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+
+          # Store a memory
+          uteke remember "Important context" --tags project
+
+          # Recall by meaning
+          uteke recall "what was that context?"
+
+          # Start server for fast AI agent access
+          uteke-serve --port 8767
+          ```
+
+          **Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md
+          RELEASEEOF
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Fix release notes generation: heredoc instead of printf with double-escaped \n.