### PR TITLE
fix(config): add missing sections to default config template (#862)

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -909,6 +909,18 @@ impl Config {
 # graph_authority_weight = 0.1
 # graph_rerank_enabled = true
 # jaccard_weight = 0.0  # Post-RRF token overlap boost (#719). 0=off, 0.10-0.15 recommended
+# salience_weight = 0.0  # Post-RRF importance/pin boost. 0=off, 0.05-0.10 recommended
+# recency_weight = 0.0   # Post-RRF time-decay boost. 0=off, 0.05-0.10 recommended
+
+[embed_fallback]
+# Fallback when embedding model fails or is unavailable (#598)
+# enabled = true
+# strategy = "hash"  # hash | random | zero
+
+[extraction]
+# Content extraction settings for document chunking
+# max_chunk_size = 512
+# overlap = 50
 
 [server]
 # enabled = false


### PR DESCRIPTION
## What

The default `uteke.toml` template generated by `write_default_config()` was missing 2 sections and 2 recall fields.

## Why

Users running `uteke init` get an incomplete config file. When they try to set `[embed_fallback]` or `[extraction]` values (which are documented), the sections are missing from the template — causing confusion. The template should be a complete reference for all available config options.

## Changes

Added to default template:
- `[embed_fallback]` section — fallback strategy for embedding model failures
- `[extraction]` section — document chunking parameters
- `salience_weight` and `recency_weight` fields under `[recall]`

The template now covers all 12 config sections that `merge_from_file()` processes.

## Testing

- [x] `cargo check` — clean
- [x] Cora review: No issues found