### PR TITLE
chore(release): merge develop → main for v0.11.0

### DIFF
--- a/.github/workflows/cora-review.yml
+++ b/.github/workflows/cora-review.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Cora AI Code Review
-        uses: codecoradev/cora-review-action@v1
+        uses: codecoradev/cora-review-action@v1.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cora-api-key: ${{ secrets.CORA_API_KEY }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,8 +13,15 @@ jobs:
       - name: Check branch name
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "Checking branch: $HEAD_REF"
+
+          # Skip check for merge PRs from protected branches (develop → main)
+          if echo "$HEAD_REF" | grep -qE "^(develop|main)$"; then
+            echo "⏭️ Skipping branch naming check for protected branch: $HEAD_REF"
+            exit 0
+          fi
 
           # Allowed prefixes (kebab-case)
           ALLOWED="^(feat|fix|docs|chore|perf|security|refactor|test|build|ci)/"


### PR DESCRIPTION
## What
Merge develop into main for v0.11.0 release.

## Why
Standard release flow: develop (with CI fixes) → main → tag → release.

## Testing
- [x] All CI checks passing on develop
- [ ] CI on this PR