### PR TITLE
feat(mcp,cli): expose room-document junction operations (#859)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -708,6 +708,30 @@ pub enum RoomCommands {
         /// Room ID
         room_id: String,
     },
+    /// Link a document to a room
+    AddDocument {
+        /// Room ID
+        room_id: String,
+        /// Document slug
+        doc_slug: String,
+    },
+    /// Unlink a document from a room
+    RemoveDocument {
+        /// Room ID
+        room_id: String,
+        /// Document slug
+        doc_slug: String,
+    },
+    /// List documents linked to a room
+    ListDocuments {
+        /// Room ID
+        room_id: String,
+    },
+    /// List rooms that reference a document
+    ListRooms {
+        /// Document slug
+        doc_slug: String,
+    },
 }
 
 /// Subcommands for memory aging operations.

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -247,5 +247,85 @@ pub(crate) fn run(
             }
             Ok(())
         }
+        RoomCommands::AddDocument { room_id, doc_slug } => {
+            uteke
+                .room_add_document(room_id, &doc_slug)
+                .map_err(|e| format!("Failed to link document: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "room_id": room_id,
+                        "doc_slug": doc_slug,
+                        "linked": true
+                    })
+                );
+            } else {
+                println!("Linked document '{doc_slug}' to room '{room_id}'.");
+            }
+            Ok(())
+        }
+        RoomCommands::RemoveDocument { room_id, doc_slug } => {
+            uteke
+                .room_remove_document(room_id, &doc_slug)
+                .map_err(|e| format!("Failed to unlink document: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "room_id": room_id,
+                        "doc_slug": doc_slug,
+                        "linked": false
+                    })
+                );
+            } else {
+                println!("Unlinked document '{doc_slug}' from room '{room_id}'.");
+            }
+            Ok(())
+        }
+        RoomCommands::ListDocuments { room_id } => {
+            let docs = uteke
+                .room_list_documents(room_id)
+                .map_err(|e| format!("Failed to list documents: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "room_id": room_id,
+                        "documents": docs
+                    })
+                );
+            } else if docs.is_empty() {
+                println!("No documents linked to room '{room_id}'.");
+            } else {
+                println!("Documents linked to room '{room_id}':");
+                for slug in &docs {
+                    println!("  • {slug}");
+                }
+            }
+            Ok(())
+        }
+        RoomCommands::ListRooms { doc_slug } => {
+            let rooms = uteke
+                .document_list_rooms(&doc_slug)
+                .map_err(|e| format!("Failed to list rooms: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "doc_slug": doc_slug,
+                        "rooms": rooms
+                    })
+                );
+            } else if rooms.is_empty() {
+                println!("No rooms reference document '{doc_slug}'.");
+            } else {
+                println!("Rooms referencing document '{doc_slug}':");
+                for room_id in &rooms {
+                    println!("  • {room_id}");
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -249,7 +249,7 @@ pub(crate) fn run(
         }
         RoomCommands::AddDocument { room_id, doc_slug } => {
             uteke
-                .room_add_document(room_id, &doc_slug)
+                .room_add_document(room_id, doc_slug)
                 .map_err(|e| format!("Failed to link document: {e}"))?;
             if cli.json {
                 println!(
@@ -267,7 +267,7 @@ pub(crate) fn run(
         }
         RoomCommands::RemoveDocument { room_id, doc_slug } => {
             uteke
-                .room_remove_document(room_id, &doc_slug)
+                .room_remove_document(room_id, doc_slug)
                 .map_err(|e| format!("Failed to unlink document: {e}"))?;
             if cli.json {
                 println!(
@@ -307,7 +307,7 @@ pub(crate) fn run(
         }
         RoomCommands::ListRooms { doc_slug } => {
             let rooms = uteke
-                .document_list_rooms(&doc_slug)
+                .document_list_rooms(doc_slug)
                 .map_err(|e| format!("Failed to list rooms: {e}"))?;
             if cli.json {
                 println!(

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -165,6 +165,10 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_room_stats(),
                 tool_room_summary(),
                 tool_room_document(),
+                tool_room_add_document(),
+                tool_room_remove_document(),
+                tool_room_list_documents(),
+                tool_doc_list_rooms(),
                 tool_tags_list(),
                 tool_tags_rename(),
                 tool_tags_delete(),
@@ -208,6 +212,10 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_room_stats" => exec_room_stats(uteke, &arguments)?,
                 "uteke_room_summary" => exec_room_summary(uteke, &arguments)?,
                 "uteke_room_document" => exec_room_document(uteke, &arguments)?,
+                "uteke_room_add_document" => exec_room_add_document(uteke, &arguments)?,
+                "uteke_room_remove_document" => exec_room_remove_document(uteke, &arguments)?,
+                "uteke_room_list_documents" => exec_room_list_documents(uteke, &arguments)?,
+                "uteke_doc_list_rooms" => exec_doc_list_rooms(uteke, &arguments)?,
                 "uteke_tags_list" => exec_tags_list(uteke, &arguments)?,
                 "uteke_tags_rename" => exec_tags_rename(uteke, &arguments)?,
                 "uteke_tags_delete" => exec_tags_delete(uteke, &arguments)?,
@@ -587,6 +595,64 @@ fn tool_room_document() -> Value {
                 "room_id": { "type": "string", "description": "Room identifier" }
             },
             "required": ["room_id"]
+        }
+    })
+}
+
+fn tool_room_add_document() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_add_document",
+        "description": "Link a document to a room. The document must already exist (use uteke_doc_upsert first).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "doc_slug": { "type": "string", "description": "Document slug to link" }
+            },
+            "required": ["room_id", "doc_slug"]
+        }
+    })
+}
+
+fn tool_room_remove_document() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_remove_document",
+        "description": "Unlink a document from a room. Does not delete the document itself.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "doc_slug": { "type": "string", "description": "Document slug to unlink" }
+            },
+            "required": ["room_id", "doc_slug"]
+        }
+    })
+}
+
+fn tool_room_list_documents() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_list_documents",
+        "description": "List all document slugs linked to a room.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" }
+            },
+            "required": ["room_id"]
+        }
+    })
+}
+
+fn tool_doc_list_rooms() -> Value {
+    serde_json::json!({
+        "name": "uteke_doc_list_rooms",
+        "description": "List all rooms that reference a specific document.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "doc_slug": { "type": "string", "description": "Document slug to look up" }
+            },
+            "required": ["doc_slug"]
         }
     })
 }
@@ -1597,6 +1663,99 @@ fn exec_room_document(uteke: &Uteke, args: &Value) -> Result<ToolResult, String>
         content: vec![McpContent::Text {
             r#type: "text".to_string(),
             text: lines.join("\n"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_add_document(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let doc_slug = args["doc_slug"].as_str().ok_or("Missing 'doc_slug'")?;
+
+    uteke
+        .room_add_document(room_id, doc_slug)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("Linked document '{doc_slug}' to room '{room_id}'."),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_remove_document(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let doc_slug = args["doc_slug"].as_str().ok_or("Missing 'doc_slug'")?;
+
+    uteke
+        .room_remove_document(room_id, doc_slug)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("Unlinked document '{doc_slug}' from room '{room_id}'."),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_list_documents(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+
+    let docs = uteke
+        .room_list_documents(room_id)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let text = if docs.is_empty() {
+        format!("No documents linked to room '{room_id}'.")
+    } else {
+        format!(
+            "Documents linked to room '{}':\n{}",
+            room_id,
+            docs.iter()
+                .map(|s| format!("  • {s}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_doc_list_rooms(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let doc_slug = args["doc_slug"].as_str().ok_or("Missing 'doc_slug'")?;
+
+    let rooms = uteke
+        .document_list_rooms(doc_slug)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let text = if rooms.is_empty() {
+        format!("No rooms reference document '{doc_slug}'.")
+    } else {
+        format!(
+            "Rooms referencing document '{}':\n{}",
+            doc_slug,
+            rooms
+                .iter()
+                .map(|s| format!("  • {s}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
         }],
         is_error: false,
     })


### PR DESCRIPTION
## What

The HTTP API had 4 endpoints for room↔document junction management (`PUT /room/document/add`, `DELETE /room/document/remove`, `POST /room/document/list`, `POST /doc/room/list`) but **neither MCP nor CLI exposed them**. AI agents using MCP had no way to link documents to rooms.

## Why

Agents that use uteke via MCP (Claude, GPT, etc.) can create documents and rooms, but **cannot link them together**. This makes the room-document relationship inaccessible without falling back to HTTP API calls — a significant feature gap.

## Changes

**4 new MCP tools:**
- `uteke_room_add_document` — link a document to a room
- `uteke_room_remove_document` — unlink a document from a room
- `uteke_room_list_documents` — list documents linked to a room
- `uteke_doc_list_rooms` — list rooms referencing a document

**4 new CLI subcommands** under `uteke room`:
- `room add-document <room_id> <doc_slug>`
- `room remove-document <room_id> <doc_slug>`
- `room list-documents <room_id>`
- `room list-rooms <doc_slug>`

All CLI commands support `--json` output mode.

## Testing

- [x] `cargo check` — clean
- [x] `cargo test -p uteke-mcp -p uteke-cli` — all passed
- [x] Cora review: No issues found