### PR TITLE
fix(docs): correct critical errors, stale versions, mismatched defaults

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -78,7 +78,7 @@ See [LongMemEval retrieval harness](https://github.com/codecoradev/uteke/tree/de
 | OS | Linux 6.8.0 (aarch64) |
 | Rust | 1.85+ |
 | Embedding | EmbeddingGemma Q4, 768d, ONNX Runtime CPU |
-| Uteke | v0.7.2 |
+| Uteke | v0.12.0 |
 
 ## Methodology
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.8.0**.
+Complete reference for all uteke commands. Version **0.12.0**.
 
 ## Global Flags
 
@@ -338,8 +338,8 @@ uteke room create "project-kickoff" --title "Project Kickoff"
 uteke room list
 uteke room list --namespace my-agent  # scoped
 
-# Add memory to room
-uteke room add "project-kickoff" <memory-id> --author cto
+# Show room stats and participants
+uteke room stats "project-kickoff"
 
 # Recall within a room (semantic)
 uteke room recall "project-kickoff" --query "database decision"
@@ -350,23 +350,20 @@ uteke room document "project-kickoff"
 # Room summary (LLM-free, tag clustering)
 uteke room summary "project-kickoff"
 
-# Remove memory from room
-uteke room remove "project-kickoff" <memory-id>
+# Delete room (memories are NOT deleted, only room links)
+uteke room delete "project-kickoff" --confirm
 
-# Delete room
-uteke room delete "project-kickoff"
-
-# Link a document to a room (#859)
-uteke room add-document "project-kickoff" --slug "architecture-spec"
+# Link a document to a room (#859, positional slug)
+uteke room add-document "project-kickoff" "architecture-spec"
 
 # Unlink a document from a room (#859)
-uteke room remove-document "project-kickoff" --slug "architecture-spec"
+uteke room remove-document "project-kickoff" "architecture-spec"
 
 # List documents linked to a room (#859)
 uteke room list-documents "project-kickoff"
 
-# List rooms that reference a document (#859)
-uteke room list-rooms --slug "architecture-spec"
+# List rooms that reference a document (#859, positional slug)
+uteke room list-rooms "architecture-spec"
 ```
 
 ## uteke bench

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -20,7 +20,7 @@ title: Comparison
 | Recall Cache | ✅ LRU + TTL | ❌ | ❌ | ❌ |
 | Benchmarks | ✅ Built-in | ❌ | ❌ | ❌ |
 | Privacy | ✅ Data stays local | ⚠️ Sent to LLM | ⚠️ Sent to LLM | ⚠️ Sent to LLM |
-| Recall Speed | ~30ms | Network RTT | Network RTT | Network RTT |
+| Recall Speed | ~40-45ms | Network RTT | Network RTT | Network RTT |
 | Tag Management | ✅ list/rename/delete | ⚠️ Basic | ❌ | ⚠️ Basic |
 | Memory Aging | ✅ Auto-cleanup | ✅ | ✅ Core memory | ✅ TTL-based |
 | Shell Hooks | ✅ bash/zsh/fish | ❌ | ❌ | ❌ |
@@ -30,7 +30,7 @@ title: Comparison
 
 uteke runs entirely on your machine. No network calls, no API keys, no data leaving your machine. Your memories — your infrastructure.
 
-**Performance:** ~30ms recall is possible because embedding inference, HNSW vector search, and FTS5 all run in-process. No network round-trip.
+**Performance:** ~40-45ms recall is possible because embedding inference, HNSW vector search, and FTS5 all run in-process. No network round-trip.
 
 **Privacy:** Data never leaves your machine. No telemetry. No cloud dependency.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ namespace = "default"
 
 [logging]
 # Log level: trace, debug, info, warn, error
-level = "info"
+level = "warn"
 
 # Optional log file path. Empty = stderr only.
 # file = ""
@@ -134,22 +134,22 @@ unconfigured, no cloud calls are made.
 
 ```toml
 [embed_fallback]
-enabled = false               # opt-in: must be true to activate
-base_url = ""                 # e.g. "https://api.openai.com/v1"
 api_key = ""                  # or use UTEKE_EMBED_FALLBACK_API_KEY
+base_url = ""                 # e.g. "https://api.openai.com/v1"
+endpoint_path = ""            # path appended to base_url. Empty = "/embeddings"
 model = ""                    # e.g. "text-embedding-3-small"
-dims = 0                      # 0 = use fallback model default
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `enabled` | `false` | Must be explicitly enabled — no surprise cloud calls |
-| `base_url` | `""` | Fallback API endpoint (OpenAI-compatible) |
 | `api_key` | `""` | API key for the fallback endpoint |
+| `base_url` | `""` | Fallback API endpoint (OpenAI-compatible) |
+| `endpoint_path` | `""` | Path appended to `base_url`. Empty = `/embeddings` |
 | `model` | `""` | Fallback embedding model |
-| `dims` | `0` | Fallback dimensions (0 = model default) |
 
-**Environment variables** take precedence: `UTEKE_EMBED_FALLBACK_ENABLED`, `UTEKE_EMBED_FALLBACK_BASE_URL`, `UTEKE_EMBED_FALLBACK_API_KEY`, `UTEKE_EMBED_FALLBACK_MODEL`, `UTEKE_EMBED_FALLBACK_DIMS`.
+Fallback is **active** when all three of `api_key`, `base_url`, and `model` are non-empty. No `enabled` flag needed — empty fields mean inactive.
+
+**Environment variables** take precedence: `UTEKE_EMBED_FALLBACK_API_KEY`, `UTEKE_EMBED_FALLBACK_BASE_URL`, `UTEKE_EMBED_FALLBACK_ENDPOINT_PATH`, `UTEKE_EMBED_FALLBACK_MODEL`.
 
 **Dimension validation** — if the fallback produces different dimensions than the primary, uteke rejects it at startup with a clear error. Both backends must produce vectors of the same dimensionality.
 
@@ -231,12 +231,11 @@ Opt-in per query via `--salience` / `--recency` CLI flags. The `dream` cycle's `
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `salience_weight` | 0.0 | Salience boost weight (0 = off, 0.15 recommended) |
-| `recency_weight` | 0.0 | Recency boost weight (0 = off, 0.15 recommended) |
+| `salience_weight` | 0.15 | Salience boost weight (0 = disable) |
+| `recency_weight` | 0.15 | Recency boost weight (0 = disable) |
+| `jaccard_weight` | 0.0 | Jaccard token-overlap reranking weight (0 = disable) |
 
-Default is off (0.0) to preserve backward-compatible ranking. Enable via CLI flags or API.
-
-Use `--strict` flag, `--min <score>`, or `--strategy <name>` to override per-query.
+Enabled by default (0.15). Override per-query with `--strict`, `--min <score>`, or `--strategy <name>`.
 
 ## Environment Variables
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -6,12 +6,12 @@ title: Contributing Guides
 
 Long-form contributor and maintainer guides. [`CONTRIBUTING.md`](https://github.com/codecoradev/uteke/blob/develop/CONTRIBUTING.md) at the repo root is the quick-start contribution guide; these documents elaborate on specific areas without duplicating it.
 
-If a guide conflicts with [`CONTRIBUTING.md`](https://github.com/codecoradev/uteke/blob/develop/CONTRIBUTING.md) or [`UTEKE.md`](https://github.com/codecoradev/uteke/blob/develop/UTEKE.md), the root files win.
+If a guide conflicts with [`CONTRIBUTING.md`](https://github.com/codecoradev/uteke/blob/develop/CONTRIBUTING.md) or [`AGENT.md`](https://github.com/codecoradev/uteke/blob/develop/AGENT.md), the root files win.
 
 ## Getting started
 
 - [`CONTRIBUTING.md`](https://github.com/codecoradev/uteke/blob/develop/CONTRIBUTING.md) — quick-start guide, quality bar, branch naming, what gets rejected
-- [`UTEKE.md`](https://github.com/codecoradev/uteke/blob/develop/UTEKE.md) — living architecture doc, read before making changes
+- [`AGENT.md`](https://github.com/codecoradev/uteke/blob/develop/AGENT.md) — living architecture doc, read before making changes
 
 ## Architecture
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ title: Docker
 
 # Docker
 
-Uteke ships as a lightweight multi-arch Docker image (~10MB). The embedding model (~208MB) downloads automatically on first run and is cached in the volume — subsequent updates are instant.
+Uteke ships as a lightweight multi-arch Docker image (~10MB). The embedding model (~188MB) downloads automatically on first run and is cached in the volume — subsequent updates are instant.
 
 ## Quick Start
 
@@ -125,9 +125,8 @@ Docker automatically pulls the correct architecture.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.7.2` | Specific version |
-| `v0.6.6` | Specific version |
-| `0.6` | Minor version (latest patch) |
+| `v0.12.0` | Specific version |
+| `0.12` | Minor version (latest patch) |
 | `slim` | Slim image (no embedded model — mount model volume separately, see below) |
 
 ## CLI in Docker

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Pin a specific version:
 
 ```bash
-UTEKE_VERSION=v0.8.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.12.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ## Install via Cargo
@@ -40,11 +40,19 @@ Download from [GitHub Releases](https://github.com/codecoradev/uteke/releases):
 
 ```bash
 # Linux (x86_64)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-linux-x86_64.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-v0.12.0.tar.gz | tar xz
+mv uteke ~/.local/bin/
+
+# Linux (x86_64, legacy — no AVX2/SSE4.2)
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-legacy-v0.12.0.tar.gz | tar xz
+mv uteke ~/.local/bin/
+
+# Linux (aarch64 / ARM)
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-unknown-linux-gnu-v0.12.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-darwin-aarch64.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-apple-darwin-v0.12.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 ```
 
@@ -53,8 +61,20 @@ Supported platforms:
 | Platform | Architecture | Format |
 |----------|-------------|--------|
 | Linux | x86_64 | tar.gz |
+| Linux | x86_64 (legacy, no AVX2) | tar.gz |
 | Linux | aarch64 (ARM) | tar.gz |
 | macOS | aarch64 (Apple Silicon) | tar.gz |
+| Windows | x86_64 | zip |
+
+### Windows (PowerShell)
+
+```powershell
+# Quick install via PowerShell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+irm https://raw.githubusercontent.com/codecoradev/uteke/main/install.ps1 | iex
+```
+
+Or download the `.zip` binary from [Releases](https://github.com/codecoradev/uteke/releases) and extract it to a directory on your `PATH`.
 
 ## Docker
 
@@ -77,7 +97,7 @@ uteke --version
 
 ```bash
 $ uteke --version
-uteke 0.8.0
+uteke 0.12.0
 
 $ uteke doctor
 ✓ Database     OK

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -266,12 +266,6 @@ curl http://127.0.0.1:8767/stats?namespace=cto
 
 **All endpoints that accept parameters use POST with JSON body**, not GET with query strings.
 
-### Known Issues
-
-- **#784** — `room/stats` counts deprecated memories (inflated counts vs `room/summary`)
-- **#785** — `room/recall` requires `query` parameter (cannot list all memories in a room)
-- **#786** — Full HTTP API reference documentation is pending
-
 ## Memory-Provider for Other Agents
 
 The `--memory-provider` pattern also works for non-Hermes agents (#575, #577):

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,7 +132,7 @@ uteke init --agent hermes  # Installs pre_llm_call hook
 
 ## Available Tools
 
-Both transports expose the same 29 tools (MCP protocol version `2025-06-18`):
+Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 
 | Tool | Description |
 |------|-------------|

--- a/docs/relationship-graph.md
+++ b/docs/relationship-graph.md
@@ -17,7 +17,7 @@ Supported relationship types:
 | `rel:supersedes` | This memory replaces an older one |
 | `rel:contradicts` | This memory contradicts another |
 | `rel:references` | This memory references another |
-| `rel:derived-from` | This memory was derived from another |
+| `rel:part_of` | This memory is part of another (component, sub-item) |
 
 ## Linking Memories
 

--- a/docs/shell-hooks.md
+++ b/docs/shell-hooks.md
@@ -8,8 +8,19 @@ Auto-load project-scoped memory when you cd into a project directory.
 
 ## Installation
 
+The `uteke hook` command prints a shell script to **stdout** — you redirect or `eval` it into your shell config.
+
+### bash / zsh
+
 ```bash
-uteke hook install bash   # or zsh, fish
+# Add to ~/.bashrc (or ~/.zshrc):
+eval "$(uteke hook bash)"
+```
+
+### fish
+
+```bash
+uteke hook fish >> ~/.config/fish/conf.d/uteke.fish
 ```
 
 ## How It Works

--- a/docs/smart-decay.md
+++ b/docs/smart-decay.md
@@ -29,7 +29,7 @@ uteke importance
 Track memory freshness with hot/warm/cold tiers:
 
 ```bash
-# Show hot/warm/cold/never-accessed breakdown
+# Show hot/warm/cold breakdown
 uteke aging status
 
 # Preview memories older than 90 days
@@ -43,10 +43,11 @@ uteke aging cleanup --older-than-days 180 --yes
 
 | Tier | Description |
 |------|-------------|
-| **Hot** | Recently accessed, high importance |
-| **Warm** | Accessed within the aging window |
-| **Cold** | Older than the aging threshold |
-| **Never** | Never been recalled after creation |
+| **Hot** | Accessed within `hot_days` (default 7), gets a `hot_boost` score bonus |
+| **Warm** | Accessed within `warm_days` (default 30) |
+| **Cold** | Older than the warm window, or never accessed after creation |
+
+Never-accessed memories are classified as **Cold**. Tier thresholds and boost are configurable via the `[tier]` config section.
 
 Pinned memories bypass aging entirely — they stay in the store regardless of access patterns.
 


### PR DESCRIPTION
## What

Fixes 19 documentation issues found during full docs audit (27 files, 5,939 lines cross-referenced against actual source code).

### Critical (would break user UX)
- **install.md**: Download URLs gave 404 — fixed to match actual release asset names (`uteke-x86_64-unknown-linux-gnu-v0.12.0.tar.gz`, etc.)
- **install.md**: Added Windows/PowerShell install section (`install.ps1` existed in repo but was undocumented)
- **shell-hooks.md**: `uteke hook install bash` → `uteke hook bash` (no `install` subcommand exists)
- **cli-reference.md**: Removed phantom `room add` / `room remove` commands (not in clap enum)
- **cli-reference.md**: `--slug` flag → positional `doc_slug` argument
- **relationship-graph.md**: `rel:derived-from` → `rel:part_of` (only 4 valid types exist)
- **smart-decay.md**: Removed non-existent `Never` tier (only Hot/Warm/Cold)
- **api-reference.md**: Fixed broken auth header markdown

### Stale/Incorrect
- Version refs: `v0.8.0` → `v0.12.0` (install.md, cli-reference.md)
- MCP tool count: `29` → `35`
- Benchmarks env: `v0.7.2` → `v0.12.0`
- Docker model size: `~208MB` → `~188MB`
- Docker image tags: updated to `v0.12.0` / `0.12`
- Comparison recall latency: `~30ms` → `~40-45ms` (matches benchmarks.md)
- Configuration `embed_fallback`: removed fictitious `enabled`/`dims`, added real `endpoint_path`
- Configuration `salience_weight`/`recency_weight`: default `0.0` → `0.15`, added missing `jaccard_weight`
- Configuration logging example: `info` → `warn`
- Contributing guide: `UTEKE.md` → `AGENT.md`
- Hermes integration: removed 3 already-fixed Known Issues (#784, #785, #786 all CLOSED)

## Why

Every finding was verified against actual source code (`cli.rs` clap definitions, `config.rs` struct fields, `graph.rs` valid relationship types, `types.rs` MemoryTier enum). The download URLs alone would cause 404 for every new user following the install guide.

## Testing
- [x] All changes verified against source code
- [x] Download URLs match `gh release view v0.12.0` asset names
- [x] CLI commands match clap enum variants
- [x] Config fields match `EmbedFallbackConfig` struct
- [x] Relationship types match `VALID_REL_TYPES`
- [x] Cora review: passed

Closes #879, #880