### PR TITLE
fix(#905): aging count discrepancy across namespaces + --dry-run

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -780,5 +780,8 @@ pub enum AgingCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         yes: bool,
+        /// Preview what would be deleted without actually deleting
+        #[arg(long)]
+        dry_run: bool,
     },
 }

--- a/crates/uteke-cli/src/commands/aging.rs
+++ b/crates/uteke-cli/src/commands/aging.rs
@@ -47,6 +47,7 @@ pub(crate) fn run(
             older_than_days,
             max_access_count,
             yes,
+            dry_run,
         } => {
             // Preview first
             let preview = uteke
@@ -58,6 +59,23 @@ pub(crate) fn run(
                     output::print_json(&uteke_core::CleanupResult { deleted: 0 });
                 } else {
                     println!("No aged memories to clean up.");
+                }
+                return Ok(());
+            }
+
+            // --dry-run: show preview without deleting
+            if *dry_run {
+                if cli.json {
+                    output::print_json(&uteke_core::CleanupResult {
+                        deleted: preview.len(),
+                    });
+                } else {
+                    output::print_aging_preview_human(&preview);
+                    println!();
+                    println!(
+                        "\u{1f441} Dry run: {} memory(ies) would be deleted. No changes made.",
+                        preview.len()
+                    );
                 }
                 return Ok(());
             }

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -95,15 +95,19 @@ impl super::Store {
 
     /// Count memories never accessed in a namespace.
     pub fn count_never_accessed(&self, namespace: Option<&str>) -> Result<usize, Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
-        let count: usize = self
-            .conn
-            .query_row(
+        let count: usize = match namespace {
+            Some(ns) => self.conn.query_row(
                 "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed IS NULL",
                 params![ns],
                 |row| row.get::<_, i64>(0),
-            )
-            .map_err(|e| Error::db("database operation", e))? as usize;
+            ),
+            None => self.conn.query_row(
+                "SELECT COUNT(*) FROM memories WHERE last_accessed IS NULL",
+                [],
+                |row| row.get::<_, i64>(0),
+            ),
+        }
+        .map_err(|e| Error::db("database operation", e))? as usize;
         Ok(count)
     }
 
@@ -114,37 +118,58 @@ impl super::Store {
         hot_days: i64,
         warm_days: i64,
     ) -> Result<(usize, usize, usize), Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         let now = chrono::Utc::now();
         let hot_cutoff = (now - chrono::Duration::days(hot_days)).to_rfc3339();
         let warm_cutoff = (now - chrono::Duration::days(warm_days)).to_rfc3339();
 
-        let hot: usize = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed >= ?2",
-                params![ns, hot_cutoff],
-                |row| row.get::<_, i64>(0),
-            )
-            .map_err(|e| Error::db("database operation", e))? as usize;
+        let (hot, warm, cold) = match namespace {
+            Some(ns) => {
+                let hot: usize = self.conn.query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed >= ?2",
+                    params![ns, hot_cutoff],
+                    |row| row.get::<_, i64>(0),
+                ).map_err(|e| Error::db("database operation", e))? as usize;
 
-        let warm: usize = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed >= ?2 AND last_accessed < ?3",
-                params![ns, warm_cutoff, hot_cutoff],
-                |row| row.get::<_, i64>(0),
-            )
-            .map_err(|e| Error::db("database operation", e))? as usize;
+                let warm: usize = self.conn.query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND last_accessed >= ?2 AND last_accessed < ?3",
+                    params![ns, warm_cutoff, hot_cutoff],
+                    |row| row.get::<_, i64>(0),
+                ).map_err(|e| Error::db("database operation", e))? as usize;
 
-        let cold: usize = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)",
-                params![ns, warm_cutoff],
-                |row| row.get::<_, i64>(0),
-            )
-            .map_err(|e| Error::db("database operation", e))? as usize;
+                let cold: usize = self.conn.query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND (last_accessed < ?2 OR last_accessed IS NULL)",
+                    params![ns, warm_cutoff],
+                    |row| row.get::<_, i64>(0),
+                ).map_err(|e| Error::db("database operation", e))? as usize;
+
+                (hot, warm, cold)
+            }
+            None => {
+                let hot: usize = self
+                    .conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM memories WHERE last_accessed >= ?1",
+                        params![hot_cutoff],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(|e| Error::db("database operation", e))?
+                    as usize;
+
+                let warm: usize = self.conn.query_row(
+                    "SELECT COUNT(*) FROM memories WHERE last_accessed >= ?1 AND last_accessed < ?2",
+                    params![warm_cutoff, hot_cutoff],
+                    |row| row.get::<_, i64>(0),
+                ).map_err(|e| Error::db("database operation", e))? as usize;
+
+                let cold: usize = self.conn.query_row(
+                    "SELECT COUNT(*) FROM memories WHERE last_accessed < ?1 OR last_accessed IS NULL",
+                    params![warm_cutoff],
+                    |row| row.get::<_, i64>(0),
+                ).map_err(|e| Error::db("database operation", e))? as usize;
+
+                (hot, warm, cold)
+            }
+        };
 
         Ok((hot, warm, cold))
     }


### PR DESCRIPTION
## What

Two aging bug fixes from E2E testing (#905):

### 905a: Count discrepancy — tier_counts & count_never_accessed
`tier_counts()` and `count_never_accessed()` silently fell back to
`DEFAULT_NAMESPACE` ("default") when `namespace = None`, producing
counts 2.5x lower than `stats()` which correctly treats `None` as
"all namespaces".

**Root cause:** `namespace.unwrap_or(DEFAULT_NAMESPACE)` in aging.rs
hardcoded fallback to a single namespace, while `count()` treated
`None` as all-namespaces. Inconsistent semantics.

**Fix:** Match `count()` semantics — `None` = all namespaces (no
WHERE namespace filter), `Some(ns)` = filtered.

### 905b: `--dry-run` flag for aging cleanup
`aging cleanup --dry-run` shows what would be deleted without
actually performing deletion. Existing `aging preview` subcommand
remains as-is.

## Why

- Aging count was off by 2.5x → decisions based on incorrect data
- No preview before destructive cleanup → irreversible data loss risk

## Testing

- `cargo check --workspace` — ✅ pass
- `cargo clippy --workspace --all-targets -- -D warnings` — ✅ clean
- `cargo test --workspace` — ✅ 454 passed, 0 failed
- Existing tier_counts tests pass with both `None` and `Some(ns)`
