### PR TITLE
fix(server): deny unknown fields in DocMoveRequest + UUID fallback for new_parent (#833)

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1276,17 +1276,24 @@ impl Uteke {
         id_or_slug: &str,
         new_parent_slug: Option<&str>,
     ) -> Result<usize, Error> {
-        let doc = self
-            .store
-            .get_document_by_slug(id_or_slug)?
-            .or_else(|| self.store.get_document(id_or_slug).unwrap_or(None))
-            .ok_or_else(|| Error::validation("document not found for move"))?;
+        // Resolve by slug first, fall back to UUID lookup (#833).
+        let doc = match self.store.get_document_by_slug(id_or_slug)? {
+            Some(d) => d,
+            None => self
+                .store
+                .get_document(id_or_slug)?
+                .ok_or_else(|| Error::validation("document not found for move"))?,
+        };
 
         let new_parent_id = match new_parent_slug {
             Some(ps) => {
-                let parent = self.store.get_document_by_slug(ps)?.ok_or_else(|| {
-                    Error::validation(format!("parent document '{ps}' not found"))
-                })?;
+                // Resolve by slug first, fall back to UUID lookup (#833).
+                let parent = match self.store.get_document_by_slug(ps)? {
+                    Some(d) => d,
+                    None => self.store.get_document(ps)?.ok_or_else(|| {
+                        Error::validation(format!("parent document '{ps}' not found"))
+                    })?,
+                };
                 Some(parent.id)
             }
             None => None,

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -49,6 +49,7 @@ pub struct DocSearchRequest {
 
 #[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DocMoveRequest {
     pub id: Option<String>,
     pub slug: Option<String>,


### PR DESCRIPTION
## What

Two fixes to `POST /doc/move` (DocMoveRequest + doc_move core function):

1. Add `#[serde(deny_unknown_fields)]` to `DocMoveRequest` — consumers sending wrong field names (e.g. `parent_slug`, `parent_id`) now get HTTP 400 instead of silent data loss.
2. Add UUID fallback for `new_parent` resolution — `doc_move()` now tries slug first, then UUID (consistent with source doc resolution and `doc_delete()`).
3. Fix error propagation in both source doc and parent resolution — switched from `.unwrap_or(None)` (which silently swallowed DB errors) to proper `?` + `match` pattern (DB errors propagate correctly, only `None` triggers fallback).

## Why

**Silent data loss:** Sending wrong field names caused `new_parent = None` → doc moved to root (parent_id=NULL, depth=0) with `{"moved": 1}` response. No error, no indication of failure.

**UUID rejection:** `doc_move()` only resolved parent by slug lookup. Sending a UUID as `new_parent` returned 404 "parent not found" even when the document existed. Inconsistent with source doc resolution.

**Error swallowing (CI finding):** `.unwrap_or(None)` on `get_document()` converted transient DB errors (connection issues, corruption) into misleading "not found" validation errors. Real errors were hidden from operators.

Closes #833

## How

- `types.rs`: Added `#[serde(deny_unknown_fields)]` attribute to `DocMoveRequest` struct.
- `lib.rs`: Replaced `.unwrap_or(None)` fallback chain with explicit `match` blocks that propagate `Result::Err` via `?` and only fall back to UUID on `Result::Ok(None)`. Applied to both source doc resolution and parent resolution in `doc_move()`.

## Testing

- [x] `cargo test --workspace` — all pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Cora pre-commit review — no issues
- [x] CI build, check, test, format, clippy — all pass (2a117b2)
- Manual: CLI `uteke doc move` validated on production instance (from earlier session)

## Related Issues

Closes #833
Validated and closed #832 (stale — already fixed in prior release)

## Checklist

- [x] Branch name follows convention (`fix/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR