### PR TITLE
chore: replace star-history.com embed with self-hosted chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,9 @@ Contributions welcome! Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full guid
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/?repos=codecoradev%2Futeke&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=codecoradev/uteke&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=codecoradev/uteke&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=codecoradev/uteke&type=date&legend=top-left" />
- </picture>
-</a>
+<p align="center">
+  <img src="https://s3.ajianaz.dev/hermes/codecoradev/uteke/star-history.png" alt="Uteke Star History" width="720" />
+</p>
 
 ---
 


### PR DESCRIPTION
## What

Replace third-party star-history.com embed with self-hosted chart on MinIO.

## Why

- **No dependency on star-history.com** — GitHub has restricted star data access for third-party tools
- **Auto-updated weekly** via no-agent cron job (Monday)
- **Dark themed**, branded with CodeCora logo
- **Faster load** — static PNG from our own CDN

## Testing

- Chart generated and uploaded to `https://s3.ajianaz.dev/hermes/codecoradev/uteke/star-history.png` — verified HTTP 200
- Script (`uteke_star_history.py`) tested locally — runs silent on success, exits non-zero on failure
- Cron job created (weekly Monday 09:00 WIB, no-agent) — next run Aug 10
- README markdown verified — image renders correctly at 720px width

## Details

- Chart URL: `https://s3.ajianaz.dev/hermes/codecoradev/uteke/star-history.png`
- Generated from GitHub Stargazers API via `gh api`
- Script: `/opt/data/scripts/uteke_star_history.py`
- Cron: weekly Monday, no-agent (silent on success)