### PR TITLE
fix(ci): resolve zig binary path for current step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,10 @@ jobs:
           # Pin both packages for reproducible builds.
           # ziglang provides the Zig compiler binary used by cargo-zigbuild.
           pip install cargo-zigbuild==0.23.0 ziglang==0.14.1
-          # ziglang installs to ~/.local/bin which may not be in PATH
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          # Add user site-packages bin to PATH for THIS step and subsequent steps
+          SITE_BIN="$(python3 -m site --user-base)/bin"
+          echo "$SITE_BIN" >> $GITHUB_PATH
+          export PATH="$SITE_BIN:$PATH"
           zig version
 
       - name: Download prebuilt ORT shared library


### PR DESCRIPTION
## What

Fix `zig: command not found` yang masih terjadi setelah PR #953. `GITHUB_PATH` hanya effektif untuk step selanjutnya, BUKAN step yang sama saat menulis ke `GITHUB_PATH`.

## Why

GitHub Actions `GITHUB_PATH` file menambah entries ke PATH untuk **step berikutnya**, bukan step yang sedang berjalan. Saat `zig version` dipanggil di step yang sama dengan `pip install`, zig binary masih tidak ditemukan karena PATH belum di-update.

## Changes

- Gunakan `python3 -m site --user-base` untuk dinamically resolve dimana pip menginstall binary
- `export PATH` inline untuk step saat ini
- Tetap write ke `GITHUB_PATH` untuk step berikutnya

## Testing

CI akan verify:
1. `zig version` berjalan di step install (PATH inline)
2. `cargo zigbuild` berjalan di step build (PATH via GITHUB_PATH)
3. GLIBC verification step berjalan