### PR TITLE
fix: move embedder lock outside reembed loop (#919 review)

### DIFF
--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -181,15 +181,17 @@ impl crate::Uteke {
         let mut failed = 0usize;
         let mut new_items: Vec<(String, Vec<f32>)> = Vec::new();
 
-        for mem in &missing {
-            let embedder = self
-                .embedder
-                .lock()
-                .map_err(|_| Error::lock("embedder lock during reembed"))?;
-            let embedder = embedder
-                .as_ref()
-                .ok_or_else(|| Error::embed("reembed", "embedder not initialized"))?;
+        // Acquire embedder lock ONCE before the loop to avoid
+        // per-iteration mutex overhead (codecoradev/uteke#919 review).
+        let embedder_guard = self
+            .embedder
+            .lock()
+            .map_err(|_| Error::lock("embedder lock during reembed"))?;
+        let embedder = embedder_guard
+            .as_ref()
+            .ok_or_else(|| Error::embed("reembed", "embedder not initialized"))?;
 
+        for mem in &missing {
             match embedder.embed(&mem.content) {
                 Ok(vec) => {
                     // Update memory in database.


### PR DESCRIPTION
## What

Moves `self.embedder.lock()` from inside the `for` loop to before it in `reembed_missing()`.

## Why

PR #919 review alerts from Cora + CodeCora (both valid):
- `embedder.lock()` was called on every iteration of the re-embed loop
- For large datasets (thousands of memories), this adds significant mutex overhead
- The embedder is already guaranteed initialized via `ensure_embedder()` — no need to re-acquire per item

## How

```rust
// BEFORE (per-iteration lock):
for mem in &missing {
    let embedder = self.embedder.lock()...;
    embedder.embed(...)
}

// AFTER (single lock before loop):
let embedder_guard = self.embedder.lock()...;
let embedder = embedder_guard.as_ref()...;
for mem in &missing {
    embedder.embed(...)
}
```

## Testing

- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ clean
- `cargo test --workspace` ✅ 452 passed, 0 failed
- Cora pre-commit review ✅ zero issues
