### PR TITLE
feat(#906): repair --reembed to regenerate missing embeddings

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -224,12 +224,19 @@ pub enum Commands {
         #[arg(long)]
         binary: String,
     },
-    /// Repair index by rebuilding from SQLite
+    /// Repair index by rebuilding from SQLite.
+    /// Use --rebuild to delete corrupt index files first.
+    /// Use --reembed to regenerate embeddings for memories missing them.
     Repair {
         /// Delete existing index files before rebuilding (ignores corrupt index).
         /// Use when the index is corrupted and normal repair fails.
         #[arg(long)]
         rebuild: bool,
+
+        /// Re-generate embeddings for memories with missing/empty vectors.
+        /// Makes previously invisible memories searchable via semantic recall.
+        #[arg(long)]
+        reembed: bool,
     },
     /// Export all memories to JSONL file (no embeddings — portable)
     Export {

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -32,6 +32,7 @@ pub(crate) fn run_repair(
     cli: &Cli,
     uteke: &Uteke,
     rebuild: bool,
+    reembed: bool,
     config: &crate::Config,
 ) -> Result<(), String> {
     if rebuild {
@@ -68,6 +69,34 @@ pub(crate) fn run_repair(
     } else {
         output::print_repair_human(&report);
     }
+
+    // Optional: re-embed memories with missing vectors.
+    if reembed {
+        tracing::info!("Running repair --reembed (regenerating missing embeddings)");
+        let reembed_report = uteke
+            .reembed_missing()
+            .map_err(|e| format!("Re-embed failed: {e}"))?;
+        if cli.json {
+            output::print_json(&reembed_report);
+        } else {
+            println!();
+            if reembed_report.missing_count == 0 {
+                println!(
+                    "✓ All {} memories have embeddings — nothing to re-embed.",
+                    reembed_report.total_scanned
+                );
+            } else {
+                println!(
+                    "Re-embedded {}/{} memories ({} failed) out of {} total scanned.",
+                    reembed_report.reembedded,
+                    reembed_report.missing_count,
+                    reembed_report.failed,
+                    reembed_report.total_scanned
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -169,7 +169,9 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
 
         Commands::Verify => maintenance::run_verify(cli, uteke),
 
-        Commands::Repair { rebuild } => maintenance::run_repair(cli, uteke, *rebuild, config),
+        Commands::Repair { rebuild, reembed } => {
+            maintenance::run_repair(cli, uteke, *rebuild, *reembed, config)
+        }
 
         Commands::Tags { command } => tags::run(cli, uteke, ns, command),
 

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -64,7 +64,9 @@ pub use embed::Embedder;
 #[cfg(feature = "onnx")]
 pub use embed::OnnxEmbedder;
 pub use error::{Error, format_bytes};
-pub use types::{DoctorCheck, DoctorReport, DoctorStatus, RepairReport, VerifyReport};
+pub use types::{
+    DoctorCheck, DoctorReport, DoctorStatus, ReembedReport, RepairReport, VerifyReport,
+};
 
 /// Maximum memory content length (characters) — default, overridable via config (#404).
 pub const MAX_CONTENT_LENGTH: usize = 100_000;

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -2,7 +2,9 @@
 
 use crate::error::{Error, format_bytes};
 use crate::memory::types::{AgingStatus, CleanupResult, Memory, PruneResult, StoreStats};
-use crate::types::{DoctorCheck, DoctorReport, DoctorStatus, RepairReport, VerifyReport};
+use crate::types::{
+    DoctorCheck, DoctorReport, DoctorStatus, ReembedReport, RepairReport, VerifyReport,
+};
 use crate::uteke_home;
 
 impl crate::Uteke {
@@ -139,6 +141,99 @@ impl crate::Uteke {
             db_count: before_db,
             index_before: before_index,
             index_after: items.len(),
+        })
+    }
+
+    /// Re-embed memories that have missing or empty embedding vectors.
+    ///
+    /// Scans all non-deprecated memories, finds those with empty embeddings,
+    /// generates new embeddings, updates the database, and adds them to the index.
+    pub fn reembed_missing(&self) -> Result<ReembedReport, Error> {
+        let all_memories = self.store.load_all(None)?;
+        let total_scanned = all_memories.len();
+
+        // Filter to memories with empty embeddings, excluding deprecated.
+        let missing: Vec<&Memory> = all_memories
+            .iter()
+            .filter(|m| !m.deprecated && m.embedding.is_empty())
+            .collect();
+
+        let missing_count = missing.len();
+        if missing_count == 0 {
+            return Ok(ReembedReport {
+                total_scanned,
+                missing_count,
+                reembedded: 0,
+                failed: 0,
+            });
+        }
+
+        tracing::info!(
+            total = total_scanned,
+            missing = missing_count,
+            "Re-embedding memories with missing vectors"
+        );
+
+        // Ensure embedder is initialized.
+        self.ensure_embedder()?;
+
+        let mut reembedded = 0usize;
+        let mut failed = 0usize;
+        let mut new_items: Vec<(String, Vec<f32>)> = Vec::new();
+
+        for mem in &missing {
+            let embedder = self
+                .embedder
+                .lock()
+                .map_err(|_| Error::lock("embedder lock during reembed"))?;
+            let embedder = embedder
+                .as_ref()
+                .ok_or_else(|| Error::embed("reembed", "embedder not initialized"))?;
+
+            match embedder.embed(&mem.content) {
+                Ok(vec) => {
+                    // Update memory in database.
+                    let mut updated = (*mem).clone();
+                    updated.embedding = vec.clone();
+                    updated.updated_at = chrono::Utc::now();
+                    if let Err(e) = self.store.update(&updated) {
+                        tracing::warn!(id = %mem.id, error = %e, "Failed to update embedding in DB");
+                        failed += 1;
+                        continue;
+                    }
+                    new_items.push((mem.id.clone(), vec));
+                    reembedded += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(id = %mem.id, error = %e, "Failed to generate embedding");
+                    failed += 1;
+                }
+            }
+        }
+
+        // Add newly-embedded memories to the index.
+        if !new_items.is_empty() {
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write during reembed"))?;
+            for (id, vec) in &new_items {
+                if let Err(e) = index.insert(id, vec) {
+                    tracing::warn!(id = %id, error = %e, "Failed to add to index");
+                }
+            }
+            if let Err(e) = index.save() {
+                tracing::warn!(error = %e, "Failed to save index after reembed");
+            }
+        }
+
+        tracing::info!(reembedded, failed, "Re-embed complete");
+
+        Ok(ReembedReport {
+            total_scanned,
+            missing_count,
+            reembedded,
+            failed,
         })
     }
 

--- a/crates/uteke-core/src/types.rs
+++ b/crates/uteke-core/src/types.rs
@@ -50,6 +50,19 @@ pub struct RepairReport {
     pub index_after: usize,
 }
 
+/// Result of `uteke repair --reembed`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReembedReport {
+    /// Total memories scanned.
+    pub total_scanned: usize,
+    /// Memories that had missing/empty embeddings.
+    pub missing_count: usize,
+    /// Memories successfully re-embedded.
+    pub reembedded: usize,
+    /// Memories that failed re-embedding.
+    pub failed: usize,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Adds `uteke repair --reembed` to regenerate embedding vectors for memories that were stored without them (empty embedding column in SQLite).

## Why

**Problem:** 20 active memories have no embedding vector — they're invisible to all semantic/vector recall. The `remember` code path stores memories without embeddings when the embedder fails, but there was no recovery mechanism. Once stored without a vector, the memory was silently lost from semantic search forever.

This is the second part of the repair improvement started in PR #918 (which fixed corrupt index recovery). Now that `repair` actually works, we can also fix the data itself.

## How

**Core (`maintenance.rs`):**
- New `reembed_missing()` method: loads all non-deprecated memories, filters to those with `embedding.is_empty()`, generates new embeddings via the configured embedder, updates each memory in SQLite, and inserts the new vectors into the usearch index.

**CLI:**
- `uteke repair --reembed` flag runs re-embedding after the normal index rebuild.
- Human output: `Re-embedded 18/20 memories (2 failed) out of 2,265 total scanned.`
- JSON output: full `ReembedReport` object.

**Types:**
- New `ReembedReport { total_scanned, missing_count, reembedded, failed }`.

## Testing

- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ clean
- `cargo test --workspace` ✅ 452 passed, 0 failed
- Cora pre-commit review ✅ zero issues
