### PR TITLE
test: guard API registry against route drift

### DIFF
--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -593,16 +593,38 @@ pub const ENDPOINTS: &[Endpoint] = &[
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::*;
 
     #[test]
-    fn endpoints_count_matches_handlers() {
-        // This test enforces that the registry stays in sync with handlers.rs.
-        // If you add/remove a handler, update ENDPOINTS above.
-        // Current count: derived from handlers.rs route matches.
+    fn registry_covers_handler_routes() {
+        let handler_source = include_str!("handlers.rs");
+        let handler_paths = handler_source
+            .lines()
+            .filter_map(|line| {
+                let method_start = line.find("(Method::")?;
+                let path_start = line[method_start..].find(", \"")? + method_start + 3;
+                let path_end = line[path_start..].find('"')? + path_start;
+                Some(&line[path_start..path_end])
+            })
+            .collect::<BTreeSet<_>>();
+        let registered_paths = ENDPOINTS
+            .iter()
+            .map(|endpoint| endpoint.path)
+            .collect::<BTreeSet<_>>();
+
+        let missing = handler_paths
+            .difference(&registered_paths)
+            .copied()
+            .collect::<Vec<_>>();
+        assert!(
+            missing.is_empty(),
+            "Handler routes missing from API registry: {missing:?}"
+        );
+
         assert!(!ENDPOINTS.is_empty(), "Endpoint registry must not be empty");
-        // Spot-check: we should have at least the core endpoints
-        let paths: Vec<&str> = ENDPOINTS.iter().map(|e| e.path).collect();
+        let paths = registered_paths;
         assert!(paths.contains(&"/health"), "Missing /health");
         assert!(paths.contains(&"/remember"), "Missing /remember");
         assert!(paths.contains(&"/recall"), "Missing /recall");


### PR DESCRIPTION
Closes #828.\n\nThe existing registry test only spot-checked a few paths. This replaces it with a source-backed guard that extracts (Method, path) route arms from uteke-server/src/handlers.rs and asserts every handler path is represented in ENDPOINTS. It keeps the existing core endpoint checks as a smoke test.\n\nValidation:\n- cargo fmt --all -- --check\n- Focused source-level route comparison: 46 handler paths, 57 registered paths, 0 missing\n- git diff --check\n\ncargo test -p uteke-server registry_covers_handler_routes was attempted twice, but this environment exceeded 5 minutes compiling the workspace dependencies. No test result is being claimed from that command.