### PR TITLE
fix(ci): add ~/.local/bin to PATH for ziglang binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
           # Pin both packages for reproducible builds.
           # ziglang provides the Zig compiler binary used by cargo-zigbuild.
           pip install cargo-zigbuild==0.23.0 ziglang==0.14.1
+          # ziglang installs to ~/.local/bin which may not be in PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           zig version
 
       - name: Download prebuilt ORT shared library


### PR DESCRIPTION
## What

Fix `zig: command not found` error pada Linux build jobs. `ziglang` pip package menginstall binary ke `~/.local/bin` yang tidak ada di PATH ubuntu-24.04 runner.

## Why

Release workflow run `31254262977` gagal di dua Linux build jobs:
- Build x86_64-unknown-linux-gnu ❌
- Build aarch64-unknown-linux-gnu ❌

Root cause: `pip install ziglang==0.14.1` sukses, tapi `zig` binary ada di `~/.local/bin/` yang tidak di-include di PATH default GitHub Actions runner.

## Changes

- Tambah `echo "$HOME/.local/bin" >> $GITHUB_PATH` setelah pip install
- `$GITHUB_PATH` adalah mekanisme standar GitHub Actions untuk add PATH

## Testing

CI akan verify:
1. `zig version` berjalan tanpa error
2. `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` sukses
3. GLIBC verification step berjalan