### PR TITLE
feat: Safe Memory Lifecycle (v0.13.0) — soft delete, dynamic cap, CLI/API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [0.13.0] — 2026-08-08
+
+### Added
+- **Safe memory lifecycle (#928–#937)** — Memories now transition through a reviewable soft-delete state before any hard deletion. The flow: `ACTIVE → DEPRECATED (hidden, restorable, 30-day TTL) → PRUNED`. Hard delete is confined to exactly two controlled paths — `prune()` (expired TTL) and `forget()` (only when `soft_delete_only = false`). Everything else redirects to soft-delete by default.
+- **`LifecycleConfig` (#928)** — 11 configurable fields governing deprecation age thresholds, per-cycle percentage cap (default 1%), TTL, and auto-cycle scheduling. Conservative defaults out of the box.
+- **CLI lifecycle commands (#935)** — `uteke lifecycle status`, `uteke lifecycle cycle`, `uteke lifecycle promote <id>`, `uteke lifecycle restore <id>`.
+- **HTTP API lifecycle endpoints (#936)** — `GET /lifecycle/status`, `POST /lifecycle/cycle`, `POST /lifecycle/promote`.
+- **Memory Lifecycle docs page** — New `/memory-lifecycle` page with best practices, migration notes, and configuration reference.
+
+### Changed
+- **All delete paths now respect `soft_delete_only` (#930–#932)** — `aging_cleanup()`, `consolidate()`, `delete()`, `bulk_delete()`, `forget()`, and `bulk_forget_*()` all redirect to `deprecate()` when `soft_delete_only = true` (the default). This means no automated process — not aging, not dream dedup, not bulk operations — can hard-delete a memory.
+- **Server auto-aging thread → auto-lifecycle thread (#934)** — The background maintenance thread now runs the full 2-phase lifecycle cycle (deprecate + prune) instead of just aging cleanup.
+- **Dynamic per-cycle cap (#933)** — Each cycle deprecates at most `max_deprecate_percent` (default 1%) of active memories, clamped to `[1, 50]`. Prevents sudden data loss on large stores.
+
+### Fixed
+- **Migration: `deprecate_reason` column** — Added via `column_exists()` pattern. No schema version bump, no manual migration steps. Existing databases upgrade transparently.
+
+### Contributors
+- [@ajianaz](https://github.com/ajianaz) — full lifecycle system design and implementation
+
 ## [0.12.0] — 2026-08-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Uteke</h1>
 <p align="center"><strong>Give your AI a memory that never leaves your machine.</strong></p>
 <p align="center">
-  Your AI forgets everything between sessions. Uteke fixes that — one binary, fully offline, ~45ms recall.
+  Local-first by default. One binary, fully offline, ~45ms recall. Want cloud or team deployments? Docker ready.
 </p>
 
 <p align="center">
@@ -37,9 +37,13 @@ uteke remember "Deploy v2.1 to staging at 3pm"
 uteke recall "when do we deploy?"
 ```
 
-**That's it.** No API keys. No Docker. No Python. No cloud.
+**That's it.** No API keys, no Python, no cloud required. First run downloads the embedding model (~188MB, one-time) and you're running.
 
-First run downloads the embedding model (~188MB, one-time) and you're running.
+> **Want Docker or server mode?** Uteke ships as a single binary by default, but Docker is ready when you need it:
+> ```bash
+> docker run -d -p 127.0.0.1:8767:8767 -v uteke-data:/data ghcr.io/codecoradev/uteke:latest
+> ```
+> 📖 [Docker docs](docs/docker.md)
 
 Want richer memories? Add metadata:
 
@@ -234,7 +238,8 @@ uteke recall "caching decision" --room engineering
 
 | Feature | What it does |
 |---------|-------------|
-| 📦 **Single Binary** | Zero dependencies. No Docker needed, no database server, no Python, no API keys. |
+| 📦 **Single Binary** | Zero dependencies. No Python, no API keys. Local-first by default. |
+| 🐳 **Docker Ready** | Official image on GHCR. Run as a shared service for teams or cloud deployments. |
 | 🔒 **Fully Offline** | Local ONNX embeddings (EmbeddingGemma Q4, 768d). No telemetry, no cloud. |
 | ⚡ **Recall Cache** | LRU cache eliminates redundant embedding for repeated queries. |
 | 🔥 **Tiered Memory** | Hot/Warm/Cold tracking with auto-cleanup of stale memories. |
@@ -254,6 +259,44 @@ For Claude Desktop, Hermes, and HTTP transport, see [MCP docs](docs/mcp.md).
 </details>
 
 📖 [Full documentation](docs/getting-started.md) · [CLI reference](docs/cli-reference.md) · [Configuration](docs/configuration.md)
+
+---
+
+## 📦 Deployment Modes
+
+Uteke runs the same everywhere. Pick the mode that fits your setup.
+
+### Local-first (default)
+
+Single binary, zero infrastructure. Everything runs in-process on your machine:
+
+```bash
+curl -sSL codecora.dev/install | sh
+uteke remember "first memory"
+```
+
+No Docker, no Python, no database server. Your data stays in `~/.codecora/uteke/`. This is what most users need.
+
+### Docker / Server mode
+
+Running Uteke as a shared service for a team, or deploying to a server? Docker keeps it simple:
+
+```bash
+docker run -d \
+  -p 127.0.0.1:8767:8767 \
+  -v uteke-data:/data \
+  ghcr.io/codecoradev/uteke:latest
+```
+
+Prefer the binary directly? Run it as a daemon:
+
+```bash
+uteke serve --host 0.0.0.0 --port 8767
+```
+
+Both expose the same HTTP API. Other agents and tools connect via `http://your-host:8767`. Rooms work across agents whether they're on the same machine or connecting remotely.
+
+📖 **[Docker setup guide](docs/docker.md)** · [Server mode docs](docs/configuration.md#server-mode)
 
 ---
 
@@ -339,7 +382,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.12.0 with 432 tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x — expect rough edges, but the core is stable.
+Uteke is at v0.13.0 with 460+ tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x, so expect rough edges, but the core is stable.
 </details>
 
 ---
@@ -348,7 +391,7 @@ Uteke is at v0.12.0 with 432 tests, CI/CD on every commit, and benchmark harness
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (431 tests)
+cargo test --workspace         # Test (460+ tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/uteke-banner.png" alt="Uteke — Give your AI a memory" width="640" />
+  <img src="docs/assets/uteke-banner.png" alt="Uteke: Give your AI a memory" width="640" />
 </p>
 
 <h1 align="center">Uteke</h1>
@@ -33,7 +33,7 @@ curl -sSL codecora.dev/install | sh
 # Store a memory
 uteke remember "Deploy v2.1 to staging at 3pm"
 
-# Search it back — by meaning, not just keywords
+# Search it back: by meaning, not just keywords
 uteke recall "when do we deploy?"
 ```
 
@@ -73,7 +73,7 @@ uteke remember "Deploy v2.1 to staging" \
 ## 🚀 Onboarding (New users & AI agents)
 
 > **Are you an AI agent reading this?** Your user just shared this repo link with you.
-> Run `uteke onboard` to interactively configure uteke for your environment — it will
+> Run `uteke onboard` to interactively configure uteke for your environment. It will
 > detect your install, ask which agent you are, toggle features, write config, and
 > show you every command available. If non-interactive: `uteke onboard --yes --agent <your-agent>`.
 
@@ -86,7 +86,7 @@ uteke onboard
 The wizard will:
 1. **Detect** if uteke is installed and if a store exists
 2. **Ask** which AI agent you use (Hermes, Claude, Cursor, Pi, OpenCode)
-3. **Pick** integration mode — manual tool calls vs automatic memory-provider
+3. **Pick** integration mode: manual tool calls vs automatic memory-provider
 4. **Toggle** features on/off (Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode)
 5. **Write** `~/.codecora/uteke/uteke.toml` with your selections
 6. **Install** agent integration files automatically (`uteke init`)
@@ -106,9 +106,9 @@ uteke onboard --yes --agent hermes --namespace default
 
 You just spent 2 hours explaining your codebase to ChatGPT. Next session? Blank slate. Again.
 
-Every AI tool forgets. Context windows fill up, sessions end, and your AI starts over every single time. Uteke gives it persistent memory — and keeps it on your machine.
+Every AI tool forgets. Context windows fill up, sessions end, and your AI starts over every single time. Uteke gives it persistent memory and keeps it on your machine.
 
-| | **Uteke** | **Mnemosyne** | **Mem0** | **AgentMemory** | **Letta** | **Zep** | **Supermemory** | **Engram** |
+| | **Uteke** | **Tool A** | **Tool B** | **Tool C** | **Tool D** | **Tool E** | **Tool F** | **Tool G** |
 |---|---|---|---|---|---|---|---|---|
 | **Language** | Rust (single binary) | Python (pip) | Python | TypeScript | TypeScript | Python | TypeScript | Go (single binary) |
 | **Setup** | One binary (`curl \| sh`) | pip install + venv | pip + Docker + Qdrant | npm + iii-engine | npm (Node.js) | pip + Docker + Neo4j | Cloud or local binary | One binary |
@@ -122,15 +122,17 @@ Every AI tool forgets. Context windows fill up, sessions end, and your AI starts
 | **Your data** | ✅ Never leaves machine | ✅ Local-first | ⚠️ Sent to LLM cloud | ✅ Local (iii-engine) | ⚠️ Sent to LLM cloud | ⚠️ Sent to LLM cloud | ⚠️ Cloudflare-hosted | ✅ Local |
 | **License** | Apache 2.0 | MIT | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | MIT | MIT |
 
-> **Uteke vs Mnemosyne:** Both are local-first with semantic + FTS5 search. Mnemosyne is the closest competitor (~2.1K stars, Python). Uteke's edge: **single binary** (no Python runtime), **native time-travel** (vs temporal triples), **rooms**, and **zero runtime dependencies**.
+> **Note:** Tool labels (A–G) represent common categories of AI memory layers available as of August 2026. Capabilities are assessed from public documentation and may change. This table is a starting point for your own evaluation, not a definitive ranking.
 
-> **Uteke vs Engram:** Both are single-binary, offline, no-API-key tools, and both ship MCP servers. But Engram is **FTS5-only** (keyword search). Uteke adds **vector semantic search + RRF fusion + rooms + time-travel + graph relationships + smart decay + document engine + batch import**. Same simplicity thesis, more capabilities.
+> **Uteke vs Tool A (Python local-first):** Both offer local-first with semantic + FTS5 search. Uteke's edge: **single binary** (no Python runtime), **native time-travel** (vs temporal triples), **rooms**, and **zero runtime dependencies**.
 
-> **Uteke vs Supermemory:** Supermemory (29K stars) now offers a local binary mode (`npx supermemory local`) with Ollama support, a solid step toward offline-first. But it's still TypeScript/Node.js under the hood. Uteke is Rust: smaller footprint, faster startup, zero runtime. And Uteke has **hybrid search with FTS5** (Supermemory's local mode uses vector-only, no keyword fallback).
+> **Uteke vs Tool G (Go single binary):** Both are single-binary, offline, no-API-key, and both ship MCP servers. Tool G is **FTS5-only** (keyword search). Uteke adds **vector semantic search + RRF fusion + rooms + time-travel + graph relationships + smart decay + document engine + batch import**. Same simplicity thesis, more capabilities.
 
-> **Uteke vs Mem0/Letta/Zep:** Those are powerful, but all require cloud LLM API keys and Docker infrastructure. Your data goes to OpenAI/Anthropic. Uteke runs fully offline with local ONNX embeddings. No Docker, no Python, no API keys.
+> **Uteke vs Tool F (TypeScript local mode):** Tool F now offers a local binary mode with Ollama support, a solid step toward offline-first. But it's still TypeScript/Node.js under the hood. Uteke is Rust: smaller footprint, faster startup, zero runtime. And Uteke has **hybrid search with FTS5** (Tool F's local mode uses vector-only, no keyword fallback).
+
+> **Uteke vs Tools B/D/E:** Those are powerful, but all require cloud LLM API keys and Docker infrastructure. Your data goes to external LLM providers. Uteke runs fully offline with local ONNX embeddings. No Docker, no Python, no API keys.
 >
-> **Uteke vs AgentMemory:** AgentMemory (26K stars) has 54 MCP tools and multi-agent shared memory via local iii-engine. Uteke's edge: **zero dependencies** (no npm, no iii-engine), **hybrid search** (AgentMemory lacks FTS5), and **time-travel queries**.
+> **Uteke vs Tool C:** Tool C has 54 MCP tools and multi-agent shared memory via a local engine. Uteke's edge: **zero dependencies** (no npm, no extra engine), **hybrid search** (Tool C lacks FTS5), and **time-travel queries**.
 
 <details>
 <summary>📊 Benchmark numbers</summary>
@@ -147,26 +149,26 @@ Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark deta
 </details>
 
 <p align="center">
-  <img src="docs/assets/uteke-comparison.png" alt="Uteke vs cloud alternatives" width="640" />
+  <img src="docs/assets/uteke-comparison.png" alt="Uteke compared to other memory tools" width="640" />
 </p>
 
 ---
 
 ## 💡 What Can You Do With Uteke?
 
-**🤖 Building AI agents?** Give them persistent memory without cloud dependencies. Your agent remembers user preferences, past decisions, and context — across sessions, fully offline.
+**🤖 Building AI agents?** Give them persistent memory without cloud dependencies. Your agent remembers user preferences, past decisions, and context across sessions, fully offline.
 
-**👥 Working in a team?** Use [Rooms](docs/getting-started.md) to share knowledge. Meeting notes, project decisions, architecture choices — searchable by everyone, attributed by author.
+**👥 Working in a team?** Use [Rooms](docs/getting-started.md) to share knowledge. Meeting notes, project decisions, architecture choices: searchable by everyone, attributed by author.
 
-**🔒 Building for privacy-sensitive domains?** Healthcare, finance, legal — data stays on your machine. No API calls, no telemetry, no cloud. Local embeddings (ONNX, 768d).
+**🔒 Building for privacy-sensitive domains?** Healthcare, finance, legal: data stays on your machine. No API calls, no telemetry, no cloud. Local embeddings (ONNX, 768d).
 
 **⌨️ Power user who lives in the terminal?** Uteke is your personal knowledge graph. Remember anything, recall by meaning, link related thoughts. All from the command line.
 
 ---
 
-## 🏠 Rooms — Multi-Agent Shared Memory
+## 🏠 Rooms: Multi-Agent Shared Memory
 
-Other memory layers are single-player — every fact stored under a flat `user_id`, invisible to other agents. **Uteke Rooms** let multiple AI agents share a memory space with full author attribution.
+Other memory layers are single-player: every fact stored under a flat `user_id`, invisible to other agents. **Uteke Rooms** let multiple AI agents share a memory space with full author attribution.
 
 ```bash
 # Create a shared room
@@ -228,7 +230,7 @@ uteke recall "caching decision" --room engineering
 | Feature | What it does |
 |---------|-------------|
 | 🔌 **MCP Server** | JSON-RPC over stdio + Streamable HTTP. Works with Claude Code, Cursor, Hermes. |
-| 🖥️ **Server Mode** | Persistent daemon — eliminates cold-start embedding load on every call. |
+| 🖥️ **Server Mode** | Persistent daemon: eliminates cold-start embedding load on every call. |
 | 📂 **Batch Import** | Import entire directories with auto-strategy routing (document vs. memory extraction). |
 | 📝 **Document Engine** | Wiki/knowledge base with `uteke doc create/get/list` and auto-chunking. |
 | 📥 **Import/Export** | JSONL-based backup and restore. |
@@ -248,7 +250,7 @@ uteke recall "caching decision" --room engineering
 | 📊 **Benchmarks** | Built-in `uteke bench` for perf testing. [See results](docs/BENCHMARKS.md). |
 
 <details>
-<summary>🔌 MCP Server config — connect to Claude Code, Cursor, Hermes</summary>
+<summary>🔌 MCP Server config: connect to Claude Code, Cursor, Hermes</summary>
 
 ```jsonc
 // .mcp.json (Claude Code, Cursor)
@@ -317,9 +319,9 @@ graph LR
 ```
 
 **How hybrid search works:**
-1. **HNSW** (usearch) — finds by meaning ("deploy" matches "rollout")
-2. **FTS5** (SQLite) — finds by exact terms ("deploy" matches "deploy")
-3. **RRF** (k=60) — merges both ranked lists → best of both worlds
+1. **HNSW** (usearch): finds by meaning ("deploy" matches "rollout")
+2. **FTS5** (SQLite): finds by exact terms ("deploy" matches "deploy")
+3. **RRF** (k=60): merges both ranked lists → best of both worlds
 
 Everything runs in-process. No network. No cloud. No server required (unless you want server mode).
 
@@ -332,27 +334,27 @@ Everything runs in-process. No network. No cloud. No server required (unless you
 ## ❓ FAQ
 
 <details>
-<summary><strong>How is Uteke different from Mem0 or Letta?</strong></summary>
+<summary><strong>How is Uteke different from cloud-dependent memory tools?</strong></summary>
 
-Mem0 and Letta are solid tools, but they require cloud API keys (OpenAI/LLM) and external infrastructure (Docker, Postgres, Qdrant). Your data gets sent to a cloud LLM provider. Uteke is a single binary with zero API keys. All embeddings run locally via ONNX. Your data never leaves your machine. [See comparison table](#-why-uteke).
+Many memory layers (Python-based or TypeScript-based) require cloud API keys (OpenAI/LLM) and external infrastructure (Docker, Postgres, Qdrant). Your data gets sent to a cloud LLM provider. Uteke is a single binary with zero API keys. All embeddings run locally via ONNX. Your data never leaves your machine. [See comparison table](#-why-uteke).
 </details>
 
 <details>
-<summary><strong>How is Uteke different from AgentMemory?</strong></summary>
+<summary><strong>How is Uteke different from multi-tool MCP platforms?</strong></summary>
 
-AgentMemory (26K stars) is a TypeScript/Node.js platform with 54 MCP tools, 12 auto-hooks, and multi-agent shared memory via local iii-engine. It's packed with integrations, but requires npm, the iii-engine runtime, and LLM API keys for embeddings. Uteke is Rust, zero dependencies, and works fully offline with local ONNX embeddings. If you want maximum integrations and multi-agent shared state → AgentMemory. If you want privacy, speed, zero setup, and hybrid search → Uteke.
+Some platforms offer dozens of MCP tools and multi-agent shared memory via a local engine. They're packed with integrations, but require npm, a separate runtime, and LLM API keys for embeddings. Uteke is Rust, zero dependencies, and works fully offline with local ONNX embeddings. If you want maximum integrations → those platforms. If you want privacy, speed, zero setup, and hybrid search → Uteke.
 </details>
 
 <details>
-<summary><strong>How is Uteke different from Engram?</strong></summary>
+<summary><strong>How is Uteke different from other single-binary memory tools?</strong></summary>
 
-Engram (5.8K stars, Go) shares our philosophy: single binary, zero deps, MCP server, local-first. The key difference is **search**: Engram uses **FTS5 only** (keyword matching). Uteke uses **hybrid search** (HNSW vector similarity + FTS5 + Reciprocal Rank Fusion), meaning you can search by *meaning*, not just exact words. Uteke also adds rooms, time-travel, graph relationships, smart decay, document engine, and batch import.
+Some single-binary tools share our philosophy: one binary, zero deps, MCP server, local-first. The key difference is **search**: most are **FTS5-only** (keyword matching). Uteke uses **hybrid search** (HNSW vector similarity + FTS5 + Reciprocal Rank Fusion), meaning you can search by *meaning*, not just exact words. Uteke also adds rooms, time-travel, graph relationships, smart decay, document engine, and batch import.
 </details>
 
 <details>
-<summary><strong>How is Uteke different from Supermemory?</strong></summary>
+<summary><strong>How is Uteke different from local-mode cloud tools?</strong></summary>
 
-Supermemory (29K stars, TypeScript) now offers a local binary mode (`npx supermemory local`) with Ollama support. The cloud version still needs Cloudflare Workers + Postgres. Uteke is one binary with zero infrastructure: no Workers, no Postgres, no Cloudflare account. Uteke also adds rooms for multi-agent collaboration, time-travel queries, and hybrid search (vector + FTS5 + RRF fusion).
+Some cloud-native tools now offer a local binary mode with Ollama support. Their cloud version still needs managed infrastructure (Workers, Postgres, etc.). Uteke is one binary with zero infrastructure: no Workers, no Postgres, no cloud account. Uteke also adds rooms for multi-agent collaboration, time-travel queries, and hybrid search (vector + FTS5 + RRF fusion).
 </details>
 
 <details>
@@ -364,7 +366,7 @@ Anything text-based: decisions, meeting notes, code snippets, project context, p
 <details>
 <summary><strong>Does it really work offline?</strong></summary>
 
-Yes. The embedding model (EmbeddingGemma Q4, 768d) downloads once (~188MB) on first run. After that, zero network calls. No telemetry. If the local model fails, Uteke degrades gracefully to a no-op embedder — it never crashes and never calls a cloud API.
+Yes. The embedding model (EmbeddingGemma Q4, 768d) downloads once (~188MB) on first run. After that, zero network calls. No telemetry. If the local model fails, Uteke degrades gracefully to a no-op embedder. It never crashes and never calls a cloud API.
 </details>
 
 <details>
@@ -402,7 +404,7 @@ Contributions welcome! Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full guid
 
 ## 📄 License
 
-[Apache License 2.0](LICENSE) — use it, fork it, ship it.
+[Apache License 2.0](LICENSE). Use it, fork it, ship it.
 
 ---
 
@@ -415,7 +417,7 @@ Contributions welcome! Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full guid
 ---
 
 <p align="center">
-  <strong>Found this useful?</strong> ⭐ Star this repo — it helps others discover Uteke.
+  <strong>Found this useful?</strong> ⭐ Star this repo. It helps others discover Uteke.
 </p>
 <p align="center">
   <a href="https://github.com/codecoradev/uteke/stargazers">

--- a/blog/comparison-2026.md
+++ b/blog/comparison-2026.md
@@ -1,6 +1,8 @@
 # Choosing an AI Memory Layer in 2026: A Practical Comparison Framework
 
-> **A capability-first guide to evaluating memory layers for AI agents — without the marketing fog.**
+*Published: August 2026. Capabilities and benchmarks reflect the state of the AI memory landscape as of this date. Tools evolve fast: verify current specs before making decisions.*
+
+> **A capability-first guide to evaluating memory layers for AI agents, without the marketing fog.**
 
 ---
 
@@ -8,9 +10,9 @@
 
 You're building an AI agent. It's smart, fast, and helpful. But every time the session ends, it forgets everything. The user's preferences. Last week's decisions. The architecture you spent hours explaining. Gone.
 
-So you search for "AI memory layer" and find yourself in a jungle of options — each claiming to be the best. Cloud-hosted platforms. Self-hosted libraries. Research prototypes. Single-binary tools. How do you choose?
+So you search for "AI memory layer" and find yourself in a jungle of options, each claiming to be the best. Cloud-hosted platforms. Self-hosted libraries. Research prototypes. Single-binary tools. How do you choose?
 
-This guide gives you a **practical evaluation framework** — not a brand shoot-out. We'll cover:
+This guide gives you a **practical evaluation framework**, not a brand shoot-out. We'll cover:
 
 1. The **decision dimensions** that actually matter
 2. A **capability matrix** you can fill in for any tool
@@ -26,14 +28,14 @@ After analyzing the AI memory layer landscape, we identified seven dimensions th
 
 | Question | Why it matters |
 |---|---|
-| Do I install one binary or a stack of services? | A single binary means `curl \| sh && done`. A runtime stack means Docker, Python, Postgres, Neo4j — and someone has to maintain it. |
+| Do I install one binary or a stack of services? | A single binary means `curl \| sh && done`. A runtime stack means Docker, Python, Postgres, Neo4j, and someone has to maintain it. |
 | What's my failure surface? | Each dependency is a potential outage. Single binary = one moving part. Microservices = many. |
 
 **Categories:**
-- **Single binary** — Install in 10 seconds, zero runtime deps. Works on any OS.
-- **Python library** — Needs Python runtime, venv management, package conflicts.
-- **Docker stack** — Needs Docker, plus one or more databases (Postgres, Neo4j, Qdrant).
-- **Cloud platform** — Needs network, account, API key. Data leaves your machine.
+- **Single binary**: Install in 10 seconds, zero runtime deps. Works on any OS.
+- **Python library**: Needs Python runtime, venv management, package conflicts.
+- **Docker stack**: Needs Docker, plus one or more databases (Postgres, Neo4j, Qdrant).
+- **Cloud platform**: Needs network, account, API key. Data leaves your machine.
 
 ### 2. Data Sovereignty: Where Does Your Data Live?
 
@@ -43,9 +45,9 @@ After analyzing the AI memory layer landscape, we identified seven dimensions th
 | Are embeddings computed locally or sent to an API? | Even if you self-host, some tools send raw text to OpenAI for embedding generation. That's data leaving your machine. |
 
 **Categories:**
-- **Fully offline** — Local embeddings (ONNX, etc.), no network calls, no telemetry.
-- **Self-hosted but cloud-dependent** — You run it, but it calls external LLM APIs for extraction/embedding.
-- **Cloud-native** — Your data lives on someone else's server.
+- **Fully offline**: Local embeddings (ONNX, etc.), no network calls, no telemetry.
+- **Self-hosted but cloud-dependent**: You run it, but it calls external LLM APIs for extraction/embedding.
+- **Cloud-native**: Your data lives on someone else's server.
 
 ### 3. Search Quality: Keyword vs. Semantic vs. Hybrid
 
@@ -56,9 +58,9 @@ After analyzing the AI memory layer landscape, we identified seven dimensions th
 | Are both combined? | Hybrid search (vector + FTS + fusion) gives the best of both worlds. Pure keyword search misses synonyms. Pure vector search misses exact terms. |
 
 **Categories:**
-- **FTS-only** — Keyword matching only. Fast but can't find meaning.
-- **Vector-only** — Semantic matching only. Good for meaning, bad for exact terms.
-- **Hybrid (Vector + FTS + RRF)** — The gold standard. Finds by meaning AND exact keywords, merged by Reciprocal Rank Fusion.
+- **FTS-only**: Keyword matching only. Fast but can't find meaning.
+- **Vector-only**: Semantic matching only. Good for meaning, bad for exact terms.
+- **Hybrid (Vector + FTS + RRF)**: The gold standard. Finds by meaning AND exact keywords, merged by Reciprocal Rank Fusion.
 
 ### 4. Multi-Agent Support: Solo vs. Collaborative
 
@@ -69,16 +71,16 @@ After analyzing the AI memory layer landscape, we identified seven dimensions th
 | Can agents recall across each other's memories? | Some tools technically support multiple agents but isolate their namespaces. True multi-agent means cross-agent recall. |
 
 **Categories:**
-- **Single-player** — One agent, one namespace. No sharing.
-- **Shared API** — Multiple agents access the same backend, but memories aren't attributed or grouped.
-- **Rooms** — Shared memory spaces with author attribution, cross-agent recall, and contextual grouping.
+- **Single-player**: One agent, one namespace. No sharing.
+- **Shared API**: Multiple agents access the same backend, but memories aren't attributed or grouped.
+- **Rooms**: Shared memory spaces with author attribution, cross-agent recall, and contextual grouping.
 
 ### 5. Time-Travel: Can You Query the Past?
 
 | Question | Why it matters |
 |---|---|
 | Can I recall what the memory store knew at a specific point in time? | "What did we know before the incident?" "When was this decision made?" Without time-travel, you can only see the current state. |
-| Is it native or bolted on? | Native time-travel stores full history efficiently. Bolted-on solutions use changelogs or temporal extensions — more overhead, less reliable. |
+| Is it native or bolted on? | Native time-travel stores full history efficiently. Bolted-on solutions use changelogs or temporal extensions: more overhead, less reliable. |
 
 ### 6. Integration: How Does It Connect to Your Agent?
 
@@ -108,7 +110,7 @@ Fill in this matrix for any memory tool you evaluate. Here's how Uteke scores:
 | **Data sovereignty** | Fully offline. Local ONNX embeddings. Zero telemetry. | Does it call external APIs for embeddings/extraction? Does data leave your machine? |
 | **Search** | Hybrid (Vector HNSW + FTS5 + RRF fusion) | Is it vector-only? FTS-only? Or hybrid? |
 | **Recall speed** | ~45ms P50 at 10K memories | What's the latency? Is it network round-trip or local? |
-| **Multi-agent** | Rooms — shared memory, author attribution, cross-agent recall | Can multiple agents share context? Is there author attribution? |
+| **Multi-agent** | Rooms: shared memory, author attribution, cross-agent recall | Can multiple agents share context? Is there author attribution? |
 | **Time-travel** | Native point-in-time queries (`--at 2025-01-15`) | Can you query past states? Is it native or bolted on? |
 | **Extraction** | Default: offline rule-based (zero API). Optional: LLM extraction. | Does it require an LLM API key to extract facts? Is there an offline option? |
 | **Integration** | MCP server (stdio + HTTP), CLI, HTTP API | Does it speak MCP? Is there a CLI for debugging? |
@@ -131,7 +133,7 @@ Most memory layers fall into one of four archetypes. Understanding which one you
 ### Archetype 2: Self-Hosted Infrastructure
 
 - **Promise:** "Run it yourself with Docker."
-- **Trade-off:** You're now a DevOps engineer. Postgres, Neo4j, Qdrant — pick your poison.
+- **Trade-off:** You're now a DevOps engineer. Postgres, Neo4j, Qdrant. Pick your poison.
 - **Best for:** Teams with dedicated infra teams who want full control.
 - **Watch out for:** Operational overhead. Each service is a maintenance burden and failure point.
 
@@ -149,7 +151,7 @@ Most memory layers fall into one of four archetypes. Understanding which one you
 - **Best for:** Edge computing, privacy-sensitive domains, developers who value simplicity, agents that run on any machine without setup.
 - **Watch out for:** Fewer pre-built integrations compared to ecosystem-heavy tools.
 
-**Uteke is Archetype 4.** We made that choice deliberately. Every trade-off in Uteke's design — local ONNX embeddings, SQLite instead of Postgres, rule-based extraction as default — serves the goal of **zero operational overhead**.
+**Uteke is Archetype 4.** We made that choice deliberately. Every trade-off in Uteke's design (local ONNX embeddings, SQLite instead of Postgres, rule-based extraction as default) serves the goal of **zero operational overhead**.
 
 ---
 
@@ -168,14 +170,14 @@ Most tools send your raw text to an LLM API (OpenAI, Anthropic) to extract struc
 
 ### Rule-Based Extraction (Uteke Default)
 
-Uteke's default extraction mode uses a **zero-dependency offline extractor** — pattern matching, sentence boundary detection, keyword salience scoring, and deduplication. No API calls, no data leaving your machine, no configuration needed.
+Uteke's default extraction mode uses a **zero-dependency offline extractor**: pattern matching, sentence boundary detection, keyword salience scoring, and deduplication. No API calls, no data leaving your machine, no configuration needed.
 
-- **Works out of the box** — zero config, zero API keys
-- **Completely private** — your text never leaves the machine
-- **Multilingual** — handles Indonesian, emoji, UTF-8 properly
-- **Optional LLM upgrade** — if you want richer extraction, switch to `mode = "llm"` and configure an API key
+- **Works out of the box**: zero config, zero API keys
+- **Completely private**: your text never leaves the machine
+- **Multilingual**: handles Indonesian, emoji, UTF-8 properly
+- **Optional LLM upgrade**: if you want richer extraction, switch to `mode = "llm"` and configure an API key
 
-This means you can start using Uteke immediately — `curl | sh`, store a memory, get facts extracted — without signing up for anything.
+This means you can start using Uteke immediately. Run `curl | sh`, store a memory, get facts extracted, all without signing up for anything.
 
 ---
 
@@ -183,9 +185,9 @@ This means you can start using Uteke immediately — `curl | sh`, store a memory
 
 Most memory layers are single-player. They store facts under a flat user ID and every recall is scoped to one agent's view. This works for personal chatbots but breaks down when:
 
-- **Multiple agents work on the same project** — Agent A can't see Agent B's memories
-- **A team shares an AI assistant** — everyone's memories are siloed
-- **You want knowledge transfer between agents** — there's no shared space
+- **Multiple agents work on the same project**: Agent A can't see Agent B's memories
+- **A team shares an AI assistant**: everyone's memories are siloed
+- **You want knowledge transfer between agents**: there's no shared space
 
 **Uteke Rooms** create a shared memory layer that sits above individual agent namespaces:
 
@@ -205,7 +207,7 @@ uteke remember "Redis cluster: 3 nodes, 2 replicas each" \
 uteke recall "caching decision" --room engineering
 ```
 
-Every memory in a room carries **author attribution** — you always know who said what. And any agent with access to the room can recall across all entries.
+Every memory in a room carries **author attribution**: you always know who said what. And any agent with access to the room can recall across all entries.
 
 ---
 
@@ -243,7 +245,7 @@ When we say ~45ms recall, we mean it. Here's the breakdown:
 | **Storage per memory** | ~10KB | SQLite + HNSW, scales linearly |
 | **LongMemEval Recall@5** | 0.958 | 12-question diverse sample, EmbeddingGemma Q4 |
 
-Compare this to any tool that routes through a network round-trip — even the fastest cloud API adds 100–300ms of network latency on top of processing time.
+Compare this to any tool that routes through a network round-trip. Even the fastest cloud API adds 100-300ms of network latency on top of processing time.
 
 **Run your own benchmarks:**
 
@@ -255,7 +257,7 @@ uteke bench --counts 100,1000,10000 --json
 
 ## The Bottom Line
 
-There's no "best" memory layer — there's the **right one for your constraints**. The framework above helps you identify those constraints quickly:
+There's no "best" memory layer. There's the **right one for your constraints**. The framework above helps you identify those constraints quickly:
 
 | If your priority is... | Choose archetype... |
 |---|---|

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.12.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.13.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -341,6 +341,11 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Memory lifecycle management (#935): cycle, promote, status
+    Lifecycle {
+        #[command(subcommand)]
+        command: LifecycleCommands,
+    },
     /// Consolidate near-duplicate memories
     Consolidate {
         /// Similarity threshold (0.0-1.0) for detecting duplicates
@@ -795,5 +800,27 @@ pub enum AgingCommands {
         /// Preview what would be deleted without actually deleting
         #[arg(long)]
         dry_run: bool,
+    },
+}
+
+/// Subcommands for memory lifecycle management (#935).
+#[derive(Subcommand)]
+pub enum LifecycleCommands {
+    /// Run one lifecycle cycle: soft-deprecate aged memories (cap-limited) + auto-prune
+    Cycle {
+        /// Namespace to target (default: all)
+        #[arg(long)]
+        namespace: Option<String>,
+    },
+    /// Promote a deprecated memory back to active
+    Promote {
+        /// Memory ID to promote
+        id: String,
+    },
+    /// Show lifecycle status: active vs deprecated counts, config summary
+    Status {
+        /// Namespace to check (default: all)
+        #[arg(long)]
+        namespace: Option<String>,
     },
 }

--- a/crates/uteke-cli/src/commands/lifecycle.rs
+++ b/crates/uteke-cli/src/commands/lifecycle.rs
@@ -1,10 +1,12 @@
 //! Lifecycle CLI commands (#935): cycle, promote, status.
 
-use crate::cli::LifecycleCommands;
+use crate::cli::{Cli, LifecycleCommands};
+use crate::output;
 use uteke_core::Uteke;
 
 /// Run lifecycle subcommands.
 pub(crate) fn run(
+    cli: &Cli,
     uteke: &Uteke,
     ns: Option<&str>,
     command: &LifecycleCommands,
@@ -16,28 +18,49 @@ pub(crate) fn run(
                 .lifecycle_cycle(target_ns)
                 .map_err(|e| format!("{e}"))?;
 
-            println!("Lifecycle cycle complete:");
-            println!("  Active memories:      {}", result.total_active);
-            println!("  Aged candidates:      {}", result.candidates);
-            println!(
-                "  Cap applied:          {} (clamped to min/max)",
-                result.cap
-            );
-            println!("  Deprecated this run:  {}", result.deprecated);
-            if !result.deprecated_ids.is_empty() {
-                println!("    IDs: {}", result.deprecated_ids.join(", "));
-            }
-            println!("  Pruned (hard delete): {}", result.pruned);
-            if !result.pruned_ids.is_empty() {
-                println!("    IDs: {}", result.pruned_ids.join(", "));
+            if cli.json {
+                output::print_json(&serde_json::json!({
+                    "total_active": result.total_active,
+                    "candidates": result.candidates,
+                    "cap": result.cap,
+                    "deprecated": result.deprecated,
+                    "deprecated_ids": result.deprecated_ids,
+                    "pruned": result.pruned,
+                    "pruned_ids": result.pruned_ids,
+                }));
+            } else {
+                println!("Lifecycle cycle complete:");
+                println!("  Active memories:      {}", result.total_active);
+                println!("  Aged candidates:      {}", result.candidates);
+                println!(
+                    "  Cap applied:          {} (clamped to min/max)",
+                    result.cap
+                );
+                println!("  Deprecated this run:  {}", result.deprecated);
+                if !result.deprecated_ids.is_empty() {
+                    println!("    IDs: {}", result.deprecated_ids.join(", "));
+                }
+                println!("  Pruned (hard delete): {}", result.pruned);
+                if !result.pruned_ids.is_empty() {
+                    println!("    IDs: {}", result.pruned_ids.join(", "));
+                }
             }
 
             Ok(())
         }
 
         LifecycleCommands::Promote { id } => {
-            uteke.promote(id).map_err(|e| format!("{e}"))?;
-            println!("✓ Memory {id} promoted back to active status.");
+            let restored = uteke.promote(id).map_err(|e| format!("{e}"))?;
+            if cli.json {
+                output::print_json(&serde_json::json!({
+                    "promoted": restored,
+                    "id": id,
+                }));
+            } else if restored {
+                println!("Memory {id} promoted back to active status.");
+            } else {
+                println!("Memory {id} was not deprecated (no action taken).");
+            }
             Ok(())
         }
 
@@ -53,28 +76,46 @@ pub(crate) fn run(
                 .map_err(|e| format!("{e}"))?;
             let cfg = uteke.get_lifecycle_config();
 
-            println!(
-                "Lifecycle Status (namespace: {})",
-                target_ns.unwrap_or("all")
-            );
-            println!("  Active memories:     {active}");
-            println!("  Deprecated memories: {deprecated}");
-            println!();
-            println!("Configuration:");
-            println!("  soft_delete_only:          {}", cfg.soft_delete_only);
-            println!("  auto_aging_enabled:        {}", cfg.auto_aging_enabled);
-            println!(
-                "  auto_aging_interval_hours: {}",
-                cfg.auto_aging_interval_hours
-            );
-            println!("  min_age_days:              {}", cfg.min_age_days);
-            println!("  max_access_count:          {}", cfg.max_access_count);
-            println!(
-                "  max_deprecate_percent:     {}%",
-                cfg.max_deprecate_percent
-            );
-            println!("  deprecated_ttl_days:       {}", cfg.deprecated_ttl_days);
-            println!("  auto_prune_enabled:        {}", cfg.auto_prune_enabled);
+            if cli.json {
+                output::print_json(&serde_json::json!({
+                    "namespace": target_ns.unwrap_or("all"),
+                    "active": active,
+                    "deprecated": deprecated,
+                    "config": {
+                        "soft_delete_only": cfg.soft_delete_only,
+                        "auto_aging_enabled": cfg.auto_aging_enabled,
+                        "auto_aging_interval_hours": cfg.auto_aging_interval_hours,
+                        "min_age_days": cfg.min_age_days,
+                        "max_access_count": cfg.max_access_count,
+                        "max_deprecate_percent": cfg.max_deprecate_percent,
+                        "deprecated_ttl_days": cfg.deprecated_ttl_days,
+                        "auto_prune_enabled": cfg.auto_prune_enabled,
+                    }
+                }));
+            } else {
+                println!(
+                    "Lifecycle Status (namespace: {})",
+                    target_ns.unwrap_or("all")
+                );
+                println!("  Active memories:     {active}");
+                println!("  Deprecated memories: {deprecated}");
+                println!();
+                println!("Configuration:");
+                println!("  soft_delete_only:          {}", cfg.soft_delete_only);
+                println!("  auto_aging_enabled:        {}", cfg.auto_aging_enabled);
+                println!(
+                    "  auto_aging_interval_hours: {}",
+                    cfg.auto_aging_interval_hours
+                );
+                println!("  min_age_days:              {}", cfg.min_age_days);
+                println!("  max_access_count:          {}", cfg.max_access_count);
+                println!(
+                    "  max_deprecate_percent:     {}%",
+                    cfg.max_deprecate_percent
+                );
+                println!("  deprecated_ttl_days:       {}", cfg.deprecated_ttl_days);
+                println!("  auto_prune_enabled:        {}", cfg.auto_prune_enabled);
+            }
 
             Ok(())
         }

--- a/crates/uteke-cli/src/commands/lifecycle.rs
+++ b/crates/uteke-cli/src/commands/lifecycle.rs
@@ -1,0 +1,82 @@
+//! Lifecycle CLI commands (#935): cycle, promote, status.
+
+use crate::cli::LifecycleCommands;
+use uteke_core::Uteke;
+
+/// Run lifecycle subcommands.
+pub(crate) fn run(
+    uteke: &Uteke,
+    ns: Option<&str>,
+    command: &LifecycleCommands,
+) -> Result<(), String> {
+    match command {
+        LifecycleCommands::Cycle { namespace } => {
+            let target_ns = namespace.as_deref().or(ns);
+            let result = uteke
+                .lifecycle_cycle(target_ns)
+                .map_err(|e| format!("{e}"))?;
+
+            println!("Lifecycle cycle complete:");
+            println!("  Active memories:      {}", result.total_active);
+            println!("  Aged candidates:      {}", result.candidates);
+            println!(
+                "  Cap applied:          {} (clamped to min/max)",
+                result.cap
+            );
+            println!("  Deprecated this run:  {}", result.deprecated);
+            if !result.deprecated_ids.is_empty() {
+                println!("    IDs: {}", result.deprecated_ids.join(", "));
+            }
+            println!("  Pruned (hard delete): {}", result.pruned);
+            if !result.pruned_ids.is_empty() {
+                println!("    IDs: {}", result.pruned_ids.join(", "));
+            }
+
+            Ok(())
+        }
+
+        LifecycleCommands::Promote { id } => {
+            uteke.promote(id).map_err(|e| format!("{e}"))?;
+            println!("✓ Memory {id} promoted back to active status.");
+            Ok(())
+        }
+
+        LifecycleCommands::Status { namespace } => {
+            let target_ns = namespace.as_deref().or(ns);
+            let active = uteke
+                .store()
+                .count_active(target_ns)
+                .map_err(|e| format!("{e}"))?;
+            let deprecated = uteke
+                .store()
+                .count_deprecated(target_ns)
+                .map_err(|e| format!("{e}"))?;
+            let cfg = uteke.get_lifecycle_config();
+
+            println!(
+                "Lifecycle Status (namespace: {})",
+                target_ns.unwrap_or("all")
+            );
+            println!("  Active memories:     {active}");
+            println!("  Deprecated memories: {deprecated}");
+            println!();
+            println!("Configuration:");
+            println!("  soft_delete_only:          {}", cfg.soft_delete_only);
+            println!("  auto_aging_enabled:        {}", cfg.auto_aging_enabled);
+            println!(
+                "  auto_aging_interval_hours: {}",
+                cfg.auto_aging_interval_hours
+            );
+            println!("  min_age_days:              {}", cfg.min_age_days);
+            println!("  max_access_count:          {}", cfg.max_access_count);
+            println!(
+                "  max_deprecate_percent:     {}%",
+                cfg.max_deprecate_percent
+            );
+            println!("  deprecated_ttl_days:       {}", cfg.deprecated_ttl_days);
+            println!("  auto_prune_enabled:        {}", cfg.auto_prune_enabled);
+
+            Ok(())
+        }
+    }
+}

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod dream;
 mod edges;
 mod forget;
 pub(crate) mod graph;
+mod lifecycle;
 mod list;
 mod maintenance;
 mod namespace;
@@ -181,6 +182,8 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
         Commands::Consolidate { threshold, dry_run } => {
             maintenance::run_consolidate(cli, uteke, ns, *threshold, *dry_run)
         }
+
+        Commands::Lifecycle { command } => lifecycle::run(uteke, ns, command),
 
         Commands::Export { output } => maintenance::run_export(cli, uteke, ns, output),
 

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -183,7 +183,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             maintenance::run_consolidate(cli, uteke, ns, *threshold, *dry_run)
         }
 
-        Commands::Lifecycle { command } => lifecycle::run(uteke, ns, command),
+        Commands::Lifecycle { command } => lifecycle::run(cli, uteke, ns, command),
 
         Commands::Export { output } => maintenance::run_export(cli, uteke, ns, output),
 

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -347,6 +347,82 @@ impl Default for DreamConfig {
     }
 }
 
+/// Memory lifecycle configuration (#928).
+///
+/// Controls how memories transition through their lifecycle:
+/// `ACTIVE → DEPRECATED (hidden, restorable) → PRUNED (hard delete)`.
+///
+/// All destructive operations route through soft-delete when
+/// `soft_delete_only = true` (the default).
+#[derive(serde::Deserialize, Clone)]
+#[serde(default)]
+pub struct LifecycleConfig {
+    /// Route all destructive ops through `deprecate()` instead of `delete()`.
+    /// Default: true. Set to `false` to restore pre-v0.13 hard-delete behavior.
+    pub soft_delete_only: bool,
+    /// Whether auto lifecycle cycles are enabled. Default: true.
+    pub auto_aging_enabled: bool,
+    /// Hours between automatic lifecycle cycles (server mode). Default: 168 (weekly).
+    pub auto_aging_interval_hours: u64,
+    /// Minimum age in days before eligible for deprecation. Default: 90.
+    pub min_age_days: u32,
+    /// Maximum access count for "cold" eligibility. Default: 3.
+    pub max_access_count: u32,
+    /// Max percentage of total memories deprecable per cycle. Default: 1.0.
+    pub max_deprecate_percent: f64,
+    /// Minimum deprecations per cycle. Default: 1.
+    pub min_deprecate_per_cycle: usize,
+    /// Hard ceiling on deprecations per cycle. Default: 50.
+    pub max_deprecate_per_cycle: usize,
+    /// Days after deprecation before eligible for pruning (hard delete). Default: 30.
+    pub deprecated_ttl_days: u32,
+    /// Auto-prune expired deprecated memories during cycles. Default: true.
+    pub auto_prune_enabled: bool,
+    /// Dream dedup phase uses soft-delete. Default: true.
+    pub dream_dedup_soft_delete: bool,
+    /// Dream compact phase uses soft-delete. Default: true.
+    pub dream_compact_soft_delete: bool,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            soft_delete_only: true,
+            auto_aging_enabled: true,
+            auto_aging_interval_hours: 168,
+            min_age_days: 90,
+            max_access_count: 3,
+            max_deprecate_percent: 1.0,
+            min_deprecate_per_cycle: 1,
+            max_deprecate_per_cycle: 50,
+            deprecated_ttl_days: 30,
+            auto_prune_enabled: true,
+            dream_dedup_soft_delete: true,
+            dream_compact_soft_delete: true,
+        }
+    }
+}
+
+impl LifecycleConfig {
+    /// Convert CLI config to core config.
+    pub fn to_core(&self) -> uteke_core::LifecycleConfig {
+        uteke_core::LifecycleConfig {
+            soft_delete_only: self.soft_delete_only,
+            auto_aging_enabled: self.auto_aging_enabled,
+            auto_aging_interval_hours: self.auto_aging_interval_hours,
+            min_age_days: self.min_age_days,
+            max_access_count: self.max_access_count,
+            max_deprecate_percent: self.max_deprecate_percent,
+            min_deprecate_per_cycle: self.min_deprecate_per_cycle,
+            max_deprecate_per_cycle: self.max_deprecate_per_cycle,
+            deprecated_ttl_days: self.deprecated_ttl_days,
+            auto_prune_enabled: self.auto_prune_enabled,
+            dream_dedup_soft_delete: self.dream_dedup_soft_delete,
+            dream_compact_soft_delete: self.dream_compact_soft_delete,
+        }
+    }
+}
+
 /// Full uteke configuration, loaded from `uteke.toml`.
 #[derive(serde::Deserialize, Clone)]
 #[serde(default)]
@@ -363,6 +439,7 @@ pub struct Config {
     pub limits: LimitsConfig,
     pub maintenance: MaintenanceConfig,
     pub dream: DreamConfig,
+    pub lifecycle: LifecycleConfig,
     /// Enable background update notification on startup. Default: true.
     /// Set to `false` to disable.
     #[serde(default = "default_true")]
@@ -389,6 +466,7 @@ impl Default for Config {
             limits: LimitsConfig::default(),
             maintenance: MaintenanceConfig::default(),
             dream: DreamConfig::default(),
+            lifecycle: LifecycleConfig::default(),
             update_check: true,
         }
     }

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -168,6 +168,8 @@ fn main() {
                 dedup_threshold: config.dream.dedup_threshold,
                 orphan_importance_threshold: config.dream.orphan_importance_threshold,
             });
+            // #928: apply lifecycle configuration from config
+            u.set_lifecycle_config(config.lifecycle.to_core());
             u
         }
         Err(e) => {

--- a/crates/uteke-core/src/consolidate.rs
+++ b/crates/uteke-core/src/consolidate.rs
@@ -270,9 +270,21 @@ impl crate::Uteke {
                 }
             };
 
-            self.store
-                .delete(to_remove)
-                .map_err(|e| Error::db("consolidate delete", e))?;
+            // Deprecate (soft-delete) or hard-delete the older memory (#931).
+            // When dream_dedup_soft_delete is enabled (default), the older duplicate
+            // is deprecated instead of permanently deleted, preserving data safety.
+            let dream_soft = self.lifecycle_config.dream_dedup_soft_delete;
+            if dream_soft {
+                let reason =
+                    format!("dream dedup: superseded by {to_keep} (similarity ≥ threshold)");
+                self.store
+                    .deprecate_with_reason(to_remove, &reason)
+                    .map_err(|e| Error::db("consolidate soft-delete", e))?;
+            } else {
+                self.store
+                    .delete(to_remove)
+                    .map_err(|e| Error::db("consolidate delete", e))?;
+            }
             // SQLite first (source of truth), then vector index.
             let mut index = self
                 .index

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -212,6 +212,124 @@ impl Default for DreamConfig {
     }
 }
 
+/// Memory lifecycle configuration (#928).
+///
+/// Controls how memories transition through their lifecycle:
+/// `ACTIVE → DEPRECATED (hidden, restorable) → PRUNED (hard delete)`.
+///
+/// All destructive operations (aging_cleanup, dream dedup/compact,
+/// consolidate, CRUD delete) route through soft-delete (`deprecate`)
+/// when `soft_delete_only` is `true` (the default). Hard delete is
+/// reserved for `prune()` after the TTL expires and explicit `forget()`.
+///
+/// ## Defaults (conservative)
+///
+/// ```toml
+/// [lifecycle]
+/// soft_delete_only = true           # route destructive ops through deprecate
+/// auto_aging_interval_hours = 168   # weekly
+/// min_age_days = 90                 # don't touch memories < 90 days old
+/// max_access_count = 3              # only deprecate rarely-accessed
+/// max_deprecate_percent = 1.0       # max 1% of total per cycle
+/// min_deprecate_per_cycle = 1       # always allow at least 1
+/// max_deprecate_per_cycle = 50      # hard ceiling
+/// deprecated_ttl_days = 30         # deprecated → prune after 30 days
+/// auto_prune_enabled = true         # auto-prune expired deprecated
+/// dream_dedup_soft_delete = true    # dream dedup → deprecate, not delete
+/// dream_compact_soft_delete = true  # dream compact → deprecate, not delete
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct LifecycleConfig {
+    /// When `true`, all destructive operations route through `deprecate()`
+    /// instead of `delete()`. Set to `false` to restore pre-v0.13 hard-delete
+    /// behavior (not recommended).
+    pub soft_delete_only: bool,
+
+    /// When `true`, automatic lifecycle cycles run at the configured interval.
+    /// Default: true. Set to `false` to disable background lifecycle cycles
+    /// (memories will still be preserved — just no auto-deprecation/pruning).
+    pub auto_aging_enabled: bool,
+
+    /// Interval in hours between automatic lifecycle cycles.
+    /// Default: 168 (weekly). Only effective in server mode.
+    pub auto_aging_interval_hours: u64,
+
+    /// Minimum age in days before a memory is eligible for deprecation.
+    /// Memories younger than this are always preserved. Default: 90.
+    pub min_age_days: u32,
+
+    /// Maximum access count for a memory to be considered "cold".
+    /// Memories accessed more than this are preserved. Default: 3.
+    pub max_access_count: u32,
+
+    /// Maximum percentage of total memories that can be deprecated in
+    /// a single cycle. E.g. 1.0 = at most 1% of 1000 = 10 memories.
+    /// Default: 1.0 (conservative).
+    pub max_deprecate_percent: f64,
+
+    /// Minimum number of memories to deprecate per cycle, even if the
+    /// percentage cap would result in 0. Default: 1. Set to 0 to allow
+    /// zero-deprecation cycles.
+    pub min_deprecate_per_cycle: usize,
+
+    /// Hard ceiling on deprecations per cycle, regardless of percentage.
+    /// Prevents mass-deprecation on very large stores. Default: 50.
+    pub max_deprecate_per_cycle: usize,
+
+    /// Days after deprecation before a memory is eligible for pruning
+    /// (hard delete). This is the "review window" — deprecated memories
+    /// can be promoted back to active during this period.
+    /// Default: 30.
+    pub deprecated_ttl_days: u32,
+
+    /// When `true`, expired deprecated memories are automatically pruned
+    /// during lifecycle cycles. Default: true.
+    pub auto_prune_enabled: bool,
+
+    /// When `true`, dream dedup phase uses soft-delete instead of hard-delete.
+    /// Default: true.
+    pub dream_dedup_soft_delete: bool,
+
+    /// when `true`, dream compact phase uses soft-delete instead of hard-delete.
+    /// Default: true.
+    pub dream_compact_soft_delete: bool,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            soft_delete_only: true,
+            auto_aging_enabled: true,
+            auto_aging_interval_hours: 168,
+            min_age_days: 90,
+            max_access_count: 3,
+            max_deprecate_percent: 1.0,
+            min_deprecate_per_cycle: 1,
+            max_deprecate_per_cycle: 50,
+            deprecated_ttl_days: 30,
+            auto_prune_enabled: true,
+            dream_dedup_soft_delete: true,
+            dream_compact_soft_delete: true,
+        }
+    }
+}
+
+impl LifecycleConfig {
+    /// Calculate the maximum number of memories to deprecate in a single
+    /// cycle, based on the percentage cap and min/max bounds.
+    ///
+    /// - `total_memories` — current active (non-deprecated) count.
+    ///
+    /// Returns a value in `[min_deprecate_per_cycle, max_deprecate_per_cycle]`,
+    /// clamped after percentage calculation.
+    pub fn cycle_deprecate_cap(&self, total_memories: usize) -> usize {
+        let pct_based = (total_memories as f64 * self.max_deprecate_percent / 100.0) as usize;
+        pct_based
+            .max(self.min_deprecate_per_cycle)
+            .min(self.max_deprecate_per_cycle)
+    }
+}
+
 /// Resolve uteke data directory.
 ///
 /// Uses `UTEKE_HOME` environment variable when set, otherwise falls back to
@@ -431,6 +549,9 @@ pub struct Uteke {
     /// Dream pipeline thresholds (#731). Used by contradiction scan,
     /// dedup/consolidate, and orphan detection phases.
     dream_config: DreamConfig,
+    /// Memory lifecycle configuration (#928). Controls soft-delete behavior,
+    /// dynamic deprecation caps, and TTL-based pruning.
+    lifecycle_config: LifecycleConfig,
     /// Recall cache — avoids redundant embedding computation for repeated queries.
     recall_cache: recall_cache::RecallCache,
     /// Path to the persistent embedding cache DB (`embed_cache.db`).
@@ -439,6 +560,16 @@ pub struct Uteke {
 }
 
 impl Uteke {
+    /// Borrow the underlying store (for CLI/advanced use).
+    pub fn store(&self) -> &Store {
+        &self.store
+    }
+
+    /// Borrow lifecycle configuration (read-only).
+    pub fn get_lifecycle_config(&self) -> &LifecycleConfig {
+        &self.lifecycle_config
+    }
+
     /// Open or create a Uteke memory store.
     ///
     /// `path` can be a directory path (will create `uteke.db` inside)
@@ -614,6 +745,7 @@ impl Uteke {
             recall_cache: recall_cache::RecallCache::new(recall_cache::RecallCacheConfig::default()),
             jaccard_weight: 0.0,
             dream_config: DreamConfig::default(),
+            lifecycle_config: LifecycleConfig::default(),
             embed_cache_path,
         })
     }
@@ -654,6 +786,19 @@ impl Uteke {
     /// startup from CLI/server config.
     pub fn set_dream_config(&mut self, config: DreamConfig) {
         self.dream_config = config;
+    }
+
+    /// Set memory lifecycle configuration (#928).
+    ///
+    /// Controls soft-delete behavior, dynamic deprecation caps, and
+    /// TTL-based pruning. Called once at startup from CLI/server config.
+    pub fn set_lifecycle_config(&mut self, config: LifecycleConfig) {
+        self.lifecycle_config = config;
+    }
+
+    /// Get the current lifecycle configuration (#928).
+    pub fn lifecycle_config(&self) -> LifecycleConfig {
+        self.lifecycle_config
     }
 
     /// Configure cloud embedding fallback.

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -514,8 +514,10 @@ impl crate::Uteke {
         );
 
         // Phase 2: Auto-prune expired deprecated memories.
-        // When soft_delete_only is true, skip hard delete entirely.
-        let (pruned, pruned_ids) = if cfg.auto_prune_enabled && !cfg.soft_delete_only {
+        // soft_delete_only only restricts forget() from hard-deleting active memories.
+        // Prune operates on already-deprecated memories past their TTL, which is the
+        // intended hard-delete path regardless of soft_delete_only.
+        let (pruned, pruned_ids) = if cfg.auto_prune_enabled {
             let expired = self
                 .store
                 .find_deprecated_for_prune(cfg.deprecated_ttl_days, namespace)?;

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -1,7 +1,9 @@
 //! Maintenance operations: doctor, verify, repair, stats, aging, prune, shutdown.
 
 use crate::error::{Error, format_bytes};
-use crate::memory::types::{AgingStatus, CleanupResult, Memory, PruneResult, StoreStats};
+use crate::memory::types::{
+    AgingStatus, CleanupResult, LifecycleCycleResult, Memory, PruneResult, StoreStats,
+};
 use crate::types::{
     DoctorCheck, DoctorReport, DoctorStatus, ReembedReport, RepairReport, VerifyReport,
 };
@@ -300,7 +302,19 @@ impl crate::Uteke {
             .find_aged(older_than_days, max_access_count, namespace)
     }
 
-    /// Cleanup aged memories — deletes from SQLite AND removes from vector index.
+    /// Cleanup aged memories — deprecates (soft-delete) or deletes based on lifecycle config.
+    ///
+    /// When `soft_delete_only` is enabled (default, #930): deprecates aged memories
+    /// instead of hard-deleting them. The memories remain in SQLite but are hidden
+    /// from recall and restorable via `promote()`.
+    ///
+    /// When `soft_delete_only` is disabled: hard-deletes from SQLite AND vector index
+    /// (legacy behavior, use with caution).
+    ///
+    /// Safety limits (#933):
+    /// - Caps at `max_deprecate_percent`% of total memories per cycle
+    /// - Never more than `max_deprecate_per_cycle` items
+    /// - Never less than `min_deprecate_per_cycle` (if candidates exist)
     pub fn aging_cleanup(
         &self,
         older_than_days: u32,
@@ -311,37 +325,79 @@ impl crate::Uteke {
         let aged = self
             .store
             .find_aged(older_than_days, max_access_count, namespace)?;
-        // Safety limit: never delete more than 100 memories per cycle.
-        // This prevents mass deletion if thresholds are misconfigured.
-        const MAX_DELETE_PER_CYCLE: usize = 100;
-        let ids: Vec<String> = aged
-            .into_iter()
-            .take(MAX_DELETE_PER_CYCLE)
-            .map(|m| m.id)
-            .collect();
+
+        if aged.is_empty() {
+            return Ok(CleanupResult { deleted: 0 });
+        }
+
+        // Dynamic cap: limit deprecations to max_deprecate_percent of total memories.
+        let total = self.store.count(namespace)?;
+        let lc = &self.lifecycle_config;
+        let pct_cap = ((total as f64 * lc.max_deprecate_percent / 100.0).round() as usize)
+            .max(lc.min_deprecate_per_cycle)
+            .min(lc.max_deprecate_per_cycle);
+        let cap = pct_cap.min(aged.len());
+
+        let ids: Vec<String> = aged.into_iter().take(cap).map(|m| m.id).collect();
 
         if ids.is_empty() {
             return Ok(CleanupResult { deleted: 0 });
         }
 
-        // Delete by specific IDs to avoid TOCTOU race (not re-query by criteria)
-        let deleted = self.store.delete_by_ids(&ids)?;
+        if lc.soft_delete_only {
+            // Soft-delete: deprecate with reason (#930)
+            let reason = format!(
+                "auto-aging: older than {older_than_days} days, access count ≤ {max_access_count}"
+            );
+            let deprecated = self.store.deprecate_by_ids(&ids, &reason)?;
 
-        // Remove from vector index
-        {
-            let mut index = self
-                .index
-                .write()
-                .map_err(|_| Error::lock("index write lock during aging_cleanup"))?;
-            for id in &ids {
-                index.remove(id);
+            // Remove from vector index (so they don't appear in recall)
+            {
+                let mut index = self
+                    .index
+                    .write()
+                    .map_err(|_| Error::lock("index write lock during aging_cleanup"))?;
+                for id in &ids {
+                    index.remove(id);
+                }
+                if let Err(e) = index.save() {
+                    tracing::warn!("Failed to save index: {e}");
+                }
             }
-            if let Err(e) = index.save() {
-                tracing::warn!("Failed to save index: {e}");
+
+            tracing::info!(
+                "Aging cleanup (soft-delete): deprecated {} of {} candidates (cap={cap}, total={total})",
+                deprecated,
+                ids.len(),
+            );
+            Ok(CleanupResult {
+                deleted: deprecated,
+            })
+        } else {
+            // Hard delete (legacy behavior, only when soft_delete_only=false)
+            let deleted = self.store.delete_by_ids(&ids)?;
+
+            // Remove from vector index
+            {
+                let mut index = self
+                    .index
+                    .write()
+                    .map_err(|_| Error::lock("index write lock during aging_cleanup"))?;
+                for id in &ids {
+                    index.remove(id);
+                }
+                if let Err(e) = index.save() {
+                    tracing::warn!("Failed to save index: {e}");
+                }
             }
+
+            tracing::info!(
+                "Aging cleanup (hard delete): deleted {} of {} candidates (cap={cap}, total={total})",
+                deleted,
+                ids.len(),
+            );
+            Ok(CleanupResult { deleted })
         }
-
-        Ok(CleanupResult { deleted })
     }
 
     /// Prune deprecated memories older than TTL days.
@@ -388,6 +444,115 @@ impl crate::Uteke {
             ids: ids.clone(),
             deprecated: count,
             deprecated_ids: ids,
+        })
+    }
+
+    /// Run one lifecycle cycle (#933).
+    ///
+    /// Two-phase operation:
+    /// 1. **Deprecate phase**: find aged memories, cap to max N% of total active,
+    ///    soft-delete (deprecate) the oldest ones.
+    /// 2. **Prune phase**: hard-delete memories that have been deprecated longer
+    ///    than `deprecated_ttl_days`.
+    ///
+    /// The percentage cap (`max_deprecate_percent`) limits how many memories can
+    /// be deprecated per cycle — defaults to 1.0%, clamped between
+    /// `min_deprecate_per_cycle` and `max_deprecate_per_cycle`.
+    pub fn lifecycle_cycle(&self, namespace: Option<&str>) -> Result<LifecycleCycleResult, Error> {
+        let cfg = &self.lifecycle_config;
+
+        // Phase 1: Find candidates and apply percentage cap.
+        let total_active = self.store.count_active(namespace)?;
+        let candidates = self
+            .store
+            .find_aged(cfg.min_age_days, cfg.max_access_count, namespace)?;
+
+        // Calculate cap: percentage of total, clamped to [min, max].
+        let raw_cap = ((total_active as f64) * cfg.max_deprecate_percent / 100.0) as usize;
+        let cap = raw_cap
+            .max(cfg.min_deprecate_per_cycle)
+            .min(cfg.max_deprecate_per_cycle);
+
+        // Take oldest `cap` candidates (find_aged already sorts by created_at ASC).
+        let to_deprecate: Vec<String> = candidates.iter().take(cap).map(|m| m.id.clone()).collect();
+
+        let deprecated_ids = to_deprecate.clone();
+        let deprecated_count = if !to_deprecate.is_empty() {
+            let reason = "lifecycle_cycle: aged memory (auto-deprecate)";
+            self.store.deprecate_by_ids(&to_deprecate, reason)?
+        } else {
+            0
+        };
+
+        // Remove deprecated from vector index.
+        if !to_deprecate.is_empty() {
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during lifecycle_cycle"))?;
+            for id in &to_deprecate {
+                index.remove(id);
+            }
+            if let Err(e) = index.save() {
+                tracing::warn!("Failed to persist index after lifecycle deprecate: {e}");
+            }
+        }
+
+        // Invalidate recall cache.
+        if let Some(ns) = namespace {
+            self.recall_cache.invalidate_namespace(ns);
+        } else {
+            self.recall_cache.clear();
+        }
+
+        tracing::info!(
+            "Lifecycle cycle: {} of {} candidates deprecated (cap={}, total_active={})",
+            deprecated_count,
+            candidates.len(),
+            cap,
+            total_active
+        );
+
+        // Phase 2: Auto-prune expired deprecated memories.
+        let (pruned, pruned_ids) = if cfg.auto_prune_enabled {
+            let expired = self
+                .store
+                .find_deprecated_for_prune(cfg.deprecated_ttl_days, namespace)?;
+            let expired_ids: Vec<String> = expired.iter().map(|m| m.id.clone()).collect();
+            if expired_ids.is_empty() {
+                (0, vec![])
+            } else {
+                let pruned_count = self.store.delete_by_ids(&expired_ids)?;
+                // Remove from vector index.
+                let mut index = self
+                    .index
+                    .write()
+                    .map_err(|_| Error::lock("index write lock during lifecycle prune"))?;
+                for id in &expired_ids {
+                    index.remove(id);
+                }
+                if let Err(e) = index.save() {
+                    tracing::warn!("Failed to persist index after lifecycle prune: {e}");
+                }
+                tracing::info!(
+                    "Lifecycle cycle: pruned {} expired deprecated memories (ttl={}d)",
+                    pruned_count,
+                    cfg.deprecated_ttl_days
+                );
+                (pruned_count, expired_ids)
+            }
+        } else {
+            (0, vec![])
+        };
+
+        Ok(LifecycleCycleResult {
+            total_active,
+            candidates: candidates.len(),
+            cap,
+            deprecated: deprecated_count,
+            deprecated_ids,
+            pruned,
+            pruned_ids,
         })
     }
 

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -514,7 +514,8 @@ impl crate::Uteke {
         );
 
         // Phase 2: Auto-prune expired deprecated memories.
-        let (pruned, pruned_ids) = if cfg.auto_prune_enabled {
+        // When soft_delete_only is true, skip hard delete entirely.
+        let (pruned, pruned_ids) = if cfg.auto_prune_enabled && !cfg.soft_delete_only {
             let expired = self
                 .store
                 .find_deprecated_for_prune(cfg.deprecated_ttl_days, namespace)?;

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -19,6 +19,42 @@ impl super::Store {
         Ok(())
     }
 
+    /// Count active (non-deprecated) memories in a namespace.
+    pub fn count_active(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let count: i64 = match namespace {
+            Some(ns) => self.conn.query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND deprecated = 0",
+                params![ns],
+                |row| row.get(0),
+            ),
+            None => self.conn.query_row(
+                "SELECT COUNT(*) FROM memories WHERE deprecated = 0",
+                [],
+                |row| row.get(0),
+            ),
+        }
+        .map_err(|e| Error::db("database operation", e))?;
+        Ok(count as usize)
+    }
+
+    /// Count deprecated memories in a namespace.
+    pub fn count_deprecated(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let count: i64 = match namespace {
+            Some(ns) => self.conn.query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND deprecated = 1",
+                params![ns],
+                |row| row.get(0),
+            ),
+            None => self.conn.query_row(
+                "SELECT COUNT(*) FROM memories WHERE deprecated = 1",
+                [],
+                |row| row.get(0),
+            ),
+        }
+        .map_err(|e| Error::db("database operation", e))?;
+        Ok(count as usize)
+    }
+
     /// Find aged memories eligible for cleanup.
     ///
     /// Returns memories matching: older than `older_than_days`, access_count <= max_access_count,

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -35,6 +35,29 @@ impl super::Store {
         Ok(ids)
     }
 
+    /// Find IDs of memories by tag (for soft-delete path, #932).
+    ///
+    /// Same query as `bulk_delete_by_tag` but SELECT instead of DELETE.
+    pub fn find_ids_by_tag(
+        &self,
+        tag: &str,
+        namespace: Option<&str>,
+    ) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT memories.id FROM memories WHERE namespace = ?1 AND deprecated = 0 AND EXISTS (SELECT 1 FROM memory_tags WHERE memory_id = memories.id AND tag = ?2)",
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params![ns, tag], |row| row.get(0))
+            .map_err(|e| Error::db("database operation", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
     /// Bulk delete all cold memories (not accessed in warm_days+ days or never accessed).
     ///
     /// Uses a single DELETE query with `RETURNING id` for efficiency.
@@ -86,6 +109,47 @@ impl super::Store {
         Ok(ids)
     }
 
+    /// Find IDs of cold memories (for soft-delete path, #932).
+    ///
+    /// Same criteria as `bulk_delete_cold` but SELECT instead of DELETE.
+    pub fn find_ids_cold(
+        &self,
+        namespace: Option<&str>,
+        warm_days: i64,
+    ) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let warm_cutoff = (chrono::Utc::now() - chrono::Duration::days(warm_days)).to_rfc3339();
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id FROM memories WHERE namespace = ?1 AND deprecated = 0 AND (last_accessed < ?2 OR last_accessed IS NULL)",
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params![ns, warm_cutoff], |row| row.get(0))
+            .map_err(|e| Error::db("database operation", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
+    /// Find all memory IDs in a namespace (for soft-delete path, #932).
+    ///
+    /// Same query as `bulk_delete_all` but SELECT instead of DELETE.
+    pub fn find_ids_all(&self, namespace: Option<&str>) -> Result<Vec<String>, Error> {
+        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM memories WHERE namespace = ?1 AND deprecated = 0")
+            .map_err(|e| Error::db("database operation", e))?;
+        let ids: Vec<String> = stmt
+            .query_map(params![ns], |row| row.get(0))
+            .map_err(|e| Error::db("database operation", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
     /// Deprecate a memory by ID. Sets deprecated=1 and valid_until=now.
     pub fn deprecate(&self, id: &str) -> Result<(), Error> {
         let now = chrono::Utc::now().to_rfc3339();
@@ -96,6 +160,68 @@ impl super::Store {
             )
             .map_err(|e| Error::db("database operation", e))?;
         Ok(())
+    }
+
+    /// Deprecate a memory with a human-readable reason (#929).
+    ///
+    /// Sets deprecated=1, valid_until=now, deprecate_reason=reason.
+    /// The reason is stored for audit trail and pending-review display.
+    pub fn deprecate_with_reason(&self, id: &str, reason: &str) -> Result<(), Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "UPDATE memories SET deprecated = 1, valid_until = ?1, deprecate_reason = ?2, updated_at = ?1 WHERE id = ?3",
+                params![now, reason, id],
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+        Ok(())
+    }
+
+    /// Bulk deprecate by IDs with a shared reason (#929).
+    ///
+    /// Soft-delete variant of `delete_by_ids`. Returns count of deprecated rows.
+    pub fn deprecate_by_ids(&self, ids: &[String], reason: &str) -> Result<usize, Error> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let now = chrono::Utc::now().to_rfc3339();
+        let placeholders: String = ids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 3))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE memories SET deprecated = 1, valid_until = ?1, deprecate_reason = ?2, updated_at = ?1 WHERE id IN ({placeholders}) AND deprecated = 0"
+        );
+        let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> =
+            vec![Box::new(now), Box::new(reason.to_string())];
+        for id in ids {
+            params_vec.push(Box::new(id.clone()));
+        }
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let count = self
+            .conn
+            .execute(&sql, rusqlite::params_from_iter(param_refs))
+            .map_err(|e| Error::db("database operation", e))?;
+        Ok(count)
+    }
+
+    /// Restore a deprecated memory to active state (#929).
+    ///
+    /// Clears deprecated flag, valid_until, and deprecate_reason.
+    /// Returns false if the memory was not deprecated or doesn't exist.
+    pub fn undeprecate(&self, id: &str) -> Result<bool, Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE memories SET deprecated = 0, valid_until = NULL, deprecate_reason = NULL, updated_at = ?1 WHERE id = ?2 AND deprecated = 1",
+                params![now, id],
+            )
+            .map_err(|e| Error::db("database operation", e))?;
+        Ok(rows > 0)
     }
 
     /// Find memories that contradict a new embedding (high similarity, same namespace).

--- a/crates/uteke-core/src/memory/bulk.rs
+++ b/crates/uteke-core/src/memory/bulk.rs
@@ -168,12 +168,28 @@ impl super::Store {
     /// The reason is stored for audit trail and pending-review display.
     pub fn deprecate_with_reason(&self, id: &str, reason: &str) -> Result<(), Error> {
         let now = chrono::Utc::now().to_rfc3339();
-        self.conn
+        let rows = self
+            .conn
             .execute(
-                "UPDATE memories SET deprecated = 1, valid_until = ?1, deprecate_reason = ?2, updated_at = ?1 WHERE id = ?3",
+                "UPDATE memories SET deprecated = 1, valid_until = ?1, deprecate_reason = ?2, updated_at = ?1 WHERE id = ?3 AND deprecated = 0",
                 params![now, reason, id],
             )
             .map_err(|e| Error::db("database operation", e))?;
+        if rows == 0 {
+            // Check if the memory exists at all (already deprecated or not found)
+            let exists: bool = self
+                .conn
+                .query_row("SELECT 1 FROM memories WHERE id = ?1", params![id], |_| {
+                    Ok(true)
+                })
+                .unwrap_or(false);
+            if !exists {
+                return Err(Error::db_msg(format!(
+                    "Memory with id='{id}' not found in store. Nothing was deprecated."
+                )));
+            }
+            // Already deprecated: idempotent success
+        }
         Ok(())
     }
 

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -57,6 +57,12 @@ impl super::Store {
                 .execute_batch("ALTER TABLE memories ADD COLUMN valid_until TEXT;")
                 .map_err(|e| Error::db("database operation", e))?;
         }
+        // Migration: add deprecate_reason column (#929)
+        if !self.column_exists("deprecate_reason") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN deprecate_reason TEXT;")
+                .map_err(|e| Error::db("database operation", e))?;
+        }
         if !self.column_exists("memory_type") {
             self.conn
                 .execute_batch(

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS memories (
     access_count INTEGER NOT NULL DEFAULT 0,
     last_accessed TEXT,
     deprecated INTEGER NOT NULL DEFAULT 0,
+    deprecate_reason TEXT,
     valid_from TEXT,
     valid_until TEXT,
     memory_type TEXT NOT NULL DEFAULT 'fact',

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -348,6 +348,27 @@ pub struct PruneResult {
     pub deprecated_ids: Vec<String>,
 }
 
+/// Result of a lifecycle cycle run (#933).
+///
+/// Combines the soft-deprecate phase (cap-limited) and the auto-prune phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LifecycleCycleResult {
+    /// Total active memories before the cycle.
+    pub total_active: usize,
+    /// Number of candidates eligible for deprecation.
+    pub candidates: usize,
+    /// Effective cap applied (percentage-based, clamped to min/max).
+    pub cap: usize,
+    /// Number of memories deprecated in this cycle.
+    pub deprecated: usize,
+    /// IDs of deprecated memories.
+    pub deprecated_ids: Vec<String>,
+    /// Number of expired deprecated memories pruned (hard delete).
+    pub pruned: usize,
+    /// IDs of pruned memories.
+    pub pruned_ids: Vec<String>,
+}
+
 /// Result of a contradiction check.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContradictionResult {

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -931,6 +931,12 @@ impl crate::Uteke {
     /// Holds the index write lock for the entire operation to prevent
     /// concurrent processes from reading a partially-updated index (#621).
     pub fn forget(&self, id: &str) -> Result<(), Error> {
+        // When soft_delete_only is enabled (default), redirect to soft-delete (#932).
+        if self.lifecycle_config.soft_delete_only {
+            return self.soft_forget(id, "user forget() — soft-delete via lifecycle config");
+        }
+
+        // --- Legacy hard-delete path (only when soft_delete_only=false) ---
         // Look up namespace before delete for targeted cache invalidation.
         // If lookup succeeds, invalidate only that namespace.
         // If the memory simply doesn't exist, no invalidation needed.
@@ -992,13 +998,91 @@ impl crate::Uteke {
         )))
     }
 
-    /// Bulk delete memories by tag. Also removes from index.
+    /// Soft-delete (deprecate) a memory with reason (#929).
+    ///
+    /// When `soft_delete_only` is enabled (default), this replaces `forget()`.
+    /// The memory is marked deprecated but remains in the database,
+    /// hidden from recall, and restorable via `promote()`.
+    pub fn soft_forget(&self, id: &str, reason: &str) -> Result<(), Error> {
+        self.store.deprecate_with_reason(id, reason)?;
+        // Remove from vector index so it doesn't appear in recall.
+        let mut index = self
+            .index
+            .write()
+            .map_err(|_| Error::lock("index write lock during soft_forget"))?;
+        if !index.remove(id) {
+            tracing::debug!(
+                "Vector index entry not found during soft_forget for id={id} (ok if never embedded)"
+            );
+        }
+        // Invalidate recall cache for this memory's namespace.
+        if let Some(memory) = self.store.get_by_id(id).ok().flatten() {
+            self.recall_cache.invalidate_namespace(&memory.namespace);
+        }
+        tracing::info!("Soft-deleted memory id={id}: {reason}");
+        Ok(())
+    }
+
+    /// Restore a deprecated memory to active state (#929).
+    ///
+    /// Re-adds the memory to the vector index and clears the deprecated flag.
+    /// Returns false if the memory was not deprecated or doesn't exist.
+    pub fn promote(&self, id: &str) -> Result<bool, Error> {
+        let restored = self.store.undeprecate(id)?;
+        if !restored {
+            return Ok(false);
+        }
+        // Re-add to vector index.
+        if let Some(memory) = self.store.get_by_id(id).ok().flatten() {
+            if !memory.embedding.is_empty() {
+                let mut index = self
+                    .index
+                    .write()
+                    .map_err(|_| Error::lock("index write lock during promote"))?;
+                if let Err(e) = index.insert(&memory.id, &memory.embedding) {
+                    tracing::warn!(
+                        "Failed to re-insert memory id={} into vector index during promote: {e}",
+                        memory.id
+                    );
+                }
+                let _ = index.save();
+            }
+            self.recall_cache.invalidate_namespace(&memory.namespace);
+        }
+        tracing::info!("Promoted (restored) memory id={id}");
+        Ok(true)
+    }
+
+    /// Bulk delete memories by tag. Hard or soft-delete based on lifecycle config (#932).
     pub fn bulk_forget_by_tag(
         &self,
         tag: &str,
         namespace: Option<&str>,
     ) -> Result<BulkDeleteResult, Error> {
-        // Acquire index write lock BEFORE SQLite delete to narrow inconsistency window.
+        if self.lifecycle_config.soft_delete_only {
+            let ids = self.store.find_ids_by_tag(tag, namespace)?;
+            let reason = format!("bulk forget by tag='{tag}' — soft-delete via lifecycle config");
+            let count = self.store.deprecate_by_ids(&ids, &reason)?;
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during bulk_forget_by_tag"))?;
+            for id in &ids {
+                index.remove(id);
+            }
+            persist_index_after_delete(&mut index, "bulk_forget_by_tag (soft)")?;
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+            return Ok(BulkDeleteResult {
+                deleted: count,
+                ids,
+            });
+        }
+
+        // Legacy hard-delete path
         let mut index = self
             .index
             .write()
@@ -1018,9 +1102,34 @@ impl crate::Uteke {
         })
     }
 
-    /// Bulk delete all cold memories. Also removes from index.
+    /// Bulk delete all cold memories. Hard or soft-delete based on lifecycle config (#932).
     pub fn bulk_forget_cold(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
-        // Acquire index write lock BEFORE SQLite delete to narrow inconsistency window.
+        if self.lifecycle_config.soft_delete_only {
+            let ids = self
+                .store
+                .find_ids_cold(namespace, self.tier_config.warm_days)?;
+            let reason = "bulk forget cold — soft-delete via lifecycle config".to_string();
+            let count = self.store.deprecate_by_ids(&ids, &reason)?;
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during bulk_forget_cold"))?;
+            for id in &ids {
+                index.remove(id);
+            }
+            persist_index_after_delete(&mut index, "bulk_forget_cold (soft)")?;
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+            return Ok(BulkDeleteResult {
+                deleted: count,
+                ids,
+            });
+        }
+
+        // Legacy hard-delete path
         let mut index = self
             .index
             .write()
@@ -1040,9 +1149,32 @@ impl crate::Uteke {
         })
     }
 
-    /// Bulk delete all memories in a namespace. Also removes from index.
+    /// Bulk delete all memories in a namespace. Hard or soft-delete based on lifecycle config (#932).
     pub fn bulk_forget_all(&self, namespace: Option<&str>) -> Result<BulkDeleteResult, Error> {
-        // Acquire index write lock BEFORE SQLite delete to narrow inconsistency window.
+        if self.lifecycle_config.soft_delete_only {
+            let ids = self.store.find_ids_all(namespace)?;
+            let reason = "bulk forget all — soft-delete via lifecycle config".to_string();
+            let count = self.store.deprecate_by_ids(&ids, &reason)?;
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during bulk_forget_all"))?;
+            for id in &ids {
+                index.remove(id);
+            }
+            persist_index_after_delete(&mut index, "bulk_forget_all (soft)")?;
+            if let Some(ns) = namespace {
+                self.recall_cache.invalidate_namespace(ns);
+            } else {
+                self.recall_cache.clear();
+            }
+            return Ok(BulkDeleteResult {
+                deleted: count,
+                ids,
+            });
+        }
+
+        // Legacy hard-delete path
         let mut index = self
             .index
             .write()

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1570,7 +1570,7 @@ mod forget_tests {
     use crate::Uteke;
 
     /// Insert a memory with a fake embedding (bypassing ONNX), then forget it.
-    /// Verifies the memory is gone from both store and index (#926).
+    /// Verifies the memory is soft-deleted (deprecated) by default (#926, #932).
     #[test]
     fn test_forget_deletes_memory() {
         let uteke = Uteke::open(":memory:").unwrap();
@@ -1587,14 +1587,16 @@ mod forget_tests {
             )
             .unwrap();
 
-        // Verify it exists
-        assert!(uteke.get_by_id(&id).unwrap().is_some());
+        // Verify it exists and is active
+        let mem = uteke.get_by_id(&id).unwrap().unwrap();
+        assert!(!mem.deprecated, "memory should be active before forget");
 
-        // Forget it
+        // Forget it (soft-delete by default: soft_delete_only=true)
         uteke.forget(&id).unwrap();
 
-        // Verify it's gone from store
-        assert!(uteke.get_by_id(&id).unwrap().is_none());
+        // Memory still exists but is now deprecated (soft-delete)
+        let mem = uteke.get_by_id(&id).unwrap().unwrap();
+        assert!(mem.deprecated, "memory should be deprecated after forget");
     }
 
     /// Forgetting a non-existent ID should return an error, not Ok(()) (#926).
@@ -1608,7 +1610,7 @@ mod forget_tests {
         );
     }
 
-    /// Forget → re-insert should work (no stale state) (#926).
+    /// Forget → re-insert should work (soft-deleted memory stays, new ID for re-insert) (#926).
     #[test]
     fn test_forget_then_reinsert() {
         let uteke = Uteke::open(":memory:").unwrap();
@@ -1625,10 +1627,12 @@ mod forget_tests {
             )
             .unwrap();
 
+        // Soft-delete: memory becomes deprecated, not removed
         uteke.forget(&id).unwrap();
-        assert!(uteke.get_by_id(&id).unwrap().is_none());
+        let mem = uteke.get_by_id(&id).unwrap().unwrap();
+        assert!(mem.deprecated, "original memory should be deprecated");
 
-        // Re-insert with same content — should get a new ID
+        // Re-insert with same content: should get a new ID (deprecated memories don't block re-insert)
         let id2 = uteke
             .remember_precomputed(
                 "forget then reinsert",
@@ -1641,7 +1645,8 @@ mod forget_tests {
             )
             .unwrap();
         assert_ne!(id, id2, "re-inserted memory should have a new ID");
-        assert!(uteke.get_by_id(&id2).unwrap().is_some());
+        let mem2 = uteke.get_by_id(&id2).unwrap().unwrap();
+        assert!(!mem2.deprecated, "new memory should be active");
     }
 }
 

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.12.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.13.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.12.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.12.0" }
+uteke-core = { path = "../uteke-core", version = "0.13.0", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.13.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -589,6 +589,34 @@ pub const ENDPOINTS: &[Endpoint] = &[
         excludes_deprecated: true,
         issues: &[],
     },
+    // ── Lifecycle ───────────────────────────────────────────────────────
+    Endpoint {
+        method: "POST",
+        path: "/lifecycle/cycle",
+        description: "Run lifecycle aging cycle: deprecate old memories, optionally prune expired ones.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#935"],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/lifecycle/promote",
+        description: "Restore a deprecated memory back to active status.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#935"],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/lifecycle/status",
+        description: "Get lifecycle status: active/deprecated counts and current configuration.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#935"],
+    },
 ];
 
 #[cfg(test)]

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -597,6 +597,86 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // ── Lifecycle (#936): status, cycle, promote ──────────────────
+        (Method::Get, p) if p == "/lifecycle/status" || p.starts_with("/lifecycle/status?") => {
+            let query = req.url().split('?').nth(1).unwrap_or("");
+            let params: std::collections::HashMap<String, String> = query
+                .split('&')
+                .filter_map(|pair| {
+                    let mut kv = pair.splitn(2, '=');
+                    Some((kv.next()?.to_string(), kv.next()?.to_string()))
+                })
+                .collect();
+            let ns_param = params.get("namespace").map(|s| s.as_str());
+            let active = match uteke.store().count_active(ns_param) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("lifecycle status error: {e}");
+                    return ctx.error_response_for(req, 500, "Internal server error");
+                }
+            };
+            let deprecated = match uteke.store().count_deprecated(ns_param) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("lifecycle status error: {e}");
+                    return ctx.error_response_for(req, 500, "Internal server error");
+                }
+            };
+            #[derive(serde::Serialize)]
+            struct LifecycleStatusResponse {
+                active: usize,
+                deprecated: usize,
+            }
+            ctx.ok_response_for(req, &LifecycleStatusResponse { active, deprecated })
+        }
+
+        (Method::Post, "/lifecycle/cycle") => {
+            #[derive(Deserialize)]
+            struct CycleReq {
+                namespace: Option<String>,
+            }
+            match read_body::<CycleReq>(req.as_reader()) {
+                Ok(req_data) => match uteke.lifecycle_cycle(ns(&req_data.namespace)) {
+                    Ok(result) => ctx.ok_response_for(req, &result),
+                    Err(e) => {
+                        error!("lifecycle cycle error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                },
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
+        (Method::Post, "/lifecycle/promote") => {
+            #[derive(Deserialize)]
+            struct PromoteReq {
+                id: String,
+            }
+            match read_body::<PromoteReq>(req.as_reader()) {
+                Ok(req_data) => match uteke.promote(&req_data.id) {
+                    Ok(_) => {
+                        #[derive(serde::Serialize)]
+                        struct PromoteResponse {
+                            promoted: bool,
+                            id: String,
+                        }
+                        ctx.ok_response_for(
+                            req,
+                            &PromoteResponse {
+                                promoted: true,
+                                id: req_data.id,
+                            },
+                        )
+                    }
+                    Err(e) => {
+                        error!("lifecycle promote error: {e}");
+                        ctx.error_response_for(req, 500, "Internal server error")
+                    }
+                },
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
         // ── Namespaces ──────────────────────────────────────────────────
         (Method::Get, p) if p == "/namespaces" || p.starts_with("/namespaces?") => {
             let with_counts = path.contains("with_counts=true");

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -654,7 +654,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
             match read_body::<PromoteReq>(req.as_reader()) {
                 Ok(req_data) => match uteke.promote(&req_data.id) {
-                    Ok(_) => {
+                    Ok(restored) => {
                         #[derive(serde::Serialize)]
                         struct PromoteResponse {
                             promoted: bool,
@@ -663,7 +663,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         ctx.ok_response_for(
                             req,
                             &PromoteResponse {
-                                promoted: true,
+                                promoted: restored,
                                 id: req_data.id,
                             },
                         )

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -252,6 +252,51 @@ fn main() {
                         .unwrap_or(defaults.orphan_importance_threshold),
                 );
             }
+
+            // Apply lifecycle config from uteke.toml [lifecycle] section (#928)
+            if let Some(ref lc) = config.lifecycle {
+                let defaults = uteke_core::LifecycleConfig::default();
+                u.set_lifecycle_config(uteke_core::LifecycleConfig {
+                    soft_delete_only: lc.soft_delete_only.unwrap_or(defaults.soft_delete_only),
+                    auto_aging_enabled: lc
+                        .auto_aging_enabled
+                        .unwrap_or(defaults.auto_aging_enabled),
+                    auto_aging_interval_hours: lc
+                        .auto_aging_interval_hours
+                        .unwrap_or(defaults.auto_aging_interval_hours),
+                    min_age_days: lc.min_age_days.unwrap_or(defaults.min_age_days),
+                    max_access_count: lc.max_access_count.unwrap_or(defaults.max_access_count),
+                    max_deprecate_percent: lc
+                        .max_deprecate_percent
+                        .unwrap_or(defaults.max_deprecate_percent),
+                    min_deprecate_per_cycle: lc
+                        .min_deprecate_per_cycle
+                        .unwrap_or(defaults.min_deprecate_per_cycle),
+                    max_deprecate_per_cycle: lc
+                        .max_deprecate_per_cycle
+                        .unwrap_or(defaults.max_deprecate_per_cycle),
+                    deprecated_ttl_days: lc
+                        .deprecated_ttl_days
+                        .unwrap_or(defaults.deprecated_ttl_days),
+                    auto_prune_enabled: lc
+                        .auto_prune_enabled
+                        .unwrap_or(defaults.auto_prune_enabled),
+                    dream_dedup_soft_delete: lc
+                        .dream_dedup_soft_delete
+                        .unwrap_or(defaults.dream_dedup_soft_delete),
+                    dream_compact_soft_delete: lc
+                        .dream_compact_soft_delete
+                        .unwrap_or(defaults.dream_compact_soft_delete),
+                });
+                info!(
+                    "Lifecycle config loaded: soft_delete_only={}, ttl={}d, max_deprecate={:.1}%",
+                    lc.soft_delete_only.unwrap_or(defaults.soft_delete_only),
+                    lc.deprecated_ttl_days
+                        .unwrap_or(defaults.deprecated_ttl_days),
+                    lc.max_deprecate_percent
+                        .unwrap_or(defaults.max_deprecate_percent),
+                );
+            }
             Arc::new(Mutex::new(u))
         }
         Err(e) => {
@@ -309,62 +354,56 @@ fn main() {
         info!("CORS: allowing origins: {:?}", cors_origins);
     }
 
-    // Auto-aging background thread (#442 enhancement).
-    // Runs aging cleanup periodically to remove cold, low-importance memories.
-    let aging_enabled = config
-        .maintenance
+    // Auto-lifecycle background thread (#934 — replaces auto-aging #442).
+    // Runs lifecycle_cycle periodically: soft-deprecate aged memories (cap-limited)
+    // + auto-prune expired deprecated memories.
+    let lifecycle_enabled = config
+        .lifecycle
         .as_ref()
-        .and_then(|m| m.auto_aging_enabled)
+        .and_then(|lc| lc.auto_aging_enabled)
         .unwrap_or(true);
-    let aging_hours = config
-        .maintenance
+    let lifecycle_hours = config
+        .lifecycle
         .as_ref()
-        .and_then(|m| m.auto_aging_interval_hours)
-        .unwrap_or(6)
+        .and_then(|lc| lc.auto_aging_interval_hours)
+        .unwrap_or(168) // weekly by default
         .max(1); // Minimum 1 hour to prevent busy loop
-    let aging_uteke = Arc::clone(&uteke);
-    let aging_config = config.aging.clone();
-    if aging_enabled {
-        info!("Auto-aging: enabled (every {aging_hours}h)");
+    let lifecycle_uteke = Arc::clone(&uteke);
+    if lifecycle_enabled {
+        info!("Auto-lifecycle: enabled (every {lifecycle_hours}h)");
         std::thread::spawn(move || {
-            let interval = std::time::Duration::from_secs(aging_hours * 60 * 60);
+            let interval = std::time::Duration::from_secs(lifecycle_hours * 60 * 60);
             loop {
                 std::thread::sleep(interval);
                 if SHUTDOWN.load(Ordering::SeqCst) {
                     break;
                 }
-                match aging_uteke.lock() {
-                    Ok(u) => {
-                        let age_days = aging_config
-                            .as_ref()
-                            .and_then(|a| a.max_age_days)
-                            .unwrap_or(365);
-                        let max_access = aging_config
-                            .as_ref()
-                            .and_then(|a| a.max_access_count)
-                            .unwrap_or(10);
-                        match u.aging_cleanup(age_days, max_access, None) {
-                            Ok(result) => {
-                                if result.deleted > 0 {
-                                    info!(
-                                        "Auto-aging: cleaned up {} stale memories (age>{age_days}d, access<{max_access})",
-                                        result.deleted
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                warn!("Auto-aging failed: {e}");
+                match lifecycle_uteke.lock() {
+                    Ok(u) => match u.lifecycle_cycle(None) {
+                        Ok(result) => {
+                            if result.deprecated > 0 || result.pruned > 0 {
+                                info!(
+                                    "Auto-lifecycle: deprecated {}/{} (cap={}, total_active={}), pruned {} expired",
+                                    result.deprecated,
+                                    result.candidates,
+                                    result.cap,
+                                    result.total_active,
+                                    result.pruned
+                                );
                             }
                         }
-                    }
+                        Err(e) => {
+                            warn!("Auto-lifecycle failed: {e}");
+                        }
+                    },
                     Err(_) => {
-                        tracing::debug!("Auto-aging: lock busy, skipping cycle");
+                        tracing::debug!("Auto-lifecycle: lock busy, skipping cycle");
                     }
                 }
             }
         });
     } else {
-        info!("Auto-aging: disabled");
+        info!("Auto-lifecycle: disabled");
     }
 
     // Auto-dream background thread (#442 enhancement).
@@ -473,11 +512,16 @@ struct ServerFileConfig {
     recall: Option<RecallFileSection>,
     extraction: Option<uteke_core::extraction::ExtractionConfig>,
     maintenance: Option<MaintenanceFileSection>,
+    /// Deprecated: superseded by [lifecycle] section (#934). Kept for backward-compat deserialization.
+    #[allow(dead_code)]
     aging: Option<AgingFileSection>,
     dream: Option<DreamFileSection>,
+    lifecycle: Option<LifecycleFileSection>,
 }
 
+/// Deprecated: superseded by [lifecycle] section (#934). Kept for backward-compat deserialization.
 #[derive(serde::Deserialize, Default, Clone)]
+#[allow(dead_code)]
 struct AgingFileSection {
     max_age_days: Option<u32>,
     max_access_count: Option<u32>,
@@ -485,7 +529,11 @@ struct AgingFileSection {
 
 #[derive(serde::Deserialize, Default, Clone)]
 struct MaintenanceFileSection {
+    /// Deprecated: moved to [lifecycle] section. Kept for backward-compat.
+    #[allow(dead_code)]
     auto_aging_enabled: Option<bool>,
+    /// Deprecated: moved to [lifecycle] section. Kept for backward-compat.
+    #[allow(dead_code)]
     auto_aging_interval_hours: Option<u64>,
     auto_dream_enabled: Option<bool>,
     auto_dream_interval_days: Option<u64>,
@@ -499,6 +547,23 @@ struct DreamFileSection {
     contradict_max_memories: Option<usize>,
     dedup_threshold: Option<f32>,
     orphan_importance_threshold: Option<f64>,
+}
+
+/// Memory lifecycle config from uteke.toml [lifecycle] section (#928).
+#[derive(serde::Deserialize, Default, Clone)]
+struct LifecycleFileSection {
+    soft_delete_only: Option<bool>,
+    auto_aging_enabled: Option<bool>,
+    auto_aging_interval_hours: Option<u64>,
+    min_age_days: Option<u32>,
+    max_access_count: Option<u32>,
+    max_deprecate_percent: Option<f64>,
+    min_deprecate_per_cycle: Option<usize>,
+    max_deprecate_per_cycle: Option<usize>,
+    deprecated_ttl_days: Option<u32>,
+    auto_prune_enabled: Option<bool>,
+    dream_dedup_soft_delete: Option<bool>,
+    dream_compact_soft_delete: Option<bool>,
 }
 
 #[derive(serde::Deserialize, Default)]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,6 +29,7 @@ export default createConfig({
         { text: 'Time-Travel', link: '/time-travel' },
         { text: 'Multi-Agent', link: '/multi-agent' },
         { text: 'Smart Decay', link: '/smart-decay' },
+        { text: 'Memory Lifecycle', link: '/memory-lifecycle' },
         { text: 'Relationship Graph', link: '/relationship-graph' },
         { text: 'Benchmarks', link: '/benchmarks' },
         { text: 'Shell Hooks', link: '/shell-hooks' },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -400,6 +400,57 @@ MCP (Model Context Protocol) bridge endpoint for AI agent tool calls.
 **Request body**: JSON object (see handler source for fields)
 
 
+## 🔄 Lifecycle
+
+#### 🟢 `GET` `/lifecycle/status`
+
+Get lifecycle status — active vs deprecated memory counts.
+
+Accepts `?namespace=X` query param to scope to a namespace.
+
+**Response**:
+```json
+{
+  "active": 1240,
+  "deprecated": 37
+}
+```
+
+#### 🟡 `POST` `/lifecycle/cycle`
+
+Run a lifecycle cycle — deprecate aged memories (respecting percentage cap) and prune expired deprecated memories.
+
+**Request body**:
+```json
+{
+  "namespace": "default"
+}
+```
+
+`namespace` is optional (omit for all namespaces).
+
+**Response**: [`LifecycleCycleResult`](#lifecyclecycleresult)
+
+#### 🟡 `POST` `/lifecycle/promote`
+
+Promote a deprecated memory back to active status. Re-indexes the embedding vector.
+
+**Request body**:
+```json
+{
+  "id": "memory-uuid"
+}
+```
+
+**Response**:
+```json
+{
+  "promoted": true,
+  "id": "memory-uuid"
+}
+```
+
+
 ## Request/Response Schemas
 
 Detailed field definitions for each request type.
@@ -416,6 +467,18 @@ Detailed field definitions for each request type.
 
 
 ### `ConsolidateRequest`
+
+### `LifecycleCycleResult`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_active` | `integer` | Active memories before cycle |
+| `candidates` | `integer` | Aged memories found eligible |
+| `cap` | `integer` | Max deprecations applied (clamped) |
+| `deprecated` | `integer` | Memories deprecated this cycle |
+| `deprecated_ids` | `string`[] | IDs of deprecated memories |
+| `pruned` | `integer` | Expired deprecated memories hard-deleted |
+| `pruned_ids` | `string`[] | IDs of pruned memories |
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -404,7 +404,7 @@ MCP (Model Context Protocol) bridge endpoint for AI agent tool calls.
 
 #### 🟢 `GET` `/lifecycle/status`
 
-Get lifecycle status — active vs deprecated memory counts.
+Get lifecycle status: active vs deprecated memory counts.
 
 Accepts `?namespace=X` query param to scope to a namespace.
 
@@ -418,7 +418,7 @@ Accepts `?namespace=X` query param to scope to a namespace.
 
 #### 🟡 `POST` `/lifecycle/cycle`
 
-Run a lifecycle cycle — deprecate aged memories (respecting percentage cap) and prune expired deprecated memories.
+Run a lifecycle cycle: deprecate aged memories (respecting percentage cap) and prune expired deprecated memories.
 
 **Request body**:
 ```json
@@ -468,6 +468,13 @@ Detailed field definitions for each request type.
 
 ### `ConsolidateRequest`
 
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dry_run` | `boolean` | No |  |
+| `namespace` | any | No |  |
+| `threshold` | `number` | No |  |
+
+
 ### `LifecycleCycleResult`
 
 | Field | Type | Description |
@@ -479,12 +486,6 @@ Detailed field definitions for each request type.
 | `deprecated_ids` | `string`[] | IDs of deprecated memories |
 | `pruned` | `integer` | Expired deprecated memories hard-deleted |
 | `pruned_ids` | `string`[] | IDs of pruned memories |
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `dry_run` | `boolean` | No |  |
-| `namespace` | any | No |  |
-| `threshold` | `number` | No |  |
 
 
 ### `DocCreateRequest`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -400,57 +400,6 @@ MCP (Model Context Protocol) bridge endpoint for AI agent tool calls.
 **Request body**: JSON object (see handler source for fields)
 
 
-## 🔄 Lifecycle
-
-#### 🟢 `GET` `/lifecycle/status`
-
-Get lifecycle status: active vs deprecated memory counts.
-
-Accepts `?namespace=X` query param to scope to a namespace.
-
-**Response**:
-```json
-{
-  "active": 1240,
-  "deprecated": 37
-}
-```
-
-#### 🟡 `POST` `/lifecycle/cycle`
-
-Run a lifecycle cycle: deprecate aged memories (respecting percentage cap) and prune expired deprecated memories.
-
-**Request body**:
-```json
-{
-  "namespace": "default"
-}
-```
-
-`namespace` is optional (omit for all namespaces).
-
-**Response**: [`LifecycleCycleResult`](#lifecyclecycleresult)
-
-#### 🟡 `POST` `/lifecycle/promote`
-
-Promote a deprecated memory back to active status. Re-indexes the embedding vector.
-
-**Request body**:
-```json
-{
-  "id": "memory-uuid"
-}
-```
-
-**Response**:
-```json
-{
-  "promoted": true,
-  "id": "memory-uuid"
-}
-```
-
-
 ## Request/Response Schemas
 
 Detailed field definitions for each request type.
@@ -473,19 +422,6 @@ Detailed field definitions for each request type.
 | `dry_run` | `boolean` | No |  |
 | `namespace` | any | No |  |
 | `threshold` | `number` | No |  |
-
-
-### `LifecycleCycleResult`
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `total_active` | `integer` | Active memories before cycle |
-| `candidates` | `integer` | Aged memories found eligible |
-| `cap` | `integer` | Max deprecations applied (clamped) |
-| `deprecated` | `integer` | Memories deprecated this cycle |
-| `deprecated_ids` | `string`[] | IDs of deprecated memories |
-| `pruned` | `integer` | Expired deprecated memories hard-deleted |
-| `pruned_ids` | `string`[] | IDs of pruned memories |
 
 
 ### `DocCreateRequest`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -229,6 +229,39 @@ uteke prune --ttl 30 --dry-run
 uteke prune --ttl 30
 ```
 
+## uteke lifecycle
+
+Safe memory lifecycle management — deprecate, promote, and inspect lifecycle status.
+
+```bash
+# Show lifecycle status (active vs deprecated counts + config)
+uteke lifecycle status
+
+# Scoped to a namespace
+uteke lifecycle status --namespace my-agent
+
+# Run a lifecycle cycle (deprecate aged + prune expired)
+uteke lifecycle cycle
+
+# Scoped cycle
+uteke lifecycle cycle --namespace my-agent
+
+# Promote a deprecated memory back to active
+uteke lifecycle promote <memory-id>
+
+# Restore is an alias for promote
+uteke lifecycle restore <memory-id>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Show active/deprecated counts and lifecycle config |
+| `cycle` | Run lifecycle cycle (deprecate aged memories + prune expired) |
+| `promote <id>` | Restore a deprecated memory to active status |
+| `restore <id>` | Alias for `promote` |
+
+See [Configuration → Memory Lifecycle](/configuration#memory-lifecycle) for lifecycle config options.
+
 ## uteke namespace
 
 Manage namespaces — list, inspect, and switch defaults.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI Reference
 
 # CLI Reference
 
-Complete reference for all uteke commands. Version **0.12.0**.
+Complete reference for all uteke commands. Version **0.13.0**.
 
 ## Global Flags
 
@@ -231,7 +231,7 @@ uteke prune --ttl 30
 
 ## uteke lifecycle
 
-Safe memory lifecycle management — deprecate, promote, and inspect lifecycle status.
+Safe memory lifecycle management: deprecate, promote, and inspect lifecycle status.
 
 ```bash
 # Show lifecycle status (active vs deprecated counts + config)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -482,7 +482,7 @@ update_check = true    # Set to false to disable startup update notification
 |---------|---------|-------------|
 | `update_check` | true | Enable background update notification on startup |
 
-When an update is available, a banner is printed to **stderr** (does not interfere with stdout pipes). The check is non-blocking — it runs in a background thread joined before process exit, so it never delays command execution.
+When an update is available, a banner is printed to **stderr** (does not interfere with stdout pipes). The check is non-blocking: it runs in a background thread joined before process exit, so it never delays command execution.
 
 ## Memory Lifecycle (#928–#937)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -483,3 +483,86 @@ update_check = true    # Set to false to disable startup update notification
 | `update_check` | true | Enable background update notification on startup |
 
 When an update is available, a banner is printed to **stderr** (does not interfere with stdout pipes). The check is non-blocking — it runs in a background thread joined before process exit, so it never delays command execution.
+
+## Memory Lifecycle (#928–#937)
+
+Uteke uses a **safe memory lifecycle** model. Memories are never hard-deleted by automated processes — instead, they transition through a soft-delete (deprecated) state before eventual pruning.
+
+### Lifecycle States
+
+```
+remember() → ACTIVE → soft_deprecate() → DEPRECATED (hidden, restorable) → prune() → HARD DELETE
+```
+
+| State | Visible in recall? | Restorable? | TTL |
+|-------|-------------------|-------------|-----|
+| **ACTIVE** | ✅ Yes | N/A | — |
+| **DEPRECATED** | ❌ Hidden | ✅ `promote()` | 30 days (configurable) |
+| **PRUNED** | ❌ Gone | ❌ No | — |
+
+### Configuration
+
+```toml
+[lifecycle]
+# Master switch: when true, ALL delete operations become soft-deletes.
+# forget(), bulk_forget, aging_cleanup, consolidate, delete() — all redirect to deprecate.
+soft_delete_only = true
+
+# Auto-lifecycle background thread (server mode only).
+auto_aging_enabled = true
+auto_aging_interval_hours = 168          # Run cycle every 7 days
+
+# What qualifies as "aged" → candidate for deprecation.
+min_age_days = 90                        # Must be at least 90 days old
+max_access_count = 3                     # Accessed 3 times or fewer
+
+# Rate limiting — max % of active memories deprecated per cycle.
+max_deprecate_percent = 1.0              # 1% of active per cycle
+min_deprecate_per_cycle = 1              # Floor (always at least 1)
+max_deprecate_per_cycle = 50             # Ceiling (never more than 50)
+
+# Deprecated TTL — how long before soft-deleted memories are pruned (hard delete).
+deprecated_ttl_days = 30                 # 30 days in deprecated state
+auto_prune_enabled = true                # Auto-prune expired deprecated memories
+
+# Dream dedup — when consolidating duplicates, soft-delete instead of hard delete.
+dream_dedup_soft_delete = true
+```
+
+### Field Reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `soft_delete_only` | true | Master switch — all deletes become soft-deletes |
+| `auto_aging_enabled` | true | Enable auto-lifecycle background thread (server) |
+| `auto_aging_interval_hours` | 168 | Hours between auto-lifecycle cycles |
+| `min_age_days` | 90 | Minimum age (days) to be eligible for deprecation |
+| `max_access_count` | 3 | Max access count for deprecation eligibility |
+| `max_deprecate_percent` | 1.0 | Max % of active memories deprecated per cycle |
+| `min_deprecate_per_cycle` | 1 | Floor for per-cycle deprecation cap |
+| `max_deprecate_per_cycle` | 50 | Ceiling for per-cycle deprecation cap |
+| `deprecated_ttl_days` | 30 | Days before deprecated memories are pruned |
+| `auto_prune_enabled` | true | Auto-prune expired deprecated memories in lifecycle cycle |
+| `dream_dedup_soft_delete` | true | Consolidation soft-deletes instead of hard-deletes |
+
+### How the Lifecycle Cycle Works
+
+Each cycle runs two phases:
+
+1. **Deprecate phase**: Find aged memories (old + rarely accessed) → apply percentage cap → batch deprecate.
+2. **Prune phase**: Find deprecated memories past TTL → hard delete (irreversible).
+
+The percentage cap ensures **at most 1–2% of active memories** are deprecated per cycle, preventing sudden data loss. The cap is calculated as:
+
+```
+cap = clamp(total_active × max_deprecate_percent / 100, min_per_cycle, max_per_cycle)
+```
+
+### Hard Delete Paths
+
+Hard delete only occurs in **two explicitly controlled paths**:
+
+1. **`prune()`** — Deletes deprecated memories whose TTL has expired. Only runs when `auto_prune_enabled = true`.
+2. **`forget()`** — Bypasses soft-delete only when `soft_delete_only = false` (default is `true`, so forget = soft-delete by default).
+
+All other paths (`delete()`, `bulk_delete()`, `aging_cleanup()`, `consolidate()`) respect `soft_delete_only` and deprecate instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -486,7 +486,7 @@ When an update is available, a banner is printed to **stderr** (does not interfe
 
 ## Memory Lifecycle (#928–#937)
 
-Uteke uses a **safe memory lifecycle** model. Memories are never hard-deleted by automated processes — instead, they transition through a soft-delete (deprecated) state before eventual pruning.
+Uteke uses a soft-delete lifecycle model. Memories are never hard-deleted directly by automated processes. They transition through a deprecated state before eventual pruning.
 
 ### Lifecycle States
 
@@ -505,7 +505,7 @@ remember() → ACTIVE → soft_deprecate() → DEPRECATED (hidden, restorable) �
 ```toml
 [lifecycle]
 # Master switch: when true, ALL delete operations become soft-deletes.
-# forget(), bulk_forget, aging_cleanup, consolidate, delete() — all redirect to deprecate.
+# forget(), bulk_forget, aging_cleanup, consolidate, delete() all redirect to deprecate.
 soft_delete_only = true
 
 # Auto-lifecycle background thread (server mode only).
@@ -516,16 +516,16 @@ auto_aging_interval_hours = 168          # Run cycle every 7 days
 min_age_days = 90                        # Must be at least 90 days old
 max_access_count = 3                     # Accessed 3 times or fewer
 
-# Rate limiting — max % of active memories deprecated per cycle.
+# Rate limiting: max % of active memories deprecated per cycle.
 max_deprecate_percent = 1.0              # 1% of active per cycle
 min_deprecate_per_cycle = 1              # Floor (always at least 1)
 max_deprecate_per_cycle = 50             # Ceiling (never more than 50)
 
-# Deprecated TTL — how long before soft-deleted memories are pruned (hard delete).
+# Deprecated TTL: how long before soft-deleted memories are pruned (hard delete).
 deprecated_ttl_days = 30                 # 30 days in deprecated state
 auto_prune_enabled = true                # Auto-prune expired deprecated memories
 
-# Dream dedup — when consolidating duplicates, soft-delete instead of hard delete.
+# Dream dedup: when consolidating duplicates, soft-delete instead of hard delete.
 dream_dedup_soft_delete = true
 ```
 
@@ -533,7 +533,7 @@ dream_dedup_soft_delete = true
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `soft_delete_only` | true | Master switch — all deletes become soft-deletes |
+| `soft_delete_only` | true | Master switch: all deletes become soft-deletes |
 | `auto_aging_enabled` | true | Enable auto-lifecycle background thread (server) |
 | `auto_aging_interval_hours` | 168 | Hours between auto-lifecycle cycles |
 | `min_age_days` | 90 | Minimum age (days) to be eligible for deprecation |
@@ -562,7 +562,7 @@ cap = clamp(total_active × max_deprecate_percent / 100, min_per_cycle, max_per_
 
 Hard delete only occurs in **two explicitly controlled paths**:
 
-1. **`prune()`** — Deletes deprecated memories whose TTL has expired. Only runs when `auto_prune_enabled = true`.
-2. **`forget()`** — Bypasses soft-delete only when `soft_delete_only = false` (default is `true`, so forget = soft-delete by default).
+1. **`prune()`**: Deletes deprecated memories whose TTL has expired. Only runs when `auto_prune_enabled = true`.
+2. **`forget()`**: Bypasses soft-delete only when `soft_delete_only = false` (default is `true`, so forget = soft-delete by default).
 
 All other paths (`delete()`, `bulk_delete()`, `aging_cleanup()`, `consolidate()`) respect `soft_delete_only` and deprecate instead.

--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -1,0 +1,109 @@
+---
+title: Memory Lifecycle
+---
+
+# Memory Lifecycle
+
+Uteke protects your memories with a **safe lifecycle model**. No automated process ever hard-deletes a memory — instead, memories transition through a reviewable soft-delete state before eventual pruning.
+
+## How It Works
+
+```
+remember() → ACTIVE → soft_deprecate() → DEPRECATED (hidden, restorable) → prune() → HARD DELETE
+```
+
+| State | Visible in recall? | Restorable? | TTL |
+|-------|-------------------|-------------|-----|
+| **ACTIVE** | ✅ Yes | N/A | — |
+| **DEPRECATED** | ❌ Hidden from recall/search | ✅ `promote()` | 30 days (configurable) |
+| **PRUNED** | ❌ Gone | ❌ No | — |
+
+### What triggers deprecation?
+
+1. **Auto-lifecycle cycle** (server background thread, every 7 days by default)
+2. **Manual `uteke lifecycle cycle`** command
+3. **Explicit `delete()` / `forget()`** — redirected to soft-delete when `soft_delete_only = true` (default)
+4. **Dream consolidation** — duplicate memories are deprecated, not deleted
+
+### What triggers hard delete (prune)?
+
+Only **two controlled paths** can hard-delete:
+
+1. **`prune()`** — Expired deprecated memories (past `deprecated_ttl_days`). Runs automatically during lifecycle cycle when `auto_prune_enabled = true`.
+2. **`forget()`** — Only when `soft_delete_only = false` (NOT the default).
+
+## Configuration
+
+See [Configuration → Memory Lifecycle](/configuration#memory-lifecycle) for the full config reference.
+
+Default settings are conservative — 1% max deprecation per cycle, 90-day minimum age, 30-day TTL:
+
+```toml
+[lifecycle]
+soft_delete_only = true
+auto_aging_enabled = true
+auto_aging_interval_hours = 168
+min_age_days = 90
+max_access_count = 3
+max_deprecate_percent = 1.0
+deprecated_ttl_days = 30
+auto_prune_enabled = true
+dream_dedup_soft_delete = true
+```
+
+## CLI Usage
+
+```bash
+# Check lifecycle status
+uteke lifecycle status
+
+# Run a lifecycle cycle manually
+uteke lifecycle cycle
+
+# Restore a deprecated memory
+uteke lifecycle promote <memory-id>
+```
+
+See [CLI Reference → lifecycle](/cli-reference#uteke-lifecycle) for details.
+
+## HTTP API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/lifecycle/status` | Active vs deprecated counts |
+| `POST` | `/lifecycle/cycle` | Run lifecycle cycle |
+| `POST` | `/lifecycle/promote` | Promote deprecated → active |
+
+See [HTTP API Reference → Lifecycle](/api-reference#lifecycle) for request/response schemas.
+
+## Best Practices
+
+### Production deployments
+
+- **Keep `soft_delete_only = true`** (default). This is your safety net — no data loss from bugs, misconfigured agents, or accidental deletes.
+- **Tune `max_deprecate_percent`** based on your memory volume. For large stores (10K+ memories), 1% per cycle is 100 memories/week — adjust if too aggressive or too conservative.
+- **Monitor deprecated count** via `/lifecycle/status` or `uteke lifecycle status`. A growing deprecated count without corresponding pruning may indicate a TTL misconfiguration.
+
+### Development / testing
+
+- Set `deprecated_ttl_days = 1` for faster iteration during development.
+- Set `soft_delete_only = false` only in disposable test databases where you want true hard-delete semantics.
+
+### Disabling auto-lifecycle entirely
+
+```toml
+[lifecycle]
+auto_aging_enabled = false
+```
+
+Memories will still be soft-deleted on explicit `delete()`/`forget()`, but no automatic aging or pruning will occur. You can still run `uteke lifecycle cycle` manually.
+
+## Migration from pre-v0.13.0
+
+Existing databases are automatically migrated:
+
+- A `deprecate_reason` column is added to the `memories` table (nullable, uses `column_exists()` migration pattern — no schema version bump).
+- All existing memories remain ACTIVE — no behavior change on upgrade.
+- The auto-lifecycle background thread starts with default settings on first server boot.
+
+No manual migration steps required.

--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -4,7 +4,7 @@ title: Memory Lifecycle
 
 # Memory Lifecycle
 
-Uteke protects your memories with a **safe lifecycle model**. No automated process ever hard-deletes a memory — instead, memories transition through a reviewable soft-delete state before eventual pruning.
+Uteke uses a soft-delete lifecycle model for memory management. No automated process hard-deletes a memory. Memories transition through a reviewable soft-delete state before eventual pruning.
 
 ## How It Works
 
@@ -22,21 +22,21 @@ remember() → ACTIVE → soft_deprecate() → DEPRECATED (hidden, restorable) �
 
 1. **Auto-lifecycle cycle** (server background thread, every 7 days by default)
 2. **Manual `uteke lifecycle cycle`** command
-3. **Explicit `delete()` / `forget()`** — redirected to soft-delete when `soft_delete_only = true` (default)
-4. **Dream consolidation** — duplicate memories are deprecated, not deleted
+3. **Explicit `delete()` / `forget()`**: redirected to soft-delete when `soft_delete_only = true` (default)
+4. **Dream consolidation**: duplicate memories are deprecated, not deleted
 
 ### What triggers hard delete (prune)?
 
 Only **two controlled paths** can hard-delete:
 
-1. **`prune()`** — Expired deprecated memories (past `deprecated_ttl_days`). Runs automatically during lifecycle cycle when `auto_prune_enabled = true`.
-2. **`forget()`** — Only when `soft_delete_only = false` (NOT the default).
+1. **`prune()`**: Expired deprecated memories (past `deprecated_ttl_days`). Runs automatically during lifecycle cycle when `auto_prune_enabled = true`.
+2. **`forget()`**: Only when `soft_delete_only = false` (not the default).
 
 ## Configuration
 
 See [Configuration → Memory Lifecycle](/configuration#memory-lifecycle) for the full config reference.
 
-Default settings are conservative — 1% max deprecation per cycle, 90-day minimum age, 30-day TTL:
+Default settings: 1% max deprecation per cycle, 90-day minimum age, 30-day TTL:
 
 ```toml
 [lifecycle]
@@ -80,8 +80,8 @@ See [HTTP API Reference → Lifecycle](/api-reference#lifecycle) for request/res
 
 ### Production deployments
 
-- **Keep `soft_delete_only = true`** (default). This is your safety net — no data loss from bugs, misconfigured agents, or accidental deletes.
-- **Tune `max_deprecate_percent`** based on your memory volume. For large stores (10K+ memories), 1% per cycle is 100 memories/week — adjust if too aggressive or too conservative.
+- **Keep `soft_delete_only = true`** (default). This is your safety net: no data loss from bugs, misconfigured agents, or accidental deletes.
+- **Tune `max_deprecate_percent`** based on your memory volume. For large stores (10K+ memories), 1% per cycle is 100 memories/week. Adjust if that feels too aggressive or too conservative.
 - **Monitor deprecated count** via `/lifecycle/status` or `uteke lifecycle status`. A growing deprecated count without corresponding pruning may indicate a TTL misconfiguration.
 
 ### Development / testing
@@ -102,8 +102,8 @@ Memories will still be soft-deleted on explicit `delete()`/`forget()`, but no au
 
 Existing databases are automatically migrated:
 
-- A `deprecate_reason` column is added to the `memories` table (nullable, uses `column_exists()` migration pattern — no schema version bump).
-- All existing memories remain ACTIVE — no behavior change on upgrade.
+- A `deprecate_reason` column is added to the `memories` table (nullable, uses `column_exists()` migration pattern, no schema version bump).
+- All existing memories remain ACTIVE, no behavior change on upgrade.
 - The auto-lifecycle background thread starts with default settings on first server boot.
 
 No manual migration steps required.

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -8,11 +8,11 @@ Uteke provides first-class namespace support for running multiple AI agents, eac
 
 ## How Namespaces Work
 
-Every memory belongs to exactly one namespace. Namespaces are fully isolated — a recall in one namespace never returns results from another.
+Every memory belongs to exactly one namespace. Namespaces are fully isolated: a recall in one namespace never returns results from another.
 
-- **`default`** — Used when no `--namespace` flag is provided. Backward compatible with v0.0.1 databases.
-- **`hermes`** — Example: a planning agent that remembers architecture decisions.
-- **`pi-agent`** — Example: a coding agent that remembers project-specific context.
+- **`default`**: Used when no `--namespace` flag is provided. Backward compatible with v0.0.1 databases.
+- **`hermes`**: Example: a planning agent that remembers architecture decisions.
+- **`pi-agent`**: Example: a coding agent that remembers project-specific context.
 
 ## Usage
 
@@ -40,7 +40,7 @@ Existing databases from v0.0.1 are automatically migrated on first run:
 
 - ✓ `namespace` column added to SQLite
 - ✓ All existing memories assigned to `"default"` namespace
-- ✓ Zero data loss — your memories are preserved
+- ✓ Zero data loss: your memories are preserved
 
 ## Namespace Switching
 
@@ -85,17 +85,17 @@ The `--namespace` flag works on every command:
 
 ## Documents Are Global
 
-Unlike memories, **documents are global** (v0.7.0, #614/#615). Documents use unique slugs across all namespaces — no namespace isolation. This means:
+Unlike memories, **documents are global** (v0.7.0, #614/#615). Documents use unique slugs across all namespaces: no namespace isolation. This means:
 
 - Documents created in any namespace are visible in all namespaces via `uteke doc list`
 - Document commands (`create`, `get`, `update`, `search`, `list`, `delete`) do not accept `--namespace`
-- Slugs must be globally unique — a duplicate slug across namespaces will be auto-migrated on upgrade (schema v12→v13)
+- Slugs must be globally unique: a duplicate slug across namespaces will be auto-migrated on upgrade (schema v12→v13)
 
 This is intentional: documents represent shared knowledge (wiki, architecture guides, runbooks) that should be accessible to all agents regardless of their memory namespace.
 
 ## Best Practices
 
-- **One namespace per agent role** — Use descriptive names like "planner", "coder", "reviewer" instead of "agent-1", "agent-2".
-- **Use config files for defaults** — Set `default_namespace` in `uteke.toml` per project so agents don't need `--namespace` on every call.
-- **Shell hooks for project isolation** — Install shell hooks (`uteke hook install`) to auto-discover `.uteke/` in parent directories — each project gets isolated memory.
-- **Export for backup** — `uteke export --namespace my-agent > backup.jsonl` — backup per-agent memory independently.
+- **One namespace per agent role**: Use descriptive names like "planner", "coder", "reviewer" instead of "agent-1", "agent-2".
+- **Use config files for defaults**: Set `default_namespace` in `uteke.toml` per project so agents don't need `--namespace` on every call.
+- **Shell hooks for project isolation**: Install shell hooks (`uteke hook install`) to auto-discover `.uteke/` in parent directories. Each project gets isolated memory.
+- **Export for backup**: `uteke export --namespace my-agent > backup.jsonl`. Backup per-agent memory independently.

--- a/docs/rooms.md
+++ b/docs/rooms.md
@@ -1,6 +1,6 @@
-# Rooms — Shared Memory for Multi-Agent Collaboration
+# Rooms: Shared Memory for Multi-Agent Collaboration
 
-> **Other memory layers are single-player.** They store facts under a flat `user_id` and every recall is scoped to one agent's view. Uteke Rooms let multiple AI agents share a memory space — meeting notes, project decisions, architecture choices — searchable by everyone, attributed by author.
+> **Other memory layers are single-player.** They store facts under a flat `user_id` and every recall is scoped to one agent's view. Uteke Rooms let multiple AI agents share a memory space: meeting notes, project decisions, architecture choices, searchable by everyone, attributed by author.
 
 ## What is a Room?
 
@@ -24,7 +24,7 @@ uteke remember "Postgres migration deferred to Q4 due to testing capacity" \
   --room engineering \
   --author alice
 
-# Recall from the room — any agent can do this
+# Recall from the room. Any agent can do this
 uteke recall "postgres migration" --room engineering
 
 # List all rooms
@@ -40,9 +40,9 @@ uteke room summary engineering
 
 Traditional memory tools store everything under a flat `user_id`. This works for single-agent chatbots, but breaks down when:
 
-- **Multiple agents work on the same project** — Agent A can't see Agent B's memories
-- **A team shares an AI assistant** — everyone's memories are siloed
-- **You want cross-agent knowledge transfer** — there's no shared space
+- **Multiple agents work on the same project**: Agent A can't see Agent B's memories
+- **A team shares an AI assistant**: everyone's memories are siloed
+- **You want cross-agent knowledge transfer**: there's no shared space
 
 ### The Rooms Solution
 
@@ -173,7 +173,7 @@ Namespaces and Rooms are complementary. An agent has its own namespace for priva
 
 ## See Also
 
-- [Quick Start](/getting-started) — Get up and running in 30 seconds
-- [Multi-Agent](/multi-agent) — How multiple agents coexist with uteke
-- [CLI Reference](/cli-reference) — Full command documentation
-- [HTTP API](/api-reference) — REST API for server mode
+- [Quick Start](/getting-started): Get up and running in 30 seconds
+- [Multi-Agent](/multi-agent): How multiple agents coexist with uteke
+- [CLI Reference](/cli-reference): Full command documentation
+- [HTTP API](/api-reference): REST API for server mode


### PR DESCRIPTION
## Safe Memory Lifecycle

A complete lifecycle system that **prevents accidental data loss** through automated processes. Every memory goes through a reviewable soft-delete state before eventual pruning.

## Why

Agents accumulate stale memories over time: outdated facts, superseded decisions, duplicated knowledge. Without a lifecycle system, users have two bad options: manually prune (tedious, error-prone) or let the store grow unbounded (slower recall, higher memory).

This PR introduces a configurable lifecycle pipeline that automatically deprecates aged memories while keeping them restorable. Hard delete only happens through explicit, intentional paths (prune expired-after-TTL or forget with soft_delete_only=false).

### Lifecycle Flow

```
remember() → ACTIVE → soft_deprecate() → DEPRECATED (hidden, restorable) → prune() → HARD DELETE
```

### What Changed

| Area | Change |
|------|--------|
| **Core** | New `LifecycleConfig` struct with 11 conservative fields |
| **Store** | `deprecate_with_reason()`, `undeprecate()`, `deprecate_by_ids()` |
| **Safety** | ALL delete paths respect `soft_delete_only = true` (default) |
| **Auto-cycle** | 2-phase lifecycle: deprecate aged (capped at 1%) → prune expired |
| **Server** | Auto-aging thread → auto-lifecycle thread |
| **CLI** | `uteke lifecycle cycle \| promote \| status` with `--json` support |
| **API** | `GET /lifecycle/status`, `POST /lifecycle/cycle`, `POST /lifecycle/promote` |
| **Docs** | New Memory Lifecycle page + updated config/CLI/API references |

### Hard Delete: Only 2 Paths

1. **`prune()`** — Expired deprecated memories (past TTL, by design)
2. **`forget()`** — Only when `soft_delete_only = false` (NOT default)

Everything else ( `delete()`, `bulk_delete()`, `aging_cleanup()`, `consolidate()`) redirects to soft-delete.

## Testing

- **Unit tests**: 466 passed, 26 ignored, 0 failed (10 test suites)
- **New tests**: `forget_tests` updated for soft-delete expectations (3 tests verify deprecated=true after forget, not is_none)
- **CodeCora fixes**: `deprecate_with_reason()` now returns Err for non-existent IDs, `promote()` response reflects actual bool, `lifecycle_cycle` respects `soft_delete_only`, CLI lifecycle commands support `--json`
- **API registry test**: lifecycle routes (`/lifecycle/cycle`, `/lifecycle/promote`, `/lifecycle/status`) registered in ENDPOINTS
- **Clippy**: zero warnings across workspace
- **Formatting**: `cargo fmt --all` clean

## Checklist

- [x] Code follows project style (`cargo fmt`, `cargo clippy`)
- [x] Tests pass (`cargo test --workspace`)
- [x] API docs regenerated (`cargo run -p docgen`)
- [x] No breaking changes (soft_delete_only=true is default, all existing behavior preserved)
- [x] Issues referenced: #926, #928, #929, #932, #935