### PR TITLE
fix: detect broken stdout pipe to prevent MCP ghost process (#843)

### DIFF
--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -61,8 +61,12 @@ fn main() {
         // Delegate to the shared handler (#381).
         // None = notification (no response per JSON-RPC 2.0 §4.1).
         if let Some(response) = uteke_mcp::handle_jsonrpc(&uteke, &line) {
-            let _ = writeln!(stdout, "{response}");
-            let _ = stdout.flush();
+            // Detect broken pipe: if the parent process has disconnected,
+            // writes to stdout will fail. Exit cleanly instead of hanging (#843).
+            if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
+                eprintln!("stdout write failed — parent process disconnected. Exiting.");
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Fix ghost process bug in `uteke-mcp` where the server hangs indefinitely after parent agent disconnects.

## Why

**Issue #843**: When the parent agent process terminates, crashes, or re-spawns, `uteke-mcp` fails to detect the pipe closure. `writeln!` and `flush` errors on stdout were silently swallowed by `let _ =`, so the server keeps blocking on `stdin.lock().lines()` forever as a ghost process, blocking subsequent re-initialization.

## Changes

`crates/uteke-mcp/src/main.rs`:
- Check `writeln!` and `stdout.flush()` results instead of ignoring them
- On write/flush failure: log to stderr and `break` out of the read loop
- Process exits naturally instead of hanging

## Root Cause

```rust
// BEFORE (bug):
let _ = writeln!(stdout, "{response}");  // silently ignores broken pipe
let _ = stdout.flush();

// AFTER (fixed):
if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
    eprintln!("stdout write failed — parent process disconnected. Exiting.");
    break;
}
```

## Testing

- [x] `cargo check` — clean compile, 0 warnings
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] Cora code review — passed, no issues

Closes #843