### PR TITLE
fix(ci): ziglang PATH fix for Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
           # Pin both packages for reproducible builds.
           # ziglang provides the Zig compiler binary used by cargo-zigbuild.
           pip install cargo-zigbuild==0.23.0 ziglang==0.14.1
+          # ziglang installs to ~/.local/bin which may not be in PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           zig version
 
       - name: Download prebuilt ORT shared library


### PR DESCRIPTION
## What

Fix `zig: command not found` pada release workflow. `ziglang` pip package installs ke `~/.local/bin` yang tidak ada di PATH ubuntu-24.04 runner.

## Why

Release workflow run `31254262977` gagal di dua Linux build jobs karena `zig` binary tidak ditemukan setelah `pip install ziglang`. `pip install` ke user site-packages (`~/.local/bin/`) sementara GitHub Actions ubuntu-24.04 runner tidak include path tersebut di `PATH` default.

## Changes

- Add `~/.local/bin` to `$GITHUB_PATH` setelah pip install ziglang
- `$GITHUB_PATH` adalah mekanisme standar GitHub Actions untuk menambah PATH

## Testing

CI akan verify:
1. `zig version` berjalan tanpa error
2. `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` sukses
3. GLIBC verification step berjalan