### PR TITLE
fix: CLI JSON safety and Windows vector race condition (#981 #982)

### DIFF
--- a/crates/uteke-cli/src/commands/doc.rs
+++ b/crates/uteke-cli/src/commands/doc.rs
@@ -56,11 +56,13 @@ pub(crate) fn run(
                 .map_err(|e| format!("Failed to create document: {e}"))?;
 
             if cli.json {
-                let parent_json = parent
-                    .as_ref()
-                    .map(|p| format!(r#", "parent": "{p}""#))
-                    .unwrap_or_default();
-                println!(r#"{{"id": "{id}", "slug": "{slug}"{parent_json}, "status": "created"}}"#);
+                let json = serde_json::json!({
+                    "id": id,
+                    "slug": slug,
+                    "parent": parent,
+                    "status": "created",
+                });
+                println!("{json}");
             } else {
                 println!("✓ Document '{slug}' created (id: {id})");
                 println!("  Title: {doc_title}");
@@ -407,7 +409,11 @@ pub(crate) fn run(
                 .map_err(|e| format!("Failed to delete document: {e}"))?;
             if deleted {
                 if cli.json {
-                    println!(r#"{{"deleted": "{id}", "subtree_size": {subtree_size}}}"#);
+                    let json = serde_json::json!({
+                        "deleted": id,
+                        "subtree_size": subtree_size,
+                    });
+                    println!("{json}");
                 } else {
                     println!("✓ Document deleted: {id}");
                     if subtree_size > 1 {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -275,7 +275,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             let pinned = uteke.pin(id).map_err(|e| format!("Failed to pin: {e}"))?;
             if pinned {
                 if cli.json {
-                    println!("{{\"pinned\": \"{id}\"}}");
+                    println!("{}", serde_json::json!({"pinned": id}));
                 } else {
                     println!("Pinned memory {}.", &id[..8.min(id.len())]);
                 }
@@ -291,7 +291,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
                 .map_err(|e| format!("Failed to unpin: {e}"))?;
             if unpinned {
                 if cli.json {
-                    println!("{{\"unpinned\": \"{id}\"}}");
+                    println!("{}", serde_json::json!({"unpinned": id}));
                 } else {
                     println!("Unpinned memory {}.", &id[..8.min(id.len())]);
                 }
@@ -338,7 +338,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
                 .recompute_importance()
                 .map_err(|e| format!("Failed to recompute: {e}"))?;
             if cli.json {
-                println!("{{\"updated\": {updated}}}");
+                println!("{}", serde_json::json!({"updated": updated}));
             } else {
                 println!("Recalculated importance for {updated} memories.");
             }

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -201,23 +201,43 @@ impl VectorIndex {
 
             // On Windows, `std::fs::rename` fails with `ERROR_ACCESS_DENIED` if
             // the destination file is locked by `LockFileEx` via fs2 (#926).
-            // Temporarily release the lock, perform the rename, then re-acquire.
+            // Instead of releasing the lock (which creates a race window #982),
+            // retry the rename with exponential backoff — Windows often releases
+            // the lock momentarily between operations.
             #[cfg(windows)]
             {
-                if let Some(ref lock_file) = self._lock_file {
-                    // Best-effort unlock — ignore errors, worst case rename fails below
-                    let _ = fs2::FileExt::unlock(lock_file);
+                let mut delay = std::time::Duration::from_millis(10);
+                let max_delay = std::time::Duration::from_millis(640);
+                loop {
+                    match std::fs::rename(&tmp_path, path) {
+                        Ok(()) => break,
+                        Err(e) if e.raw_os_error() == Some(5) => {
+                            // ERROR_ACCESS_DENIED — retry after backoff
+                            if delay > max_delay {
+                                return Err(Error::embed_msg(format!(
+                                    "rename timeout (ACCESS_DENIED) after retries: {e}"
+                                )));
+                            }
+                            std::thread::sleep(delay);
+                            delay *= 2;
+                        }
+                        Err(e) => {
+                            return Err(Error::embed("rename temp to final usearch index", e));
+                        }
+                    }
                 }
             }
+            #[cfg(not(windows))]
+            {
+                std::fs::rename(&tmp_path, path)
+                    .map_err(|e| Error::embed("rename temp to final usearch index", e))?;
+            }
 
-            std::fs::rename(&tmp_path, path)
-                .map_err(|e| Error::embed("rename temp to final usearch index", e))?;
-
+            // On Windows, reopen the file after rename to refresh the lock
+            // handle — it now points to the new file written via rename.
             #[cfg(windows)]
             {
                 if let Some(ref mut lock_file) = self._lock_file {
-                    // Re-open the file handle (path was just replaced by rename)
-                    // and re-acquire the lock.
                     let new_file = std::fs::OpenOptions::new()
                         .read(true)
                         .write(true)


### PR DESCRIPTION
## What

Closes the last 2 remaining issues from cora re-scan: manual JSON construction and Windows cross-process race condition.

## Why

Issues #981 and #982 were deferred in PR #983 as lower priority. This PR closes them out — completing all 10 issues from the cora scan audit.

## Changes

### #981 — CLI manual JSON construction
- **doc.rs**: 2 locations replaced `format!()` string interpolation with `serde_json::json!()` for document create and delete JSON output
- **mod.rs**: 3 locations replaced manual `println!("{{...}}")` with `serde_json::json!()` for pin, unpin, and importance JSON output
- Prevents corrupted JSON output when slugs/ids contain quotes, backslashes, or other special characters

### #982 — Windows vector race condition
- Replaced unlock-rename-relock pattern with retry-based rename using exponential backoff (10ms → 640ms, ~7 retries)
- After successful rename, reopens and re-locks the file to refresh the handle
- Eliminates the race window where another process could access the partially-written file between unlock and rename

## Testing

- `cargo fmt --all` pass
- `cargo clippy --workspace --all-targets` — 0 warnings
- `cargo test --workspace` — 476 passed, 0 failed
- Pre-commit: fmt + clippy + cora review all passed