### PR TITLE
fix: ORT init cascade — AVX2 fallthrough, error message, embedder init cache

### DIFF
--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -60,8 +60,7 @@ impl OnnxEmbedder {
             .map_err(|e| {
                 Error::embed_msg(format!(
                     "ONNX Runtime initialization failed: {e}. \
-                 CPU may lack required SIMD support. Use the 'legacy' bundle \
-                 (includes SSE4.2 ORT) or set ORT_LIB_PATH."
+                     Set ORT_LIB_PATH to the library file, or use the standard release bundle."
                 ))
             })?;
 

--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -5,10 +5,11 @@
 //!
 //! Resolution order:
 //! 1. `ORT_LIB_PATH` env var — explicit override (for testing / custom setups).
-//! 2. If AVX2 is detected → `./libonnxruntime.so` (AVX2 build, ships in standard bundle).
-//! 3. If AVX2 is NOT detected → `./ort-legacy/libonnxruntime.so` (SSE4.2 build, sidecar).
+//! 2. If AVX2 is detected → `<exe_dir>/libonnxruntime.so` (AVX2 build, ships in standard bundle).
+//!    If not found, falls through to step 4 (does NOT error immediately).
+//! 3. If AVX2 is NOT detected → `<exe_dir>/ort-legacy/libonnxruntime.so` (SSE4.2 build, sidecar).
 //! 4. System lib paths: `/usr/local/lib`, `/usr/lib`, `/lib` (Docker / package installs).
-//! 5. If no library found → return error (caller can fall back to non-ORT embedder).
+//! 5. If no library found → return error with all searched locations.
 
 use std::path::PathBuf;
 
@@ -65,7 +66,10 @@ pub fn has_avx2() -> bool {
 /// Search order:
 /// 1. `ORT_LIB_PATH` environment variable (explicit override).
 /// 2. AVX2 detected → `<exe_dir>/libonnxruntime.so` (standard bundle).
+///    If not found, falls through to step 4.
 /// 3. No AVX2 → `<exe_dir>/ort-legacy/libonnxruntime.so` (legacy sidecar).
+/// 4. Unix system paths: `/usr/local/lib`, `/usr/lib`, `/lib`.
+/// 5. Error with all searched locations.
 ///
 /// # Errors
 ///
@@ -93,8 +97,8 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
     let exe_dir = exe_dir()?;
     let avx2 = has_avx2();
 
+    // 2. AVX2 CPU → try standard library next to binary
     if avx2 {
-        // 2. AVX2 CPU → use standard library next to binary
         let standard_path = exe_dir.join(ORT_LIB_NAME);
         if standard_path.exists() {
             tracing::info!(
@@ -106,23 +110,19 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
                 has_avx2: true,
             });
         }
-        // Standard lib not found — this is fine during development (cargo run)
-        // The error will be caught when ort::init_from() is called.
-        tracing::warn!(
-            "ORT: AVX2 detected but no standard library found at {}. \
-             If running from source, set ORT_LIB_PATH or build with download-binaries.",
+        // Standard lib not found in exe_dir — fall through to system paths.
+        // This is common in Docker where binary is in /usr/local/bin/ but .so
+        // is in /usr/local/lib/.
+        tracing::debug!(
+            "ORT: AVX2 detected but no standard library at {}. \
+             Falling through to system path search.",
             standard_path.display()
         );
-        return Err(format!(
-            "AVX2 detected but ONNX Runtime library not found at '{}'. \
-             Set ORT_LIB_PATH or use the standard release bundle.",
-            standard_path.display()
-        ));
     }
 
     // 3. No AVX2 → look for legacy sidecar
     let legacy_path = exe_dir.join(LEGACY_ORT_DIR).join(ORT_LIB_NAME);
-    if legacy_path.exists() {
+    if !avx2 && legacy_path.exists() {
         tracing::info!(
             "ORT: No AVX2 detected, using legacy (SSE4.2) library: {}",
             legacy_path.display()
@@ -151,11 +151,22 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
         }
     }
 
-    Err(format!(
-        "CPU lacks AVX2 and legacy ORT library not found at '{}'. \
-         Use the 'legacy' release bundle which includes the ort-legacy/ sidecar.",
-        legacy_path.display()
-    ))
+    // 5. No library found anywhere — build a descriptive error.
+    if avx2 {
+        Err(format!(
+            "ONNX Runtime library not found. Searched:\n\
+             - {} (exe directory)\n\
+             - /usr/local/lib, /usr/lib, /lib (system paths)\n\
+             Set ORT_LIB_PATH to the library file, or use the standard release bundle.",
+            exe_dir.join(ORT_LIB_NAME).display()
+        ))
+    } else {
+        Err(format!(
+            "No AVX2 support and legacy ORT library not found at '{}'. \
+             Use the 'legacy' release bundle which includes the ort-legacy/ sidecar.",
+            legacy_path.display()
+        ))
+    }
 }
 
 /// Get the directory containing the running executable.

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -400,6 +400,11 @@ pub struct Uteke {
     store: Store,
     index: RwLock<VectorIndex>,
     embedder: Mutex<Option<Box<dyn Embedder>>>,
+    /// Cached initialization error message (#822). Set once on the first
+    /// `ensure_embedder` failure so subsequent calls return immediately
+    /// instead of retrying the expensive ORT/model load on every request.
+    /// Stored as String because our Error type is not Clone (contains io::Error).
+    embedder_init_error: Mutex<Option<String>>,
     /// Embedding backend name ("onnx", "openai", "ollama", "custom"). Used by lazy init.
     embedder_backend: String,
     /// Caller-supplied embedding settings (from uteke.toml). Env vars still
@@ -566,6 +571,7 @@ impl Uteke {
             store,
             index: RwLock::new(index),
             embedder: Mutex::new(embedder),
+            embedder_init_error: Mutex::new(None),
             embedder_backend,
             embedding_settings,
             fallback_settings: FallbackSettings::default(),
@@ -631,7 +637,25 @@ impl Uteke {
     /// Commands that don't need embedding (list, get, stats, tags, namespace,
     /// aging, export, forget) never trigger this, making them instant (~1ms)
     /// instead of waiting for model load (~2.5s).
+    ///
+    /// On failure, the error is cached (#822) so subsequent calls return
+    /// immediately instead of retrying the expensive ORT/model init on every
+    /// request (which causes log spam and CPU waste in Docker environments).
     fn ensure_embedder(&self) -> Result<(), Error> {
+        // #822: Short-circuit — return cached init error if we already failed.
+        if let Ok(cached) = self.embedder_init_error.lock() {
+            if let Some(ref msg) = *cached {
+                return Err(Error::embed_msg(format!(
+                    "Embedder initialization previously failed (cached): {msg}"
+                )));
+            }
+        }
+
+        // #822: Helper to cache an init error message.
+        fn cache_init_err(slot: &Mutex<Option<String>>, e: &Error) {
+            let _ = slot.lock().map(|mut g| *g = Some(e.to_string()));
+        }
+
         let mut guard = self
             .embedder
             .lock()
@@ -641,7 +665,23 @@ impl Uteke {
             let backend = self.embedder_backend.as_str();
             let embedder: Box<dyn crate::embed::Embedder> = match backend {
                 #[cfg(feature = "onnx")]
-                "onnx" | "" => Box::new(crate::embed::OnnxEmbedder::new()?),
+                "onnx" | "" => {
+                    let r = crate::embed::OnnxEmbedder::new();
+                    match r {
+                        Ok(e) => Box::new(e),
+                        Err(err) => {
+                            cache_init_err(&self.embedder_init_error, &err);
+                            return Err(err);
+                        }
+                    }
+                }
+                #[cfg(not(feature = "onnx"))]
+                "onnx" | "" => {
+                    return Err(Error::embed_msg(
+                        "ONNX embedding backend requested but 'onnx' feature is disabled at compile time. \
+                         Rebuild with --features onnx or use openai/ollama backend."
+                    ));
+                }
                 "custom" => {
                     return Err(Error::generic(
                         "Custom embedder backend set but no embedder was provided",
@@ -664,13 +704,20 @@ impl Uteke {
                     } else {
                         cfg.dims
                     };
-                    Box::new(crate::embed::OpenAiEmbedder::new(
+                    let r = crate::embed::OpenAiEmbedder::new(
                         &cfg.api_key,
                         &model,
                         &base_url,
                         &cfg.endpoint_path,
                         dims,
-                    )?)
+                    );
+                    match r {
+                        Ok(e) => Box::new(e),
+                        Err(err) => {
+                            cache_init_err(&self.embedder_init_error, &err);
+                            return Err(err);
+                        }
+                    }
                 }
                 "ollama" => {
                     let cfg = EmbeddingSettings::resolve_with_defaults(&self.embedding_settings);
@@ -689,7 +736,14 @@ impl Uteke {
                     } else {
                         cfg.dims
                     };
-                    Box::new(crate::embed::OllamaEmbedder::new(&base_url, &model, dims)?)
+                    let r = crate::embed::OllamaEmbedder::new(&base_url, &model, dims);
+                    match r {
+                        Ok(e) => Box::new(e),
+                        Err(err) => {
+                            cache_init_err(&self.embedder_init_error, &err);
+                            return Err(err);
+                        }
+                    }
                 }
                 other => {
                     return Err(Error::Validation(format!(

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -400,11 +400,12 @@ pub struct Uteke {
     store: Store,
     index: RwLock<VectorIndex>,
     embedder: Mutex<Option<Box<dyn Embedder>>>,
-    /// Cached initialization error message (#822). Set once on the first
-    /// `ensure_embedder` failure so subsequent calls return immediately
-    /// instead of retrying the expensive ORT/model load on every request.
-    /// Stored as String because our Error type is not Clone (contains io::Error).
-    embedder_init_error: Mutex<Option<String>>,
+    /// Cached initialization error (#822). `(message, cached_at, is_permanent)`.
+    /// Permanent failures (missing ORT lib, feature disabled) are cached forever.
+    /// Transient network failures (OpenAI/Ollama unreachable) use a 60s TTL so
+    /// they auto-retry after the outage passes. Stored as String because Error
+    /// is not Clone (contains io::Error).
+    embedder_init_error: Mutex<Option<(String, std::time::Instant, bool)>>,
     /// Embedding backend name ("onnx", "openai", "ollama", "custom"). Used by lazy init.
     embedder_backend: String,
     /// Caller-supplied embedding settings (from uteke.toml). Env vars still
@@ -643,17 +644,31 @@ impl Uteke {
     /// request (which causes log spam and CPU waste in Docker environments).
     fn ensure_embedder(&self) -> Result<(), Error> {
         // #822: Short-circuit — return cached init error if we already failed.
-        if let Ok(cached) = self.embedder_init_error.lock() {
-            if let Some(ref msg) = *cached {
-                return Err(Error::embed_msg(format!(
-                    "Embedder initialization previously failed (cached): {msg}"
-                )));
+        // Permanent failures (ORT lib missing) are cached forever.
+        // Transient network failures use a 60s TTL.
+        if let Ok(mut cached) = self.embedder_init_error.lock() {
+            if let Some((ref msg, cached_at, is_permanent)) = *cached {
+                if is_permanent || cached_at.elapsed() < std::time::Duration::from_secs(60) {
+                    return Err(Error::embed_msg(format!(
+                        "Embedder initialization previously failed (cached): {msg}"
+                    )));
+                }
+                // TTL expired — clear and retry
+                tracing::info!("Embedder init error cache expired (60s TTL), retrying...");
+                *cached = None;
             }
         }
 
         // #822: Helper to cache an init error message.
-        fn cache_init_err(slot: &Mutex<Option<String>>, e: &Error) {
-            let _ = slot.lock().map(|mut g| *g = Some(e.to_string()));
+        // is_permanent: true for local failures (missing lib), false for network (transient).
+        fn cache_init_err(
+            slot: &Mutex<Option<(String, std::time::Instant, bool)>>,
+            e: &Error,
+            is_permanent: bool,
+        ) {
+            let _ = slot
+                .lock()
+                .map(|mut g| *g = Some((e.to_string(), std::time::Instant::now(), is_permanent)));
         }
 
         let mut guard = self
@@ -670,7 +685,7 @@ impl Uteke {
                     match r {
                         Ok(e) => Box::new(e),
                         Err(err) => {
-                            cache_init_err(&self.embedder_init_error, &err);
+                            cache_init_err(&self.embedder_init_error, &err, true);
                             return Err(err);
                         }
                     }
@@ -679,7 +694,7 @@ impl Uteke {
                 "onnx" | "" => {
                     return Err(Error::embed_msg(
                         "ONNX embedding backend requested but 'onnx' feature is disabled at compile time. \
-                         Rebuild with --features onnx or use openai/ollama backend."
+                         Rebuild with --features onnx or use openai/ollama backend.",
                     ));
                 }
                 "custom" => {
@@ -714,7 +729,7 @@ impl Uteke {
                     match r {
                         Ok(e) => Box::new(e),
                         Err(err) => {
-                            cache_init_err(&self.embedder_init_error, &err);
+                            cache_init_err(&self.embedder_init_error, &err, false);
                             return Err(err);
                         }
                     }
@@ -740,7 +755,7 @@ impl Uteke {
                     match r {
                         Ok(e) => Box::new(e),
                         Err(err) => {
-                            cache_init_err(&self.embedder_init_error, &err);
+                            cache_init_err(&self.embedder_init_error, &err, false);
                             return Err(err);
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #820, #821, #822 — three interconnected ORT library resolution issues that cascade in Docker environments.

### Changes

| Issue | File | Fix |
|-------|------|-----|
| #820 | `ort_init.rs` | AVX2 path falls through to system paths instead of early-returning Err. Added !avx2 guard on legacy path. Descriptive error lists all searched locations. |
| #821 | `engine.rs` | Replaced misleading CPU SIMD error with actionable Set ORT_LIB_PATH message. |
| #822 | `lib.rs` | Added embedder_init_error cache to prevent retry storm on every request in Docker. |

### Root Cause

In Docker, binary in /usr/local/bin/ but ORT .so in /usr/local/lib/. AVX2 path only checked exe_dir and immediately returned Err.

### Testing

- 379 tests passed, 0 failed
- cargo check --workspace clean

### Notes

- #822 uses String for cache (not Error) because Error contains io::Error which is not Clone
- Added defensive cfg(not(feature onnx)) arm for completeness
- Pre-commit cora hook timed out, review done manually