### PR TITLE
fix(ci): resolve both zig and cargo-zigbuild binary paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,15 +147,24 @@ jobs:
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: matrix.zigbuild == true
+        shell: bash
         run: |
+          set -ex
           # Pin both packages for reproducible builds.
-          # ziglang provides the Zig compiler binary used by cargo-zigbuild.
           pip install cargo-zigbuild==0.23.0 ziglang==0.14.1
-          # Add user site-packages bin to PATH for THIS step and subsequent steps
-          SITE_BIN="$(python3 -m site --user-base)/bin"
-          echo "$SITE_BIN" >> $GITHUB_PATH
-          export PATH="$SITE_BIN:$PATH"
+          # cargo-zigbuild installs to user-base/bin
+          USER_BIN="$(python3 -m site --user-base)/bin"
+          # zig binary is inside the ziglang Python package
+          ZIG_DIR="$(python3 -c "import ziglang, os; print(os.path.dirname(ziglang.__file__))")"
+          echo "USER_BIN=$USER_BIN"
+          echo "ZIG_DIR=$ZIG_DIR"
+          # Add both to GITHUB_PATH (for subsequent steps)
+          echo "$USER_BIN" >> "$GITHUB_PATH"
+          echo "$ZIG_DIR" >> "$GITHUB_PATH"
+          # Add both to PATH (for this step)
+          export PATH="$USER_BIN:$ZIG_DIR:$PATH"
           zig version
+          cargo zigbuild --version
 
       - name: Download prebuilt ORT shared library
         shell: bash


### PR DESCRIPTION
## What

Fix `zig: command not found` di release workflow. Dua binary ada di lokasi berbeda setelah pip install — perlu resolve keduanya secara dinamis.

## Why

PR sebelumnya (#953, #955) gagal karena:
1. PR #953: `$HOME/.local/bin` → salah, pip install ke user-base yang bervariasi
2. PR #955: `python3 -m site --user-base` → hanya menemukan cargo-zigbuild, bukan zig

Binary zig sebenarnya ada di dalam Python package `ziglang/` (bukan di bin/), sementara cargo-zigbuild ada di user-base/bin. Dua lokasi berbeda.

## Changes

- Resolve zig binary via `import ziglang; os.path.dirname(ziglang.__file__)`
- Resolve cargo-zigbuild via `python3 -m site --user-base/bin`
- Add kedua path ke `GITHUB_PATH` (subsequent steps) dan `PATH` (current step)
- Verify kedua command: `zig version` + `cargo zigbuild --version`

## Testing

CI akan verify:
1. `zig version` runs in install step
2. `cargo zigbuild --version` runs in install step
3. Build step can run `cargo zigbuild --target ...2.17`
4. GLIBC verification passes