### PR TITLE
fix: ONNX auto-detect + room recall UX + import help text

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -237,17 +237,23 @@ pub enum Commands {
         /// Import format: auto, jsonl, markdown, text (default: auto-detect)
         #[arg(long, default_value = "auto")]
         format: String,
-        /// Distill the input into atomic facts with an LLM before storing
-        /// (opt-in; requires an OpenAI-compatible endpoint + API key).
+        /// Distill the input into atomic facts before storing.
+        ///
+        /// Extraction mode depends on config:
+        /// - offline (default): rule-based, zero API calls, no key needed.
+        /// - llm: requires an OpenAI-compatible endpoint + API key.
         #[arg(long)]
         extract: bool,
-        /// Override the extraction model (else [extraction] model / UTEKE_EXTRACTION_MODEL)
+        /// Override the extraction model (only used in LLM mode;
+        /// else [extraction] model / UTEKE_EXTRACTION_MODEL)
         #[arg(long)]
         extract_model: Option<String>,
-        /// Override the extraction API key (else config / UTEKE_EXTRACTION_API_KEY / OPENAI_API_KEY)
+        /// Override the extraction API key (only used in LLM mode;
+        /// else config / UTEKE_EXTRACTION_API_KEY / OPENAI_API_KEY)
         #[arg(long)]
         extract_api_key: Option<String>,
-        /// Override the extraction base URL (e.g. http://localhost:11434/v1 for Ollama)
+        /// Override the extraction base URL for LLM mode
+        /// (e.g. http://localhost:11434/v1 for Ollama)
         #[arg(long)]
         extract_base_url: Option<String>,
         /// Max facts to keep per document (0 = default)
@@ -674,12 +680,21 @@ pub enum RoomCommands {
         room_id: String,
     },
     /// Recall all memories in a room (cross-namespace)
+    ///
+    /// Examples:
+    ///   uteke room recall engineering                    # all memories
+    ///   uteke room recall engineering "caching strategy" # semantic search
+    ///   uteke room recall engineering --author alice     # filter by author
     Recall {
         /// Room ID
         room_id: String,
-        /// Semantic query — rank memories by relevance instead of chronological
-        #[arg(long)]
+        /// Semantic query (optional positional) — rank memories by relevance.
+        /// Equivalent to --query. Use when you want natural `room recall <id> "<query>"` syntax.
         query: Option<String>,
+        /// Semantic query (flag form) — same as positional query.
+        /// If both are given, positional takes precedence.
+        #[arg(long = "query", visible_alias = "query-flag")]
+        query_flag: Option<String>,
         /// Filter by author
         #[arg(long)]
         author: Option<String>,

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -88,11 +88,14 @@ pub(crate) fn run(
         RoomCommands::Recall {
             room_id,
             query,
+            query_flag,
             author,
             limit,
             min,
         } => {
-            if let Some(q) = query {
+            // Positional query takes precedence over --query flag.
+            let effective_query = query.as_ref().or(query_flag.as_ref());
+            if let Some(q) = effective_query {
                 // Semantic recall — rank by relevance
                 let min_score = min.unwrap_or(config.recall.min_score as f32);
                 let results = uteke

--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -151,12 +151,28 @@ pub fn resolve_ort_lib() -> Result<OrtLibInfo, String> {
         }
     }
 
-    // 5. No library found anywhere — build a descriptive error.
+    // 5. Python site-packages fallback — many users have onnxruntime via pip.
+    // This covers: ~/.local/lib/python*/site-packages/onnxruntime/capi/
+    // Also checks pyke cache: ~/.cache/ort.pyke.io/
+    if let Some(path) = find_python_or_conda_lib() {
+        tracing::info!(
+            "ORT: Using library from Python/conda install: {}",
+            path.display()
+        );
+        return Ok(OrtLibInfo {
+            lib_path: path,
+            has_avx2: avx2,
+        });
+    }
+
+    // 6. No library found anywhere — build a descriptive error.
     if avx2 {
         Err(format!(
             "ONNX Runtime library not found. Searched:\n\
              - {} (exe directory)\n\
              - /usr/local/lib, /usr/lib, /lib (system paths)\n\
+             - Python site-packages (~/.local/lib/python*/site-packages/onnxruntime/capi/)\n\
+             - pyke cache (~/.cache/ort.pyke.io/)\n\
              Set ORT_LIB_PATH to the library file, or use the standard release bundle.",
             exe_dir.join(ORT_LIB_NAME).display()
         ))
@@ -176,6 +192,119 @@ fn exe_dir() -> Result<PathBuf, String> {
     exe.parent()
         .map(|p| p.to_path_buf())
         .ok_or_else(|| "executable path has no parent directory".into())
+}
+
+/// Search for ONNX Runtime library in Python and conda installations.
+///
+/// Covers:
+/// - `~/.local/lib/python*/site-packages/onnxruntime/capi/` (pip user install)
+/// - `/usr/lib/python*/site-packages/onnxruntime/capi/` (pip system install)
+/// - `~/.cache/ort.pyke.io/` (pyke cache, nested dfbin dirs)
+/// - Conda: `~/miniconda3/lib/`, `~/anaconda3/lib/` (conda install)
+///
+/// Handles versioned library names: `libonnxruntime.so.1.25.0`, etc.
+///
+/// Returns the first match found, or `None`.
+fn find_python_or_conda_lib() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+
+    // Collect all candidate directories.
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    // 1. pip user site-packages: ~/.local/lib/python*/site-packages/onnxruntime/capi/
+    let pip_user_base = PathBuf::from(&home).join(".local/lib");
+    if let Ok(entries) = std::fs::read_dir(&pip_user_base) {
+        for entry in entries.flatten() {
+            let py_dir = entry.path().join("site-packages/onnxruntime/capi");
+            if py_dir.is_dir() {
+                candidates.push(py_dir);
+            }
+        }
+    }
+
+    // 2. pip system site-packages: /usr/lib/python*/site-packages/onnxruntime/capi/
+    //    and /usr/local/lib/python*/site-packages/onnxruntime/capi/
+    for sys_base in ["/usr/lib", "/usr/local/lib"] {
+        if let Ok(entries) = std::fs::read_dir(sys_base) {
+            for entry in entries.flatten() {
+                let py_dir = entry.path().join("site-packages/onnxruntime/capi");
+                if py_dir.is_dir() {
+                    candidates.push(py_dir);
+                }
+            }
+        }
+    }
+
+    // 3. pyke cache: ~/.cache/ort.pyke.io/ (nested dfbin dirs with hash names)
+    let pyke_base = PathBuf::from(&home).join(".cache/ort.pyke.io");
+    if pyke_base.is_dir() {
+        collect_pyke_dirs(&pyke_base, &mut candidates, 0);
+    }
+
+    // 4. Conda: ~/miniconda3/lib/, ~/anaconda3/lib/, ~/miniforge3/lib/
+    for conda in ["miniconda3", "anaconda3", "miniforge3"] {
+        candidates.push(PathBuf::from(&home).join(conda).join("lib"));
+    }
+
+    // Search each candidate for the ORT library (exact name or versioned variant).
+    for dir in &candidates {
+        if let Some(path) = find_ort_in_dir(dir) {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+/// Recursively collect directories from pyke cache (max depth 3).
+fn collect_pyke_dirs(base: &PathBuf, candidates: &mut Vec<PathBuf>, depth: usize) {
+    if depth > 3 {
+        return;
+    }
+    if let Ok(entries) = std::fs::read_dir(base) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Check if this dir contains the ORT lib directly.
+                if find_ort_in_dir(&path).is_some() {
+                    candidates.push(path);
+                } else {
+                    // Recurse deeper.
+                    collect_pyke_dirs(&path, candidates, depth + 1);
+                }
+            }
+        }
+    }
+}
+
+/// Look for the ORT library in a specific directory.
+///
+/// Tries exact filename first (`libonnxruntime.so`), then versioned
+/// variants (`libonnxruntime.so.*`).
+fn find_ort_in_dir(dir: &PathBuf) -> Option<PathBuf> {
+    // Exact match.
+    let exact = dir.join(ORT_LIB_NAME);
+    if exact.exists() {
+        return Some(exact);
+    }
+
+    // Versioned variant: libonnxruntime.so.1.25.0, etc.
+    // Only on Unix (.so suffix).
+    #[cfg(unix)]
+    {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                // Match: libonnxruntime.so.<anything>
+                if name_str.starts_with("libonnxruntime.so.") && entry.path().is_file() {
+                    return Some(entry.path());
+                }
+            }
+        }
+    }
+
+    None
 }
 
 /// Initialize the ORT environment using the resolved library path.
@@ -260,5 +389,47 @@ mod tests {
     fn exe_dir_returns_parent() {
         let dir = exe_dir().unwrap();
         assert!(dir.exists(), "exe dir should exist: {}", dir.display());
+    }
+
+    #[test]
+    fn find_ort_in_dir_finds_exact_match() {
+        let tmp = std::env::temp_dir();
+        let dir = tmp.join("test_ort_exact");
+        std::fs::create_dir_all(&dir).unwrap();
+        let lib = dir.join("libonnxruntime.so");
+        std::fs::write(&lib, b"fake").unwrap();
+
+        let result = find_ort_in_dir(&dir);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), lib);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn find_ort_in_dir_finds_versioned_variant() {
+        let tmp = std::env::temp_dir();
+        let dir = tmp.join("test_ort_versioned");
+        std::fs::create_dir_all(&dir).unwrap();
+        let lib = dir.join("libonnxruntime.so.1.25.0");
+        std::fs::write(&lib, b"fake").unwrap();
+
+        let result = find_ort_in_dir(&dir);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), lib);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn find_ort_in_dir_returns_none_when_empty() {
+        let tmp = std::env::temp_dir();
+        let dir = tmp.join("test_ort_empty");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let result = find_ort_in_dir(&dir);
+        assert!(result.is_none());
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## What

Three improvements from E2E testing of milestone v0.13.0:

1. **ONNX Runtime auto-detection** — fallback search for Python site-packages (`~/.local/lib/python*/site-packages/onnxruntime/capi/`), pyke cache, conda paths, and versioned library names (`libonnxruntime.so.1.25.0`). Eliminates the need for manual `ORT_LIB_PATH` in common setups.

2. **Room recall positional query** — `uteke room recall <id> "query"` now works as natural syntax. `--query` flag preserved as backward-compatible alias. Positional takes precedence.

3. **Import --help accuracy** — documents offline mode (default) vs LLM mode. Removes misleading "requires API key" from `--extract` description.

## Why

E2E testing revealed three friction points:
- First-run experience broken without manual `ORT_LIB_PATH` env var
- Room recall required reading `--help` to discover `--query` flag
- Import help text still referenced API key requirement despite offline mode being the new default

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` ✅ zero warnings
- `cargo test --workspace` ✅ 446 passed, 0 failed, 24 ignored
- E2E: remember + recall **without ORT_LIB_PATH** ✅ auto-detected from Python site-packages
- E2E: `room recall testroom "caching"` (positional) ✅
- E2E: `room recall testroom --query "db"` (backward compat) ✅
- E2E: `room recall testroom` (no query, all memories) ✅
- E2E: `import --help` shows offline mode as default ✅
- 3 new unit tests for `find_ort_in_dir()` (exact match, versioned variant, empty dir)

Closes #893, #894, #895