### PR TITLE
fix(recall): normalize FTS5 scores AFTER filtering, not before

### DIFF
--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -722,8 +722,14 @@ impl crate::Uteke {
 
         // Compute min-max from SURVIVING results only.
         // BM25 rank: negative values, more negative = more relevant.
-        let best = filtered.iter().map(|(_, r)| *r).fold(f64::INFINITY, f64::min);
-        let worst = filtered.iter().map(|(_, r)| *r).fold(f64::NEG_INFINITY, f64::max);
+        let best = filtered
+            .iter()
+            .map(|(_, r)| *r)
+            .fold(f64::INFINITY, f64::min);
+        let worst = filtered
+            .iter()
+            .map(|(_, r)| *r)
+            .fold(f64::NEG_INFINITY, f64::max);
         let range = best - worst;
 
         let results: Vec<SearchResult> = filtered

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -695,15 +695,10 @@ impl crate::Uteke {
             }
         };
 
-        // Pre-compute min-max normalization of BM25 ranks.
-        // BM25 rank: negative values, more negative = more relevant.
-        // Normalize to 0.0..1.0 so min_score filter is meaningful.
-        let ranks: Vec<f64> = fts_results.iter().map(|(_, r)| *r).collect();
-        let best = ranks.iter().copied().fold(f64::INFINITY, f64::min); // most negative
-        let worst = ranks.iter().copied().fold(f64::NEG_INFINITY, f64::max); // least negative
-        let range = best - worst;
-
-        let results: Vec<SearchResult> = fts_results
+        // Filter first, then normalize — otherwise the range is computed
+        // from items that get filtered out (e.g. namespace mismatch),
+        // producing skewed scores (#854 cora review).
+        let filtered: Vec<(Memory, f64)> = fts_results
             .into_iter()
             .filter(|(memory, _)| {
                 // Namespace filter (None = ALL, #448)
@@ -723,10 +718,17 @@ impl crate::Uteke {
                 }
                 true
             })
+            .collect();
+
+        // Compute min-max from SURVIVING results only.
+        // BM25 rank: negative values, more negative = more relevant.
+        let best = filtered.iter().map(|(_, r)| *r).fold(f64::INFINITY, f64::min);
+        let worst = filtered.iter().map(|(_, r)| *r).fold(f64::NEG_INFINITY, f64::max);
+        let range = best - worst;
+
+        let results: Vec<SearchResult> = filtered
+            .into_iter()
             .map(|(memory, rank)| {
-                // Convert FTS5 BM25 rank to 0..1 score via min-max normalization.
-                // BM25 returns negative values (more negative = better match).
-                // After normalization: best match = 1.0, worst match = 0.0.
                 let score = if range.abs() < f64::EPSILON {
                     1.0f32 // single result or all same rank
                 } else {


### PR DESCRIPTION
## What

Follow-up fix to PR #854 — FTS5 min-max normalization order bug caught by **cora review**.

## Why

PR #854 introduced min-max BM25 normalization but computed the range (best/worst) from ALL fts_results **before** the namespace/tag filter step. If the best or worst-ranked items get filtered out, the surviving scores no longer span the full 0.0..1.0 range.

## How

Restructured the pipeline:

1. Filter first, collect surviving (Memory, rank) pairs
2. Compute min-max from surviving results only
3. Map to scores using the correct range
4. Take limit

Before: compute_range(all) then filter then map
After: filter then compute_range(filtered) then map

## Testing

- [x] cargo test --workspace — 432 passed, 0 failed, 24 ignored
- [x] cargo clippy — 0 warnings
- [x] Cora review (bifrost provider) — clean

## Related Issues

Follow-up to #854