### PR TITLE
fix(#894): bounded room search with fallback for complete coverage

### DIFF
--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -73,7 +73,13 @@ impl crate::Uteke {
     /// Semantic recall within room context using hybrid search (vector + FTS5).
     ///
     /// Returns room memories ranked by relevance to query, with scores.
-    /// Algorithm: over-fetch via recall_hybrid, post-filter to room members, truncate.
+    ///
+    /// Algorithm (two-stage, bounded):
+    /// 1. **Primary**: hybrid search with adaptive bounded limit, post-filter to room IDs.
+    /// 2. **Fallback**: if primary returns fewer room memories than the room contains,
+    ///    load remaining room memories directly and score them with cosine similarity
+    ///    against the query embedding. This guarantees complete room coverage without
+    ///    unbounded global fetch (#894 follow-up).
     pub fn recall_room_semantic(
         &self,
         room_id: &str,
@@ -87,48 +93,97 @@ impl crate::Uteke {
         if room_ids.is_empty() {
             return Ok(Vec::new());
         }
+        let room_size = room_ids.len();
         let id_set: std::collections::HashSet<String> = room_ids.into_iter().collect();
 
-        // 2. Over-fetch via hybrid recall (no namespace filter — rooms are cross-ns).
+        // 2. Adaptive bounded fetch_limit.
         //
-        // Fetch ALL memories so post-filter to room IDs has complete coverage.
-        // HNSW vector search is O(log N), so fetching 2K+ results is still fast.
-        // The old fixed cap of 200 (#546) caused small rooms to return zero (#894).
+        // Scale with room size (×10 gives generous over-fetch for post-filter)
+        // and caller limit (×5). Hard cap at MAX_ROOM_FETCH prevents unbounded
+        // scans on large databases (50K+ memories).
+        const MAX_ROOM_FETCH: usize = 5_000;
+        let effective_limit = if limit == 0 { 1000 } else { limit };
         let total_memories = self.store.count_all_memories()?;
-        let fetch_limit = total_memories;
-        let results = self.recall_hybrid(
+        let fetch_limit = (room_size * 10)
+            .max(effective_limit * 5)
+            .min(total_memories)
+            .min(MAX_ROOM_FETCH);
+
+        // 3. Primary: hybrid search → post-filter to room IDs
+        let hybrid_results = self.recall_hybrid(
             query,
             fetch_limit,
             None, // no tag filter
             None, // no namespace filter — rooms are cross-namespace
             RecallStrategy::Hybrid,
-            0.0, // no min_score at fetch stage, we filter after
+            0.0,
         )?;
 
-        // 3. Post-filter: only keep results whose memory ID is in the room
-        let mut filtered: Vec<SearchResult> = results
+        let mut results: Vec<SearchResult> = hybrid_results
             .into_iter()
             .filter(|sr| id_set.contains(&sr.memory.id))
             .collect();
 
-        // 4. Apply min_score filter
-        if min_score > 0.0 {
-            filtered.retain(|sr| sr.score >= min_score);
+        // 4. Fallback: if hybrid missed some room memories, score them directly.
+        //
+        // This happens when room memories rank below the fetch_limit boundary in
+        // global search (e.g. small room in a large DB — the original #894 bug).
+        // We embed the query and compute cosine similarity for the missing IDs.
+        let found_ids: std::collections::HashSet<&str> =
+            results.iter().map(|sr| sr.memory.id.as_str()).collect();
+        let missing_ids: Vec<&str> = id_set
+            .iter()
+            .filter(|id| !found_ids.contains(id.as_str()))
+            .map(|s| s.as_str())
+            .collect();
+
+        if !missing_ids.is_empty() {
+            // Load missing room memories (includes embeddings)
+            let mut missing_memories = Vec::new();
+            for id in &missing_ids {
+                if let Some(mem) = self.store.get_by_id(id)? {
+                    if !mem.deprecated {
+                        missing_memories.push(mem);
+                    }
+                }
+            }
+
+            if !missing_memories.is_empty() {
+                // Embed query and score each missing memory by cosine similarity.
+                self.ensure_embedder()?;
+                let query_emb = self
+                    .embedder
+                    .lock()
+                    .map_err(|_| Error::lock("embedder in room fallback"))?
+                    .as_ref()
+                    .expect("embedder ensured above")
+                    .embed(query)?;
+
+                for mem in missing_memories {
+                    let score = crate::consolidate::cosine_similarity(&query_emb, &mem.embedding);
+                    results.push(SearchResult { memory: mem, score });
+                }
+            }
         }
 
-        // 5. Sort by score descending (already sorted by recall_hybrid, but re-sort after filtering)
-        filtered.sort_by(|a, b| {
+        // 5. Apply min_score filter
+        if min_score > 0.0 {
+            results.retain(|sr| sr.score >= min_score);
+        }
+
+        // 6. Sort by score descending
+        results.sort_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        // 6. Truncate to limit (0 = return all, no truncation)
+        // 7. Truncate to limit (0 = return all, no truncation)
         if limit > 0 {
-            filtered.truncate(limit);
+            results.truncate(limit);
         }
 
-        Ok(filtered)
+        Ok(results)
     }
 
     /// Delete a room and all its memory links.


### PR DESCRIPTION
## What

Replace unbounded `fetch_limit = total_memories` (PR #897) with a **two-stage bounded algorithm** that guarantees complete room coverage without scanning the entire database.

## Why

PR #897 fixed #894 (small rooms returning zero results) by setting `fetch_limit = total_memories`. This works but is unbounded — for a 50K+ memory database, every `room recall` call fetches, deserializes, and hybrid-scores all 50K memories, even when the caller only wants 5 results.

The HNSW ANN lookup is O(log N), but downstream operations (row deserialization, FTS5 search, RRF score merging) all scale with `fetch_limit`. A bounded approach is needed.

## How It Works

### Stage 1: Primary (bounded hybrid search)

```
fetch_limit = max(room_size * 10, effective_limit * 5)
                .min(total_memories)
                .min(MAX_ROOM_FETCH=5000)
```

- `room_size * 10`: generous over-fetch ratio for post-filtering to room IDs
- `effective_limit * 5`: ensures caller gets enough results even in large rooms
- `MAX_ROOM_FETCH = 5000`: hard cap prevents unbounded scans on 50K+ DBs

### Stage 2: Fallback (direct cosine scoring)

If Stage 1's post-filter returns fewer room memories than the room contains, load the **missing** room memories by ID (their embeddings are stored in SQLite), embed the query, and compute cosine similarity directly.

This handles the edge case where room memories rank below position 5000 in global search — exactly the #894 scenario, but now bounded.

## Performance Characteristics

| Scenario | Old (#897) | New (this PR) |
|----------|-----------|---------------|
| 2K DB, 20-mem room | Fetch 2K | Fetch 200 (20×10) |
| 50K DB, 20-mem room | Fetch **50K** | Fetch 5000 (capped) |
| 50K DB, 500-mem room | Fetch **50K** | Fetch 5000 (capped) |
| Small room missed by hybrid | Works (scans all) | Works (fallback scores directly) |

The fallback stage only runs when needed (room memories missing from primary results) and only processes the **missing** IDs, not the entire room.

## Testing

- cargo clippy --workspace --all-targets -- -D warnings — clean
- cargo fmt --all — clean
- cargo test --workspace — 453 passed, 0 failed, 26 ignored
- E2E verification with production clone (2,486 memories, 74 rooms):
  - cora-code (20 mems): 5 results (primary path)
  - uteke-dev (small room): 1 result (fallback path)
  - codecora-dev: 2 results (fallback path)
  - uteke-marketing: 5 results (primary path)

Addresses reviewer concern on PR #897 about unbounded fetch_limit.

Ref #894
