### PR TITLE
fix: pin Linux builds to ubuntu-22.04 for GLIBC backward compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,12 +110,22 @@ jobs:
       matrix:
         include:
           # Linux x86_64
-          - os: ubuntu-latest
+          # IMPORTANT: Pin to ubuntu-22.04 (GLIBC 2.35) for backward compatibility.
+          # ubuntu-latest = 24.04 (GLIBC 2.39) — binary won't run on Debian 12,
+          # Ubuntu 22.04, RHEL 9, or any system with GLIBC < 2.39.
+          # See: https://github.com/codecoradev/uteke issues — GLIBC_2.39 not found.
+          #
+          # EOL: Ubuntu 22.04 standard support ends April 2027.
+          # Before that date, migrate to cargo-zigbuild targeting GLIBC 2.17,
+          # which covers Ubuntu 18.04+, Debian 10+, RHEL 8+ and is runner-independent.
+          # (musl static is NOT viable — ort crate has no static-link feature,
+          #  and musl binary dlopen-ing glibc-linked ORT .so risks ABI conflicts.)
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: uteke-x86_64-unknown-linux-gnu
             ext: tar.gz
           # Linux ARM64
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: uteke-aarch64-unknown-linux-gnu
             ext: tar.gz

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,69 @@ install() {
     if [ -f "${INSTALL_DIR}/${MCP_BINARY_NAME}" ]; then
         info "Successfully installed ${MCP_BINARY_NAME} to ${INSTALL_DIR}/${MCP_BINARY_NAME}"
     fi
+
+    # GLIBC compatibility check — verify binary actually runs
+    if [ "$OS" = "linux" ]; then
+        GLIBC_TEST=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 || true)
+        if echo "$GLIBC_TEST" | grep -qi "GLIBC.*not found"; then
+            echo ""
+            error "${GLIBC_TEST}
+
+Your system's GLIBC is too old for the prebuilt binary.
+Options:
+  1. Build from source:
+     curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh -s -- --from-source
+  2. Upgrade your OS to Ubuntu 22.04+ or Debian 12+
+  3. Use Docker: docker run --rm ghcr.io/${REPO}:latest"
+        fi
+    fi
+}
+
+# Build from source fallback
+build_from_source() {
+    info "Building from source..."
+
+    if ! command -v cargo >/dev/null 2>&1; then
+        error "cargo not found. Install Rust: https://rustup.rs"
+    fi
+
+    info "Cloning repository..."
+    TEMP_DIR=$(mktemp -d)
+
+    git clone --depth 1 "https://github.com/${REPO}.git" "$TEMP_DIR" || error "Clone failed."
+
+    cd "$TEMP_DIR"
+    info "Building release binary (this may take a few minutes)..."
+
+    # Download ORT library for linking
+    ORT_VER="1.24.4"
+    ORT_PKG=""
+    case "$(uname -m)" in
+        x86_64|amd64)  ORT_PKG="onnxruntime-linux-x64-${ORT_VER}.tgz" ;;
+        arm64|aarch64) ORT_PKG="onnxruntime-linux-aarch64-${ORT_VER}.tgz" ;;
+        *)             error "Unsupported architecture for source build: $(uname -m)" ;;
+    esac
+    curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" | tar xz
+    mkdir -p ort-lib
+    find onnxruntime-*/lib -name 'libonnxruntime.so*' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
+    export ORT_LIB_DIR=ort-lib
+
+    # Use trap to ensure cleanup even on build failure
+    trap 'cd /; rm -rf "$TEMP_DIR"' EXIT
+    cargo build --release -p uteke-cli -p uteke-server -p uteke-mcp || error "Build failed."
+
+    mkdir -p "$INSTALL_DIR"
+    cp target/release/${BINARY_NAME} "${INSTALL_DIR}/"
+    cp target/release/${SERVER_BINARY_NAME} "${INSTALL_DIR}/" 2>/dev/null || true
+    cp target/release/${MCP_BINARY_NAME} "${INSTALL_DIR}/" 2>/dev/null || true
+    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Copy ORT .so next to binary
+    cp ort-lib/libonnxruntime.so* "${INSTALL_DIR}/" 2>/dev/null || true
+
+    # Cleanup handled by trap (set before cargo build)
+
+    info "✓ Installed from source to ${INSTALL_DIR}/${BINARY_NAME}"
 }
 
 # Verify installation
@@ -192,6 +255,16 @@ verify() {
 }
 
 main() {
+    # --from-source flag: skip binary download, compile directly
+    if [ "${1:-}" = "--from-source" ]; then
+        info "Installing ${BINARY_NAME} from source..."
+        build_from_source
+        verify
+        echo ""
+        info "Installation complete! Run '${BINARY_NAME} --help' to get started."
+        return
+    fi
+
     info "Installing ${BINARY_NAME}..."
 
     detect_os
@@ -210,4 +283,4 @@ main() {
     info "Installation complete! Run '${BINARY_NAME} --help' to get started."
 }
 
-main
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -205,14 +205,17 @@ build_from_source() {
         arm64|aarch64) ORT_PKG="onnxruntime-linux-aarch64-${ORT_VER}.tgz" ;;
         *)             error "Unsupported architecture for source build: $(uname -m)" ;;
     esac
-    curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" | tar xz
+    info "Downloading ONNX Runtime ${ORT_VER}..."
+    curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/${ORT_PKG}" -o /tmp/ort-pkg.tgz || error "Failed to download ORT"
+    tar xzf /tmp/ort-pkg.tgz -C "$TEMP_DIR" || error "Failed to extract ORT"
+    rm -f /tmp/ort-pkg.tgz
     mkdir -p ort-lib
     find onnxruntime-*/lib -name 'libonnxruntime.so*' \( -type f -o -type l \) -exec cp -a {} ort-lib/ \;
     export ORT_LIB_DIR=ort-lib
 
-    # Use trap to ensure cleanup even on build failure
-    trap 'cd /; rm -rf "$TEMP_DIR"' EXIT
-    cargo build --release -p uteke-cli -p uteke-server -p uteke-mcp || error "Build failed."
+    cargo build --release -p uteke-cli -p uteke-server -p uteke-mcp || {
+        cd /; rm -rf "$TEMP_DIR"; error "Build failed."
+    }
 
     mkdir -p "$INSTALL_DIR"
     cp target/release/${BINARY_NAME} "${INSTALL_DIR}/"
@@ -220,10 +223,12 @@ build_from_source() {
     cp target/release/${MCP_BINARY_NAME} "${INSTALL_DIR}/" 2>/dev/null || true
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
-    # Copy ORT .so next to binary
+    # Copy ORT .so next to binary and set up loader path
     cp ort-lib/libonnxruntime.so* "${INSTALL_DIR}/" 2>/dev/null || true
 
-    # Cleanup handled by trap (set before cargo build)
+    # Cleanup
+    cd /
+    rm -rf "$TEMP_DIR"
 
     info "✓ Installed from source to ${INSTALL_DIR}/${BINARY_NAME}"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,11 +127,12 @@ install_uteke() {
     if echo "${installed_version}" | grep -qi "GLIBC.*not found"; then
         # GLIBC too old — binary downloaded but can't execute
         echo ""
-        error "${installed_version}\n\n\
-Your system's GLIBC is too old for the prebuilt binary.\n\
-Options:\n\
-  1. Build from source: curl -fsSL https://raw.githubusercontent.com/${REPO}/develop/scripts/install.sh | sh -s -- --from-source\n\
-  2. Upgrade your OS to Ubuntu 22.04+ or Debian 12+\n\
+        error "${installed_version}
+
+Your system's GLIBC is too old for the prebuilt binary.
+Options:
+  1. Build from source: curl -fsSL https://raw.githubusercontent.com/${REPO}/develop/scripts/install.sh | sh -s -- --from-source
+  2. Upgrade your OS to Ubuntu 22.04+ or Debian 12+
   3. Use Docker: docker run --rm ghcr.io/${REPO}:latest"
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -118,12 +118,24 @@ install_uteke() {
     cp "${binary}" "${INSTALL_DIR}/${BINARY_NAME}"
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
+    # Post-install: verify binary actually runs (GLIBC compatibility check)
     info "Installed to ${INSTALL_DIR}/${BINARY_NAME}"
 
-    # Verify
+    local installed_version
+    installed_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1 || true)
+
+    if echo "${installed_version}" | grep -qi "GLIBC.*not found"; then
+        # GLIBC too old — binary downloaded but can't execute
+        echo ""
+        error "${installed_version}\n\n\
+Your system's GLIBC is too old for the prebuilt binary.\n\
+Options:\n\
+  1. Build from source: curl -fsSL https://raw.githubusercontent.com/${REPO}/develop/scripts/install.sh | sh -s -- --from-source\n\
+  2. Upgrade your OS to Ubuntu 22.04+ or Debian 12+\n\
+  3. Use Docker: docker run --rm ghcr.io/${REPO}:latest"
+    fi
+
     if command -v "${BINARY_NAME}" &>/dev/null; then
-        local installed_version
-        installed_version=$("${BINARY_NAME}" --version 2>/dev/null || echo "unknown")
         info "✓ Uteke ${installed_version} installed successfully!"
     else
         warn "Uteke installed but not in PATH."
@@ -170,11 +182,17 @@ main() {
     echo "  https://github.com/${REPO}"
     echo ""
 
+    # Check for --from-source flag
+    if [[ "${1:-}" == "--from-source" ]]; then
+        install_from_source
+        return
+    fi
+
     # Try binary release first, fallback to source
     if install_uteke 2>/dev/null; then
         :
     else
-        warn "Binary release not available for your platform."
+        warn "Binary release not available or incompatible."
         info "Falling back to building from source..."
         install_from_source
     fi


### PR DESCRIPTION
## What

Pin Linux CI builds to `ubuntu-22.04` (GLIBC 2.35) instead of `ubuntu-latest` (24.04, GLIBC 2.39), and add GLIBC compatibility checks + `--from-source` fallback to install scripts.

## Why

Uteke binaries compiled on `ubuntu-latest` (GLIBC 2.39) crash on Debian 12, Ubuntu 22.04, RHEL 9 — any system with GLIBC < 2.39. External user on Debian 12 reported:

```
uteke: /lib64/libc.so.6: version 'GLIBC_2.39' not found (required by uteke)
```

This affects all Linux users on non-bleeding-edge distros.

## How

| File | Change |
|------|--------|
| `release.yml` | `ubuntu-latest` → `ubuntu-22.04` (x86_64), `ubuntu-24.04-arm` → `ubuntu-22.04-arm` (ARM64) |
| `install.sh` | Post-install GLIBC check + `--from-source` flag + `build_from_source()` |
| `scripts/install.sh` | Same GLIBC check + `--from-source` support |

**GLIBC 2.35 coverage:** Ubuntu 22.04+, Debian 12+, RHEL 9+, Fedora 36+

**Opsi B (musl) investigated — NOT viable:** `ort` crate has no `static-link` feature; musl binary dlopen-ing glibc-linked ORT `.so` risks ABI conflicts. Long-term path: `cargo-zigbuild` targeting GLIBC 2.17.

**Note:** Ubuntu 22.04 EOL April 2027. Migrate to cargo-zigbuild before then.

## Testing

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] Shell syntax validated (`sh -n install.sh`, `bash -n scripts/install.sh`)
- [x] Cora review passed (local)
- [ ] CI pipeline green (pending)

## Related Issues

External user report via ChatGPT share link (Debian 12, GLIBC 2.36).

## Checklist

- [x] Branch name follows convention (`fix/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR (GLIBC compat fix)