### PR TITLE
feat: Offline rule-based extraction (zero API/LLM, default mode)

### DIFF
--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -226,11 +226,15 @@ pub(crate) fn run_import(
 }
 
 /// Resolve extraction settings (CLI flag > env-merged config > built-in
-/// default), call the LLM to distill facts, and store each fact as a memory.
+/// default), dispatch to offline or LLM extractor, and store each fact.
 ///
-/// API-key resolution falls back to the embedding/OpenAI key so users who
-/// already configured an OpenAI-compatible setup for embeddings don't have to
-/// duplicate the credential.
+/// When config `mode` is "offline" (or empty/unconfigured), uses the
+/// zero-dependency rule-based extractor. When `mode` is "llm" and an API
+/// key is available, uses the OpenAI-compatible LLM extractor.
+///
+/// API-key resolution for LLM mode falls back to the embedding/OpenAI key
+/// so users who already configured an OpenAI-compatible setup for embeddings
+/// don't have to duplicate the credential.
 fn import_with_extraction(
     uteke: &Uteke,
     content: &str,
@@ -241,37 +245,63 @@ fn import_with_extraction(
     use uteke_core::ImportResult;
 
     let cfg = opts.cfg;
-    let model = opts
-        .model
-        .clone()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| cfg.model.clone());
-    let base_url = opts
-        .base_url
-        .clone()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| cfg.base_url.clone());
-    let api_key = opts
-        .api_key
-        .clone()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| cfg.api_key.clone());
+    let mode = cfg.mode.as_str();
     let max_facts = opts.max_facts.unwrap_or(cfg.max_facts);
 
-    let ext_config = uteke_core::extraction::ExtractionConfig {
-        model,
-        api_key,
-        base_url,
-        endpoint_path: cfg.endpoint_path.clone(),
-        max_facts,
+    // Determine extraction mode: explicit mode in config, or infer from
+    // whether an API key is available.
+    let use_llm = if mode == "llm" {
+        true
+    } else if mode == "offline" {
+        false
+    } else {
+        // Unconfigured — try LLM if API key available, else offline.
+        let api_key = opts
+            .api_key
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| cfg.api_key.clone());
+        !api_key.is_empty()
     };
 
-    let extractor = uteke_core::extraction::Extractor::new(&ext_config)
-        .map_err(|e| format!("Failed to initialize extractor: {e}"))?;
+    let facts = if use_llm {
+        // LLM extraction path
+        let model = opts
+            .model
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| cfg.model.clone());
+        let base_url = opts
+            .base_url
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| cfg.base_url.clone());
+        let api_key = opts
+            .api_key
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| cfg.api_key.clone());
 
-    let facts = extractor
-        .extract(content)
-        .map_err(|e| format!("Extraction failed: {e}"))?;
+        let ext_config = uteke_core::extraction::ExtractionConfig {
+            mode: "llm".to_string(),
+            model,
+            api_key,
+            base_url,
+            endpoint_path: cfg.endpoint_path.clone(),
+            max_facts,
+        };
+
+        let extractor = uteke_core::extraction::Extractor::new(&ext_config)
+            .map_err(|e| format!("Failed to initialize extractor: {e}"))?;
+
+        extractor
+            .extract(content)
+            .map_err(|e| format!("Extraction failed: {e}"))?
+    } else {
+        // Offline extraction path — zero API calls
+        tracing::info!("Using offline rule-based extraction (zero API)");
+        uteke_core::offline_extraction::extract_facts(content, max_facts)
+    };
 
     if facts.is_empty() {
         tracing::warn!("Extraction produced no facts from input");

--- a/crates/uteke-core/src/extraction.rs
+++ b/crates/uteke-core/src/extraction.rs
@@ -40,13 +40,18 @@ Rules:\n\
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct ExtractionConfig {
-    /// Chat-completions model (e.g. "gpt-4o-mini").
+    /// Extraction mode: "offline" (rule-based, default), "llm" (API-based), or "" (unconfigured).
+    ///
+    /// When "offline" or "", extraction uses pattern matching with no network calls.
+    /// When "llm", extraction sends text to an OpenAI-compatible chat completions endpoint.
+    pub mode: String,
+    /// Chat-completions model (e.g. "gpt-4o-mini"). Only used when mode = "llm".
     pub model: String,
-    /// API key for the extraction endpoint.
+    /// API key for the extraction endpoint. Only used when mode = "llm".
     pub api_key: String,
-    /// Base URL of the OpenAI-compatible endpoint.
+    /// Base URL of the OpenAI-compatible endpoint. Only used when mode = "llm".
     pub base_url: String,
-    /// Endpoint path appended to base_url.
+    /// Endpoint path appended to base_url. Only used when mode = "llm".
     pub endpoint_path: String,
     /// Maximum facts to keep per document. 0 = default.
     pub max_facts: usize,
@@ -312,6 +317,7 @@ mod tests {
 
     fn default_config() -> ExtractionConfig {
         ExtractionConfig {
+            mode: "llm".into(),
             api_key: "test-key".into(),
             model: String::new(),
             base_url: String::new(),
@@ -342,6 +348,7 @@ mod tests {
     #[test]
     fn endpoint_path_without_slash_normalized() {
         let cfg = ExtractionConfig {
+            mode: "llm".into(),
             api_key: "k".into(),
             model: "m".into(),
             base_url: "https://gw.example.com/v1".into(),

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -22,6 +22,7 @@ mod import_export;
 mod jaccard;
 mod maintenance;
 pub mod memory;
+pub mod offline_extraction;
 mod operations;
 mod orphans;
 mod recall_cache;

--- a/crates/uteke-core/src/offline_extraction.rs
+++ b/crates/uteke-core/src/offline_extraction.rs
@@ -1,0 +1,554 @@
+//! Offline rule-based fact extraction — zero API calls, zero LLM dependencies,
+//! zero regex dependencies.
+//!
+//! This module provides a lightweight, pattern-driven extractor that distills
+//! raw text (chat transcripts, notes, documents) into atomic facts *without*
+//! any network or API access. It is the default extraction mode, used when:
+//!
+//! - The user selects "offline" during onboarding
+//! - `[extraction]` mode is set to `"offline"` in the config
+//! - No API key is configured and `--extract` is requested
+//!
+//! ## How it works
+//!
+//! 1. **Sentence segmentation** — split text into candidate sentences.
+//! 2. **Noise filtering** — drop greetings, fillers, tool output, URLs, code.
+//! 3. **Keyword scoring** — rank candidates by information density.
+//! 4. **Deduplication** — near-duplicate removal (case-insensitive).
+//! 5. **Output** — return up to `max_facts` atomic facts.
+//!
+//! ## Limitations
+//!
+//! Offline extraction catches explicit, declarative facts well:
+//! "My name is John", "I switched from Vim to Helix", "Deploy at 3pm".
+//!
+//! It does NOT handle nuanced context, multi-sentence reasoning, or pronoun
+//! resolution across sentences. For those use cases, configure `mode = "llm"`.
+
+use std::collections::HashSet;
+
+/// Maximum facts to extract per document when not specified.
+const DEFAULT_MAX_FACTS: usize = 20;
+
+/// Minimum sentence length to be considered a fact candidate.
+const MIN_FACT_LEN: usize = 10;
+
+/// Maximum sentence length — longer sentences are likely paragraphs, not facts.
+const MAX_FACT_LEN: usize = 300;
+
+/// Keywords that indicate a factual, memorable statement.
+///
+/// Each tuple is (keyword(s), weight boost). Checked via case-insensitive
+/// substring match — no regex needed.
+static FACT_KEYWORDS: &[(&[&str], f32)] = &[
+    // Identity & preferences (high signal)
+    (&["my name is", "i'm ", "i am "], 1.5),
+    (
+        &[
+            "i prefer",
+            "i like",
+            "i love",
+            "i enjoy",
+            "i hate",
+            "i dislike",
+        ],
+        2.0,
+    ),
+    (&["i use", "using "], 1.0),
+    (&["i work", "i live", "working at", "living in"], 1.5),
+    (
+        &["i have", "i've", "i had", "i need", "i want", "i decided"],
+        1.0,
+    ),
+    // Decisions & plans
+    (&["decided", "need to", "have to", "must", "should"], 1.5),
+    (
+        &["will", "going to", "plan to", "planning", "going forward"],
+        1.0,
+    ),
+    (
+        &[
+            "sprint",
+            "deadline",
+            "milestone",
+            "release",
+            "deploy",
+            "launch",
+        ],
+        1.0,
+    ),
+    (
+        &[
+            "switched",
+            "migrated",
+            "upgraded",
+            "downgraded",
+            "moved to",
+            "moved from",
+        ],
+        2.0,
+    ),
+    // Technical facts
+    (
+        &["version", "endpoint", "url", "port", "address", "config"],
+        0.5,
+    ),
+    // Relationships & roles
+    (
+        &[
+            "team",
+            "colleague",
+            "manager",
+            "report",
+            "partner",
+            "client",
+        ],
+        0.8,
+    ),
+    // Strong factual indicators
+    (
+        &["fact", "important", "note:", "remember", "key point", "fyi"],
+        1.5,
+    ),
+    // Dates & times
+    (
+        &[
+            "today",
+            "tomorrow",
+            "yesterday",
+            "next week",
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+        ],
+        0.5,
+    ),
+    (
+        &[
+            "january",
+            "february",
+            "march",
+            "april",
+            "june",
+            "july",
+            "august",
+            "september",
+            "october",
+            "november",
+            "december",
+        ],
+        0.5,
+    ),
+];
+
+/// Greetings and fillers — sentences that are ONLY these words are noise.
+static NOISE_WORDS: &[&str] = &[
+    "hi",
+    "hey",
+    "hello",
+    "good morning",
+    "good afternoon",
+    "good evening",
+    "thanks",
+    "thank you",
+    "ok",
+    "okay",
+    "sure",
+    "right",
+    "got it",
+    "cool",
+    "nice",
+    "great",
+    "awesome",
+    "yes",
+    "no",
+    "yep",
+    "nope",
+    "yup",
+    "sure thing",
+    "lol",
+    "haha",
+];
+
+/// Line prefixes that indicate tool output / system messages.
+static NOISE_PREFIXES: &[&str] = &[
+    "[",
+    "{",
+    "<",
+    "running ",
+    "executing ",
+    "loading ",
+    "error ",
+    "warning ",
+    "debug ",
+    "trace ",
+    "info ",
+    "warn ",
+    "http",
+    "running `",
+    "```",
+];
+
+/// Extract atomic facts from text using rule-based pattern matching.
+///
+/// No network calls, no API keys, no external dependencies.
+/// Returns a list of factual statements worth remembering.
+pub fn extract_facts(text: &str, max_facts: usize) -> Vec<String> {
+    let max = if max_facts == 0 {
+        DEFAULT_MAX_FACTS
+    } else {
+        max_facts
+    };
+
+    if text.trim().is_empty() {
+        return Vec::new();
+    }
+
+    // 1. Segment into sentences
+    let candidates = segment_sentences(text);
+
+    // 2. Filter noise
+    let filtered: Vec<&str> = candidates
+        .iter()
+        .map(|s| s.as_str())
+        .filter(|s| !is_noise(s))
+        .filter(|s| s.len() >= MIN_FACT_LEN && s.len() <= MAX_FACT_LEN)
+        .collect();
+
+    // 3. Score by salience
+    let mut scored: Vec<(f32, &str)> = filtered.iter().map(|s| (score_salience(s), *s)).collect();
+
+    // 4. Sort by score descending
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // 5. Dedup (case-insensitive, first 50 chars as prefix key)
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut facts: Vec<String> = Vec::new();
+
+    for (_, sentence) in &scored {
+        let normalized = normalize_for_dedup(sentence);
+        // Use char-based prefix to avoid panicking on multibyte UTF-8 boundaries.
+        let prefix: String = normalized.chars().take(50).collect();
+
+        if seen.iter().any(|s| s.starts_with(&prefix)) {
+            continue;
+        }
+
+        seen.insert(normalized);
+
+        let fact = clean_fact(sentence);
+        if !fact.is_empty() {
+            facts.push(fact);
+        }
+
+        if facts.len() >= max {
+            break;
+        }
+    }
+
+    facts
+}
+
+/// Segment text into candidate sentences.
+///
+/// Handles common sentence boundaries: `.`, `!`, `?`, newlines.
+/// Also handles bullet points and numbered lists.
+fn segment_sentences(text: &str) -> Vec<String> {
+    let mut sentences = Vec::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Split each line on sentence boundaries
+        let mut current = String::new();
+        for ch in trimmed.chars() {
+            current.push(ch);
+            if ch == '.' || ch == '!' || ch == '?' {
+                let s = current.trim();
+                if !s.is_empty() {
+                    sentences.push(s.to_string());
+                }
+                current.clear();
+            }
+        }
+
+        // Remainder of line without terminal punctuation
+        let s = current.trim();
+        if !s.is_empty() {
+            sentences.push(s.to_string());
+        }
+    }
+
+    sentences
+}
+
+/// Check if a sentence is noise (greeting, question, tool output, etc.)
+fn is_noise(sentence: &str) -> bool {
+    let lower = sentence.to_lowercase();
+    let lower_trimmed = lower.trim();
+
+    // Check if it's ONLY a noise word
+    for word in NOISE_WORDS {
+        if lower_trimmed == *word || lower_trimmed == format!("{}.", word) {
+            return true;
+        }
+    }
+
+    // Check noise prefixes
+    for prefix in NOISE_PREFIXES {
+        if lower_trimmed.starts_with(prefix) {
+            return true;
+        }
+    }
+
+    // Questions (ends with ? and starts with question word)
+    if lower_trimmed.ends_with('?') {
+        let q_words = [
+            "what",
+            "why",
+            "how",
+            "when",
+            "where",
+            "who",
+            "which",
+            "can you",
+            "could you",
+            "would you",
+            "do you",
+            "are you",
+            "is it",
+            "should i",
+            "will it",
+        ];
+        if q_words.iter().any(|w| lower_trimmed.starts_with(w)) {
+            return true;
+        }
+    }
+
+    // URLs alone
+    if lower_trimmed.starts_with("http://") || lower_trimmed.starts_with("https://") {
+        let parts: Vec<&str> = lower_trimmed.split_whitespace().collect();
+        if parts.len() <= 1 {
+            return true;
+        }
+    }
+
+    // Code lines (4+ space indent)
+    if sentence.starts_with("    ") {
+        return true;
+    }
+
+    false
+}
+
+/// Score a sentence's salience — how likely it contains a durable fact.
+fn score_salience(sentence: &str) -> f32 {
+    let lower = sentence.to_lowercase();
+    let mut score: f32 = 0.1;
+
+    // Keyword boosts
+    for (keywords, boost) in FACT_KEYWORDS {
+        if keywords.iter().any(|kw| lower.contains(kw)) {
+            score += boost;
+        }
+    }
+
+    // Length bonus — sentences between 20-150 chars are ideal
+    let len = sentence.len();
+    if (20..=150).contains(&len) {
+        score += 0.3;
+    } else if len > 150 {
+        score -= 0.2;
+    }
+
+    // Number bonus — concrete data (dates, versions, counts)
+    let digit_count = sentence.chars().filter(|c| c.is_ascii_digit()).count();
+    if digit_count > 0 {
+        score += 0.1 * digit_count.min(5) as f32;
+    }
+
+    // Proper noun bonus — capitalized words (names, places, products)
+    let cap_words = sentence
+        .split_whitespace()
+        .filter(|w| w.chars().next().map(|c| c.is_uppercase()).unwrap_or(false))
+        .count();
+    if cap_words >= 2 {
+        score += 0.2;
+    }
+
+    score
+}
+
+/// Normalize a sentence for deduplication purposes.
+fn normalize_for_dedup(s: &str) -> String {
+    s.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Clean up a fact for final output.
+fn clean_fact(sentence: &str) -> String {
+    let mut s = sentence.trim().to_string();
+
+    // Strip leading bullet markers — use char-based slicing for UTF-8 safety.
+    while s
+        .chars()
+        .next()
+        .map(|c| matches!(c, '-' | '*' | '•' | '·' | '#'))
+        .unwrap_or(false)
+    {
+        s = s
+            .chars()
+            .skip(1)
+            .collect::<String>()
+            .trim_start()
+            .to_string();
+    }
+
+    // Strip leading numbering (1. 2. etc.)
+    let chars: Vec<char> = s.chars().collect();
+    if !chars.is_empty() && chars[0].is_ascii_digit() {
+        let mut idx = 0;
+        while idx < chars.len() && (chars[idx].is_ascii_digit() || chars[idx] == '.') {
+            idx += 1;
+        }
+        if idx < chars.len() {
+            s = chars[idx..]
+                .iter()
+                .collect::<String>()
+                .trim_start()
+                .to_string();
+        }
+    }
+
+    // Strip markdown emphasis
+    s = s.replace("**", "");
+    s = s.replace("__", "");
+    s = s.replace('*', "");
+    s = s.replace('_', "");
+    s = s.replace('`', "");
+
+    // Strip leading/trailing quotes
+    s = s
+        .trim_matches(|c: char| c == '"' || c == '\'' || c == '(' || c == ')')
+        .trim()
+        .to_string();
+
+    // Ensure ends with punctuation
+    if !s.is_empty() {
+        let last = s.chars().last().unwrap();
+        if last != '.' && last != '!' && last != '?' {
+            s.push('.');
+        }
+    }
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_input() {
+        assert!(extract_facts("", 10).is_empty());
+        assert!(extract_facts("   \n\n  ", 10).is_empty());
+    }
+
+    #[test]
+    fn test_preference_extraction() {
+        let text = "Hi there! My name is John. I prefer Vim over Emacs. What time is it?";
+        let facts = extract_facts(text, 10);
+        assert!(!facts.is_empty());
+        assert!(facts.iter().any(|f| f.to_lowercase().contains("prefer")));
+    }
+
+    #[test]
+    fn test_noise_filtering() {
+        let text = "Hi! Hey! Hello! Yes. No. Okay. Thanks!";
+        let facts = extract_facts(text, 10);
+        assert!(facts.is_empty(), "Should filter out all noise");
+    }
+
+    #[test]
+    fn test_technical_fact() {
+        let text = "I upgraded to Rust 1.75. The deploy is scheduled for Friday.";
+        let facts = extract_facts(text, 10);
+        assert!(!facts.is_empty());
+    }
+
+    #[test]
+    fn test_dedup() {
+        let text = "I use Vim. I use Vim. I use Vim for editing.";
+        let facts = extract_facts(text, 10);
+        assert!(facts.len() <= 2, "Should dedup near-identical sentences");
+    }
+
+    #[test]
+    fn test_max_facts() {
+        let text = "I prefer tea. I like coffee. I enjoy hiking. I love coding. I hate bugs.";
+        let facts = extract_facts(text, 2);
+        assert!(facts.len() <= 2);
+    }
+
+    #[test]
+    fn test_clean_bullet() {
+        assert_eq!(clean_fact("- My name is John"), "My name is John.");
+        assert_eq!(clean_fact("1. Deploy at 3pm"), "Deploy at 3pm.");
+    }
+
+    #[test]
+    fn test_chat_transcript() {
+        let text = r"
+User: Hi, can you help me?
+Assistant: Sure, what do you need?
+User: My name is Sarah and I switched from VS Code to Zed recently.
+Assistant: Nice choice!
+User: I work at Acme Corp as a backend engineer.
+        ";
+        let facts = extract_facts(text, 10);
+        assert!(
+            facts.iter().any(|f| f.to_lowercase().contains("sarah")),
+            "Should extract name"
+        );
+        assert!(
+            facts.iter().any(|f| f.to_lowercase().contains("zed")),
+            "Should extract tool switch"
+        );
+    }
+
+    #[test]
+    fn test_url_filtered() {
+        assert!(is_noise("https://example.com"));
+        assert!(!is_noise("Check https://example.com for details"));
+    }
+
+    #[test]
+    fn test_question_filtered() {
+        assert!(is_noise("What time is the meeting?"));
+        assert!(is_noise("Can you help me?"));
+        assert!(!is_noise("The meeting is at 3pm."));
+    }
+
+    #[test]
+    fn test_utf8_multibyte_safe() {
+        // Text with multibyte characters (Indonesian, emoji) must not panic.
+        let text = "Nama saya Budi. Saya suka nasi goreng. 🍜";
+        let facts = extract_facts(text, 10);
+        assert!(!facts.is_empty(), "Should handle UTF-8 text");
+
+        // Bullet with multibyte
+        assert_eq!(
+            clean_fact("• Saya tinggal di Jakarta"),
+            "Saya tinggal di Jakarta."
+        );
+    }
+}

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -1948,6 +1948,7 @@ fn resolve_extraction_config(
 ) -> uteke_core::extraction::ExtractionConfig {
     let base = ctx.extraction_config.clone().unwrap_or_default();
     uteke_core::extraction::ExtractionConfig {
+        mode: base.mode,
         model: req_model.map(String::from).unwrap_or(base.model),
         api_key: req_api_key.map(String::from).unwrap_or(base.api_key),
         base_url: base.base_url,

--- a/internal/research/competitor-analysis-2026-08.md
+++ b/internal/research/competitor-analysis-2026-08.md
@@ -1,0 +1,671 @@
+# Uteke Competitive Analysis Report
+
+**Date:** August 2026  
+**Analyst:** CodeCora Research  
+**Subject:** AI Memory Layer Landscape & Uteke Positioning
+
+---
+
+## Executive Summary
+
+The AI agent memory layer market has exploded in 2024–2026. Driven by LLM agent adoption, dozens of products now compete to be the "memory infrastructure" for AI applications. The market is splitting into **managed cloud platforms** (mem0, Zep) that abstract away infrastructure and **self-hosted/open-source libraries** (LangMem, Cognee, Letta) that give developers control.
+
+**Uteke occupies a defensible niche** — local-first, offline, CPU-only semantic memory — that no major competitor directly addresses. While mem0 and Zep chase cloud-hosted enterprise contracts, uteke serves developers and edge/offline use cases where data sovereignty, zero API costs, and minimal dependencies are paramount. The main challenge is awareness (179 stars vs. 62K+ for mem0) and ecosystem maturity.
+
+---
+
+## 1. Market Landscape Overview
+
+### The AI Memory Stack
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    APPLICATION LAYER                         │
+│        AI Agents (AutoGPT, Devin, custom agents)            │
+├─────────────────────────────────────────────────────────────┤
+│                    MEMORY LAYER                              │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌───────────────┐  │
+│  │  mem0    │ │   Zep    │ │  Letta   │ │   uteke       │  │
+│  │ (cloud)  │ │ (cloud)  │ │ (hybrid) │ │ (local-first) │  │
+│  └──────────┘ └──────────┘ └──────────┘ └───────────────┘  │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐                    │
+│  │ LangMem  │ │  Cognee  │ │  A-MEM   │                    │
+│  │ (lib)    │ │ (hybrid) │ │ (research)│                    │
+│  └──────────┘ └──────────┘ └──────────┘                    │
+├─────────────────────────────────────────────────────────────┤
+│              INFRASTRUCTURE LAYER                            │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌───────────────┐  │
+│  │ Qdrant   │ │  Chroma  │ │ Weaviate │ │   Pinecone    │  │
+│  │ (vector) │ │ (vector) │ │ (vector) │ │   (managed)   │  │
+│  └──────────┘ └──────────┘ └──────────┘ └───────────────┘  │
+├─────────────────────────────────────────────────────────────┤
+│              FRAMEWORK LAYER                                 │
+│     LangChain · LlamaIndex · OpenAI Agents SDK              │
+│     (built-in memory modules / conversation buffers)        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Market Categories
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| **Dedicated Memory Platforms** | Purpose-built memory layer with extraction, storage, retrieval | mem0, Zep, LangMem, uteke |
+| **Agent Frameworks w/ Memory** | Full agent runtime where memory is a core subsystem | Letta (MemGPT), Cognee |
+| **Graph-Based Memory** | Knowledge graph + temporal reasoning for agent memory | Graphiti (Zep), GraphRAG (Microsoft) |
+| **Vector DBs (Adjacent)** | General-purpose vector storage, not purpose-built for memory | Qdrant, Chroma, Weaviate, Pinecone |
+| **Framework Memory Modules** | Basic conversation buffer in LLM frameworks | LangChain Memory, LlamaIndex Memory |
+
+---
+
+## 2. Direct Competitors — Detailed Analysis
+
+### 2.1 mem0 (mem0ai/mem0)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 62,570 ⭐ · 7,297 forks |
+| **Language** | Python |
+| **License** | Apache-2.0 |
+| **Architecture** | Cloud-first SaaS + self-hosted option |
+| **Pricing** | Free: $0 (10K adds/mo) · Pro: $19/mo · Enterprise: $249/mo |
+| **Funding** | Well-funded ($13.5M seed, 2024) |
+
+**Positioning:** "The memory layer for AI agents" — explicitly owns the category keyword. Positioned as managed infrastructure: "use OSS for control, use Platform for production reliability."
+
+**Key Features:**
+- Automatic memory extraction from conversations (LLM-powered)
+- Memory deduplication and conflict resolution
+- Graph memory support (relationships between memories)
+- Multi-backend vector store support (Qdrant, Chroma, etc.)
+- REST API + Python/JS SDKs + MCP server
+- Admin dashboard, analytics, audit logs (platform)
+- User-scoped and agent-scoped memories
+
+**Strengths:**
+- Massive mindshare (62K stars — the category leader)
+- Strong documentation and developer experience
+- Cloud platform with enterprise features (SSO, audit logs, on-prem)
+- Active community and integrations ecosystem
+
+**Weaknesses:**
+- **Requires LLM API calls** for memory extraction (OpenAI/Anthropic) — adds latency and cost
+- Self-hosted version still needs external vector DB + LLM API
+- Python-only (no Rust/Go native binary)
+- Cloud platform = data leaves your infrastructure
+- No offline capability — embedding generation depends on external APIs
+- Heavy resource footprint for self-hosted (Python + vector DB + LLM)
+
+**Multi-tenant:** Yes — user_id scoping built into API. Platform supports projects, organizations, multiple end users per project.
+
+---
+
+### 2.2 Zep (getzep/zep)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 4,812 ⭐ · 646 forks |
+| **Language** | Python |
+| **License** | Apache-2.0 |
+| **Architecture** | Cloud-first (credit-based) + self-hosted (zep-cloud, zep-self-hosted) |
+| **Pricing** | Free (limited credits) · Flex: auto $25/10K credits · Flex Plus: $75/40K credits · Enterprise: BYOK/BYOC |
+| **Funding** | Funded ($4.75M, 2024) |
+
+**Positioning:** "Context engineering platform for AI agents" — focuses on temporal knowledge graphs and GraphRAG. Differentiates from mem0 with **graph-based memory** (Graphiti) rather than flat vector store.
+
+**Key Features:**
+- Graphiti engine: temporal knowledge graphs from conversation data
+- Entity extraction and relationship modeling
+- 200ms retrieval latency (claimed)
+- SOC 2 Type II, HIPAA compliance
+- BYOK (bring your own keys), BYOC (bring your own cloud)
+- Credit-based pricing (consumption model)
+- No storage charges — only ingestion/processing
+
+**Strengths:**
+- Graph-based memory is more sophisticated than flat vectors
+- Temporal reasoning (knows when facts were true)
+- Enterprise compliance (SOC2, HIPAA, DPA)
+- Flexible deployment (Cloud, BYOK, BYOC)
+- Well-funded with enterprise sales motion
+
+**Weaknesses:**
+- **Requires external LLM** for graph extraction (OpenAI API)
+- Complex architecture (Neo4j + vector store + LLM)
+- Self-hosted is heavy (many dependencies)
+- No offline/edge capability
+- Credit-based pricing can be unpredictable at scale
+- Python-centric; no lightweight binary
+
+**Multi-tenant:** Yes — session-based, user-scoped memories. Enterprise supports organizations, multiple projects, API key management.
+
+---
+
+### 2.3 Graphiti (getzep/graphiti)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 29,574 ⭐ · 2,991 forks |
+| **Language** | Python |
+| **License** | Apache-2.0 |
+| **Architecture** | Self-hosted library (Zep's graph engine, open-sourced separately) |
+
+**Positioning:** Temporal knowledge graph library for AI agents. Powers Zep's backend but usable standalone. Massively popular (29K stars) as an open-source graph memory tool.
+
+**Key Features:**
+- Temporal knowledge graphs (bi-temporal data model)
+- Entity and relationship extraction from unstructured data
+- Support for multiple graph backends (Neo4j, FalkorDB)
+- Mixed-node search (combination of semantic + keyword + graph traversal)
+- Episode-based data ingestion (messages, JSON, text)
+- Custom entity types and edge definitions
+
+**Strengths:**
+- Highest star count among graph memory tools (29K)
+- Extremely flexible data model
+- Temporal queries (when was a fact true?)
+- Active community development
+
+**Weaknesses:**
+- Requires graph database (Neo4j/FalkorDB) + LLM API + embedding service
+- No built-in storage — orchestrates external systems
+- No offline capability
+- Complex setup for simple use cases
+- No built-in CPU embeddings
+
+---
+
+### 2.4 LangMem (langchain-ai/langmem)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 1,596 ⭐ · 183 forks |
+| **Language** | Python |
+| **License** | MIT |
+| **Architecture** | Python library (LangChain ecosystem) |
+| **Pricing** | Free / open-source (LangSmith SaaS separate) |
+
+**Positioning:** LangChain's memory toolkit — "memory primitives for LLM applications." Library-level memory management within the LangChain ecosystem.
+
+**Key Features:**
+- Semantic memory (vector-based recall)
+- Episodic memory (conversation history)
+- Procedural memory (learned instructions/prompts)
+- Memory namespace management
+- Integration with LangGraph and LangSmith
+- Multiple memory store backends
+
+**Strengths:**
+- Deep LangChain ecosystem integration
+- Multiple memory types (semantic, episodic, procedural)
+- MIT licensed, lightweight
+- LangSmith integration for observability
+
+**Weaknesses:**
+- **Requires external LLM** for memory extraction/processing
+- Requires external vector store
+- Tightly coupled to LangChain ecosystem
+- No standalone runtime — library only
+- No offline capability
+- Small community (1.6K stars)
+
+**Multi-tenant:** Namespace-based isolation — memories scoped by namespace (user/session/agent). No built-in tenant management; relies on application layer.
+
+---
+
+### 2.5 Cognee (topoteretes/cognee)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 29,790 ⭐ · 2,881 forks |
+| **Language** | Python |
+| **License** | Apache-2.0 |
+| **Architecture** | Hybrid (self-hosted framework + cloud platform) |
+| **Pricing** | Free: $0 · Pro: $2.50 (workspace-based) · $5/additional workspace |
+
+**Positioning:** "DataPipes for AI" — focuses on transforming unstructured data into knowledge graphs for RAG and agent memory. Emphasis on data processing pipeline.
+
+**Key Features:**
+- Graph-based memory (knowledge graph extraction)
+- Data pipeline framework (ingest → process → graphify → query)
+- Multiple vector/graph backend support
+- LLM-powered entity extraction and relationship modeling
+- Framework-agnostic (not tied to LangChain)
+- Semantic search over knowledge graph
+
+**Strengths:**
+- High GitHub traction (29.8K stars)
+- Data pipeline approach (good for bulk ingestion)
+- Graph + vector hybrid model
+- Workspace-based organization
+- Active development
+
+**Weaknesses:**
+- **Requires external LLM** for extraction
+- Complex pipeline setup
+- No offline capability
+- No CPU-only embeddings
+- No MCP server support
+- Python-only
+
+**Multi-tenant:** Workspace-based isolation — separate workspaces for different tenants/projects.
+
+---
+
+### 2.6 Letta / MemGPT (letta-ai/letta)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 24,099 ⭐ · 2,565 forks |
+| **Language** | Python |
+| **License** | Apache-2.0 |
+| **Architecture** | Agent framework with stateful memory (Letta Cloud + self-hosted) |
+| **Pricing** | Self-hosted: free · Letta Cloud: usage-based (details not public) |
+| **Funding** | $10M seed (2024, a16z) |
+
+**Positioning:** Not just memory — a **full stateful agent framework**. Memory is a core subsystem but Letta manages the entire agent lifecycle (LLM calls, tool execution, state persistence). Originated as "MemGPT" (OS-level memory management for LLMs).
+
+**Key Features:**
+- Core memory (in-context) + archival memory (vector store)
+- Memory blocks with token budget management
+- Agent identity persistence across sessions
+- "Context Constitution" — formal memory management policy
+- Letta Cloud hosted platform
+- Desktop app + CLI + Agent SDK + App Server
+- Multi-provider LLM support
+
+**Strengths:**
+- Academic pedigree (Berkeley research → product)
+- Full agent runtime (not just memory)
+- Memory block abstraction is elegant
+- Well-funded, strong community
+- Cloud + self-hosted options
+
+**Weaknesses:**
+- **Heavyweight** — it's a full agent framework, not just memory
+- Coupled to their agent runtime paradigm
+- Requires external LLM + external vector store for archival memory
+- No offline CPU embeddings
+- Python-only
+- Overkill if you just need a memory layer
+
+**Multi-tenant:** Agent-level isolation — each agent has its own memory state. Letta Cloud supports organizations and API keys. Self-hosted uses agent IDs as partition keys.
+
+---
+
+### 2.7 A-MEM (agiresearch/A-mem)
+
+| Attribute | Detail |
+|-----------|--------|
+| **GitHub** | 1,137 ⭐ · 120 forks |
+| **Language** | Python |
+| **License** | MIT |
+| **Architecture** | Research library (academic origin) |
+
+**Positioning:** Agentic memory inspired by Zettelkasten — memories are self-organizing and link themselves. Research-oriented, from "A-MEM: Agentic Memory for LLM Agents" paper.
+
+**Key Features:**
+- Zettelkasten-inspired memory structure
+- Self-organizing memory links
+- Memory evolution over time
+- Academic/proof-of-concept implementation
+
+**Strengths:**
+- Novel memory organization approach
+- MIT licensed, lightweight
+- Research community interest
+
+**Weaknesses:**
+- Research/proof-of-concept (not production-ready)
+- No cloud platform
+- Requires external LLM + vector store
+- No offline capability
+- Limited documentation
+- Last updated December 2025
+
+---
+
+## 3. Adjacent Solutions
+
+### 3.1 Vector Databases with Memory Use Cases
+
+| Database | Stars | Language | Self-Hosted | Cloud | Multi-tenant | Memory Features |
+|----------|-------|----------|-------------|-------|--------------|-----------------|
+| **Qdrant** | 33,787 | Rust | ✅ | ✅ | ✅ (payload-based partitioning) | Vector search only, no extraction |
+| **Chroma** | 28,958 | Rust | ✅ | ✅ | ⚠️ (collection-based) | Embedding + storage, no memory logic |
+| **Weaviate** | 16,694 | Go | ✅ | ✅ | ✅ (multi-tenancy native) | GraphQL + vector hybrid, modules |
+| **Pinecone** | N/A | Proprietary | ❌ | ✅ | ✅ (namespaces) | Managed vector only |
+
+**Key Insight:** Vector DBs provide storage and search but **lack memory management logic** (extraction, deduplication, decay, importance scoring). They're infrastructure, not memory platforms. You must build the memory layer on top.
+
+**Qdrant Multi-Tenancy:** Single collection with payload-based partitioning (recommended approach). Each point has a `tenant_id` payload field; filtered search by tenant. Efficient for most users. Alternative: separate collections per tenant (stricter isolation, more resource overhead).
+
+---
+
+### 3.2 LLM Framework Built-in Memory
+
+| Framework | Stars | Memory Type | Limitation |
+|-----------|-------|-------------|------------|
+| **LangChain** | 143,473 | Conversation buffer, summary, vector store | Basic — no extraction, no dedup, no decay |
+| **LlamaIndex** | 51,393 | Chat memory buffer, vector index | RAG-focused, not agent memory |
+| **OpenAI Agents SDK** | 28,397 | Session context | Minimal — just conversation state |
+
+**Key Insight:** Framework memory is **conversation state**, not persistent semantic memory. No extraction, no deduplication, no cross-session recall, no importance scoring. Developers outgrow these quickly and seek dedicated memory layers.
+
+---
+
+### 3.3 Graph RAG / Knowledge Graph Platforms
+
+| Platform | Stars | Focus |
+|----------|-------|-------|
+| **GraphRAG (Microsoft)** | 35,262 | Knowledge graph construction from documents for RAG |
+| **Graphiti (Zep)** | 29,574 | Temporal knowledge graph for agent memory |
+
+**Key Insight:** Graph-based approaches excel at relationship modeling but require significant infrastructure (graph DB + LLM + embedding service). Overkill for simple memory use cases.
+
+---
+
+## 4. Comparative Analysis Matrix
+
+### 4.1 Feature Comparison
+
+| Feature | mem0 | Zep | LangMem | Cognee | Letta | Graphiti | **uteke** |
+|---------|------|-----|---------|--------|-------|----------|-----------|
+| **Offline Operation** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **✅** |
+| **CPU-only Embeddings** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **✅** |
+| **Single Binary** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **✅ (Rust)** |
+| **No External Dependencies** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **✅** |
+| **MCP Server** | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | **✅** |
+| **Memory Extraction** | ✅ (LLM) | ✅ (LLM) | ✅ (LLM) | ✅ (LLM) | ✅ (LLM) | ✅ (LLM) | **Manual/API** |
+| **Hybrid Search** | ⚠️ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ | **✅ (HNSW+FTS5)** |
+| **Relationship Graph** | ✅ | ✅ | ⚠️ | ✅ | ❌ | ✅ | **✅** |
+| **Smart Decay** | ❌ | ⚠️ | ❌ | ❌ | ❌ | ⚠️ | **✅** |
+| **Context Rooms** | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ❌ | ❌ | **✅** |
+| **Multi-tenant** | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | **⚠️ (namespaces)** |
+| **HTTP API** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | **✅** |
+| **CLI** | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | **✅** |
+| **Zero API Cost** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **✅** |
+| **Data Sovereignty** | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ | ✅ | **✅** |
+
+### 4.2 Architecture Comparison
+
+| Aspect | mem0 | Zep | Cognee | Letta | **uteke** |
+|--------|------|-----|--------|-------|-----------|
+| **Language** | Python | Python | Python | Python | **Rust** |
+| **Binary Size** | N/A (pip) | N/A (Docker) | N/A (pip) | N/A (pip) | **~15MB** |
+| **Runtime Deps** | Python + vector DB + LLM | Python + Neo4j + vector DB + LLM | Python + graph DB + LLM | Python + vector DB + LLM | **None (SQLite embedded)** |
+| **Setup Complexity** | Medium | High | Medium | Medium | **Low (single binary)** |
+| **Latency** | 100-500ms (cloud) | ~200ms (cloud) | Varies | Varies | **<10ms (local)** |
+| **Scalability** | High (cloud) | High (cloud) | Medium | Medium | **Single-node (by design)** |
+| **Resource Footprint** | Heavy | Heavy | Heavy | Heavy | **Light (~50MB RAM)** |
+
+### 4.3 GitHub Traction (August 2026)
+
+| Project | Stars | Forks | Trend |
+|---------|-------|-------|-------|
+| LangChain | 143,473 | 23,895 | 📈 Framework giant |
+| mem0 | 62,570 | 7,297 | 📈 Category leader |
+| LlamaIndex | 51,393 | 7,876 | 📈 Stable |
+| GraphRAG | 35,262 | 3,703 | 📈 Hot (graph RAG) |
+| Qdrant | 33,787 | 2,554 | 📈 Growing |
+| Cognee | 29,790 | 2,881 | 📈 Fast-growing |
+| Graphiti | 29,574 | 2,991 | 📈 Fast-growing |
+| Chroma | 28,958 | 2,423 | ➡️ Stable |
+| Letta | 24,099 | 2,565 | 📈 Steady |
+| Weaviate | 16,694 | 1,357 | ➡️ Stable |
+| Zep | 4,812 | 646 | ➡️ Moderate |
+| LangMem | 1,596 | 183 | ➡️ Niche |
+| A-MEM | 1,137 | 120 | ➡️ Academic |
+| **uteke** | **179** | **20** | **🌱 Early** |
+
+---
+
+## 5. Monetization Models
+
+### 5.1 Competitor Revenue Models
+
+| Company | Model | Pricing | Revenue Driver |
+|---------|-------|---------|----------------|
+| **mem0** | Cloud SaaS (freemium) | $0 / $19 / $249 per month | API calls (adds + retrievals) |
+| **Zep** | Credit-based cloud | Free / $25-75 per 10K credits | Ingestion volume (episodes) |
+| **Cognee** | Cloud platform (freemium) | $0 / $2.50 / $5 per workspace | Workspaces + data volume |
+| **Letta** | Cloud platform + enterprise | Usage-based (custom) | Agent runtime + storage |
+| **Qdrant** | Managed cloud + enterprise | Free tier / $25+ / Enterprise | Storage + compute |
+| **Weaviate** | Managed cloud + enterprise | Free / $25+ / Custom | Storage + compute |
+
+### 5.2 Monetization Patterns Observed
+
+1. **Cloud Hosted (mem0, Zep, Cognee, Letta):** Open-source core + managed cloud platform. Cloud adds: reliability, analytics, enterprise features (SSO, audit logs, compliance), no DevOps. Revenue from usage/credits.
+
+2. **Enterprise License (Zep, Letta, Qdrant):** Self-hosted enterprise edition with advanced features (BYOK, BYOC, compliance, dedicated support). Custom pricing.
+
+3. **Managed Infrastructure (Qdrant, Weaviate, Pinecone):** Managed vector database hosting. Revenue from storage + compute + features.
+
+4. **SaaS Add-ons:** LangSmith (LangChain), observability and tracing. Revenue from platform features, not the memory itself.
+
+### 5.3 Uteke Monetization Opportunities
+
+Given uteke's local-first positioning, traditional cloud-hosted SaaS doesn't align. Viable models:
+
+| Model | Fit | Revenue Potential | Notes |
+|-------|-----|-------------------|-------|
+| **Enterprise License** | ✅ High | Medium-High | Enterprise features: multi-tenant management, audit logs, RBAC, support SLA |
+| **Managed Cloud (optional sync)** | ✅ Medium | Medium | Optional cloud sync/backup — local-first with cloud fallback |
+| **Embedded/OEM Licensing** | ✅ High | Medium | License uteke as embedded memory in other products (desktop apps, edge devices) |
+| **Pro Features (open-core)** | ✅ High | Medium | Free core + paid pro: clustering, advanced decay models, multi-room federation |
+| **Consulting/Integration** | ✅ Medium | Low-Medium | Custom deployment, integration services |
+| **Marketplace/Extensions** | ⚠️ Low | Low | Community plugins, embedding models, MCP integrations |
+
+**Recommended:** **Open-core with enterprise license.** Keep the core engine free (MIT/Apache). Add enterprise tier with: multi-tenant management UI, RBAC, audit logging, cloud sync/backup, cluster mode, priority support. This aligns with local-first ethos while capturing enterprise value.
+
+---
+
+## 6. Multi-Tenant Patterns Analysis
+
+### 6.1 Current Multi-Tenant Approaches
+
+| Platform | Pattern | Isolation Level | Complexity |
+|----------|---------|-----------------|------------|
+| **mem0** | user_id + project_id scoping | Logical (application-level) | Low |
+| **Zep** | Session + user scoping, org-level API keys | Logical (application-level) | Medium |
+| **Cognee** | Workspace-based isolation | Logical (workspace-level) | Low |
+| **Letta** | Agent-level state isolation | Strong (per-agent) | Medium |
+| **Qdrant** | Single collection + payload partitioning | Logical (payload filtering) | Low |
+| **Qdrant (alt)** | Separate collections per tenant | Physical (collection-level) | Medium |
+| **Weaviate** | Native multi-tenancy (tenant header) | Strong (built-in) | Low |
+
+### 6.2 Multi-Tenant Architecture Patterns
+
+**Pattern 1: Payload-Based Partitioning (Qdrant recommended)**
+```
+Single collection → points tagged with tenant_id → filtered search
+Pros: Efficient, simple, good for many tenants
+Cons: Logical isolation only, potential cross-tenant leakage if filter fails
+```
+
+**Pattern 2: Separate Collections (Qdrant alternative)**
+```
+Each tenant gets own collection → isolated vector space
+Pros: Strong isolation, independent scaling
+Cons: Resource overhead per collection, doesn't scale to thousands of tenants
+```
+
+**Pattern 3: Application-Level Scoping (mem0, Zep, Cognee)**
+```
+user_id/namespace in API → memory store filters by scope
+Pros: Simple, flexible
+Cons: No storage-level isolation, application must enforce
+```
+
+**Pattern 4: Native Multi-Tenancy (Weaviate)**
+```
+Tenant header in every request → built-in data isolation
+Pros: Strong isolation, transparent to application
+Cons: Requires database-level support
+```
+
+### 6.3 Uteke Multi-Tenant Opportunity
+
+Uteke currently uses **namespaces** (rooms) for logical grouping. To support true multi-tenancy:
+
+1. **Near-term:** Room-based tenant isolation — each tenant gets dedicated room(s). SQLite file-per-tenant for physical isolation. Simple, strong isolation for small-scale multi-tenancy.
+
+2. **Medium-term:** Built-in tenant management in HTTP API — `tenant_id` parameter on all operations. Automatic room routing. Per-tenant embedding model configuration.
+
+3. **Long-term:** Federated rooms — cross-tenant memory sharing with explicit permission grants. Useful for collaboration scenarios.
+
+**Unique advantage:** SQLite-per-tenant gives **physical data isolation** for free — each tenant's data is in a separate file. No other competitor offers this (they all use shared databases with logical partitioning). This is a strong selling point for privacy-sensitive and regulated industries.
+
+---
+
+## 7. Market Gaps & Uteke Unique Advantages
+
+### 7.1 Gaps in the Current Market
+
+| Gap | Description | Who's Missing It | Uteke Position |
+|-----|-------------|------------------|----------------|
+| **Offline/Edge Memory** | No competitor works without internet/API access | ALL competitors | **Uteke is the only fully offline option** |
+| **Zero-Cost Memory** | Every competitor requires paid LLM API calls for extraction | ALL competitors | **Uteke has zero recurring API costs** |
+| **Lightweight Binary** | All competitors are Python libraries needing Python runtime + deps | ALL competitors | **Uteke is a single Rust binary (~15MB)** |
+| **Data Sovereignty** | Cloud platforms move data off-premises | mem0, Zep, Cognee cloud | **Uteke never sends data anywhere** |
+| **CPU-Only Embeddings** | All competitors use cloud embedding APIs | ALL competitors | **Uteke runs ONNX embeddings on CPU** |
+| **Edge/IoT Deployment** | No memory layer runs on Raspberry Pi/edge devices | ALL competitors | **Uteke runs on ARM, minimal resources** |
+| **Privacy-First** | No competitor guarantees zero data exfiltration | ALL competitors | **Uteke has no network calls by design** |
+| **Air-Gapped Environments** | Enterprise/gov air-gapped deployments need local memory | ALL competitors | **Uteke works with zero network** |
+| **Desktop App Memory** | Local AI apps need local memory without cloud dependency | ALL competitors | **Uteke embeds into desktop apps trivially** |
+| **Simple Setup** | Competitors need Docker + DB + LLM + vector store | mem0, Zep, Letta | **Uteke: download binary, run** |
+
+### 7.2 Uteke's Defensible Moat
+
+```
+┌─────────────────────────────────────────────────────┐
+│              UTEKE'S DEFENSIBLE MOAT                  │
+│                                                       │
+│  1. ONLY fully offline semantic memory engine        │
+│  2. ONLY single-binary solution (Rust)               │
+│  3. ONLY CPU-only embedding (no GPU/API needed)      │
+│  4. ONLY zero-dependency memory layer                 │
+│  5. SQLite storage = simplest possible deployment    │
+│  6. MCP protocol = native AI agent integration        │
+│  7. Smart decay = automatic memory lifecycle          │
+│                                                       │
+│  No competitor can match ALL of these simultaneously. │
+│  Cloud-first competitors would need a complete        │
+│  architectural rewrite to match this positioning.    │
+└─────────────────────────────────────────────────────┘
+```
+
+### 7.3 Where Uteke Loses
+
+| Area | Competitor Advantage | Impact |
+|------|---------------------|--------|
+| **Automatic Memory Extraction** | mem0/Zep extract memories from conversations via LLM | Uteke requires manual/API memory insertion |
+| **Mindshare** | mem0 has 62K stars; uteke has 179 | Harder to get discovered |
+| **Graph Reasoning** | Zep/Graphiti have temporal knowledge graphs | Uteke's relationship graph is simpler |
+| **Scale** | Cloud platforms scale horizontally | Uteke is single-node |
+| **SDK Ecosystem** | mem0/LangMem have rich SDKs | Uteke needs more language bindings |
+| **Cloud Convenience** | Managed platforms remove all DevOps | Uteke requires self-hosting |
+| **Enterprise Features** | SSO, audit logs, compliance built-in | Uteke needs to build these |
+
+---
+
+## 8. Strategic Recommendations
+
+### 8.1 Positioning Strategy
+
+**Current positioning:** "Local-first semantic memory engine"  
+**Recommended positioning:** "The memory layer for AI agents that runs anywhere — offline, on-device, zero API costs"
+
+Emphasize the **impossible triangle** that competitors can't solve:
+```
+        Offline
+         / \
+        /   \
+       /     \
+  Zero Cost ─── Zero Dependencies
+
+  Uteke is the ONLY solution in the center.
+```
+
+### 8.2 Target Segments
+
+| Segment | Why Uteke Wins | Priority |
+|---------|---------------|----------|
+| **Edge/IoT AI** | Only memory layer that runs on ARM devices | 🔴 High |
+| **Privacy-Regulated Industries** (healthcare, finance, gov) | Data never leaves premises | 🔴 High |
+| **Desktop AI Apps** | Embed trivially, no Python/runtime dependency | 🔴 High |
+| **Developer Tools / CLI Agents** | MCP server + CLI, zero setup | 🟡 Medium |
+| **Air-Gapped Environments** | Works with zero network | 🟡 Medium |
+| **Cost-Sensitive Deployments** | Zero recurring API costs | 🟡 Medium |
+| **Embedded/OEM** | License as memory subsystem in other products | 🟢 Future |
+
+### 8.3 Product Roadmap Recommendations
+
+**Phase 1: Solidify Core (v0.13–v0.15)**
+- [ ] Automatic memory extraction (rule-based + lightweight local model, no external LLM)
+- [ ] Multi-tenant management API (tenant_id, room routing)
+- [ ] Python and TypeScript SDKs
+- [ ] Benchmark suite vs. mem0/Zep (latency, cost, resource usage)
+- [ ] Production deployment guides (Docker, systemd, embedded)
+
+**Phase 2: Expand Reach (v0.16–v1.0)**
+- [ ] Enterprise features (RBAC, audit logs, cloud sync/backup)
+- [ ] Plugin system (custom extractors, embedding models, decay algorithms)
+- [ ] MCP marketplace integration
+- [ ] Performance benchmarking and publication
+- [ ] 1.0 stability guarantee
+
+**Phase 3: Market Capture (v1.0+)**
+- [ ] Enterprise license tier
+- [ ] Cloud sync service (optional, local-first)
+- [ ] Federation (cross-instance memory sharing)
+- [ ] Graph reasoning (lightweight, local — not Neo4j)
+- [ ] Community ecosystem (plugins, integrations)
+
+### 8.4 Competitive Strategy
+
+1. **Don't compete with mem0 on cloud features.** They have $13.5M and 62K stars. Compete where they can't follow: offline, edge, privacy.
+
+2. **Own the "local-first memory" category.** Create and dominate this category. Be the default choice when developers need memory without cloud dependency.
+
+3. **Lean into MCP protocol.** As MCP adoption grows (OpenAI, Anthropic, Google all supporting), uteke's native MCP server becomes a strategic advantage.
+
+4. **Target Rust/embedded ecosystem.** No other memory tool is Rust-native. This gives uteke natural affinity with the growing Rust ecosystem.
+
+5. **Publish benchmarks.** Show concrete data: latency (<10ms vs 200ms cloud), cost ($0 vs $N/month), resource usage (50MB vs 2GB). Numbers win arguments.
+
+---
+
+## 9. Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| mem0 adds offline mode | Medium | High | They'd need complete architecture change — unlikely short-term |
+| New Rust-based competitor emerges | Low | Medium | First-mover advantage; accelerate development |
+| MCP protocol doesn't gain adoption | Low | High | Also support HTTP API + CLI; don't bet exclusively on MCP |
+| Market consolidates around cloud | Medium | Medium | Differentiate on use cases cloud can't serve |
+| LLM agents move to built-in memory | Low | High | Built-in memory is too basic; dedicated layer always needed |
+| Qdrant/Chroma add memory features | Medium | Medium | They're infrastructure, not memory layer — different focus |
+
+---
+
+## Appendix A: Data Sources
+
+- GitHub API (repos stats, README content) — accessed August 5, 2026
+- mem0.ai/pricing — JSON-LD structured data
+- getzep.com/pricing — FAQ structured data
+- cognee.ai/pricing — pricing page
+- letta.com — documentation
+- qdrant.tech/documentation — multitenancy docs
+- Company blogs and documentation
+
+## Appendix B: Methodology
+
+- GitHub data: `gh api` authenticated queries for stargazers_count, forks_count, license, language
+- Pricing data: Official pricing pages + JSON-LD/FAQ structured data extraction
+- Architecture data: README analysis from GitHub repos
+- Multi-tenant data: Official documentation pages
+- All data collected August 5, 2026
+
+---
+
+*This report was compiled for internal strategic planning. Data is point-in-time (August 2026) and should be refreshed quarterly.*


### PR DESCRIPTION
## What

New zero-dependency offline fact extraction module that works without any API keys, network calls, or LLM services. This becomes the **default extraction mode** for all new users.

- **New module**: `crates/uteke-core/src/offline_extraction.rs` (529 lines + tests)
- **ExtractionConfig** gains `mode` field: `"offline"` | `"llm"`
- **CLI import `--extract`** now dispatches based on config mode
- **Server `/extract`** endpoint forwards mode from config

## How offline extraction works

1. **Sentence segmentation** — splits on `.`, `!`, `?`, newlines, handles bullets/numbered lists
2. **Noise filtering** — drops greetings, fillers, questions, tool output, bare URLs, code blocks
3. **Keyword scoring** — salience weights for identity ("my name is"), preferences ("I prefer"), decisions ("decided", "switched to"), dates, technical terms
4. **Deduplication** — case-insensitive prefix matching (50 chars)
5. **Fact cleanup** — strip markdown, bullets, numbering, ensure terminal punctuation

## Why

Most users want fact extraction without configuring API keys or paying for LLM calls. The offline mode:
- Works **out of the box** with zero configuration
- Is **private** — no data leaves the machine
- Handles **multilingual text** (tested with Indonesian, emoji)
- Is the **sensible default** — users who want LLM extraction can opt in via `mode = "llm"`

## Mode resolution

| Config `mode` | API key present? | Result |
|---|---|---|
| `"offline"` | irrelevant | **Offline** (rule-based) |
| `"llm"` | required | **LLM** (OpenAI-compatible API) |
| `""` (empty) | yes | **LLM** (auto-detected) |
| `""` (empty) | no | **Offline** (auto-detected) |

## Testing

- `cargo test -p uteke-core offline_extraction` → **11/11 passed**
- Full core test suite: **389 passed, 0 failed**
- `cargo clippy` → zero warnings
- UTF-8 multibyte safety test (Indonesian text + emoji)

Closes #885