### PR TITLE
fix(#902,#903,#907): HTTP temporal filters, limit cap, empty query guard

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -202,6 +202,18 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         // ── Recall (semantic search) ────────────────────────────────────
         (Method::Post, "/recall") => match read_body::<RecallRequest>(req.as_reader()) {
             Ok(req_data) => {
+                // #907: Reject empty/whitespace queries — they return misleading
+                // results (top-N by recency, not relevance).
+                if req_data.query.trim().is_empty() {
+                    return ctx.error_response_for(
+                        req,
+                        400,
+                        "Query must not be empty or whitespace-only",
+                    );
+                }
+                // #903: Cap limit to prevent DoS via unbounded queries.
+                let limit = req_data.limit.min(MAX_LIMIT);
+
                 let tag_refs: Vec<&str> = req_data.tags.iter().map(|s| s.as_str()).collect();
                 let tags_filter = if tag_refs.is_empty() {
                     None
@@ -248,10 +260,43 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 let entity_filter = req_data.entity.as_deref();
                 let category_filter = req_data.category.as_deref();
 
+                // #902: Parse temporal range filters (before/after RFC3339).
+                let after_ts = match req_data.after.as_deref() {
+                    Some(ts) => match chrono::DateTime::parse_from_rfc3339(ts) {
+                        Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+                        Err(_) => {
+                            return ctx.error_response_for(
+                                req,
+                                400,
+                                format!(
+                                    "Invalid 'after' timestamp: {ts}. Use RFC3339 format (e.g. 2026-01-01T00:00:00Z)"
+                                ),
+                            );
+                        }
+                    },
+                    None => None,
+                };
+                let before_ts = match req_data.before.as_deref() {
+                    Some(ts) => match chrono::DateTime::parse_from_rfc3339(ts) {
+                        Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+                        Err(_) => {
+                            return ctx.error_response_for(
+                                req,
+                                400,
+                                format!(
+                                    "Invalid 'before' timestamp: {ts}. Use RFC3339 format (e.g. 2026-01-01T00:00:00Z)"
+                                ),
+                            );
+                        }
+                    },
+                    None => None,
+                };
+                let has_temporal = after_ts.is_some() || before_ts.is_some();
+
                 let recall_result = if let Some(pit) = point_in_time {
                     uteke.recall_at_time(
                         &req_data.query,
-                        req_data.limit,
+                        limit,
                         tags_filter,
                         ns(&req_data.namespace),
                         pit,
@@ -262,7 +307,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 } else {
                     uteke.recall(
                         &req_data.query,
-                        req_data.limit,
+                        limit,
                         tags_filter,
                         ns(&req_data.namespace),
                         min_score,
@@ -307,7 +352,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     };
                     Some(uteke.recall_unified(
                         &req_data.query,
-                        req_data.limit,
+                        limit,
                         tags_filter,
                         ns(&req_data.namespace),
                         min_score,
@@ -323,7 +368,17 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
 
                 // Prefer unified results when available (#531)
                 match unified_result {
-                    Some(Ok(results)) => {
+                    Some(Ok(mut results)) => {
+                        // #902: Post-filter by temporal range (before/after).
+                        if has_temporal {
+                            results.retain(|r| {
+                                let ts = r.created_at.as_ref();
+                                ts.is_some_and(|t| {
+                                    after_ts.is_none_or(|a| t >= &a)
+                                        && before_ts.is_none_or(|b| t <= &b)
+                                })
+                            });
+                        }
                         if api_version == Some(ApiVersion::V1) {
                             // v1: flat format [{id, content, score, ...}]
                             let v1_results: Vec<serde_json::Value> =
@@ -341,7 +396,15 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         // Memory-only recall path — entity/category filtering
                         // is already applied in the core recall candidate loop (#663).
                         match recall_result {
-                            Ok(results) => {
+                            Ok(mut results) => {
+                                // #902: Post-filter by temporal range (before/after).
+                                if has_temporal {
+                                    results.retain(|r| {
+                                        let t = &r.memory.created_at;
+                                        after_ts.is_none_or(|a| t >= &a)
+                                            && before_ts.is_none_or(|b| t <= &b)
+                                    });
+                                }
                                 if results.is_empty() && min_score > 0.0 {
                                     ctx.ok_response_for(
                                         req,

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -241,6 +241,14 @@ pub struct RecallRequest {
     /// Recall strategy: "vector" (default), "fts5", "hybrid", or "graph" (#900).
     #[serde(default)]
     pub strategy: Option<String>,
+    /// Temporal range filter: only return memories created at or after this
+    /// RFC3339 timestamp (#902).
+    #[serde(default)]
+    pub after: Option<String>,
+    /// Temporal range filter: only return memories created at or before this
+    /// RFC3339 timestamp (#902).
+    #[serde(default)]
+    pub before: Option<String>,
 }
 
 #[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]
@@ -414,6 +422,8 @@ pub struct RecallFileSection {
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
+/// Hard cap on recall/list `limit` to prevent DoS via unbounded queries (#903).
+pub const MAX_LIMIT: usize = 100;
 /// Default strict mode threshold for server recall.
 /// Used as fallback when [recall] min_score_strict is not configured.
 pub const STRICT_THRESHOLD: f32 = 0.5;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -589,7 +589,11 @@ Request for memory feedback / trust scoring (#718).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `after` | any | No | Temporal range filter: only return memories created at or after this
+RFC3339 timestamp (#902). |
 | `at` | any | No | Time-travel: query memories that existed at this RFC3339 timestamp. |
+| `before` | any | No | Temporal range filter: only return memories created at or before this
+RFC3339 timestamp (#902). |
 | `category` | any | No | Filter by category metadata. |
 | `enrich` | `boolean` | No | Enrich results with cross-entity links (doc↔memory) (#689).
 When true, populates `linked_doc_slugs` on memory results and


### PR DESCRIPTION
## What

Three HTTP API fixes bundled (same file scope — server crate only):

### #902 — Temporal range filters (`before`/`after`)
- Add `before` and `after` fields to `RecallRequest` (RFC3339 timestamps)
- Post-filter results by `created_at` in both unified and memory-only recall paths
- Invalid timestamps return `400` with descriptive error

### #903 — Limit cap (DoS prevention)
- Add `MAX_LIMIT = 100` constant in `types.rs`
- `limit` field is silently capped (`req_data.limit.min(MAX_LIMIT)`)
- Prevents unbounded query attacks via `limit: 999999`

### #907 — Empty query guard
- Reject empty/whitespace-only query strings with `400`
- Previously returned misleading top-N results (recency-based, not relevance)

## Why

| Issue | Impact | Severity |
|-------|--------|----------|
| #902 | `before`/`after` params silently ignored — temporal queries broken | 🔴 P0 |
| #903 | No limit cap — DoS vector via unbounded queries | 🟠 P1 |
| #907 | Empty query returns misleading results | 🟡 P2 |

## Testing

- ✅ `cargo check --workspace` — pass
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — clean
- ✅ `cargo test --workspace` — 454 passed, 0 failed, 26 ignored
- ✅ `cargo run -p docgen` — API docs regenerated (before/after fields visible)
- ✅ `cargo fmt --all` — formatted

Closes #902, #903, #907.
