### PR TITLE
docs: update documentation for v0.12.0

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -355,6 +355,18 @@ uteke room remove "project-kickoff" <memory-id>
 
 # Delete room
 uteke room delete "project-kickoff"
+
+# Link a document to a room (#859)
+uteke room add-document "project-kickoff" --slug "architecture-spec"
+
+# Unlink a document from a room (#859)
+uteke room remove-document "project-kickoff" --slug "architecture-spec"
+
+# List documents linked to a room (#859)
+uteke room list-documents "project-kickoff"
+
+# List rooms that reference a document (#859)
+uteke room list-rooms --slug "architecture-spec"
 ```
 
 ## uteke bench

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -265,7 +265,7 @@ Both transports expose the same tools (MCP protocol version `2025-06-18`):
 | `uteke_room_delete` | Delete a room |
 | `uteke_room_stats` | Room statistics |
 | `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
-| `uteke_room_document` | Generate summary document from room (→ `POST /room/summary-document`) |
+| `uteke_room_summary_document` | Generate summary document from room (→ `POST /room/summary-document`) |
 | `uteke_tags_list` | List all tags with counts (#566) |
 | `uteke_tags_rename` | Rename a tag across all memories (#566) |
 | `uteke_tags_delete` | Delete a tag from all memories (#566) |

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -94,7 +94,7 @@ uteke(action="room_create", room_id="sprint-planning", title="Sprint Planning")
 uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 
 # Add a reference document to a room
-uteke(action="room_document", room_id="sprint-planning", content="Architecture spec: ...", title="Arch Spec")
+uteke(action="room_summary_document", room_id="sprint-planning", content="Architecture spec: ...", title="Arch Spec")
 
 # Recall from a room (semantic search — query is required)
 uteke(action="room_recall", room_id="sprint-planning", content="deploy deadline")
@@ -214,7 +214,7 @@ hermes mcp add uteke --command uteke-mcp
 | `forget` | Delete memory |
 | `stats` | Namespace or global statistics |
 | `room_remember` | Store memory in a room with author attribution |
-| `room_document` | Store a reference document in a room |
+| `room_summary_document` | Store a reference document in a room |
 | `room_create` | Create a room |
 | `room_recall` | Semantic search within a room (requires `query`) |
 | `room_list` | List all rooms (cross-namespace) |
@@ -234,7 +234,7 @@ hermes mcp add uteke --command uteke-mcp
 
 ## Valid Memory Types
 
-When using `remember`, `room_remember`, or `room_document`, the `type` parameter accepts these values:
+When using `remember`, `room_remember`, or `room_summary_document`, the `type` parameter accepts these values:
 
 | Type | Description |
 |------|-------------|

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -160,7 +160,11 @@ Both transports expose the same 29 tools (MCP protocol version `2025-06-18`):
 | `uteke_room_delete` | Delete a room |
 | `uteke_room_stats` | Room statistics |
 | `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
-| `uteke_room_document` | Generate summary document from room (→ `POST /room/summary-document`) |
+| `uteke_room_summary_document` | Generate summary document from room (→ `POST /room/summary-document`) |
+| `uteke_room_add_document` | Link an existing document to a room (#859) |
+| `uteke_room_remove_document` | Unlink a document from a room (#859) |
+| `uteke_room_list_documents` | List documents linked to a room (#859) |
+| `uteke_doc_list_rooms` | List rooms that reference a document (#859) |
 | `uteke_tags_list` | List all tags with counts (#566) |
 | `uteke_tags_rename` | Rename a tag across all memories (#566) |
 | `uteke_tags_delete` | Delete a tag from all memories (#566) |


### PR DESCRIPTION
## What

Update 4 documentation files to reflect v0.12.0 changes:

- **docs/mcp.md** — Rename `uteke_room_document` → `uteke_room_summary_document`. Add 4 new junction tools: `uteke_room_add_document`, `uteke_room_remove_document`, `uteke_room_list_documents`, `uteke_doc_list_rooms`
- **docs/cli-reference.md** — Add 4 junction subcommands to `uteke room` section: `add-document`, `remove-document`, `list-documents`, `list-rooms`
- **docs/docker.md** — Fix renamed MCP tool reference (`uteke_room_document` → `uteke_room_summary_document`)
- **docs/integrations/hermes.md** — Update action name `room_document` → `room_summary_document` in code examples, action table, and memory type docs

## Why

v0.12.0 shipped 4 new junction tools (CLI + MCP) and renamed `uteke_room_document` to `uteke_room_summary_document` for clarity. Documentation was stale — still referenced the old tool name and missing the 4 new junction tools entirely.

## Testing

- [x] All 4 file diffs reviewed — changes are docs-only
- [x] No code changes, no tests affected
- [x] Renamed tool keeps backward-compat alias — old name still works
