### PR TITLE
fix: recall cache invalidation in delete_tag + graceful shutdown on poisoned mutex

### DIFF
--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1091,7 +1091,18 @@ impl crate::Uteke {
 
     /// Delete a tag from all memories in a namespace.
     pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        self.store.delete_tag(tag, namespace)
+        let deleted = self.store.delete_tag(tag, namespace)?;
+        if deleted > 0 {
+            // Invalidate recall cache to prevent stale search results (#844).
+            // If namespace is specified, invalidate only that namespace.
+            // Cross-namespace delete requires full cache flush.
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+        }
+        Ok(deleted)
     }
 
     /// Count memories by tag in a namespace.

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -448,10 +448,17 @@ fn main() {
         });
     }
 
-    // Graceful shutdown
-    info!("Saving index and closing DB...");
-    if let Err(e) = uteke.lock().expect("shutdown lock").shutdown() {
-        error!("Shutdown error: {e}");
+    // Graceful shutdown — save dirty index to disk.
+    // Handle poisoned mutex gracefully instead of panicking (#845).
+    match uteke.lock() {
+        Ok(u) => {
+            if let Err(e) = u.shutdown() {
+                error!("Shutdown error: {e}");
+            }
+        }
+        Err(_) => {
+            error!("Shutdown: mutex poisoned, forcing exit without index save");
+        }
     }
 
     info!("Goodbye.");


### PR DESCRIPTION
## What

- **#844**: `delete_tag()` now invalidates recall cache after deleting memories by tag
- **#845**: Graceful shutdown handles poisoned mutex without panicking

## Why

**#844 — Stale search results after tag-based delete:**
`delete_tag()` deleted memories from SQLite + vector index but did not invalidate the recall cache (TTL: 5 min). Users would see "ghost memories" in search results for up to 5 minutes after deletion. All other mutation paths (`forget`, `remember`, `update_memory`) already invalidate correctly — this was the only gap.

**#845 — Panic on shutdown if mutex poisoned:**
`main.rs` used `.expect("shutdown lock")` on the `Arc<Mutex<Uteke>>` during graceful shutdown. If any thread panicked while holding the lock, the mutex becomes poisoned and this call panics — preventing the vector index from being saved to disk. Replaced with a `match` that logs the error and exits cleanly.

## Testing

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cora review` — no issues found
- [x] Cora pre-commit hook — passed