### PR TITLE
fix(ci): cargo-zigbuild --help check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           # Add both to PATH (for this step)
           export PATH="$USER_BIN:$ZIG_DIR:$PATH"
           zig version
-          cargo zigbuild --version
+          cargo zigbuild --help >/dev/null 2>&1 && echo "cargo-zigbuild OK"
 
       - name: Download prebuilt ORT shared library
         shell: bash


### PR DESCRIPTION
## What

Fix `cargo zigbuild --version` error yang block Linux builds. Cargo-zigbuild CLI tidak support `--version`.

## Why

`--version` flag tidak ada di cargo-zigbuild. `set -e` exit sebelum build step. Fix: pakai `--help` yang memang didukung.

## Changes

- `cargo zigbuild --version` → `cargo zigbuild --help >/dev/null 2>&1`

## Testing

All 12 CI checks pass.