### PR TITLE
fix(core): cleanup room_documents junction on document delete (#858)

### DIFF
--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -794,6 +794,18 @@ impl super::Store {
         } else {
             format!("{}/%", path)
         };
+
+        // Collect all descendant document IDs (including self) for junction cleanup.
+        // Clean up room_documents junction entries BEFORE deleting the documents
+        // (so the subquery SELECT slug FROM documents still has rows to match).
+        self.conn
+            .execute(
+                "DELETE FROM room_documents WHERE doc_slug IN \
+                 (SELECT slug FROM documents WHERE id = ?1 OR path LIKE ?2)",
+                params![id, &cascade_prefix],
+            )
+            .map_err(|e| Error::db("cleanup room_documents junction on doc delete", e))?;
+
         let n = self
             .conn
             .execute(


### PR DESCRIPTION
## What

`delete_document()` only deleted from `documents` (and implicitly `document_chunks` via cascade) but left **dangling references** in the `room_documents` junction table. Since `room_documents.doc_slug` is `TEXT NOT NULL` without a FK constraint to `documents(slug)`, SQLite cannot cascade the delete.

## Why

After deleting a document that was linked to rooms, queries like `room_list_documents()` would return ghost entries pointing to non-existent documents. This causes confusing API responses and potential panics in consumers that expect the document to exist.

## Changes

- **Added** junction cleanup query in `delete_document()` — a single `DELETE FROM room_documents WHERE doc_slug IN (SELECT slug FROM ...)` that covers both the document and all its descendants (path-based cascade)
- Cleanup runs **before** the actual `DELETE FROM documents` to ensure the subquery still has rows to match

## Testing

- [x] `cargo check` — clean
- [x] `cargo test -p uteke-core -- document` — 18 passed, 0 failed
- [x] Cora review: No issues found