### PR TITLE
chore: deprecate unused pub fn (dead code cleanup)

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -322,6 +322,8 @@ impl LifecycleConfig {
     ///
     /// Returns a value in `[min_deprecate_per_cycle, max_deprecate_per_cycle]`,
     /// clamped after percentage calculation.
+    #[deprecated(note = "unused — candidate for removal in future version")]
+    #[allow(dead_code)]
     pub fn cycle_deprecate_cap(&self, total_memories: usize) -> usize {
         let pct_based = (total_memories as f64 * self.max_deprecate_percent / 100.0) as usize;
         pct_based

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -817,6 +817,8 @@ impl super::Store {
     }
 
     /// Count all documents (global).
+    #[deprecated(note = "unused — candidate for removal in future version")]
+    #[allow(dead_code)]
     pub fn count_documents(&self) -> Result<usize, Error> {
         let count: i64 = self
             .conn

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -76,6 +76,8 @@ impl crate::Uteke {
     ///
     /// This is a convenience wrapper that validates JSON before storing.
     /// The `remember()` method also auto-detects JSON content.
+    #[deprecated(note = "unused — candidate for removal in future version")]
+    #[allow(dead_code)]
     pub fn remember_json(
         &self,
         json_content: &str,
@@ -627,6 +629,8 @@ impl crate::Uteke {
     /// 2. [0.85] Increase login timeout to 5s [fix]
     /// 3. [0.70] Users report timeout on slow connections [feedback]
     /// ```
+    #[deprecated(note = "unused — candidate for removal in future version")]
+    #[allow(dead_code)]
     pub fn recall_context(
         &self,
         query: &str,


### PR DESCRIPTION
## What

Empat `pub fn` dengan zero callers di seluruh workspace ditandai `#[deprecated]`:

1. **`cycle_deprecate_cap`** (`lib.rs:325`) — deprecation cycle cap calculator
2. **`remember_json`** (`operations.rs:79`) — JSON-specific remember wrapper
3. **`recall_context`** (`operations.rs:630`) — context-aware recall helper
4. **`count_documents`** (`documents.rs:820`) — global document count

## Why

Cora intelligent scan mendeteksi 4 dead code functions. Karena ini public API di crate `uteke-core`, removal langsung akan break downstream consumers. `#[deprecated]` tag memberi signal removal intent tanpa breaking change.

## Changes

Setiap function mendapat:
```rust
#[deprecated(note = "unused — candidate for removal in future version")]
#[allow(dead_code)]
```

## Testing

- 468 tests pass, 0 fail
- Clippy: 0 warnings
- Cora review: No issues found