### PR TITLE
feat(#908): CLI context subcommand + strict strategy validation

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -149,6 +149,12 @@ pub enum Commands {
         #[arg(long)]
         enrich: bool,
     },
+    /// Show project context summary (memory counts, top tags, recent activity)
+    Context {
+        /// Namespace to summarize (default: resolved namespace)
+        #[arg(long)]
+        namespace: Option<String>,
+    },
     /// Search memories by content keywords (text search)
     Search {
         /// Keywords to search for

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -108,6 +108,17 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             *enrich,
         ),
 
+        Commands::Context { namespace } => {
+            let effective_ns = namespace.as_deref().or(ns);
+            match uteke.build_context(effective_ns) {
+                Ok(summary) => {
+                    println!("{summary}");
+                    Ok(())
+                }
+                Err(e) => Err(format!("Failed to build context: {e}")),
+            }
+        }
+
         Commands::Search { query, limit, tags } => {
             recall::run_search(cli, uteke, ns, query, *limit, tags)
         }

--- a/crates/uteke-cli/src/commands/recall.rs
+++ b/crates/uteke-cli/src/commands/recall.rs
@@ -86,8 +86,9 @@ pub(crate) fn run_recall(
     let resolved_strategy = match RecallStrategy::from_str_opt(strategy_name) {
         Some(s) => s,
         None => {
-            tracing::warn!("Unknown recall strategy '{strategy_name}', falling back to vector");
-            RecallStrategy::Vector
+            return Err(format!(
+                "Invalid strategy '{strategy_name}'. Valid options: vector, fts5, hybrid, graph."
+            ));
         }
     };
 


### PR DESCRIPTION
## What

Two CLI improvements from E2E testing (#908):

### 9a: `context` subcommand
New `uteke context` subcommand wrapping `build_context()` — outputs a
project summary (memory counts, type breakdown, top tags, recent
activity) ready for AI prompt injection. Aligns CLI with existing MCP
`uteke_context` tool.

### 9b: Strict strategy validation
Invalid `--strategy` value now returns an error with exit code 1,
instead of silently falling back to vector with only a warn log.
Lists valid options in the error message.

## Why

- **Context gap:** MCP server exposed `uteke_context` but CLI had no
  equivalent. Users on CLI couldn't get aggregated project overview.
- **Silent failure:** `--strategy invalid` returned results with no
  error indication. Users had no way to know their strategy was
  rejected unless they checked trace logs.

## Testing

- `cargo check --workspace` — ✅ pass
- `cargo clippy --workspace --all-targets -- -D warnings` — ✅ clean
- `cargo test --workspace` — ✅ 454 passed, 0 failed
- Manual: `uteke context` prints project summary
- Manual: `uteke recall "test" --strategy invalid` exits with error
