### PR TITLE
chore(release): v0.11.0 — doc_move fixes, recall score, governance docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [0.11.0] — 2026-08-03
+
+### Fixed
+- **`POST /doc/move` silent data loss on unknown fields (#833)** — Added `#[serde(deny_unknown_fields)]` to `DocMoveRequest`. Consumers sending wrong field names (e.g. `parent_slug` instead of `new_parent`) now get HTTP 400 instead of doc being moved to root with no error.
+- **`doc_move()` UUID fallback for parent resolution (#833)** — `doc_move()` now tries slug lookup first, then UUID lookup for `new_parent`. Consistent with source doc resolution and `doc_delete()` behavior.
+- **DB error propagation in doc_move (#833)** — Replaced `.unwrap_or(None)` with proper `?` + `match` pattern. Transient DB errors now propagate correctly instead of being silently swallowed.
+- **Recall score reports RRF rank instead of similarity (#831)** — `recall_unified_all` now reports cosine similarity scores instead of rank-derived RRF values when results appear in only one store.
+- **MCP/CLI store mismatch — hardcoded `~/.uteke` paths (#830)** — Four call sites hardcoded the old data directory. `uteke-mcp` opened a separate store from the CLI/server. All paths now resolve through `uteke_home()`.
+- **`POST /consolidate` rejects string threshold (#826)** — Added `flex_f32` deserializer accepting both numeric and string JSON values for `threshold` parameter. Fixes MCP layers that stringify all parameters.
+
+### Added
+- **API route drift guard test (#829)** — Source-backed test extracts handler paths from `handlers.rs` and asserts every handler route is registered in the API registry. 46 handler paths, 57 registered paths, 0 missing.
+- **Missing doc endpoints in API reference (#827)** — Registered `/doc/list`, `/doc/search`, `/doc/update` in the docgen registry. Auto-generated `api-reference.md` now covers all document endpoints.
+
+### Changed
+- **Open-source governance docs (#834)** — Added `CODE_OF_CONDUCT.md`, rewrote `CONTRIBUTING.md` (solo maintainer context, branch naming convention, test requirements), upgraded PR template (What/Why/How/Testing), replaced `.md` issue templates with YAML forms, added `pr-checks.yml` CI workflow.
+- **API reference updated** — 3 new document endpoints documented.
+
+### Contributors
+- [@ajianaz](https://github.com/ajianaz) — doc_move fixes, store path resolution, recall score fix, API docs
+
 ## [0.10.3] — 2026-08-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.3"
+version = "0.11.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh |
 Pin a specific version with `UTEKE_VERSION`:
 
 ```bash
-UTEKE_VERSION=v0.10.2 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.11.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ### Windows Setup

--- a/README.id.md
+++ b/README.id.md
@@ -274,7 +274,7 @@ Bisa. Uteke punya MCP server yang langsung pakai dengan Claude Code, Cursor, dan
 <details>
 <summary><strong>Sudah production-ready?</strong></summary>
 
-Uteke sekarang v0.10.2 dengan 431 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
+Uteke sekarang v0.11.0 dengan 431 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.10.2 with 431 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
+Uteke is at v0.11.0 with 431 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
 </details>
 
 ---

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.10.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.11.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.10.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.11.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.10.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.10.0" }
+uteke-core = { path = "../uteke-core", version = "0.11.0", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.11.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What
Version bump 0.10.3 → 0.11.0 + CHANGELOG + docs sync.

## Why
Bundling 7 merged PRs (6 fixes + docs + governance) since v0.10.3 into a minor release. Includes critical data-loss fix in doc_move, recall scoring bug, MCP store mismatch, and open-source governance infrastructure.

## Files
- `Cargo.toml` workspace + 3 crate Cargo.tomls — version bump
- `CHANGELOG.md` — v0.11.0 section (6 fixes, 2 additions, 2 changes)
- `README.md`, `README.id.md`, `INSTALL.md` — version string sync

## Includes (since v0.10.3)
- fix: DocMoveRequest deny_unknown_fields + UUID fallback (#833, #835)
- fix: Recall score reports similarity not RRF rank (#831)
- fix: MCP/CLI store mismatch — hardcoded ~/.uteke paths (#830)
- fix: consolidate threshold accepts string or number (#826)
- feat: API route drift guard test (#829)
- docs: Missing doc endpoints in API reference (#827)
- docs: Governance docs, PR template, issue templates, CI checks (#834)

## Testing
- [x] Version bump verified: workspace + all intra-workspace deps
- [x] Docs sync: README, README.id, INSTALL
- [x] CHANGELOG complete with all PRs since v0.10.3
- [ ] CI (pending re-run)