### PR TITLE
fix: security, data safety, and stability fixes (#973-#980)

### DIFF
--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -130,7 +130,7 @@ pub(crate) fn run(
                     );
                     for (i, m) in memories.iter().enumerate() {
                         let preview = if m.content.len() > 80 {
-                            format!("{}...", &m.content[..77])
+                            format!("{}...", uteke_core::safe_truncate(&m.content, 77))
                         } else {
                             m.content.clone()
                         };

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -77,6 +77,19 @@ pub const MAX_TAG_LENGTH: usize = 50;
 /// Maximum payload size for server API (bytes).
 pub const MAX_PAYLOAD_SIZE: usize = 10_485_760; // 10MB
 
+/// Truncate a string to `max_bytes` without splitting a multi-byte UTF-8 character.
+/// Returns a slice ending at a char boundary ≤ `max_bytes`.
+pub fn safe_truncate(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Validate input parameters before processing.
 /// Uses default limits. For configurable limits, use `validate_input_with_limits`.
 pub fn validate_input(content: &str, tags: &[impl AsRef<str>]) -> Result<(), Error> {
@@ -1232,7 +1245,7 @@ impl Uteke {
             lines.push("Recent memories:".to_string());
             for m in &recent {
                 let preview = if m.content.len() > 80 {
-                    format!("{}...", &m.content[..77])
+                    format!("{}...", crate::safe_truncate(&m.content, 77))
                 } else {
                     m.content.clone()
                 };
@@ -1744,9 +1757,9 @@ impl Uteke {
                     document,
                     chunk_heading,
                     chunk_snippet: if chunk_snippet.len() > 200 {
-                        format!("{}...", &chunk_snippet[..200])
+                        format!("{}...", crate::safe_truncate(chunk_snippet.as_str(), 200))
                     } else {
-                        chunk_snippet
+                        chunk_snippet.clone()
                     },
                     score,
                     mode: "semantic".to_string(),

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -117,6 +117,7 @@ impl super::Store {
             DELETE FROM memories
             WHERE namespace = ?1
               AND deprecated = 0
+              AND pinned = 0
               AND created_at < ?2
               AND access_count <= ?3
               AND (last_accessed IS NULL OR last_accessed < ?4)

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -247,38 +247,42 @@ impl super::Store {
         let metadata_json = serde_json::to_string(&memory.metadata)
             .map_err(|e| Error::db("database operation", e))?;
 
-        self.conn
-            .execute(
-                "UPDATE memories SET content = ?2, embedding = ?3, tags = ?4, metadata = ?5, updated_at = ?6, namespace = ?7
-                 WHERE id = ?1",
-                params![
-                    memory.id,
-                    memory.content,
-                    embedding_blob,
-                    tags_json,
-                    metadata_json,
-                    memory.updated_at.to_rfc3339(),
-                    memory.namespace,
-                ],
-            )
-            .map_err(|e| Error::db("database operation", e))?;
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("begin transaction", e))?;
+
+        tx.execute(
+            "UPDATE memories SET content = ?2, embedding = ?3, tags = ?4, metadata = ?5, updated_at = ?6, namespace = ?7
+             WHERE id = ?1",
+            params![
+                memory.id,
+                memory.content,
+                embedding_blob,
+                tags_json,
+                metadata_json,
+                memory.updated_at.to_rfc3339(),
+                memory.namespace,
+            ],
+        )
+        .map_err(|e| Error::db("database operation", e))?;
 
         // Dual-write: sync junction table tags
-        self.conn
-            .execute(
-                "DELETE FROM memory_tags WHERE memory_id = ?1",
-                params![memory.id],
-            )
-            .map_err(|e| Error::db("delete old tags", e))?;
+        tx.execute(
+            "DELETE FROM memory_tags WHERE memory_id = ?1",
+            params![memory.id],
+        )
+        .map_err(|e| Error::db("delete old tags", e))?;
         for tag in &memory.tags {
-            self.conn
-                .execute(
-                    "INSERT OR IGNORE INTO memory_tags (memory_id, tag) VALUES (?1, ?2)",
-                    params![memory.id, tag],
-                )
-                .map_err(|e| Error::db("insert tag", e))?;
+            tx.execute(
+                "INSERT OR IGNORE INTO memory_tags (memory_id, tag) VALUES (?1, ?2)",
+                params![memory.id, tag],
+            )
+            .map_err(|e| Error::db("insert tag", e))?;
         }
 
+        tx.commit()
+            .map_err(|e| Error::db("commit transaction", e))?;
         Ok(())
     }
 
@@ -362,30 +366,34 @@ impl super::Store {
         );
         params_vec.push(Box::new(id.to_string()));
 
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("begin transaction", e))?;
+
         let param_refs: Vec<&dyn rusqlite::types::ToSql> =
             params_vec.iter().map(|b| b.as_ref()).collect();
-        let rows = self
-            .conn
+        let rows = tx
             .execute(&sql, param_refs.as_slice())
             .map_err(|e| Error::db("update memory fields", e))?;
 
         // Dual-write: sync junction table tags if tags were provided
         if tags.is_some() {
-            self.conn
-                .execute("DELETE FROM memory_tags WHERE memory_id = ?1", params![id])
+            tx.execute("DELETE FROM memory_tags WHERE memory_id = ?1", params![id])
                 .map_err(|e| Error::db("delete old tags", e))?;
             if let Some(t) = tags {
                 for tag in t {
-                    self.conn
-                        .execute(
-                            "INSERT OR IGNORE INTO memory_tags (memory_id, tag) VALUES (?1, ?2)",
-                            params![id, tag],
-                        )
-                        .map_err(|e| Error::db("insert tag", e))?;
+                    tx.execute(
+                        "INSERT OR IGNORE INTO memory_tags (memory_id, tag) VALUES (?1, ?2)",
+                        params![id, tag],
+                    )
+                    .map_err(|e| Error::db("insert tag", e))?;
                 }
             }
         }
 
+        tx.commit()
+            .map_err(|e| Error::db("commit transaction", e))?;
         Ok(rows > 0)
     }
 

--- a/crates/uteke-core/src/memory/fts5.rs
+++ b/crates/uteke-core/src/memory/fts5.rs
@@ -116,7 +116,7 @@ impl super::Store {
                 let rows = stmt
                     .query_map(params![fts_query, ns, limit as i64], |row| {
                         let memory = row_to_memory(row)?;
-                        let rank: f64 = row.get(14)?;
+                        let rank: f64 = row.get(19)?;
                         Ok((memory, rank))
                     })
                     .map_err(|e| Error::db("execute FTS5 search", e))?;
@@ -133,7 +133,7 @@ impl super::Store {
                 let rows = stmt
                     .query_map(params![fts_query, limit as i64], |row| {
                         let memory = row_to_memory(row)?;
-                        let rank: f64 = row.get(14)?;
+                        let rank: f64 = row.get(19)?;
                         Ok((memory, rank))
                     })
                     .map_err(|e| Error::db("execute FTS5 search", e))?;
@@ -199,7 +199,7 @@ impl super::Store {
                 let rows = stmt
                     .query_map(params![fts_query, ns, limit as i64], |row| {
                         let memory = row_to_memory(row)?;
-                        let rank: f64 = row.get(14)?;
+                        let rank: f64 = row.get(19)?;
                         Ok((memory, rank))
                     })
                     .map_err(|e| Error::db("execute FTS5 token search", e))?;
@@ -216,7 +216,7 @@ impl super::Store {
                 let rows = stmt
                     .query_map(params![fts_query, limit as i64], |row| {
                         let memory = row_to_memory(row)?;
-                        let rank: f64 = row.get(14)?;
+                        let rank: f64 = row.get(19)?;
                         Ok((memory, rank))
                     })
                     .map_err(|e| Error::db("execute FTS5 token search", e))?;

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -311,8 +311,10 @@ impl Store {
                 .unwrap_or(0) as f64;
             let connectivity = (rel_count / 5.0).min(1.0);
 
-            let importance =
-                0.3 * access_score + 0.3 * recency_score + 0.2 * connectivity + 0.2 * 0.0;
+            let importance = 0.3 * access_score
+                + 0.3 * recency_score
+                + 0.2 * connectivity
+                + 0.2 * if m.pinned { 1.0 } else { 0.0 };
             let importance = importance.clamp(0.0_f64, 1.0_f64);
 
             if (m.importance - importance).abs() > f64::EPSILON {

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -267,6 +267,15 @@ impl VectorIndex {
 
         // Pre-reserve capacity for bulk insert
         if !items.is_empty() {
+            // Validate all items have consistent dimensions
+            for (id, emb) in items {
+                if emb.len() != dims {
+                    return Err(Error::validation(format!(
+                        "embedding dimension mismatch in build(): item '{id}' has {} dims, expected {dims}",
+                        emb.len()
+                    )));
+                }
+            }
             if let Err(e) = self.index.reserve(items.len()) {
                 tracing::error!("Failed to reserve usearch capacity: {e}");
             }

--- a/extensions/pi-memory-provider/index.ts
+++ b/extensions/pi-memory-provider/index.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { basename, resolve } from "node:path";
 import { existsSync } from "node:fs";
 
@@ -109,12 +109,12 @@ function runUteke(args: string[], timeout = RECALL_TIMEOUT_MS): string {
 		env.HOME = process.env.UTEKE_HOME;
 	}
 	try {
-		return execSync(`${bin} ${args.join(" ")}`, {
+		return execFileSync(bin, args, {
 			encoding: "utf-8",
 			timeout,
 			env,
 		});
-	} catch (err: any) {
+	} catch {
 		return "";
 	}
 }
@@ -125,7 +125,7 @@ function recallMemories(query: string, project: string): string[] {
 	const minScore = process.env.UTEKE_RECALL_MIN_SCORE || String(RECALL_MIN_SCORE);
 
 	const args: string[] = [
-		"recall", `"${query}"`,
+		"recall", query,
 		"--namespace", ns,
 		"--limit", limit,
 		"--min-score", minScore,
@@ -231,7 +231,7 @@ export default function (pi: ExtensionAPI) {
 			const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
 			const project = detectProjectFromCwd();
 			const cmdArgs: string[] = [
-				"remember", `"${content}"`,
+				"remember", content,
 				"--namespace", ns,
 			];
 			if (project) {

--- a/extensions/uteke-status/index.ts
+++ b/extensions/uteke-status/index.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -34,7 +34,7 @@ function getAllStats(): Stats | null {
 	].join(" ");
 
 	try {
-		const out = execSync(`sqlite3 '${dbPath}' "${sql}"`, {
+		const out = execFileSync("sqlite3", [dbPath, sql], {
 			timeout: 5000,
 			encoding: "utf-8",
 		}).trim();

--- a/install.ps1
+++ b/install.ps1
@@ -114,6 +114,7 @@ function Install-Uteke {
             $actualHash = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLower()
             if ($actualHash -ne $expectedHash.ToLower()) {
                 Write-ErrorMsg "Checksum mismatch! Expected: $expectedHash, Got: $actualHash"
+                exit 1
             }
             Write-Info "Checksum verified: $expectedHash"
         } else {


### PR DESCRIPTION
## What

Fixes 8 validated bugs from cora re-scan across 3 priority tiers: security (P4), data safety (P5), and stability (P6).

## Why

Cora re-scan found 167 findings. After validation, 10 GitHub issues were created (#973-#982). This PR addresses 8 of them — the 2 remaining (#981 CLI JSON, #982 Windows vector race) are lower priority and deferred.

## Changes

### P4 — Security (#973)
- **uteke-status/index.ts**: `execSync` -> `execFileSync("sqlite3", [dbPath, sql])` — prevents shell injection via paths
- **pi-memory-provider/index.ts**: `execSync` -> `execFileSync(bin, args)` — prevents shell injection, removed manual double-quoting

### P5 — Data Safety
- **#974 aging.rs**: Added `AND pinned = 0` to `cleanup_aged` DELETE — pinned memories were being deleted
- **#975 fts5.rs**: Changed `row.get(14)` -> `row.get(19)` for `f.rank` (4 locations) — was reading importance column instead of rank
- **#976 store.rs**: Changed `0.2 * 0.0` -> `0.2 * if m.pinned { 1.0 } else { 0.0 }` — pinned bonus was always zero
- **#977 crud.rs**: Wrapped `update()` and `update_fields()` in `unchecked_transaction()` — atomic memory + tags write

### P6 — Stability
- **#978 lib.rs + room.rs**: Added `safe_truncate()` helper, replaced 3 unsafe `&str[..N]` slicing — prevents UTF-8 panic on multi-byte content
- **#979 vector.rs**: `build()` validates all items have consistent dimensions before insert — prevents index corruption
- **#980 install.ps1**: Added `exit 1` after checksum mismatch — was printing error then continuing

## Testing

- `cargo fmt --all` pass
- `cargo clippy --workspace --all-targets` — 0 warnings
- `cargo test --workspace` — 476 passed, 0 failed, 26 ignored
- Pre-commit hooks: fmt + clippy + cora review all passed