### PR TITLE
fix(core): capture chunk IDs before upsert to prevent usearch orphans (#857)

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1098,12 +1098,13 @@ impl Uteke {
             has_children: false,
         };
 
-        let doc_id = self.store.upsert_document(&doc)?;
-
-        // Delete old chunks on update (re-chunking).
+        // Capture old chunk IDs BEFORE upsert (upsert_document deletes chunks
+        // internally as part of its transaction, so querying after returns empty).
         let old_chunk_ids = self
             .store
-            .delete_chunks_for_documents(std::slice::from_ref(&doc_id))?;
+            .get_chunk_ids_for_documents(std::slice::from_ref(&doc.id))?;
+
+        let doc_id = self.store.upsert_document(&doc)?;
 
         // Chunk and embed the content.
         self.ensure_embedder()?;

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -898,6 +898,33 @@ impl super::Store {
 
     /// Delete chunks belonging to a set of document IDs.
     ///
+    /// Get chunk IDs for a list of document IDs, WITHOUT deleting them.
+    /// Used to capture old chunk IDs before an upsert that deletes chunks internally.
+    pub fn get_chunk_ids_for_documents(&self, doc_ids: &[String]) -> Result<Vec<String>, Error> {
+        if doc_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = doc_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT id FROM document_chunks WHERE document_id IN ({})",
+            placeholders
+        );
+        let params: Vec<&dyn rusqlite::types::ToSql> = doc_ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::db("prepare select chunk ids (no-delete)", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params.as_slice(), |row| row.get::<_, String>(0))
+            .map_err(|e| Error::db("select chunk ids (no-delete)", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
     /// Used during document update to clear old chunks before re-chunking.
     /// Returns the IDs of deleted chunks (for usearch cleanup).
     pub fn delete_chunks_for_documents(&self, doc_ids: &[String]) -> Result<Vec<String>, Error> {


### PR DESCRIPTION
## What

`doc_upsert()` had a **double-delete bug** causing usearch index bloat:

1. `store.upsert_document()` deletes old chunks inside its transaction (line 222-227)
2. Caller then calls `store.delete_chunks_for_documents()` to get old chunk IDs for usearch cleanup
3. But chunks are already deleted → SELECT returns empty → usearch entries never removed

**Impact:** Every document update left orphaned entries in the usearch vector index, causing silent index bloat and degraded search quality over time.

## Why

Document updates silently corrupt the vector index. Over time this causes:
- Increased memory usage (orphaned usearch keys never freed)
- Degraded search quality (stale vectors from old content matched in queries)
- No error signal — the bug is completely silent

## Changes

- **Added** `get_chunk_ids_for_documents()` — queries chunk IDs without deleting
- **Changed** `doc_upsert` flow in `lib.rs` to capture IDs **before** upsert, then use them for usearch cleanup
- `delete_chunks_for_documents()` kept for backward compat (other internal callers)

## Testing

- [x] `cargo check` — clean
- [x] `cargo test -p uteke-core -- document` — 18 passed, 0 failed
- [x] Cora review: No issues found