### PR TITLE
fix(ci): use --help instead of --version for cargo-zigbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           # Add both to PATH (for this step)
           export PATH="$USER_BIN:$ZIG_DIR:$PATH"
           zig version
-          cargo zigbuild --version
+          cargo zigbuild --help >/dev/null 2>&1 && echo "cargo-zigbuild OK"
 
       - name: Download prebuilt ORT shared library
         shell: bash


### PR DESCRIPTION
## What

Fix `cargo zigbuild --version` yang menyebabkan CI failure. cargo-zigbuild CLI tidak support `--version` flag.

## Why

PR #957 add `cargo zigbuild --version` sebagai sanity check di install step. Tapi cargo-zigbuild tidak punya `--version` flag, jadi `set -e` exit dengan error `unexpected argument '--version' found`. Zig binary path resolution-nya **berhasil** (zig version jalan), tapi cargo-zigbuild check yang error.

## Changes

- Ganti `--version` ke `--help` (didukung oleh cargo-zigbuild)
- Redirect output ke `/dev/null` untuk clean logs

## Testing

CI akan verify install step passes. Release workflow akan verify actual build.