### PR TITLE
fix(ci): install gcc-13 on ubuntu-22.04 runners for numkong SIMD probes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install gcc-13 on ubuntu-22.04 (numkong SIMD probes need newer GCC)
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 130
+          echo "CC=gcc-13" >> $GITHUB_ENV
+          echo "CXX=g++-13" >> $GITHUB_ENV
+
       - name: Download prebuilt ORT shared library
         shell: bash
         run: |


### PR DESCRIPTION
## What

Install gcc-13 on ubuntu-22.04 CI runners before building Linux release binaries.

## Why

numkong v7.7.0 (transitive via usearch) build script probes for CPU features like `-mavx512fp16` and `-mamx-fp16`. gcc-11 (ubuntu-22.04 default) does not recognize these flags, causing hard build failures on both `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` release jobs.

v0.12.0 succeeded because it used `ubuntu-latest` (24.04 with gcc-13). We pinned to `ubuntu-22.04` for GLIBC 2.35 backward compat, but forgot to upgrade the compiler.

## How

Add a step that installs `gcc-13`/`g++-13`, sets them as default via `update-alternatives`, and exports `CC=gcc-13` / `CXX=g++-13` to `$GITHUB_ENV`. Only runs on ubuntu-22.04 variants.

## Testing

- [x] Verified numkong probe errors are gcc version related (gcc-11 fails, gcc-13 passes)
- [ ] CI green on this PR