### PR TITLE
fix: resolve every uteke home path through uteke_home()

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -756,9 +756,7 @@ impl Config {
 
     /// Ensure the global uteke directory exists and return its path.
     pub fn ensure_dirs() -> PathBuf {
-        let base = dirs::home_dir()
-            .expect("Cannot determine home directory")
-            .join(".uteke");
+        let base = uteke_core::uteke_home().expect("Cannot determine uteke home directory");
         std::fs::create_dir_all(&base).ok();
         std::fs::create_dir_all(base.join("models")).ok();
         base
@@ -863,8 +861,9 @@ impl Config {
     /// Set the default namespace in the global config file.
     /// Creates or updates the `[store]` section's `namespace` key.
     pub fn set_default_namespace(name: &str) -> Result<(), String> {
-        let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
-        let config_path = home.join(".uteke").join("uteke.toml");
+        // Must be the same file `load()` reads via global_config_path(), or the write
+        // lands in a file nothing consults and the command is a silent no-op.
+        let config_path = global_config_path().ok_or("Cannot determine uteke home directory")?;
 
         // Read existing config or start fresh
         let content = if config_path.exists() {
@@ -894,11 +893,10 @@ fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
 }
 
 fn migrate_legacy_global() {
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return,
+    let base = match uteke_core::uteke_home() {
+        Ok(b) => b,
+        Err(_) => return,
     };
-    let base = home.join(".uteke");
     let legacy = base.join("config.toml");
     let modern = base.join("uteke.toml");
 

--- a/crates/uteke-cli/src/logging.rs
+++ b/crates/uteke-cli/src/logging.rs
@@ -9,8 +9,8 @@ use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::Subscribe
 /// Initialize logging. Returns a guard that must stay alive for the
 /// file writer to continue flushing.
 pub fn init(verbose: bool) -> Box<dyn std::any::Any + Send> {
-    let log_dir = dirs::home_dir()
-        .map(|h| h.join(".uteke"))
+    let log_dir = uteke_core::uteke_home()
+        .ok()
         .filter(|d| d.is_dir() || std::fs::create_dir_all(d).is_ok())
         .unwrap_or_else(|| {
             // Fallback to temp dir instead of cwd

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -27,10 +27,14 @@ fn main() {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
 
-    // Open uteke store
-    let store_path = dirs::home_dir()
-        .map(|h| h.join(".uteke"))
-        .expect("Cannot determine home directory");
+    // Open uteke store. Must go through uteke_home() — the canonical resolver the CLI
+    // uses (UTEKE_HOME override, ~/.codecora/uteke, legacy ~/.uteke auto-migration).
+    // Hardcoding ~/.uteke here pinned the MCP server to the pre-move legacy path, so it
+    // silently opened an empty second store and never saw anything the CLI had written.
+    let store_path = uteke_core::uteke_home().unwrap_or_else(|e| {
+        eprintln!("Cannot determine uteke store path: {e}");
+        std::process::exit(1);
+    });
 
     let uteke = match Uteke::open(&store_path) {
         Ok(u) => u,


### PR DESCRIPTION
Four call sites hardcode `~/.uteke` instead of calling `uteke_core::uteke_home()` — the resolver that handles the `UTEKE_HOME` override, the current `~/.codecora/uteke` default, and legacy-path auto-migration. The store moved to `~/.codecora/uteke`; these were never updated. (`chore/migrate-default-data-dir` doesn't touch them either.)

Two of them cause real, silent misbehavior.

## 1. `uteke-mcp/src/main.rs:31` — the MCP server opens a *different store* from the CLI

Everything written via `uteke remember`, `uteke import`, or the HTTP server is invisible to `uteke_recall`, and everything written through MCP is invisible to the CLI. The server also creates an empty store at `~/.uteke` on first run. The path isn't configurable, so there's no flag or env var to work around it.

The failure is completely silent. `initialize` and `tools/list` succeed, `uteke_recall` returns a well-formed `"No results found."`, and `uteke stats` reports a healthy store the whole time. An agent looks correctly wired while its memory is permanently empty — you only catch it by comparing `uteke_stats` against `uteke stats` and noticing the DB byte counts differ.

I hit this after importing 67 memories via the CLI and finding MCP recall returning nothing:

```
uteke stats --namespace demo                     → Total memories: 67 | DB: 1421312 bytes
MCP uteke_stats {"namespace":"demo"}             → Total: 0 | Tags: 0 | DB: 253952 bytes
```

Repro:

```bash
uteke remember "canary" --namespace demo
uteke stats --namespace demo          # Total memories: 1
# via MCP: {"name":"uteke_stats","arguments":{"namespace":"demo"}}
#   → "Total: 0 | Tags: 0"
```

## 2. `config.rs` `set_default_namespace` — `uteke namespace switch` is a no-op

It writes `~/.uteke/uteke.toml`, but `Config::load` reads `global_config_path()`, which *already* resolves via `uteke_home()`. So the command reports success and changes nothing:

```
$ uteke namespace switch canary
✓ Default namespace set to 'canary'

~/.codecora/uteke/uteke.toml  → namespace = "default"   # what load() reads
~/.uteke/uteke.toml           → namespace = "canary"    # what nothing reads
```

## 3 & 4. `logging.rs` and `config.rs` `ensure_dirs` / `migrate_legacy_global`

These write the log file, `models/`, and a default `uteke.toml` to the legacy path — recreating `~/.uteke` on every CLI run and leaving a plausible-looking config file that nothing consults, which is its own debugging trap. `logging.rs` already documented itself as writing to `{uteke_home}/uteke.log`.

## Not changed

- The project-scoped `./.uteke/uteke.toml` lookups in `config.rs:419` and `uteke-server/src/main.rs:521` — that's the documented per-project config and correct as-is.
- `uteke_home()`'s own reference to `~/.uteke`, which is the migration source.

## Verification

Against an isolated `HOME`, before and after: `namespace switch` now writes the file `load()` reads, logs land in `~/.codecora/uteke/`, `~/.uteke` is no longer created on CLI runs, and CLI and MCP report the same store.

Users with existing memories at `~/.uteke` get them auto-migrated by `uteke_home()` on next start, same as the CLI already does.

`cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` both clean.