### PR TITLE
docs(readme): remove redundant static images

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -118,10 +118,6 @@ Setiap AI tool lupa. Context window penuh, sesi berakhir, dan AI kamu start over
 
 > **Uteke vs AgentMemory/Mem0/Letta/Zep:** Mereka powerful — tapi semua butuh cloud LLM API key + Docker infra. Data kamu dikirim ke OpenAI/Anthropic. Uteke jalan fully offline dengan embedding ONNX lokal. Tanpa Docker, tanpa Python, tanpa API key.
 
-<p align="center">
-  <img src="docs/assets/uteke-comparison.png" alt="Uteke vs alternatif cloud" width="640" />
-</p>
-
 ---
 
 ## 💡 Buat Apa Uteke?
@@ -253,10 +249,6 @@ graph LR
 3. **RRF** (k=60) — gabungkan dua ranked lists → terbaik dari keduanya
 
 Semua jalan in-process. Tanpa network. Tanpa cloud. Tanpa server (kecuali mau pakai mode server).
-
-<p align="center">
-  <img src="docs/assets/uteke-architecture.png" alt="Diagram arsitektur Uteke" width="640" />
-</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark deta
 
 </details>
 
-<p align="center">
-  <img src="docs/assets/uteke-comparison.png" alt="Uteke compared to other memory tools" width="640" />
-</p>
-
 ---
 
 ## 💡 What Can You Do With Uteke?
@@ -324,10 +320,6 @@ graph LR
 3. **RRF** (k=60): merges both ranked lists → best of both worlds
 
 Everything runs in-process. No network. No cloud. No server required (unless you want server mode).
-
-<p align="center">
-  <img src="docs/assets/uteke-architecture.png" alt="Uteke architecture diagram" width="640" />
-</p>
 
 ---
 


### PR DESCRIPTION
## What

Remove `uteke-comparison.png` and `uteke-architecture.png` from both `README.md` and `README.id.md` (16 lines deleted).

## Why

Both images were visual duplicates of content already rendered natively in markdown:

- **`uteke-comparison.png`** → duplicated the 13×9 Tool A–G comparison table (markdown renders natively, is maintainable, and stays in sync)
- **`uteke-architecture.png`** → duplicated the Mermaid `graph LR` diagram (GitHub renders Mermaid natively — version-controlled, diff-able, zero page weight)

Static PNGs go stale when tables or architecture change. Native markdown + Mermaid eliminates the maintenance burden entirely.

## How

Deleted the `<p align="center"><img ...></p>` blocks wrapping each image. No content changes — the table, Mermaid diagram, and explanatory text remain untouched.

## Testing

- [x] `cargo test --workspace` passes *(N/A — docs only, no code changed)*
- [x] `cargo fmt --all -- --check` passes *(N/A)*
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes *(N/A)*
- [ ] [Cora review](https://github.com/codecoradev/cora-cli) run locally (`cora review --base origin/develop`)
- [x] Manual smoke-test — verified Mermaid diagram + comparison table render correctly in both README files

## Related Issues

N/A

## Checklist

- [x] Branch name follows convention (`fix/`, `feat/`, `docs/`, `chore/`, `refactor/`, `test/`, `perf/`, `security/`)
- [x] Branch is from `develop`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials committed
- [x] One logical change per PR (no mixed concerns)