### PR TITLE
fix(ci): cargo-zigbuild for GLIBC 2.17 broad compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,30 +109,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64
-          # ubuntu-24.04 required: numkong 7.7.0 SIMD probes need GCC 14 + binutils 2.40+
-          # (ubuntu-22.04 max GCC 13 from PPA, but its binutils 2.38 GAS can't
-          # assemble AMX-FP16 / AVX10 / SVE2 dotprod instructions).
-          # TODO: migrate to cargo-zigbuild targeting GLIBC 2.17 for broader compat.
+          # Linux x86_64 — cargo-zigbuild targets GLIBC 2.17 for broad compat
+          # (RHEL 9, Debian 11/12, Ubuntu 18.04+). ubuntu-24.04 runner provides
+          # GCC 14 for numkong 7.7.0 SIMD probes; Zig relinks against old GLIBC.
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             artifact: uteke-x86_64-unknown-linux-gnu
             ext: tar.gz
-          # Linux ARM64
+            zigbuild: true
+            glibc: "2.17"
+          # Linux ARM64 — same zigbuild approach, GLIBC 2.17
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: uteke-aarch64-unknown-linux-gnu
             ext: tar.gz
+            zigbuild: true
+            glibc: "2.17"
           # macOS Apple Silicon
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: uteke-aarch64-apple-darwin
             ext: tar.gz
+            zigbuild: false
           # Windows x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: uteke-x86_64-pc-windows-msvc
             ext: zip
+            zigbuild: false
 
     steps:
       - uses: actions/checkout@v7
@@ -140,6 +144,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install Zig + cargo-zigbuild (Linux only)
+        if: matrix.zigbuild == true
+        run: |
+          # Pin both packages for reproducible builds.
+          # ziglang provides the Zig compiler binary used by cargo-zigbuild.
+          pip install cargo-zigbuild==0.23.0 ziglang==0.14.1
+          zig version
 
       - name: Download prebuilt ORT shared library
         shell: bash
@@ -178,15 +190,66 @@ jobs:
           echo "Downloaded ORT libraries:"
           ls -lh "${ORT_LIB_DIR:-ort-lib}/" || true
 
-      - name: Build release binaries
+      - name: Build release binaries (zigbuild — GLIBC 2.17)
+        if: matrix.zigbuild == true
+        run: cargo zigbuild --release --target ${{ matrix.target }}.${{ matrix.glibc }} -p uteke-cli -p uteke-server -p uteke-mcp
+
+      - name: Build release binaries (standard)
+        if: matrix.zigbuild != true
         run: cargo build --release --target ${{ matrix.target }} -p uteke-cli -p uteke-server -p uteke-mcp
+
+      - name: Resolve binary directory
+        id: bindir
+        shell: bash
+        run: |
+          # cargo-zigbuild may output to suffixed path (target/x86_64-unknown-linux-gnu.2.17/release/)
+          # or standard path (target/x86_64-unknown-linux-gnu/release/) depending on version.
+          GLIBC_SUFFIX="${{ matrix.glibc }}"
+          SUFFIXED="target/${{ matrix.target }}.${GLIBC_SUFFIX}/release"
+          STANDARD="target/${{ matrix.target }}/release"
+          if [ -n "$GLIBC_SUFFIX" ] && [ -f "$SUFFIXED/uteke" ]; then
+            echo "path=$SUFFIXED" >> $GITHUB_OUTPUT
+            echo "Using suffixed path: $SUFFIXED"
+          elif [ -f "$STANDARD/uteke" ]; then
+            echo "path=$STANDARD" >> $GITHUB_OUTPUT
+            echo "Using standard path: $STANDARD"
+          else
+            echo "::error::Binaries not found in $SUFFIXED or $STANDARD"
+            find target -name 'uteke' -type f 2>/dev/null | head -5
+            exit 1
+          fi
 
       - name: Strip binaries (Unix)
         if: runner.os != 'Windows'
         run: |
-          strip target/${{ matrix.target }}/release/uteke || true
-          strip target/${{ matrix.target }}/release/uteke-serve || true
-          strip target/${{ matrix.target }}/release/uteke-mcp || true
+          BIN_DIR="${{ steps.bindir.outputs.path }}"
+          strip "$BIN_DIR/uteke" || true
+          strip "$BIN_DIR/uteke-serve" || true
+          strip "$BIN_DIR/uteke-mcp" || true
+
+      - name: Verify GLIBC requirement (Linux zigbuild only)
+        if: matrix.zigbuild == true
+        run: |
+          BIN_DIR="${{ steps.bindir.outputs.path }}"
+          echo "=== GLIBC version requirement ==="
+          objdump -T "$BIN_DIR/uteke" | grep -oP 'GLIBC_[\d.]+' | sort -V -u
+          echo ""
+          # Extract highest GLIBC version requirement
+          MAX_GLIBC=$(objdump -T "$BIN_DIR/uteke" | grep -oP 'GLIBC_[\d.]+' | sort -V -u | tail -1)
+          FLOOR="GLIBC_2.17"
+          echo "Highest GLIBC requirement: ${MAX_GLIBC:-<none>}"
+          echo "Floor:                     $FLOOR"
+          # Guard against empty result (objdump failure, corrupt binary, static link)
+          if [ -z "$MAX_GLIBC" ]; then
+            echo "::error::No GLIBC symbols found. Binary may be statically linked or objdump failed."
+            exit 1
+          fi
+          # Use sort -V for proper version comparison (handles 2.100 > 2.99)
+          if [[ "$(echo -e "$MAX_GLIBC\n$FLOOR" | sort -V | tail -1)" != "$FLOOR" ]]; then
+            echo "::error::Binary requires $MAX_GLIBC > $FLOOR. zigbuild target not working."
+            exit 1
+          fi
+          echo "✅ Binary compatible with GLIBC 2.17+"
 
       - name: Extract version
         id: version
@@ -196,10 +259,12 @@ jobs:
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |
+          BIN_DIR="${{ steps.bindir.outputs.path }}"
           mkdir -p release
-          cp target/${{ matrix.target }}/release/uteke release/uteke
-          cp target/${{ matrix.target }}/release/uteke-serve release/uteke-serve
-          cp target/${{ matrix.target }}/release/uteke-mcp release/uteke-mcp
+          ls -la "$BIN_DIR/uteke" "$BIN_DIR/uteke-serve" "$BIN_DIR/uteke-mcp"
+          cp "$BIN_DIR/uteke" release/uteke
+          cp "$BIN_DIR/uteke-serve" release/uteke-serve
+          cp "$BIN_DIR/uteke-mcp" release/uteke-mcp
           # Include ORT shared library
           if [ -d "${ORT_LIB_DIR}" ]; then
             cp -r "${ORT_LIB_DIR}"/* release/


### PR DESCRIPTION
## What

Linux binaries sekarang di-link terhadap **GLIBC 2.17** via `cargo-zigbuild` + Zig linker.

## Why

Binary v0.13.0 sebelumnya butuh GLIBC 2.39 (ubuntu-24.04 runner) — tidak jalan di Debian 12 (2.36), Ubuntu 22.04 LTS (2.35), RHEL 9 (2.34). Sekarang compatible dengan semua Linux dari 2014+.

## Changes

- Matrix: tambah `zigbuild: true` + `glibc: "2.17"` untuk Linux targets
- Install `cargo-zigbuild==0.23.0` + `ziglang==0.14.1` untuk Linux builds
- `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` untuk Linux
- Resolve binary directory step (handle suffixed/standard output path)
- GLIBC verification step dengan empty guard + sort -V comparison
- macOS/Windows tetap standard `cargo build`

## CodeCora Findings — All Resolved

| # | Finding | Fix |
|---|---------|-----|
| 1 | Unpinned pip install | Pin `ziglang==0.14.1` |
| 2 | String comparison unreliable | `sort -V` comparison |
| 3 | Output path may differ | Dynamic resolve step |
| 4 | Empty GLIBC bypass | Empty guard + fail |

## Testing

CI workflow akan verify:
1. Build sukses di ubuntu-24.04 + cargo-zigbuild
2. GLIBC check step confirm binary ≤ 2.17 (objdump -T)
3. ARM64 build juga menggunakan zigbuild
4. macOS/Windows tidak terdampak (standard cargo build)
5. Binary path resolution handle both suffixed and standard output dirs

## Compatibility Matrix

| Distro | GLIBC | Status |
|--------|-------|--------|
| Ubuntu 18.04+ | 2.27 | ✅ |
| Debian 11+ | 2.31 | ✅ |
| Debian 12 | 2.36 | ✅ |
| Ubuntu 22.04 LTS | 2.35 | ✅ |
| RHEL 9 / Rocky 9 | 2.34 | ✅ |
| Ubuntu 24.04 | 2.39 | ✅ |