### PR TITLE
fix(recall): report similarity for memories in unified search, not RRF rank

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1793,16 +1793,25 @@ impl Uteke {
         // Max possible RRF: 1/(k+1) when rank=0 in a single source.
         let max_rrf = 1.0 / (RRF_K as f64 + 1.0);
 
+        // RRF decides the ORDER; it must not decide the reported score. Normalizing the
+        // RRF sum yields (k+1)/(k+1+rank) — a pure function of rank, identical for every
+        // query — so a query matching nothing still reports 1.000 and `min_score` can
+        // never filter. Memories carry a real cosine, so report that.
+        //
+        // Documents keep the normalized RRF for now: `DocumentSearchResult::score` means
+        // three different things by mode (cosine from doc_search_semantic, 1/(i+1) rank
+        // from doc_search_fts, an RRF sum from doc_search_hybrid), and an FTS-only hit has
+        // no similarity to report at all. Putting documents on the same scale requires
+        // unifying that first — a separate change.
         let results: Vec<UnifiedSearchResult> = scored
             .into_iter()
             .take(limit)
-            .map(|(key, score)| {
-                let normalized = (score / max_rrf).clamp(0.0, 1.0) as f32;
+            .map(|(key, rrf_sum)| {
                 if let Some(sr) = mem_map.remove(&key) {
                     let m = &sr.memory;
                     UnifiedSearchResult {
                         result_type: SearchResultType::Memory,
-                        score: normalized,
+                        score: sr.score,
                         content: m.content.clone(),
                         memory_id: Some(m.id.clone()),
                         tags: m.tags.clone(),
@@ -1827,7 +1836,7 @@ impl Uteke {
                 } else if let Some(dr) = doc_map.remove(&key) {
                     UnifiedSearchResult {
                         result_type: SearchResultType::Document,
-                        score: normalized,
+                        score: (rrf_sum / max_rrf).clamp(0.0, 1.0) as f32,
                         content: if dr.chunk_snippet.is_empty() {
                             dr.document.title.clone()
                         } else {
@@ -2312,6 +2321,55 @@ mod tests {
                 r.score
             );
         }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_unified_recall_reports_similarity_not_rrf_rank() {
+        // A real directory, not ":memory:" — the usearch index is derived from the SQLite
+        // path, so an in-memory store has no vector index and every recall returns empty.
+        let dir = tempfile::tempdir().unwrap();
+        let uteke = Uteke::open(dir.path().join("uteke.db")).unwrap();
+        uteke
+            .remember(
+                "Rust is a systems programming language focused on memory safety",
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        uteke
+            .remember(
+                "The cat sat on the mat in the afternoon sun",
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+
+        let recall = |q: &str| {
+            uteke
+                .recall_unified(q, 2, None, None, 0.0, SearchType::All, None, None, false)
+                .unwrap()
+        };
+        let matching = recall("rust memory safety");
+        let unrelated = recall("quarterly dividend tax filing deadline");
+
+        // Normalizing the RRF sum yields (k+1)/(k+1+rank) — a pure function of rank.
+        // Every query's top hit would score exactly 1.0 and its runner-up exactly
+        // 61/62, so both assertions below fail if rank leaks back into the score.
+        assert!(
+            matching[0].score < 1.0,
+            "top score {} is the normalized RRF constant, not a similarity",
+            matching[0].score
+        );
+        assert!(
+            matching[0].score > unrelated[0].score,
+            "a matching query ({}) must outscore an unrelated one ({}); \
+             equal scores mean the score is rank, not relevance",
+            matching[0].score,
+            unrelated[0].score
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`recall_unified_all` merges memory and document hits with RRF, then reports `rrf_sum / (1/(k+1))` as the score. When a result appears in only one of the two lists — every result in any store without documents — that sum is `1/(k+1+rank)`, so the reported score collapses to `(k+1)/(k+1+rank)`: **a pure function of rank**, with the cosine similarity discarded.

Every query returns the same score sequence regardless of what it matched, or whether it matched anything:

```
$ uteke recall "purple giraffe tax law sonata"
  1. (score: 1.000) <arbitrary memory>
  2. (score: 0.984) <arbitrary memory>
  3. (score: 0.968) <arbitrary memory>
```

Those are exactly `61/61, 61/62, 61/63`.

## Two consequences

**1. `min_score` cannot filter.** It's applied to the rank number, so at the documented `0.30` default a result must rank ~140th to be excluded. This silently defeats the configurable similarity threshold from #252 — the "I don't know" behavior — for every consumer on the unified path, which is the default for the CLI (`commands/recall.rs:113`), the MCP server (`uteke-mcp/src/lib.rs:765`), and the HTTP server (`handlers.rs:292`).

**2. No way to distinguish a good match from a bad one.** Recall always returns `limit` results at maximum apparent confidence. An agent consuming `uteke_recall` gets no signal that nothing relevant was found — the nonsense query above looks identical to a perfect hit.

## The fix

Keep RRF for **ordering**; report the memory's real cosine for **scoring**. Result order is unchanged; only the reported number differs.

Measured over 67 real memories after the fix:

| query | top score |
|---|---|
| `git branch naming` (direct hit) | 0.614 |
| `my safety copy vanished after rewriting history` (pure synonym match) | 0.477 |
| `purple giraffe tax law sonata` (nonsense) | 0.379 |

With `min_score = 0.45` the nonsense query correctly returns `No matching results found.`

## Scope: memories only

Documents deliberately keep the normalized RRF. `DocumentSearchResult::score` means three different things depending on mode — cosine from `doc_search_semantic`, `1/(i+1)` rank from `doc_search_fts`, an RRF sum from `doc_search_hybrid` — and an **FTS-only hit has no similarity to report at all**. Putting documents on the same scale means unifying that first, which is a larger change than this one. I'd rather not smuggle it in here; happy to follow up if you want it.

This does leave memory and document scores on different scales within one result set. That's pre-existing, not introduced here — but worth being explicit about.

## Compatibility

This lowers reported memory scores from ~1.0 to real similarity, so **any config with a `min_score` tuned against the old numbers becomes meaningfully stricter**. Worth a release-note line.

The `0.30` default sits below the noise floor measured here (~0.38); `0.45` fit that corpus better. The right default depends on the embedding model, so I've left it unchanged rather than guess for other setups.

## Test

Adds `test_unified_recall_reports_similarity_not_rrf_rank`, asserting a matching query outscores an unrelated one and that the top score isn't the RRF constant. It **fails on `develop`** with `top score 1 is the normalized RRF constant, not a similarity`, and passes here.

One note that may be useful beyond this PR: the test uses a `tempfile` store rather than `:memory:`. The usearch index path is derived from the SQLite path, so `Uteke::open(":memory:")` gets **no vector index** and every recall returns empty. The existing `#[ignore]`d recall tests around it (`test_recall_threshold_filters_low_scores`, `test_recall_threshold_zero_returns_all`, `test_recall_threshold_specific_score`) are written that way and cannot pass as written — their `assert!(!results.is_empty())` will always fail. I've left them alone here.

`cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` both clean.

