### PR TITLE
release: v0.12.0 — junction tools, FTS5 content search, config fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [0.12.0] — 2026-08-05
+
+### Fixed
+- **`merge_from_file` skips 5 config sections (#856)** — Config merge now includes `[embed_fallback]`, `[extraction]`, `[recall]` weights (`salience_weight`, `recency_weight`), `[server]` advanced fields, and `[limits]` advanced fields. Previously these sections were silently ignored when loading from `uteke.toml`.
+- **`doc_upsert` double-deletes chunks — usearch index orphaned entries (#857)** — Chunk capture now happens *before* `upsert_document` via new `get_chunk_ids_for_documents()` method. Previously the flow deleted chunks after upsert (which re-creates them), causing orphaned entries in the usearch vector index — leading to index bloat and stale results.
+- **`delete_document` leaves dangling `room_documents` references (#858)** — Document deletion now cleans up the `room_documents` junction table via `DELETE FROM room_documents WHERE doc_slug = ?1`. Previously junction rows were orphaned since there's no foreign key constraint on the junction table.
+- **Default config template only includes 5 of 12 sections (#862)** — `write_default_config()` now emits `[embed_fallback]`, `[extraction]`, `salience_weight`/`recency_weight` in `[recall]`, and other previously missing sections. Users running `uteke init` now get a complete reference template.
+- **Misleading MCP tool name `uteke_room_document` (#861)** — Renamed to `uteke_room_summary_document` for clarity (it generates a summary document, not a CRUD operation). Old name kept as backward-compatible alias — no breaking change for existing MCP clients.
+
+### Added
+- **MCP + CLI room-document junction tools (#859)** — The HTTP API had 4 junction endpoints (`/room/add-document`, `/room/remove-document`, `/room/list-documents`, `/doc/list-rooms`) but these were not exposed via MCP or CLI. Added 4 new MCP tools (`uteke_room_add_document`, `uteke_room_remove_document`, `uteke_room_list_documents`, `uteke_doc_list_rooms`) and 4 CLI subcommands (`room add-document`, `room remove-document`, `room list-documents`, `room list-rooms`). MCP and CLI clients can now manage room↔document links without HTTP.
+
+### Changed
+- **FTS5 documents index now includes content body (#860)** — The `documents_fts` virtual table previously indexed only `title` and `slug` columns. Now also indexes `content`, enabling full-text search across document bodies. Schema migration auto-detects old FTS tables (missing `content` column via `pragma_table_info`) and recreates with full indexing + backfill. Fresh databases get 3-column FTS5 from initial schema.
+
+### Contributors
+- [@ajianaz](https://github.com/ajianaz) — all fixes, features, and FTS5 migration
+
 ## [0.11.0] — 2026-08-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,9 +2084,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2094,22 +2094,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2567,18 +2567,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh |
 Pin a specific version with `UTEKE_VERSION`:
 
 ```bash
-UTEKE_VERSION=v0.11.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.12.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ### Windows Setup

--- a/README.id.md
+++ b/README.id.md
@@ -274,7 +274,7 @@ Bisa. Uteke punya MCP server yang langsung pakai dengan Claude Code, Cursor, dan
 <details>
 <summary><strong>Sudah production-ready?</strong></summary>
 
-Uteke sekarang v0.11.0 dengan 431 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
+Uteke sekarang v0.12.0 dengan 432 test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -103,25 +103,41 @@ You just spent 2 hours explaining your codebase to ChatGPT. Next session? Blank 
 
 Every AI tool forgets. Context windows fill up, sessions end, and your AI starts over every single time. Uteke gives it persistent memory — and keeps it on your machine.
 
-| | **Uteke** | **Mnemosyne** | **Mem0** | **AgentMemory** | **Letta** | **Zep** | **Engram** |
-|---|---|---|---|---|---|---|---|
-| **Language** | Rust (single binary) | Python (pip) | Python | TypeScript | Python | Python | Go (single binary) |
-| **Setup** | One binary (`curl \| sh`) | pip install + venv | pip + Docker + Qdrant | npm + Docker (iii-engine) | pip + Docker + Postgres | pip + Docker + Neo4j | One binary |
-| **API keys** | ❌ None | ⚠️ For remote embeddings | ✅ OpenAI/LLM | ✅ LLM key | ✅ LLM key | ✅ LLM key | ❌ None |
-| **Works offline** | ✅ Fully | ⚠️ Optional | ❌ Cloud embedding | ❌ Needs LLM | ❌ Needs LLM | ❌ Needs LLM + vector DB | ✅ Fully |
-| **Search** | **Hybrid** (Vector + FTS5 + RRF) | sqlite-vec + FTS5 | Vector + Graph | Vector + Graph | Vector | Temporal Graph | **FTS5 only** |
-| **Recall speed** | ~45ms | ~50ms+ | Network round-trip | Network round-trip | Network round-trip | Network round-trip | ~Fast (local) |
-| **Multi-agent** | ✅ Rooms (built-in collaboration) | ⚠️ Shared API | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Time-travel** | ✅ Native point-in-time | ⚠️ Temporal triples | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **MCP server** | ✅ JSON-RPC + HTTP | ✅ stdio + SSE | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Your data** | ✅ Never leaves machine | ✅ Local-first | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ✅ Local |
-| **License** | Apache 2.0 | MIT | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 |
+| | **Uteke** | **Mnemosyne** | **Mem0** | **AgentMemory** | **Letta** | **Zep** | **Supermemory** | **Engram** |
+|---|---|---|---|---|---|---|---|---|
+| **Language** | Rust (single binary) | Python (pip) | Python | TypeScript | Python | Python | TypeScript | Go (single binary) |
+| **Setup** | One binary (`curl \| sh`) | pip install + venv | pip + Docker + Qdrant | npm + Docker (iii-engine) | pip + Docker + Postgres | pip + Docker + Neo4j | Cloudflare Workers + Postgres | One binary |
+| **API keys** | ❌ None | ⚠️ For remote embeddings | ✅ OpenAI/LLM | ✅ LLM key | ✅ LLM key | ✅ LLM key | ⚠️ Cloudflare account | ❌ None |
+| **Works offline** | ✅ Fully | ⚠️ Optional | ❌ Cloud embedding | ❌ Needs LLM | ❌ Needs LLM | ❌ Needs LLM + vector DB | ⚠️ Self-hostable but needs infra | ✅ Fully |
+| **Search** | **Hybrid** (Vector + FTS5 + RRF) | sqlite-vec + FTS5 | Vector + Graph | Vector + Graph | Vector | Temporal Graph | Vector + rerank | **FTS5 only** |
+| **Recall speed** | ~45ms | ~50ms+ | Network round-trip | Network round-trip | Network round-trip | Network round-trip | Network round-trip | ~Fast (local) |
+| **Multi-agent** | ✅ Rooms (built-in collaboration) | ⚠️ Shared API | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Time-travel** | ✅ Native point-in-time | ⚠️ Temporal triples | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **MCP server** | ✅ JSON-RPC + HTTP | ✅ stdio + SSE | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Your data** | ✅ Never leaves machine | ✅ Local-first | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ⚠️ Cloudflare-hosted | ✅ Local |
+| **License** | Apache 2.0 | MIT | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 |
 
 > **Uteke vs Mnemosyne:** Both are local-first with semantic + FTS5 search. Mnemosyne is the closest competitor (~1.5K stars, Python). Uteke wins on **single binary** (no Python runtime), **rooms**, **time-travel queries**, and **zero runtime dependencies**.
 
 > **Uteke vs Engram:** Both are single-binary, offline, no-API-key tools. But Engram is **FTS5-only** (keyword search). Uteke adds **vector semantic search + RRF fusion + rooms + time-travel + graph relationships + smart decay + document engine + batch import**. Same simplicity thesis, 10× the features.
 
+> **Uteke vs Supermemory:** Supermemory (28K stars) markets itself as "run fully locally" but requires Cloudflare Workers + Postgres. Uteke is a true single binary with zero infrastructure. No Workers, no Postgres, no Cloudflare account.
+
 > **Uteke vs AgentMemory/Mem0/Letta/Zep:** Those are powerful — but all require cloud LLM API keys and Docker infrastructure. Your data goes to OpenAI/Anthropic. Uteke runs fully offline with local ONNX embeddings. No Docker, no Python, no API keys.
+
+<details>
+<summary>📊 Benchmark numbers</summary>
+
+| Metric | Result | Notes |
+|--------|--------|-------|
+| **Recall latency (10K memories)** | **42ms** P50, 50ms P95 | Flat from 100 to 10K memories (HNSW O(log N)) |
+| **Insert throughput** | 6-22 ops/s | CPU-bound (ONNX embedding inference) |
+| **Storage per memory** | ~10KB | SQLite + HNSW, scales linearly |
+| **LongMemEval Recall@5** | **0.958** | 12-question diverse sample, EmbeddingGemma Q4 |
+
+Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark details](docs/benchmarks.md) · [LongMemEval results](benchmarks/longmemeval/RESULTS.md)
+
+</details>
 
 <p align="center">
   <img src="docs/assets/uteke-comparison.png" alt="Uteke vs cloud alternatives" width="640" />
@@ -252,6 +268,12 @@ AgentMemory (25K stars) is a TypeScript/Node.js platform with 53 MCP tools and 1
 <summary><strong>How is Uteke different from Engram?</strong></summary>
 
 Engram (2.4K stars, Go) shares our philosophy: single binary, zero deps, MCP server, local-first. The key difference is **search**: Engram uses **FTS5 only** (keyword matching). Uteke uses **hybrid search** (HNSW vector similarity + FTS5 + Reciprocal Rank Fusion) — meaning you can search by *meaning*, not just exact words. Uteke also adds rooms, time-travel, graph relationships, smart decay, document engine, and batch import.
+</details>
+
+<details>
+<summary><strong>How is Uteke different from Supermemory?</strong></summary>
+
+Supermemory (28K stars, TypeScript) markets itself as local-first but requires Cloudflare Workers + Postgres to run. It is a web platform, not a single binary. Uteke is one binary with zero infrastructure: no Workers, no Postgres, no Cloudflare account. Uteke also adds rooms for multi-agent collaboration, time-travel queries, and hybrid search (vector + FTS5 + RRF fusion).
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ uteke remember "Deploy v2.1 to staging" \
 | **Cargo** | `cargo install uteke-cli` |
 | **Docker** | `docker run -d -p 127.0.0.1:8767:8767 -v uteke-data:/data ghcr.io/codecoradev/uteke:latest` |
 | **Binary** | [GitHub Releases](https://github.com/codecoradev/uteke/releases) (macOS, Linux, Windows) |
+| **Windows (PowerShell)** | `powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/codecoradev/uteke/main/install.ps1 | iex"` |
 
 📖 [Full install guide](INSTALL.md) · [Docker docs](docs/docker.md)
 </details>

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.11.0 with 431 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
+Uteke is at v0.12.0 with 432 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
 </details>
 
 ---

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.11.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.12.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -708,6 +708,30 @@ pub enum RoomCommands {
         /// Room ID
         room_id: String,
     },
+    /// Link a document to a room
+    AddDocument {
+        /// Room ID
+        room_id: String,
+        /// Document slug
+        doc_slug: String,
+    },
+    /// Unlink a document from a room
+    RemoveDocument {
+        /// Room ID
+        room_id: String,
+        /// Document slug
+        doc_slug: String,
+    },
+    /// List documents linked to a room
+    ListDocuments {
+        /// Room ID
+        room_id: String,
+    },
+    /// List rooms that reference a document
+    ListRooms {
+        /// Document slug
+        doc_slug: String,
+    },
 }
 
 /// Subcommands for memory aging operations.

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -247,5 +247,85 @@ pub(crate) fn run(
             }
             Ok(())
         }
+        RoomCommands::AddDocument { room_id, doc_slug } => {
+            uteke
+                .room_add_document(room_id, doc_slug)
+                .map_err(|e| format!("Failed to link document: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "room_id": room_id,
+                        "doc_slug": doc_slug,
+                        "linked": true
+                    })
+                );
+            } else {
+                println!("Linked document '{doc_slug}' to room '{room_id}'.");
+            }
+            Ok(())
+        }
+        RoomCommands::RemoveDocument { room_id, doc_slug } => {
+            uteke
+                .room_remove_document(room_id, doc_slug)
+                .map_err(|e| format!("Failed to unlink document: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "room_id": room_id,
+                        "doc_slug": doc_slug,
+                        "linked": false
+                    })
+                );
+            } else {
+                println!("Unlinked document '{doc_slug}' from room '{room_id}'.");
+            }
+            Ok(())
+        }
+        RoomCommands::ListDocuments { room_id } => {
+            let docs = uteke
+                .room_list_documents(room_id)
+                .map_err(|e| format!("Failed to list documents: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "room_id": room_id,
+                        "documents": docs
+                    })
+                );
+            } else if docs.is_empty() {
+                println!("No documents linked to room '{room_id}'.");
+            } else {
+                println!("Documents linked to room '{room_id}':");
+                for slug in &docs {
+                    println!("  • {slug}");
+                }
+            }
+            Ok(())
+        }
+        RoomCommands::ListRooms { doc_slug } => {
+            let rooms = uteke
+                .document_list_rooms(doc_slug)
+                .map_err(|e| format!("Failed to list rooms: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "doc_slug": doc_slug,
+                        "rooms": rooms
+                    })
+                );
+            } else if rooms.is_empty() {
+                println!("No rooms reference document '{doc_slug}'.");
+            } else {
+                println!("Rooms referencing document '{doc_slug}':");
+                for room_id in &rooms {
+                    println!("  • {room_id}");
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -558,6 +558,104 @@ impl Config {
             if recall.contains_key("jaccard_weight") {
                 self.recall.jaccard_weight = overlay.recall.jaccard_weight;
             }
+            if recall.contains_key("salience_weight") {
+                self.recall.salience_weight = overlay.recall.salience_weight;
+            }
+            if recall.contains_key("recency_weight") {
+                self.recall.recency_weight = overlay.recall.recency_weight;
+            }
+        }
+
+        // Merge embed_fallback section
+        if let Some(fb) = table.get("embed_fallback").and_then(|v| v.as_table()) {
+            if fb.contains_key("api_key") {
+                self.embed_fallback.api_key = overlay.embed_fallback.api_key.clone();
+            }
+            if fb.contains_key("base_url") {
+                self.embed_fallback.base_url = overlay.embed_fallback.base_url.clone();
+            }
+            if fb.contains_key("endpoint_path") {
+                self.embed_fallback.endpoint_path = overlay.embed_fallback.endpoint_path.clone();
+            }
+            if fb.contains_key("model") {
+                self.embed_fallback.model = overlay.embed_fallback.model.clone();
+            }
+        }
+
+        // Merge extraction section
+        if let Some(ext) = table.get("extraction").and_then(|v| v.as_table()) {
+            if ext.contains_key("model") {
+                self.extraction.model = overlay.extraction.model.clone();
+            }
+            if ext.contains_key("api_key") {
+                self.extraction.api_key = overlay.extraction.api_key.clone();
+            }
+            if ext.contains_key("base_url") {
+                self.extraction.base_url = overlay.extraction.base_url.clone();
+            }
+            if ext.contains_key("endpoint_path") {
+                self.extraction.endpoint_path = overlay.extraction.endpoint_path.clone();
+            }
+            if ext.contains_key("max_facts") {
+                self.extraction.max_facts = overlay.extraction.max_facts;
+            }
+        }
+
+        // Merge limits section
+        if let Some(limits) = table.get("limits").and_then(|v| v.as_table()) {
+            if limits.contains_key("max_content_length") {
+                self.limits.max_content_length = overlay.limits.max_content_length;
+            }
+            if limits.contains_key("max_tags_count") {
+                self.limits.max_tags_count = overlay.limits.max_tags_count;
+            }
+            if limits.contains_key("max_tag_length") {
+                self.limits.max_tag_length = overlay.limits.max_tag_length;
+            }
+            if limits.contains_key("max_payload_size") {
+                self.limits.max_payload_size = overlay.limits.max_payload_size;
+            }
+            if limits.contains_key("default_recall_limit") {
+                self.limits.default_recall_limit = overlay.limits.default_recall_limit;
+            }
+        }
+
+        // Merge maintenance section
+        if let Some(maint) = table.get("maintenance").and_then(|v| v.as_table()) {
+            if maint.contains_key("auto_aging_enabled") {
+                self.maintenance.auto_aging_enabled = overlay.maintenance.auto_aging_enabled;
+            }
+            if maint.contains_key("auto_aging_interval_hours") {
+                self.maintenance.auto_aging_interval_hours =
+                    overlay.maintenance.auto_aging_interval_hours;
+            }
+            if maint.contains_key("auto_dream_enabled") {
+                self.maintenance.auto_dream_enabled = overlay.maintenance.auto_dream_enabled;
+            }
+            if maint.contains_key("auto_dream_interval_days") {
+                self.maintenance.auto_dream_interval_days =
+                    overlay.maintenance.auto_dream_interval_days;
+            }
+        }
+
+        // Merge dream section
+        if let Some(dream) = table.get("dream").and_then(|v| v.as_table()) {
+            if dream.contains_key("contradict_similarity_threshold") {
+                self.dream.contradict_similarity_threshold =
+                    overlay.dream.contradict_similarity_threshold;
+            }
+            if dream.contains_key("contradict_tag_jaccard_min") {
+                self.dream.contradict_tag_jaccard_min = overlay.dream.contradict_tag_jaccard_min;
+            }
+            if dream.contains_key("contradict_max_memories") {
+                self.dream.contradict_max_memories = overlay.dream.contradict_max_memories;
+            }
+            if dream.contains_key("dedup_threshold") {
+                self.dream.dedup_threshold = overlay.dream.dedup_threshold;
+            }
+            if dream.contains_key("orphan_importance_threshold") {
+                self.dream.orphan_importance_threshold = overlay.dream.orphan_importance_threshold;
+            }
         }
 
         // Merge server section
@@ -1137,6 +1235,64 @@ model = "other-model"
             .clone()
             .merge_from_file(std::path::Path::new("/no/such/file.toml"));
         assert_eq!(merged.store.path, cfg.store.path);
+    }
+
+    #[test]
+    fn merge_all_sections_from_file() {
+        // Regression test for #856: verify all 12 sections are merged.
+        let base = Config::default();
+        let toml = r#"
+[recall]
+salience_weight = 0.25
+recency_weight = 0.20
+
+[embed_fallback]
+api_key = "sk-test"
+base_url = "https://embed.example.com"
+model = "text-embed"
+
+[extraction]
+model = "gpt-4o"
+max_facts = 30
+
+[limits]
+max_content_length = 50000
+default_recall_limit = 10
+
+[maintenance]
+auto_aging_enabled = true
+auto_aging_interval_hours = 12
+auto_dream_enabled = false
+
+[dream]
+dedup_threshold = 0.95
+orphan_importance_threshold = 0.10
+"#;
+        let tmp = std::env::temp_dir().join("uteke_test_merge_all.toml");
+        std::fs::write(&tmp, toml).unwrap();
+        let merged = base.merge_from_file(&tmp);
+        std::fs::remove_file(&tmp).ok();
+
+        // recall (salience/recency_weight were the original missing fields)
+        assert!((merged.recall.salience_weight - 0.25).abs() < f32::EPSILON);
+        assert!((merged.recall.recency_weight - 0.20).abs() < f32::EPSILON);
+        // embed_fallback
+        assert_eq!(merged.embed_fallback.api_key, "sk-test");
+        assert_eq!(merged.embed_fallback.base_url, "https://embed.example.com");
+        assert_eq!(merged.embed_fallback.model, "text-embed");
+        // extraction
+        assert_eq!(merged.extraction.model, "gpt-4o");
+        assert_eq!(merged.extraction.max_facts, 30);
+        // limits
+        assert_eq!(merged.limits.max_content_length, 50000);
+        assert_eq!(merged.limits.default_recall_limit, 10);
+        // maintenance
+        assert!(merged.maintenance.auto_aging_enabled);
+        assert_eq!(merged.maintenance.auto_aging_interval_hours, 12);
+        assert!(!merged.maintenance.auto_dream_enabled);
+        // dream
+        assert!((merged.dream.dedup_threshold - 0.95).abs() < f32::EPSILON);
+        assert!((merged.dream.orphan_importance_threshold - 0.10).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -909,6 +909,18 @@ impl Config {
 # graph_authority_weight = 0.1
 # graph_rerank_enabled = true
 # jaccard_weight = 0.0  # Post-RRF token overlap boost (#719). 0=off, 0.10-0.15 recommended
+# salience_weight = 0.0  # Post-RRF importance/pin boost. 0=off, 0.05-0.10 recommended
+# recency_weight = 0.0   # Post-RRF time-decay boost. 0=off, 0.05-0.10 recommended
+
+[embed_fallback]
+# Fallback when embedding model fails or is unavailable (#598)
+# enabled = true
+# strategy = "hash"  # hash | random | zero
+
+[extraction]
+# Content extraction settings for document chunking
+# max_chunk_size = 512
+# overlap = 50
 
 [server]
 # enabled = false

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -294,6 +294,14 @@ impl crate::Uteke {
             kept_ids.push(to_keep.clone());
             already_removed.insert(to_remove.clone());
         }
+        // Invalidate recall cache — deleted memories affect search results.
+        if !removed_ids.is_empty() {
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+        }
         Ok(crate::memory::types::ConsolidationResult {
             duplicates_found: pairs.len(),
             merged: removed_ids.len(),

--- a/crates/uteke-core/src/dream.rs
+++ b/crates/uteke-core/src/dream.rs
@@ -171,6 +171,15 @@ impl crate::Uteke {
             .filter(|r| r.status == PhaseStatus::Error)
             .count();
 
+        // Invalidate recall cache if any phase made changes.
+        if !dry_run && total_changes > 0 {
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+        }
+
         Ok(DreamReport {
             phases: results,
             total_changes,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1098,12 +1098,13 @@ impl Uteke {
             has_children: false,
         };
 
-        let doc_id = self.store.upsert_document(&doc)?;
-
-        // Delete old chunks on update (re-chunking).
+        // Capture old chunk IDs BEFORE upsert (upsert_document deletes chunks
+        // internally as part of its transaction, so querying after returns empty).
         let old_chunk_ids = self
             .store
-            .delete_chunks_for_documents(std::slice::from_ref(&doc_id))?;
+            .get_chunk_ids_for_documents(std::slice::from_ref(&doc.id))?;
+
+        let doc_id = self.store.upsert_document(&doc)?;
 
         // Chunk and embed the content.
         self.ensure_embedder()?;

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -821,17 +821,29 @@ impl Uteke {
 
     /// Pin a memory so it never decays.
     pub fn pin(&self, id: &str) -> Result<bool, Error> {
-        self.store.pin(id)
+        let pinned = self.store.pin(id)?;
+        if pinned {
+            self.invalidate_cache_for_id(id);
+        }
+        Ok(pinned)
     }
 
     /// Unpin a memory.
     pub fn unpin(&self, id: &str) -> Result<bool, Error> {
-        self.store.unpin(id)
+        let unpinned = self.store.unpin(id)?;
+        if unpinned {
+            self.invalidate_cache_for_id(id);
+        }
+        Ok(unpinned)
     }
 
     /// Set a memory's importance score directly (0.0-1.0).
     pub fn set_importance(&self, id: &str, importance: f64) -> Result<bool, Error> {
-        self.store.set_importance(id, importance)
+        let updated = self.store.set_importance(id, importance)?;
+        if updated {
+            self.invalidate_cache_for_id(id);
+        }
+        Ok(updated)
     }
 
     /// Record positive feedback: boost importance (#718).
@@ -867,7 +879,27 @@ impl Uteke {
 
         let new_importance = (current + delta).clamp(0.0, 1.0);
         self.store.set_importance(id, new_importance)?;
+        // Invalidate cache — importance affects ranking.
+        self.invalidate_cache_for_id(id);
         Ok(new_importance)
+    }
+
+    /// Invalidate recall cache for a specific memory's namespace.
+    ///
+    /// Helper for single-memory mutations (pin, unpin, set_importance,
+    /// feedback) where we need to look up the namespace before flushing.
+    fn invalidate_cache_for_id(&self, id: &str) {
+        match self.store.get_by_id(id) {
+            Ok(Some(memory)) => self.recall_cache.invalidate_namespace(&memory.namespace),
+            Ok(None) => {
+                // Memory not found — flush all as safety measure.
+                self.recall_cache.clear();
+            }
+            Err(e) => {
+                tracing::warn!("Failed to look up namespace for cache invalidation ({id}): {e}");
+                self.recall_cache.clear();
+            }
+        }
     }
 
     /// Set source provenance on a memory (#348).
@@ -882,7 +914,12 @@ impl Uteke {
 
     /// Recalculate importance scores for all memories.
     pub fn recompute_importance(&self) -> Result<usize, Error> {
-        self.store.recompute_importance()
+        let updated = self.store.recompute_importance()?;
+        if updated > 0 {
+            // Importance affects ranking — flush all cached results.
+            self.recall_cache.clear();
+        }
+        Ok(updated)
     }
 
     /// Get a reference to the raw connection for graph operations.

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -794,6 +794,18 @@ impl super::Store {
         } else {
             format!("{}/%", path)
         };
+
+        // Collect all descendant document IDs (including self) for junction cleanup.
+        // Clean up room_documents junction entries BEFORE deleting the documents
+        // (so the subquery SELECT slug FROM documents still has rows to match).
+        self.conn
+            .execute(
+                "DELETE FROM room_documents WHERE doc_slug IN \
+                 (SELECT slug FROM documents WHERE id = ?1 OR path LIKE ?2)",
+                params![id, &cascade_prefix],
+            )
+            .map_err(|e| Error::db("cleanup room_documents junction on doc delete", e))?;
+
         let n = self
             .conn
             .execute(

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -898,6 +898,33 @@ impl super::Store {
 
     /// Delete chunks belonging to a set of document IDs.
     ///
+    /// Get chunk IDs for a list of document IDs, WITHOUT deleting them.
+    /// Used to capture old chunk IDs before an upsert that deletes chunks internally.
+    pub fn get_chunk_ids_for_documents(&self, doc_ids: &[String]) -> Result<Vec<String>, Error> {
+        if doc_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = doc_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT id FROM document_chunks WHERE document_id IN ({})",
+            placeholders
+        );
+        let params: Vec<&dyn rusqlite::types::ToSql> = doc_ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::db("prepare select chunk ids (no-delete)", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params.as_slice(), |row| row.get::<_, String>(0))
+            .map_err(|e| Error::db("select chunk ids (no-delete)", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
     /// Used during document update to clear old chunks before re-chunking.
     /// Returns the IDs of deleted chunks (for usearch cleanup).
     pub fn delete_chunks_for_documents(&self, doc_ids: &[String]) -> Result<Vec<String>, Error> {

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -287,35 +287,69 @@ impl super::Store {
             )
             .map_err(|e| Error::db("check documents_fts exists (#549)", e))?;
 
-        if !exists {
-            tracing::warn!(
-                "documents_fts table missing on schema v{} DB — creating (#549)",
-                version
-            );
-            // Create FTS5 table.
+        // Check if FTS table has the `content` column (#860).
+        // Old schema only indexed title+slug; new schema also indexes content body.
+        let needs_content_upgrade = if exists {
+            let cols: Vec<String> = self
+                .conn
+                .prepare("SELECT name FROM pragma_table_info('documents_fts')")
+                .map_err(|e| Error::db("check documents_fts columns (#860)", e))?
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|e| Error::db("query documents_fts columns (#860)", e))?
+                .filter_map(|r| r.ok())
+                .collect();
+            !cols.iter().any(|c| c == "content")
+        } else {
+            false
+        };
+
+        if needs_content_upgrade {
+            tracing::info!("Upgrading documents_fts to include content column (#860)");
+            // Drop old triggers, FTS table, then recreate with content column.
             self.conn
                 .execute_batch(
-                    "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content='documents', content_rowid='rowid')",
+                    "DROP TRIGGER IF EXISTS documents_fts_insert;
+                     DROP TRIGGER IF EXISTS documents_fts_update;
+                     DROP TRIGGER IF EXISTS documents_fts_delete;
+                     DROP TABLE IF EXISTS documents_fts;",
                 )
-                .map_err(|e| Error::db("create documents_fts (#549)", e))?;
-
-            // Create sync triggers.
-            self.conn.execute_batch(
-                "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN                  INSERT INTO documents_fts(rowid, title, slug) VALUES (new.rowid, new.title, new.slug); END;                  CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN                  UPDATE documents_fts SET title = new.title, slug = new.slug WHERE rowid = new.rowid; END;                  CREATE TRIGGER IF NOT EXISTS documents_fts_delete AFTER DELETE ON documents BEGIN                  DELETE FROM documents_fts WHERE rowid = old.rowid; END;",
-            ).map_err(|e| Error::db("create documents_fts triggers (#549)", e))?;
-
-            // Backfill existing documents into FTS index.
-            self.conn
-                .execute_batch(
-                    "INSERT INTO documents_fts(rowid, title, slug)                      SELECT rowid, title, slug FROM documents",
-                )
-                .map_err(|e| Error::db("backfill documents_fts (#549)", e))?;
-
-            tracing::info!(
-                "documents_fts table created and backfilled from existing documents (#549)"
-            );
+                .map_err(|e| Error::db("drop old documents_fts (#860)", e))?;
+            // Force recreation below.
+            return self.ensure_documents_fts_create();
         }
 
+        if !exists {
+            return self.ensure_documents_fts_create();
+        }
+
+        Ok(())
+    }
+
+    fn ensure_documents_fts_create(&self) -> Result<(), Error> {
+        // Create FTS5 table with title, slug, AND content columns (#860).
+        self.conn
+            .execute_batch(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content, content='documents', content_rowid='rowid')",
+            )
+            .map_err(|e| Error::db("create documents_fts (#860)", e))?;
+
+        // Create sync triggers — include content body.
+        self.conn
+            .execute_batch(
+                "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN INSERT INTO documents_fts(rowid, title, slug, content) VALUES (new.rowid, new.title, new.slug, new.content); END;
+                 CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN UPDATE documents_fts SET title = new.title, slug = new.slug, content = new.content WHERE rowid = new.rowid; END;
+                 CREATE TRIGGER IF NOT EXISTS documents_fts_delete AFTER DELETE ON documents BEGIN DELETE FROM documents_fts WHERE rowid = old.rowid; END;",
+            )
+            .map_err(|e| Error::db("create documents_fts triggers (#860)", e))?;
+
+        // Backfill existing documents into FTS index.
+        self.conn
+            .execute_batch(
+                "INSERT INTO documents_fts(rowid, title, slug, content) SELECT rowid, title, slug, content FROM documents",
+            )
+            .map_err(|e| Error::db("backfill documents_fts (#860)", e))?;
+
+        tracing::info!("documents_fts table created and backfilled from existing documents (#860)");
         Ok(())
     }
 
@@ -834,13 +868,13 @@ impl super::Store {
             let _ = self.conn.execute(idx, []);
         }
 
-        // FTS5 virtual table for documents (title + slug search).
+        // FTS5 virtual table for documents (title + slug + content search).
         // Best-effort: skip if FTS5 is not available (e.g., custom SQLite builds).
         let fts = [
-            "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content='documents', content_rowid='rowid')",
+            "CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, slug, content, content='documents', content_rowid='rowid')",
             // Triggers to keep FTS in sync with documents table.
-            "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN INSERT INTO documents_fts(rowid, title, slug) VALUES (new.rowid, new.title, new.slug); END",
-            "CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN UPDATE documents_fts SET title = new.title, slug = new.slug WHERE rowid = new.rowid; END",
+            "CREATE TRIGGER IF NOT EXISTS documents_fts_insert AFTER INSERT ON documents BEGIN INSERT INTO documents_fts(rowid, title, slug, content) VALUES (new.rowid, new.title, new.slug, new.content); END",
+            "CREATE TRIGGER IF NOT EXISTS documents_fts_update AFTER UPDATE ON documents BEGIN UPDATE documents_fts SET title = new.title, slug = new.slug, content = new.content WHERE rowid = new.rowid; END",
             "CREATE TRIGGER IF NOT EXISTS documents_fts_delete AFTER DELETE ON documents BEGIN DELETE FROM documents_fts WHERE rowid = old.rowid; END",
         ];
         for sql in &fts {

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1091,7 +1091,18 @@ impl crate::Uteke {
 
     /// Delete a tag from all memories in a namespace.
     pub fn delete_tag(&self, tag: &str, namespace: Option<&str>) -> Result<usize, Error> {
-        self.store.delete_tag(tag, namespace)
+        let deleted = self.store.delete_tag(tag, namespace)?;
+        if deleted > 0 {
+            // Invalidate recall cache to prevent stale search results (#844).
+            // If namespace is specified, invalidate only that namespace.
+            // Cross-namespace delete requires full cache flush.
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+        }
+        Ok(deleted)
     }
 
     /// Count memories by tag in a namespace.

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -695,15 +695,10 @@ impl crate::Uteke {
             }
         };
 
-        // Pre-compute min-max normalization of BM25 ranks.
-        // BM25 rank: negative values, more negative = more relevant.
-        // Normalize to 0.0..1.0 so min_score filter is meaningful.
-        let ranks: Vec<f64> = fts_results.iter().map(|(_, r)| *r).collect();
-        let best = ranks.iter().copied().fold(f64::INFINITY, f64::min); // most negative
-        let worst = ranks.iter().copied().fold(f64::NEG_INFINITY, f64::max); // least negative
-        let range = best - worst;
-
-        let results: Vec<SearchResult> = fts_results
+        // Filter first, then normalize — otherwise the range is computed
+        // from items that get filtered out (e.g. namespace mismatch),
+        // producing skewed scores (#854 cora review).
+        let filtered: Vec<(Memory, f64)> = fts_results
             .into_iter()
             .filter(|(memory, _)| {
                 // Namespace filter (None = ALL, #448)
@@ -723,10 +718,23 @@ impl crate::Uteke {
                 }
                 true
             })
+            .collect();
+
+        // Compute min-max from SURVIVING results only.
+        // BM25 rank: negative values, more negative = more relevant.
+        let best = filtered
+            .iter()
+            .map(|(_, r)| *r)
+            .fold(f64::INFINITY, f64::min);
+        let worst = filtered
+            .iter()
+            .map(|(_, r)| *r)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let range = best - worst;
+
+        let results: Vec<SearchResult> = filtered
+            .into_iter()
             .map(|(memory, rank)| {
-                // Convert FTS5 BM25 rank to 0..1 score via min-max normalization.
-                // BM25 returns negative values (more negative = better match).
-                // After normalization: best match = 1.0, worst match = 0.0.
                 let score = if range.abs() < f64::EPSILON {
                     1.0f32 // single result or all same rank
                 } else {

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -695,6 +695,14 @@ impl crate::Uteke {
             }
         };
 
+        // Pre-compute min-max normalization of BM25 ranks.
+        // BM25 rank: negative values, more negative = more relevant.
+        // Normalize to 0.0..1.0 so min_score filter is meaningful.
+        let ranks: Vec<f64> = fts_results.iter().map(|(_, r)| *r).collect();
+        let best = ranks.iter().copied().fold(f64::INFINITY, f64::min); // most negative
+        let worst = ranks.iter().copied().fold(f64::NEG_INFINITY, f64::max); // least negative
+        let range = best - worst;
+
         let results: Vec<SearchResult> = fts_results
             .into_iter()
             .filter(|(memory, _)| {
@@ -715,13 +723,15 @@ impl crate::Uteke {
                 }
                 true
             })
-            .map(|(memory, _rank)| {
-                // Convert FTS5 BM25 rank to 0..1 score.
-                // BM25 returns negative values (more negative = worse relevance).
-                // We use rank-based scoring instead of raw BM25 since
-                // BM25 magnitudes vary by query and aren't normalized.
-                // Score is assigned by position in the result list.
-                let score = 1.0f32; // Placeholder — actual ranking done by RRF in hybrid
+            .map(|(memory, rank)| {
+                // Convert FTS5 BM25 rank to 0..1 score via min-max normalization.
+                // BM25 returns negative values (more negative = better match).
+                // After normalization: best match = 1.0, worst match = 0.0.
+                let score = if range.abs() < f64::EPSILON {
+                    1.0f32 // single result or all same rank
+                } else {
+                    (((rank - worst) / range).clamp(0.0, 1.0)) as f32
+                };
                 SearchResult { memory, score }
             })
             .take(limit)
@@ -1086,7 +1096,17 @@ impl crate::Uteke {
         new: &str,
         namespace: Option<&str>,
     ) -> Result<usize, Error> {
-        self.store.rename_tag(old, new, namespace)
+        let renamed = self.store.rename_tag(old, new, namespace)?;
+        if renamed > 0 {
+            // Invalidate recall cache — tag filters may reference the old
+            // tag name, so cached results are now stale (#849).
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+        }
+        Ok(renamed)
     }
 
     /// Delete a tag from all memories in a namespace.

--- a/crates/uteke-core/src/recall_cache.rs
+++ b/crates/uteke-core/src/recall_cache.rs
@@ -137,10 +137,15 @@ impl RecallCache {
         }
     }
 
-    /// Invalidate all cached entries for a namespace (e.g., after remember/forget).
+    /// Invalidate cached entries for a namespace (e.g., after remember/forget).
+    ///
+    /// Also flushes "all" entries because namespace-scoped mutations affect
+    /// cross-namespace queries. Without this, `recall(namespace=None)` would
+    /// return stale results after a `remember` or `forget` in a specific
+    /// namespace (#849).
     pub fn invalidate_namespace(&self, namespace: &str) {
         if let Ok(mut entries) = self.entries.lock() {
-            entries.retain(|k, _| k.namespace != namespace);
+            entries.retain(|k, _| k.namespace != namespace && k.namespace != "all");
         }
     }
 

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.11.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.12.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -207,7 +207,9 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_room_memories" => exec_room_memories(uteke, &arguments)?,
                 "uteke_room_stats" => exec_room_stats(uteke, &arguments)?,
                 "uteke_room_summary" => exec_room_summary(uteke, &arguments)?,
-                "uteke_room_document" => exec_room_document(uteke, &arguments)?,
+                "uteke_room_summary_document" | "uteke_room_document" => {
+                    exec_room_document(uteke, &arguments)?
+                }
                 "uteke_tags_list" => exec_tags_list(uteke, &arguments)?,
                 "uteke_tags_rename" => exec_tags_rename(uteke, &arguments)?,
                 "uteke_tags_delete" => exec_tags_delete(uteke, &arguments)?,
@@ -579,7 +581,7 @@ fn tool_room_summary() -> Value {
 
 fn tool_room_document() -> Value {
     serde_json::json!({
-        "name": "uteke_room_document",
+        "name": "uteke_room_summary_document",
         "description": "Generate a structured document from room memories, grouped by memory type (decisions, facts, procedures, preferences, etc.). Useful for producing meeting minutes or decision records.",
         "inputSchema": {
             "type": "object",

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -165,6 +165,10 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_room_stats(),
                 tool_room_summary(),
                 tool_room_document(),
+                tool_room_add_document(),
+                tool_room_remove_document(),
+                tool_room_list_documents(),
+                tool_doc_list_rooms(),
                 tool_tags_list(),
                 tool_tags_rename(),
                 tool_tags_delete(),
@@ -210,6 +214,10 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_room_summary_document" | "uteke_room_document" => {
                     exec_room_document(uteke, &arguments)?
                 }
+                "uteke_room_add_document" => exec_room_add_document(uteke, &arguments)?,
+                "uteke_room_remove_document" => exec_room_remove_document(uteke, &arguments)?,
+                "uteke_room_list_documents" => exec_room_list_documents(uteke, &arguments)?,
+                "uteke_doc_list_rooms" => exec_doc_list_rooms(uteke, &arguments)?,
                 "uteke_tags_list" => exec_tags_list(uteke, &arguments)?,
                 "uteke_tags_rename" => exec_tags_rename(uteke, &arguments)?,
                 "uteke_tags_delete" => exec_tags_delete(uteke, &arguments)?,
@@ -589,6 +597,64 @@ fn tool_room_document() -> Value {
                 "room_id": { "type": "string", "description": "Room identifier" }
             },
             "required": ["room_id"]
+        }
+    })
+}
+
+fn tool_room_add_document() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_add_document",
+        "description": "Link a document to a room. The document must already exist (use uteke_doc_upsert first).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "doc_slug": { "type": "string", "description": "Document slug to link" }
+            },
+            "required": ["room_id", "doc_slug"]
+        }
+    })
+}
+
+fn tool_room_remove_document() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_remove_document",
+        "description": "Unlink a document from a room. Does not delete the document itself.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "doc_slug": { "type": "string", "description": "Document slug to unlink" }
+            },
+            "required": ["room_id", "doc_slug"]
+        }
+    })
+}
+
+fn tool_room_list_documents() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_list_documents",
+        "description": "List all document slugs linked to a room.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" }
+            },
+            "required": ["room_id"]
+        }
+    })
+}
+
+fn tool_doc_list_rooms() -> Value {
+    serde_json::json!({
+        "name": "uteke_doc_list_rooms",
+        "description": "List all rooms that reference a specific document.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "doc_slug": { "type": "string", "description": "Document slug to look up" }
+            },
+            "required": ["doc_slug"]
         }
     })
 }
@@ -1599,6 +1665,99 @@ fn exec_room_document(uteke: &Uteke, args: &Value) -> Result<ToolResult, String>
         content: vec![McpContent::Text {
             r#type: "text".to_string(),
             text: lines.join("\n"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_add_document(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let doc_slug = args["doc_slug"].as_str().ok_or("Missing 'doc_slug'")?;
+
+    uteke
+        .room_add_document(room_id, doc_slug)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("Linked document '{doc_slug}' to room '{room_id}'."),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_remove_document(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let doc_slug = args["doc_slug"].as_str().ok_or("Missing 'doc_slug'")?;
+
+    uteke
+        .room_remove_document(room_id, doc_slug)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("Unlinked document '{doc_slug}' from room '{room_id}'."),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_list_documents(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+
+    let docs = uteke
+        .room_list_documents(room_id)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let text = if docs.is_empty() {
+        format!("No documents linked to room '{room_id}'.")
+    } else {
+        format!(
+            "Documents linked to room '{}':\n{}",
+            room_id,
+            docs.iter()
+                .map(|s| format!("  • {s}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_doc_list_rooms(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let doc_slug = args["doc_slug"].as_str().ok_or("Missing 'doc_slug'")?;
+
+    let rooms = uteke
+        .document_list_rooms(doc_slug)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let text = if rooms.is_empty() {
+        format!("No rooms reference document '{doc_slug}'.")
+    } else {
+        format!(
+            "Rooms referencing document '{}':\n{}",
+            doc_slug,
+            rooms
+                .iter()
+                .map(|s| format!("  • {s}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
         }],
         is_error: false,
     })

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -61,8 +61,12 @@ fn main() {
         // Delegate to the shared handler (#381).
         // None = notification (no response per JSON-RPC 2.0 §4.1).
         if let Some(response) = uteke_mcp::handle_jsonrpc(&uteke, &line) {
-            let _ = writeln!(stdout, "{response}");
-            let _ = stdout.flush();
+            // Detect broken pipe: if the parent process has disconnected,
+            // writes to stdout will fail. Exit cleanly instead of hanging (#843).
+            if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
+                eprintln!("stdout write failed — parent process disconnected. Exiting.");
+                break;
+            }
         }
     }
 }

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.11.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.11.0" }
+uteke-core = { path = "../uteke-core", version = "0.12.0", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.12.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -448,10 +448,17 @@ fn main() {
         });
     }
 
-    // Graceful shutdown
-    info!("Saving index and closing DB...");
-    if let Err(e) = uteke.lock().expect("shutdown lock").shutdown() {
-        error!("Shutdown error: {e}");
+    // Graceful shutdown — save dirty index to disk.
+    // Handle poisoned mutex gracefully instead of panicking (#845).
+    match uteke.lock() {
+        Ok(u) => {
+            if let Err(e) = u.shutdown() {
+                error!("Shutdown error: {e}");
+            }
+        }
+        Err(_) => {
+            error!("Shutdown: mutex poisoned, forcing exit without index save");
+        }
     }
 
     info!("Goodbye.");

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -355,6 +355,18 @@ uteke room remove "project-kickoff" <memory-id>
 
 # Delete room
 uteke room delete "project-kickoff"
+
+# Link a document to a room (#859)
+uteke room add-document "project-kickoff" --slug "architecture-spec"
+
+# Unlink a document from a room (#859)
+uteke room remove-document "project-kickoff" --slug "architecture-spec"
+
+# List documents linked to a room (#859)
+uteke room list-documents "project-kickoff"
+
+# List rooms that reference a document (#859)
+uteke room list-rooms --slug "architecture-spec"
 ```
 
 ## uteke bench

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -265,7 +265,7 @@ Both transports expose the same tools (MCP protocol version `2025-06-18`):
 | `uteke_room_delete` | Delete a room |
 | `uteke_room_stats` | Room statistics |
 | `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
-| `uteke_room_document` | Generate summary document from room (→ `POST /room/summary-document`) |
+| `uteke_room_summary_document` | Generate summary document from room (→ `POST /room/summary-document`) |
 | `uteke_tags_list` | List all tags with counts (#566) |
 | `uteke_tags_rename` | Rename a tag across all memories (#566) |
 | `uteke_tags_delete` | Delete a tag from all memories (#566) |

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -94,7 +94,7 @@ uteke(action="room_create", room_id="sprint-planning", title="Sprint Planning")
 uteke(action="room_remember", room_id="sprint-planning", content="Deploy scheduled for Friday", author="agent1")
 
 # Add a reference document to a room
-uteke(action="room_document", room_id="sprint-planning", content="Architecture spec: ...", title="Arch Spec")
+uteke(action="room_summary_document", room_id="sprint-planning", content="Architecture spec: ...", title="Arch Spec")
 
 # Recall from a room (semantic search — query is required)
 uteke(action="room_recall", room_id="sprint-planning", content="deploy deadline")
@@ -214,7 +214,7 @@ hermes mcp add uteke --command uteke-mcp
 | `forget` | Delete memory |
 | `stats` | Namespace or global statistics |
 | `room_remember` | Store memory in a room with author attribution |
-| `room_document` | Store a reference document in a room |
+| `room_summary_document` | Store a reference document in a room |
 | `room_create` | Create a room |
 | `room_recall` | Semantic search within a room (requires `query`) |
 | `room_list` | List all rooms (cross-namespace) |
@@ -234,7 +234,7 @@ hermes mcp add uteke --command uteke-mcp
 
 ## Valid Memory Types
 
-When using `remember`, `room_remember`, or `room_document`, the `type` parameter accepts these values:
+When using `remember`, `room_remember`, or `room_summary_document`, the `type` parameter accepts these values:
 
 | Type | Description |
 |------|-------------|

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -160,7 +160,11 @@ Both transports expose the same 29 tools (MCP protocol version `2025-06-18`):
 | `uteke_room_delete` | Delete a room |
 | `uteke_room_stats` | Room statistics |
 | `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
-| `uteke_room_document` | Generate summary document from room (→ `POST /room/summary-document`) |
+| `uteke_room_summary_document` | Generate summary document from room (→ `POST /room/summary-document`) |
+| `uteke_room_add_document` | Link an existing document to a room (#859) |
+| `uteke_room_remove_document` | Unlink a document from a room (#859) |
+| `uteke_room_list_documents` | List documents linked to a room (#859) |
+| `uteke_doc_list_rooms` | List rooms that reference a document (#859) |
 | `uteke_tags_list` | List all tags with counts (#566) |
 | `uteke_tags_rename` | Rename a tag across all memories (#566) |
 | `uteke_tags_delete` | Delete a tag from all memories (#566) |

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,223 @@
+<# 
+.SYNOPSIS
+    Uteke Windows installer — installs uteke CLI, server, and MCP binaries
+.DESCRIPTION
+    Downloads and installs the latest uteke release for Windows x64 from GitHub.
+    Usage: Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; irm https://raw.githubusercontent.com/codecoradev/uteke/main/install.ps1 | iex
+    Or:    powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/codecoradev/uteke/main/install.ps1 | iex"
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Version = "",
+    
+    [Parameter()]
+    [string]$InstallDir = "$env:USERPROFILE\.local\bin",
+    
+    [Parameter()]
+    [switch]$NoPathUpdate
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Info { param([string]$msg) Write-Host "[INFO] $msg" -ForegroundColor Green }
+function Write-Warn { param([string]$msg) Write-Host "[WARN] $msg" -ForegroundColor Yellow }
+function Write-ErrorMsg { param([string]$msg) Write-Host "[ERROR] $msg" -ForegroundColor Red; exit 1 }
+
+$REPO = "codecoradev/uteke"
+$BINARIES = @("uteke.exe", "uteke-serve.exe", "uteke-mcp.exe")
+
+# Use gh token for authenticated API requests if available
+$env:GH_TOKEN = $env:GH_TOKEN
+if (-not $env:GH_TOKEN) {
+    try { $env:GH_TOKEN = gh auth token 2>$null } catch {}
+}
+
+function Invoke-GitHubApi {
+    param([string]$Uri)
+    $params = @{ Uri = $Uri; UseBasicParsing = $true }
+    if ($env:GH_TOKEN) {
+        $params.Headers = @{ Authorization = "Bearer $env:GH_TOKEN" }
+    }
+    return Invoke-WebRequest @params
+}
+
+# Detect architecture
+$ARCH = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE")
+if ($ARCH -eq "AMD64" -or $ARCH -eq "x86_64") {
+    $TARGET = "x86_64-pc-windows-msvc"
+    $ARTIFACT = "uteke-x86_64-pc-windows-msvc"
+} elseif ($ARCH -eq "ARM64") {
+    Write-ErrorMsg "ARM64 Windows builds not yet published. Install via cargo: cargo install --path crates/uteke-cli"
+} else {
+    Write-ErrorMsg "Unsupported architecture: $ARCH"
+}
+
+# Get latest version from GitHub
+function Get-LatestVersion {
+    Write-Info "Fetching latest release from GitHub..."
+    try {
+        $apiUrl = "https://api.github.com/repos/$REPO/releases?per_page=30"
+        $response = Invoke-GitHubApi -Uri $apiUrl
+        $releases = $response.Content | ConvertFrom-Json
+        foreach ($release in $releases) {
+            if ($release.assets.Count -gt 0) {
+                foreach ($asset in $release.assets) {
+                    if ($asset.name -like "*x86_64-pc-windows-msvc*") {
+                        Write-Info "Found version: $($release.tag_name)"
+                        return $release.tag_name
+                    }
+                }
+            }
+        }
+        Write-ErrorMsg "No release with Windows binary found on GitHub."
+    } catch {
+        Write-Warn "GitHub API failed: $($_.Exception.Message)"
+        Write-ErrorMsg "Failed to get latest version. Set -Version v0.10.0 to pin a version."
+    }
+}
+
+# Download and verify
+function Install-Uteke {
+    param([string]$Version)
+    
+    Write-Info "Detected: Windows $ARCH"
+    Write-Info "Target: $TARGET"
+    Write-Info "Version: $Version"
+    
+    $archiveName = "${ARTIFACT}-${Version}.zip"
+    $downloadUrl = "https://github.com/$REPO/releases/download/$Version/$archiveName"
+    $checksumsUrl = "https://github.com/$REPO/releases/download/$Version/checksums-sha256.txt"
+    
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $archivePath = Join-Path $tempDir $archiveName
+    $checksumPath = Join-Path $tempDir "checksums-sha256.txt"
+    $extractDir = Join-Path $tempDir "uteke-extract"
+    
+    Write-Info "Downloading from: $downloadUrl"
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -ErrorAction Stop
+    } catch {
+        Write-ErrorMsg "Failed to download $archiveName. Check version exists: https://github.com/$REPO/releases/tag/$Version"
+    }
+    
+    # Download and verify checksum
+    Write-Info "Downloading checksums..."
+    try {
+        Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumPath -ErrorAction Stop
+        $checksums = Get-Content $checksumPath -Raw
+        # Split on whitespace (handles both spaces and tabs)
+        $expectedHash = ($checksums -split "`n" | Where-Object { $_ -like "*$archiveName*" } | ForEach-Object { $_ -split '\s+' })[0]
+        if ($expectedHash) {
+            Write-Info "Verifying SHA256 checksum..."
+            $actualHash = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLower()
+            if ($actualHash -ne $expectedHash.ToLower()) {
+                Write-ErrorMsg "Checksum mismatch! Expected: $expectedHash, Got: $actualHash"
+            }
+            Write-Info "Checksum verified: $expectedHash"
+        } else {
+            Write-Warn "Checksum for $archiveName not found in checksums file"
+        }
+    } catch {
+        Write-Warn "Failed to download/verify checksums - skipping verification"
+    }
+    
+    # Extract
+    Write-Info "Extracting..."
+    if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
+    New-Item -ItemType Directory -Path $extractDir | Out-Null
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+    
+    # Install binaries
+    Write-Info "Installing to $InstallDir..."
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    
+    foreach ($binary in $BINARIES) {
+        $src = Join-Path $extractDir $binary
+        $dest = Join-Path $InstallDir $binary
+        if (Test-Path $src) {
+            Copy-Item $src $dest -Force
+            Write-Info "Installed $binary"
+        } else {
+            Write-Warn "$binary not found in archive"
+        }
+    }
+    
+    # Cleanup
+    Remove-Item $archivePath -Force -ErrorAction SilentlyContinue
+    Remove-Item $checksumPath -Force -ErrorAction SilentlyContinue
+    Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Update PATH
+function Update-Path {
+    param([string]$InstallDir)
+    
+    if ($NoPathUpdate) {
+        Write-Warn 'Skipping PATH update (--NoPathUpdate specified)'
+        return
+    }
+    
+    $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($currentPath -split ";" | Where-Object { $_ -eq $InstallDir }) {
+        Write-Info "$InstallDir already in user PATH"
+        return
+    }
+    
+    Write-Info "Adding $InstallDir to user PATH..."
+    $newPath = $currentPath + ";" + $InstallDir
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Warn "PATH updated. Restart your terminal or run: `$env:PATH = [Environment]::GetEnvironmentVariable('Path','User')"
+}
+
+# Verify installation
+function Verify-Install {
+    param([string]$InstallDir)
+    
+    Write-Info "Verifying installation..."
+    $versionFlags = @{
+        "uteke.exe" = "--version"
+        "uteke-serve.exe" = "--help"
+        "uteke-mcp.exe" = "--help"
+    }
+    foreach ($binary in $BINARIES) {
+        $path = Join-Path $InstallDir $binary
+        if (Test-Path $path) {
+            try {
+                $flag = $versionFlags[$binary]
+                $version = & $path $flag 2>&1 | Select-Object -First 1
+                Write-Info ("  {0}: {1}" -f $binary, $version)
+            } catch {
+                Write-Info ("  {0}: installed" -f $binary)
+            }
+        } else {
+            Write-Warn ("  {0}: NOT FOUND" -f $binary)
+        }
+    }
+}
+
+# Main
+Write-Info "Installing uteke..."
+
+if ($Version) {
+    Write-Info "Using pinned version: $Version"
+} else {
+    $Version = Get-LatestVersion
+    if (-not $Version) { Write-ErrorMsg "Could not determine version" }
+}
+
+Install-Uteke -Version $Version
+Update-Path -InstallDir $InstallDir
+Verify-Install -InstallDir $InstallDir
+
+Write-Host ""
+Write-Info "Installation complete!"
+Write-Host "Run 'uteke --help' to get started." -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Quick start:" -ForegroundColor Cyan
+Write-Host "  uteke remember \"Deploy v2.1 to staging at 3pm\""
+Write-Host "  uteke recall \"when do we deploy?\""
+Write-Host ""
+Write-Host "MCP Server (for AI agents):" -ForegroundColor Cyan
+Write-Host "  uteke-mcp"


### PR DESCRIPTION
## What

Release v0.12.0 — merge to main for tagging.

### Changes since v0.11.0

**Bug Fixes (5):**
- #863 Config merge now includes all 12 sections (#856)
- #864 Prevent usearch index orphaned entries on doc upsert (#857)
- #865 Clean up room_documents junction on document delete (#858)
- #868 Complete default config template (#862)
- #867 Rename confusing MCP tool `uteke_room_document` → `uteke_room_summary_document` (#861)

**Features (1):**
- #866 Room↔Document junction tools in MCP + CLI (#859)

**Enhancements (1):**
- #869 FTS5 indexes document content body, not just title+slug (#860)

**Other:**
- #854 #855 Recall cache invalidation + FTS5 scoring
- #846 delete_tag cache invalidation + graceful shutdown
- #847 Supermemory comparison + benchmarks in README
- #848 MCP ghost process fix (#843)
- #850-#853 Dependency bumps (toml, clap, clap_complete, serde)
- #871 Version bump to 0.12.0
- #872 Documentation updates

### Issues Closed
#843 #844 #845 #856 #857 #858 #859 #860 #861 #862

### Contributors
- [@ajianaz](https://github.com/ajianaz) — all fixes, features, and enhancements
- [@dependabot](https://github.com/dependabot) — dependency updates (#850 #851 #852 #853)

## Why

v0.12.0 ships 4 new junction tools (MCP + CLI), full-text search inside document content, and fixes 5 bugs — including 2 silent data corruption issues (usearch orphans, dangling junction rows) and 1 config merge bug that silently ignored user settings.

## Testing

- [x] 432 tests passing (local + CI)
- [x] Release build verified (5 crates, 5m49s)
- [x] CLI runtime audit: 27/27 commands passed
- [x] MCP smoke test: 35 tools registered, 5 tool calls verified
- [x] HTTP smoke test: 31 endpoints verified, all 200 OK
- [x] FTS5 content body search verified working
- [x] Room-document junction verified via CLI + MCP + HTTP
