### PR TITLE
fix: data integrity, route matching, namespace filter, vector growth

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1143,18 +1143,44 @@ impl Uteke {
         let stats = gs.stats()?;
 
         // Filter by namespace if specified.
+        // Memory-linked nodes are filtered by their parent memory's namespace.
+        // Entity nodes (no memory_id) are always included (shared across namespaces).
         let (nodes, edges) = if let Some(ns) = namespace {
-            let ns_string = ns.to_string();
+            // Build a set of memory IDs that belong to this namespace.
+            let ns_memory_ids: std::collections::HashSet<String> = self
+                .store
+                .conn
+                .prepare("SELECT id FROM memories WHERE namespace = ?1 AND deprecated = 0")
+                .map_err(|e| Error::db("Failed to prepare namespace query", e))?
+                .query_map(rusqlite::params![ns], |row| row.get::<_, String>(0))
+                .map_err(|e| Error::db("Failed to query namespace memories", e))?
+                .filter_map(|r| r.ok())
+                .collect();
+
             let filtered_nodes: Vec<GraphNode> = nodes
                 .into_iter()
                 .filter(|n| {
-                    // Memory-linked nodes: check memory namespace.
-                    // Entity nodes: always include (shared across namespaces).
-                    n.memory_id.as_deref().is_none_or(|_| true)
+                    // Entity nodes: always include.
+                    // Memory-linked nodes: include only if memory is in this namespace.
+                    match &n.memory_id {
+                        None => true,
+                        Some(mid) => ns_memory_ids.contains(mid),
+                    }
                 })
                 .collect();
-            let _ = ns_string; // namespace filter applied at memory level
-            (filtered_nodes, edges)
+
+            // Filter edges to only those connecting nodes that remain.
+            let node_ids: std::collections::HashSet<&str> =
+                filtered_nodes.iter().map(|n| n.id.as_str()).collect();
+            let filtered_edges: Vec<GraphEdge> = edges
+                .into_iter()
+                .filter(|e| {
+                    node_ids.contains(e.source_id.as_str())
+                        && node_ids.contains(e.target_id.as_str())
+                })
+                .collect();
+
+            (filtered_nodes, filtered_edges)
         } else {
             (nodes, edges)
         };

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -68,6 +68,38 @@ impl super::Store {
         let metadata_json = serde_json::to_string(&memory.metadata)
             .map_err(|e| Error::db("database operation", e))?;
 
+        // Wrap INSERT + tag inserts in a transaction for atomicity.
+        // If any tag insert fails, the entire operation rolls back.
+        // Using unchecked_transaction (same pattern as tags.rs/documents.rs) for
+        // consistency — safe because Store access is serialized via Mutex<Uteke>.
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("Failed to begin transaction", e))?;
+
+        let result = self.try_insert_memory(memory, &embedding_blob, &tags_json, &metadata_json);
+        match result {
+            Ok(()) => {
+                tx.commit()
+                    .map_err(|e| Error::db("Failed to commit transaction", e))?;
+                Ok(())
+            }
+            Err(e) => {
+                // Drop tx triggers automatic rollback.
+                Err(e)
+            }
+        }
+    }
+
+    /// Internal helper: performs the actual INSERT + tag inserts.
+    /// Called within a transaction by `insert()`.
+    fn try_insert_memory(
+        &self,
+        memory: &Memory,
+        embedding_blob: &[u8],
+        tags_json: &str,
+        metadata_json: &str,
+    ) -> Result<(), Error> {
         self.conn
             .execute(
                 "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug, source, source_type)

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -299,9 +299,12 @@ impl VectorIndex {
         self.key_to_id.insert(key, id.to_string());
         self.id_to_key.insert(id.to_string(), key);
 
-        // Auto-reserve if at capacity
+        // Auto-reserve if at capacity using geometric growth to amortize reallocation cost.
+        // Growth strategy: max(current * 2, current + 4096, 1024).
+        // Doubling amortizes to O(1) per insertion; +4096 floor avoids tiny allocs at small scale.
         if self.index.size() >= self.index.capacity() {
-            let new_cap = (self.index.capacity() + 1024).max(1024);
+            let current = self.index.capacity();
+            let new_cap = (current * 2).max(current + 4096).max(1024);
             self.index.reserve(new_cap).map_err(|e| {
                 Error::embed_msg(format!("Failed to reserve usearch capacity: {e}"))
             })?;

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -30,6 +30,10 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         None => (None, raw_path.clone()),
     };
 
+    // Route matching uses path-only (without query string).
+    // Handler functions still receive the full `path` with query params intact.
+    let route_path = path.split('?').next().unwrap_or(&path);
+
     // CORS preflight — no auth required
     if method == Method::Options {
         return Response::new(
@@ -42,7 +46,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
     }
 
     // Health endpoint — no auth required (useful for load balancers)
-    let is_health = matches!((&method, path.as_str()), (Method::Get, "/health"));
+    let is_health = matches!((&method, route_path), (Method::Get, "/health"));
 
     // Authenticate all non-health requests
     let auth_role = if !is_health {
@@ -98,7 +102,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
     };
 
-    match (method, path.as_str()) {
+    match (method, route_path) {
         // ── Health ──────────────────────────────────────────────────────
         (Method::Get, "/health") => {
             let total = uteke.count(None).unwrap_or(0);
@@ -500,8 +504,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         },
 
         // ── Forget by ID or tag (DELETE /forget?id=xxx or ?tag=xxx) ────
-        (Method::Delete, p) if p == "/forget" || p.starts_with("/forget?") => {
-            let query = p.split('?').nth(1).unwrap_or("");
+        (Method::Delete, "/forget") => {
+            let query = path.split('?').nth(1).unwrap_or("");
             let params: std::collections::HashMap<String, String> = query
                 .split('&')
                 .filter_map(|pair| {
@@ -598,7 +602,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Lifecycle (#936): status, cycle, promote ──────────────────
-        (Method::Get, p) if p == "/lifecycle/status" || p.starts_with("/lifecycle/status?") => {
+        (Method::Get, "/lifecycle/status") => {
             let query = req.url().split('?').nth(1).unwrap_or("");
             let params: std::collections::HashMap<String, String> = query
                 .split('&')
@@ -678,7 +682,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Namespaces ──────────────────────────────────────────────────
-        (Method::Get, p) if p == "/namespaces" || p.starts_with("/namespaces?") => {
+        (Method::Get, "/namespaces") => {
             let with_counts = path.contains("with_counts=true");
             if with_counts {
                 match uteke.list_namespaces_with_counts() {
@@ -711,7 +715,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Recent (#528) ──────────────────────────────────────────────
-        (Method::Get, p) if p == "/recent" || p.starts_with("/recent?") => {
+        (Method::Get, "/recent") => {
             let ns = parse_query_namespace(&path);
             let query = path.split('?').nth(1).unwrap_or("");
             let limit = parse_query_param(query, "limit")
@@ -730,7 +734,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Graph Visualization (#408) ───────────────────────────────────
-        (Method::Get, p) if p == "/graph" || p.starts_with("/graph?") => {
+        (Method::Get, "/graph") => {
             let ns = parse_query_namespace(&path);
             match uteke.graph_data(ns.as_deref()) {
                 Ok(data) => ctx.ok_response_for(req, &data),
@@ -800,8 +804,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         },
 
         // ── Graph Mutation: Remove Edge (#542) ────────────────────────────
-        (Method::Delete, p) if p == "/graph/edge" || p.starts_with("/graph/edge?") => {
-            let query = p.split('?').nth(1).unwrap_or("");
+        (Method::Delete, "/graph/edge") => {
+            let query = path.split('?').nth(1).unwrap_or("");
             let source = parse_query_param(query, "source");
             let target = parse_query_param(query, "target");
 
@@ -903,13 +907,14 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Get memory by ID ──────────────────────────────────────────
-        (Method::Get, p) if p.starts_with("/memory?id=") => {
-            let id = p.trim_start_matches("/memory?id=");
+        (Method::Get, "/memory") => {
+            let query = path.split('?').nth(1).unwrap_or("");
+            let id = parse_query_param(query, "id").unwrap_or_default();
             // Validate UUID format
-            if uuid::Uuid::parse_str(id).is_err() {
+            if uuid::Uuid::parse_str(&id).is_err() {
                 return ctx.error_response_for(req, 400, format!("Invalid UUID format: {id}"));
             }
-            match uteke.get_by_id(id) {
+            match uteke.get_by_id(&id) {
                 Ok(Some(memory)) => ctx.ok_response_for(req, &memory),
                 Ok(None) => ctx.error_response_for(req, 404, format!("Memory not found: {id}")),
                 Err(e) => {
@@ -1112,8 +1117,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         },
 
         // ── Room Memories (chronological listing — GET /room/memories) ────
-        (Method::Get, p) if p == "/room/memories" || p.starts_with("/room/memories?") => {
-            let query_str = p.strip_prefix("/room/memories?");
+        (Method::Get, "/room/memories") => {
+            let query_str = path.split('?').nth(1);
             let room_id = query_str.and_then(|q| parse_query_param(q, "room_id"));
             let room_id = match room_id {
                 Some(id) => id,
@@ -1375,8 +1380,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
-        (Method::Delete, p) if p == "/room/delete" || p.starts_with("/room/delete?") => {
-            let room_id = if let Some(q) = p.strip_prefix("/room/delete?") {
+        (Method::Delete, "/room/delete") => {
+            let room_id = if let Some(q) = path.split('?').nth(1) {
                 parse_query_param(q, "room_id")
             } else {
                 // Try reading from query params in headers or body
@@ -1646,7 +1651,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         },
 
         // ── Document: Delete ─────────────────────────────────────────────
-        (Method::Delete, p) if p == "/doc/delete" || p.starts_with("/doc/delete?") => {
+        (Method::Delete, "/doc/delete") => {
             // Extract query string only — req.url() returns full URL which
             // parse_query_param() cannot handle (#776).
             let query = req.url().split('?').nth(1).unwrap_or("");
@@ -1727,7 +1732,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Tags: List with counts ───────────────────────────────────────
-        (Method::Get, p) if p == "/tags" || p.starts_with("/tags?") => {
+        (Method::Get, "/tags") => {
             let ns = parse_query_namespace(&path);
             match uteke.tags_with_counts(ns.as_deref()) {
                 Ok(tags) => ctx.ok_response_for(req, &tags),
@@ -1815,8 +1820,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         },
 
         // ── Timeline ─────────────────────────────────────────────────────
-        (Method::Get, p) if p.starts_with("/timeline?") || p.starts_with("/timeline?id=") => {
-            let query = p.split('?').nth(1).unwrap_or("");
+        (Method::Get, "/timeline") => {
+            let query = path.split('?').nth(1).unwrap_or("");
             let id = match parse_query_param(query, "id") {
                 Some(id) => id,
                 None => return ctx.error_response_for(req, 400, "Missing 'id' query parameter"),
@@ -1834,8 +1839,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         }
 
         // ── Edges ────────────────────────────────────────────────────────
-        (Method::Get, p) if p.starts_with("/edges?") || p.starts_with("/edges?id=") => {
-            let query = p.split('?').nth(1).unwrap_or("");
+        (Method::Get, "/edges") => {
+            let query = path.split('?').nth(1).unwrap_or("");
             let id = match parse_query_param(query, "id") {
                 Some(id) => id,
                 None => return ctx.error_response_for(req, 400, "Missing 'id' query parameter"),
@@ -1948,7 +1953,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         },
 
         // ── Export (JSONL) ──────────────────────────────────────────────
-        (Method::Get, p) if p == "/export" || p.starts_with("/export?") => {
+        (Method::Get, "/export") => {
             let export_ns = parse_query_namespace(&path);
             match uteke.export(export_ns.as_deref()) {
                 Ok(jsonl) => {


### PR DESCRIPTION
## What

Empat perbaikan P1 dari audit cora-code v0.13.0:

1. **crud.rs atomicity** — `insert()` sekarang wrap INSERT + tag inserts dalam `unchecked_transaction()`, konsisten dengan pattern di `tags.rs` dan `documents.rs`. Jika tag insert gagal, seluruh operasi rollback.

2. **handlers.rs route matching** — Query string sekarang di-strip sebelum route dispatch (`route_path = path.split("?").next()`). Semua handler yang extract query params sekarang pakai `path.split("?")` bukan `p.strip_prefix(...)`. Menghilangkan 14 clippy `redundant_guard` warnings.

3. **lib.rs namespace filter** — `graph_data(namespace)` sebelumnya no-op (`is_none_or(|_| true)` selalu return true). Sekarang query memory IDs by namespace, filter nodes by `memory_id`, dan filter edges untuk consistency.

4. **vector.rs capacity growth** — Fixed increment `+1024` → geometric growth `max(current*2, current+4096, 1024)`. Amortizes to O(1) per insertion untuk dataset besar.

## Why

- **crud.rs:** Crash di tengah tag inserts meninggalkan memory tanpa tags → data inconsistency
- **handlers.rs:** Route matching dengan query string bikin fragile dan redundant guard warnings
- **lib.rs:** Namespace filter yang no-op = fitur tidak berfungsi, user tidak bisa filter graph by namespace
- **vector.rs:** Fixed increment menyebabkan frequent reallocation pada dataset 100K+ vectors

## Changes

- `crates/uteke-core/src/memory/crud.rs` — `unchecked_transaction()` wrapper
- `crates/uteke-server/src/handlers.rs` — `route_path` variable + literal path matching
- `crates/uteke-core/src/lib.rs` — Namespace-aware graph node/edge filtering
- `crates/uteke-core/src/memory/vector.rs` — Geometric capacity growth formula

## Testing

- 476 tests pass, 0 fail, 25 ignored
- Clippy: 0 warnings
- Cora review: No issues found