### PR TITLE
ci: pin cora-review-action to @v1 major tag

### DIFF
--- a/.github/workflows/cora-review.yml
+++ b/.github/workflows/cora-review.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Cora AI Code Review
-        uses: codecoradev/cora-review-action@v1.0.2
+        uses: codecoradev/cora-review-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cora-api-key: ${{ secrets.CORA_API_KEY }}


### PR DESCRIPTION
## What

Pin `cora-review-action` from `@v1.0.2` (exact patch tag) to `@v1` (major tag) in `.github/workflows/cora-review.yml`.

## Why

The cora-review-action v1.0.3 release fixes a bug where cora's internal fallback SARIF (produced on transient LLM errors with exit=0) bypassed the action's retry logic, resulting in misleading "unable to reach LLM API" messages on PRs (observed in #912). Pinning to `@v1` ensures uteke auto-tracks future v1.x.x releases without needing a PR each time.

## How

Single line change: `@v1.0.2` → `@v1` in workflow `uses:` reference. The `v1` major tag now points to `v1.0.3` on `cora-review-action` repo.

## Testing

- [x] `cargo test --workspace` passes (N/A — no Rust changes)
- [x] `cargo fmt --all -- --check` passes (N/A — no Rust changes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (N/A — no Rust changes)
- [x] Cora review passed on this PR
- [x] Verified `v1` tag on cora-review-action points to commit `2cee09a` (v1.0.3)

## Related Issues

Related to cora-review-action #6, #7 (fixes for fallback SARIF detection and error display).

## Checklist

- [x] Branch name follows convention (`fix/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR (no mixed concerns)