### PR TITLE
docs(#880): add docgen crate to architecture workspace table

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ title: Architecture
 | `uteke-cli` | CLI binary — clap commands, JSON output, server proxy |
 | `uteke-server` | HTTP server — persistent daemon for fast agent access |
 | `uteke-mcp` | MCP JSON-RPC server — stdio + Streamable HTTP transport (#381) |
+| `docgen` | Build tooling — auto-generates `api-reference.md` from route registry (`publish = false`) |
 
 ## Components
 


### PR DESCRIPTION
## What

Add `docgen` crate to the Workspace Crates table in `architecture.md`.

## Why

Issue #880 flagged that the workspace has 5 crates but architecture.md only listed 4. This was the last remaining item from that issue. All other 14 items have been resolved in prior commits.

`docgen` is a build tool (`publish = false`) that auto-generates `api-reference.md` from the route registry. It runs in CI (`cargo run -p docgen`) to keep API docs fresh. Listing it with a clear "Build tooling" label gives users an accurate picture of the workspace.

## How

One line added to the existing table:

| `docgen` | Build tooling — auto-generates `api-reference.md` from route registry (`publish = false`) |

## Testing

- [x] No code changes (docs-only)
- [x] `docgen` confirmed in `Cargo.toml` workspace members
- [x] `publish = false` confirmed in `crates/docgen/Cargo.toml`
- [x] CI usage confirmed in `.github/workflows/ci.yml:70`

## Related Issues

Closes #880.

## Checklist

- [x] Branch name follows convention (`fix/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR