### PR TITLE
fix: P8 — CLI JSON regression, dead code SQL, chunker loop, vector persist, path corruption, thread cap

### DIFF
--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -319,7 +319,13 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
             };
             if cli.json {
                 println!(
-                    r#"{{"id": "{id}", "feedback": "{label}", "delta": "{delta_str}", "importance": {new_importance:.4}}}"#
+                    "{}",
+                    serde_json::json!({
+                        "id": id,
+                        "feedback": label,
+                        "delta": delta_str,
+                        "importance": format!("{:.4}", new_importance),
+                    })
                 );
             } else {
                 println!(

--- a/crates/uteke-core/src/chunker.rs
+++ b/crates/uteke-core/src/chunker.rs
@@ -284,7 +284,18 @@ fn split_long_text(text: &str, max_chars: usize) -> Vec<String> {
 
         let chunk_end = break_at.unwrap_or(end);
         let chunk_end = floor_char_boundary(text, chunk_end);
-        chunks.push(text[start..chunk_end].to_string());
+        // Guard against zero-length chunks that would cause an infinite loop.
+        // If chunk_end didn't advance past start, force at least 1 char forward.
+        let chunk_end = if chunk_end <= start {
+            let next = (start + 1).min(text.len());
+            floor_char_boundary(text, next)
+        } else {
+            chunk_end
+        };
+        let chunk_text = text[start..chunk_end].trim();
+        if !chunk_text.is_empty() {
+            chunks.push(chunk_text.to_string());
+        }
         start = chunk_end;
     }
 

--- a/crates/uteke-core/src/memory/documents.rs
+++ b/crates/uteke-core/src/memory/documents.rs
@@ -732,9 +732,12 @@ impl super::Store {
         .map_err(|e| Error::db("update moved document", e))?;
 
         // Update all descendants: replace old prefix with new prefix, adjust depth.
+        // Use substr() to replace ONLY the prefix portion (not all occurrences),
+        // avoiding corruption when old_path appears multiple times in a descendant path.
+        // length(old_path) is the offset where the suffix begins.
         let n = tx
             .execute(
-                "UPDATE documents SET path = REPLACE(path, ?1, ?2), depth = depth + ?3 \
+                "UPDATE documents SET path = ?2 || substr(path, length(?1) + 1), depth = depth + ?3 \
                  WHERE path LIKE ?4 AND id != ?5",
                 params![old_path_exact, new_path, depth_diff, old_prefix, doc_id,],
             )

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -580,7 +580,30 @@ impl super::Store {
     }
 
     /// Check if a column exists in a specific table.
+    ///
+    /// `table` must be a known internal table name (never user input).
+    /// We validate against an allowlist to prevent SQL injection even
+    /// though all current callers use hardcoded literals.
     pub(super) fn column_exists_in(&self, table: &str, column: &str) -> bool {
+        const ALLOWED_TABLES: &[&str] = &[
+            "memories",
+            "memory_tags",
+            "memory_metadata",
+            "memory_embeddings",
+            "memory_importance",
+            "documents",
+            "rooms",
+            "room_members",
+            "room_documents",
+            "graph_nodes",
+            "graph_edges",
+            "memory_feedback",
+            "memory_doc_refs",
+            "doc_mem_refs",
+        ];
+        if !ALLOWED_TABLES.contains(&table) {
+            return false;
+        }
         self.conn
             .prepare(&format!("SELECT * FROM {table} LIMIT 0"))
             .map(|stmt| stmt.column_names().iter().any(|n| n == &column))

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1019,6 +1019,10 @@ impl crate::Uteke {
                 "Vector index entry not found during soft_forget for id={id} (ok if never embedded)"
             );
         }
+        // Persist vector index to disk so the removal survives restart.
+        if let Err(e) = index.save() {
+            tracing::warn!("Failed to persist vector index after soft_forget: {e}");
+        }
         // Invalidate recall cache for this memory's namespace.
         if let Some(memory) = self.store.get_by_id(id).ok().flatten() {
             self.recall_cache.invalidate_namespace(&memory.namespace);

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -466,9 +466,27 @@ fn main() {
 
     // Request loop — spawn each request in a thread for concurrent handling.
     // Arc<Mutex<Uteke>> allows safe shared access across threads.
+    // Cap concurrent threads to prevent thread explosion under load:
+    // an atomic counter plus spin-yield provides simple backpressure.
+    let max_threads = std::thread::available_parallelism()
+        .map(|n| n.get() * 2)
+        .unwrap_or(8);
+    let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
     for mut req in server.incoming_requests() {
         if SHUTDOWN.load(Ordering::SeqCst) {
             info!("Shutdown requested, stopping.");
+            break;
+        }
+
+        // Backpressure: wait until a thread slot is available.
+        while active.load(Ordering::Acquire) >= max_threads {
+            if SHUTDOWN.load(Ordering::SeqCst) {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        if SHUTDOWN.load(Ordering::SeqCst) {
             break;
         }
 
@@ -478,13 +496,23 @@ fn main() {
 
         let uteke = Arc::clone(&uteke);
         let ctx = ctx.clone();
+        let active = Arc::clone(&active);
+        active.fetch_add(1, Ordering::AcqRel);
 
-        std::thread::spawn(move || {
+        let active_clone = Arc::clone(&active);
+        let result = std::thread::Builder::new().spawn(move || {
             let response = handlers::route(&uteke, &ctx, &mut req);
             if let Err(e) = req.respond(response) {
                 warn!("Response error: {e}");
             }
+            active.fetch_sub(1, Ordering::AcqRel);
         });
+
+        if let Err(e) = result {
+            // Spawn failed — release the slot we reserved.
+            active_clone.fetch_sub(1, Ordering::AcqRel);
+            warn!("Failed to spawn request thread: {e}");
+        }
     }
 
     // Graceful shutdown — save dirty index to disk.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,13 +12,23 @@ TOKENIZER_SHA256="4dda02faaf32bc91031dc8c88457ac272b00c1016cc679757d1c441b248b9c
 verify_sha256() {
   file_path="$1"
   expected="$2"
+  if [ -z "$expected" ]; then
+    echo "ERROR: No expected checksum provided for $file_path" >&2
+    return 1
+  fi
   if command -v sha256sum >/dev/null 2>&1; then
-    echo "$expected  $file_path" | sha256sum -c -
+    echo "$expected  $file_path" | sha256sum -c - || {
+      echo "ERROR: Checksum verification failed for $file_path" >&2
+      return 1
+    }
   elif command -v shasum >/dev/null 2>&1; then
-    echo "$expected  $file_path" | shasum -a 256 -c -
+    echo "$expected  $file_path" | shasum -a 256 -c - || {
+      echo "ERROR: Checksum verification failed for $file_path" >&2
+      return 1
+    }
   else
-    echo "WARNING: sha256sum not available, skipping checksum verification"
-    return 0
+    echo "WARNING: sha256sum not available, skipping checksum verification" >&2
+    return 1
   fi
 }
 


### PR DESCRIPTION
## What

Post-fix cora re-scan (163 findings) triage — 7 actionable fixes from the remaining findings.

## Why

After merging PR #983 and #984 (P0–P7), a re-scan found 163 remaining findings. Subagent analysis categorized them — 7 were validated as real issues worth fixing now, 2 were false positives (embed/engine.rs, aging.rs), and the rest are long-term backlog (N+1 queries, consolidate locking, etc.).

## Changes

| # | File | Fix |
|---|------|-----|
| R1 | `cli/commands/mod.rs` | **Regression** — remaining manual JSON `format!` converted to `serde_json::json!()` |
| R2 | `core/memory/schema.rs` | SQL injection defense-in-depth: table name allowlist in `column_exists_in` |
| R3 | `docker-entrypoint.sh` | Explicit checksum validation — fail fast on mismatch, no silent skip |
| C1 | `core/chunker.rs` | Guard zero-length chunks — `floor_char_boundary` + force advance prevents infinite loop |
| C3 | `core/operations.rs` | `soft_forget` now persists vector index removal to disk (survives restart) |
| C5 | `core/memory/documents.rs` | `REPLACE()` → `substr()` prefix swap — avoids multi-occurrence path corruption |
| C6 | `server/main.rs` | Atomic counter backpressure — caps concurrent request threads at `available_parallelism * 2` |

**False positives skipped:**
- `embed/engine.rs:116` — Cora flagged ORT init not reset on failure, but `load_model()?` propagates error without caching — correct behavior
- `memory/aging.rs:152` — Cora flagged tier_counts warm/cold inversion, but query logic is correct (hot = recent, warm = between cutoffs, cold = older)

## Testing

- `cargo fmt` ✅
- `cargo clippy --workspace --all-targets` — 0 warnings ✅
- `cargo test --workspace` — 476 pass, 0 fail ✅
- Cora pre-commit: passed (3 MAJOR findings reviewed as acceptable trade-offs)