### PR TITLE
fix(ci): prevent release notes override by workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,11 @@ jobs:
           VER="${{ steps.version.outputs.VERSION }}"
           # Prefer committed RELEASE_NOTES.md (copywriting quality, manual curation)
           if [ -f RELEASE_NOTES.md ]; then
+            # Guard: reject template with unresolved placeholders
+            if grep -qE 'vX\.Y\.Z|#NNN|N (bug|new|passing)|@user' RELEASE_NOTES.md; then
+              echo "::error::RELEASE_NOTES.md contains unresolved placeholders (vX.Y.Z, #NNN, etc). Edit it before tagging, or delete the file to use auto-generation."
+              exit 1
+            fi
             echo "Using committed RELEASE_NOTES.md"
             cp RELEASE_NOTES.md release-notes.md
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,11 +347,17 @@ jobs:
       - name: Generate release notes
         run: |
           VER="${{ steps.version.outputs.VERSION }}"
-          echo "## What's New in ${VER}" > release-notes.md
-          echo "" >> release-notes.md
-          cat changelog-body.md >> release-notes.md
-          echo "" >> release-notes.md
-          cat >> release-notes.md << RELEASEEOF
+          # Prefer committed RELEASE_NOTES.md (copywriting quality, manual curation)
+          if [ -f RELEASE_NOTES.md ]; then
+            echo "Using committed RELEASE_NOTES.md"
+            cp RELEASE_NOTES.md release-notes.md
+          else
+            echo "::notice::No RELEASE_NOTES.md found, auto-generating from CHANGELOG"
+            echo "## What's New in ${VER}" > release-notes.md
+            echo "" >> release-notes.md
+            cat changelog-body.md >> release-notes.md
+            echo "" >> release-notes.md
+            cat >> release-notes.md << RELEASEEOF
 
           ### 📦 Downloads
 
@@ -395,12 +401,13 @@ jobs:
 
           **Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md
           RELEASEEOF
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
-          name: Release ${{ steps.version.outputs.VERSION }}
+          name: ${{ steps.version.outputs.VERSION }}
           body_path: release-notes.md
           files: release-artifacts/*
           draft: false

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,63 @@
+<!-- RELEASE_NOTES.md — Manual release notes template. -->
+<!-- If this file exists when release.yml CI runs, it will be used as the release body. -->
+<!-- Delete or rename this file to fall back to auto-generated notes from CHANGELOG. -->
+<!-- Replace all placeholders before tagging a release. -->
+
+## 🧠 Your AI's memory just got sharper
+
+**vX.Y.Z** ships N bug fixes, N new tools, and ...
+
+---
+
+### ✨ Feature highlight
+
+Describe the feature in terms of the problem it solves, not the code it changes.
+
+Before: what pain existed.
+Now: what's possible.
+
+```bash
+# Example usage
+```
+
+---
+
+### 🐛 Stability fixes
+
+- **Bug name (#NNN)** — One-sentence description of what was wrong and what's fixed.
+
+---
+
+### 📊 By the numbers
+
+| Metric | Value |
+|--------|-------|
+| Tests | N passing |
+| MCP tools | N |
+| HTTP endpoints | N |
+
+---
+
+### ⬆️ Upgrade
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+```
+
+---
+
+### 👥 Contributors
+
+| Contributor | PRs |
+|-------------|-----|
+| [@user](https://github.com/user) | #NNN |
+
+### 🔗 Issues & PRs in this release
+
+**Issues closed:** #NNN
+
+**Merged PRs:** #NNN
+
+---
+
+**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md


### PR DESCRIPTION
## What

Fix `release.yml` CI workflow that overwrites manually curated release notes.

### Changes
1. **Prefer `RELEASE_NOTES.md`** — If committed in repo root, use it as release body instead of auto-generating from CHANGELOG
2. **Fallback to auto-generation** — If `RELEASE_NOTES.md` is absent, auto-generate as before (no breakage)
3. **Fix release title** — Changed from `"Release vX.Y.Z"` to just `"vX.Y.Z"` (cleaner, title is set via `gh` CLI or GitHub UI anyway)
4. **Add `RELEASE_NOTES.md` template** — Copywriting-style template for future releases

## Why

The `softprops/action-gh-release@v2` action with `body_path` **overwrites** the release body every time CI runs. This caused the v0.12.0 release notes to be replaced with:
- Raw CHANGELOG copy-paste (not copywriting style)
- Empty binary names in download table
- ANSI escape codes from `install.sh` test output
- Duplicate failed download attempts in the body

Manual `gh release edit` fixes were immediately overwritten by the next CI run.

## Testing

- [x] Workflow YAML syntax valid
- [x] Template follows copywriting style (FAB structure)
- [x] Fallback path preserves existing behavior
- [x] v0.12.0 release notes already fixed manually (verified clean)