### PR TITLE
feat: add update check to all surfaces (CLI, MCP, HTTP)

### DIFF
--- a/crates/uteke-cli/src/commands/update_check.rs
+++ b/crates/uteke-cli/src/commands/update_check.rs
@@ -1,29 +1,8 @@
-//! Background startup update notification.
+//! Background startup update notification — thin wrapper over `uteke_core::update_check`.
 //!
-//! Checks GitHub for a newer release at most once per 24h.
-//! Prints a banner to stderr if an update is available.
-//! Never auto-upgrades — notification only.
-
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use crate::Config;
-
-/// Cache file path: `~/.config/uteke/update-cache.json` (or platform equivalent).
-fn cache_path() -> Option<std::path::PathBuf> {
-    dirs::config_dir().map(|d| d.join("uteke").join("update-cache.json"))
-}
-
-/// Cache payload persisted between runs.
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Cache {
-    /// Unix timestamp (seconds) of last check.
-    checked_at: u64,
-    /// Latest version tag found (e.g. `v0.14.0`).
-    latest: String,
-}
-
-/// Seconds before re-checking GitHub (24 hours).
-const CACHE_TTL: u64 = 86_400;
+//! Delegates all logic (fetch, cache, compare, banner) to core so MCP and HTTP
+//! servers share the same code path. The config opt-out (`update_check = false`
+//! in `uteke.toml`) is CLI-specific — core doesn't know about user config.
 
 /// Entry point: returns a `JoinHandle` that the caller should `.join()`
 /// at the end of `main()` to ensure the thread isn't killed prematurely.
@@ -31,15 +10,12 @@ const CACHE_TTL: u64 = 86_400;
 /// - If cache is fresh, prints immediately and returns `None` (no thread).
 /// - If cache is stale/missing, spawns a background thread and returns
 ///   `Some(handle)`.
+/// - Respects `update_check = false` from `uteke.toml` (CLI-only).
 pub fn spawn() -> Option<std::thread::JoinHandle<()>> {
     // Try cache first — if fresh, print immediately and skip network.
-    // No config load needed for cached path (zero disk I/O for opt-out
-    // users who have no cache file either — they fall through to thread
-    // which checks config asynchronously).
-    if let Some(latest) = read_cache() {
-        let current = env!("CARGO_PKG_VERSION");
-        if is_newer(&latest, current) {
-            print_banner(&latest, current);
+    if let Some(info) = uteke_core::update_check::check_cached() {
+        if info.is_update_available() {
+            eprintln!("\n{}\n", info.banner());
         }
         return None;
     }
@@ -47,15 +23,17 @@ pub fn spawn() -> Option<std::thread::JoinHandle<()>> {
     // Cache stale or missing — spawn background check.
     // Config opt-out check happens inside the thread to avoid
     // synchronous disk I/O on the main thread.
-    // Caller MUST join() this handle before process exit so the thread
-    // isn't killed before the network request completes.
     let handle = std::thread::spawn(move || {
         let _ = std::panic::catch_unwind(|| {
             // Respect config opt-out (checked in background thread).
             if !enabled() {
                 return;
             }
-            run_check();
+            if let Ok(info) = uteke_core::update_check::check_network() {
+                if info.is_update_available() {
+                    eprintln!("\n{}\n", info.banner());
+                }
+            }
         });
     });
 
@@ -65,115 +43,5 @@ pub fn spawn() -> Option<std::thread::JoinHandle<()>> {
 /// Read config to determine if update check is enabled.
 /// Defaults to `true` when config field is unset.
 fn enabled() -> bool {
-    Config::load().update_check
-}
-
-/// Background thread body: fetch latest version, update cache, print banner.
-fn run_check() {
-    let latest = match crate::commands::upgrade::get_latest_version() {
-        Ok(tag) => tag,
-        Err(_) => return, // network failure — silently skip
-    };
-
-    write_cache(&latest);
-
-    let current = env!("CARGO_PKG_VERSION");
-    if is_newer(&latest, current) {
-        print_banner(&latest, current);
-    }
-}
-
-/// Read cache. Returns `Some(latest_version)` if cache is fresh (< 24h).
-fn read_cache() -> Option<String> {
-    let path = cache_path()?;
-    let data = std::fs::read_to_string(&path).ok()?;
-    let cache: Cache = serde_json::from_str(&data).ok()?;
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    if now.saturating_sub(cache.checked_at) < CACHE_TTL {
-        Some(cache.latest)
-    } else {
-        None
-    }
-}
-
-/// Persist cache to disk. Best-effort — ignores errors.
-fn write_cache(latest: &str) {
-    let Some(path) = cache_path() else { return };
-
-    // Ensure parent dir exists.
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    let cache = Cache {
-        checked_at: now,
-        latest: latest.to_string(),
-    };
-
-    if let Ok(json) = serde_json::to_string(&cache) {
-        let _ = std::fs::write(&path, json);
-    }
-}
-
-/// Compare semver-ish versions. Returns true if `latest` > `current`.
-/// Strips leading `v` prefix. Falls back to string comparison on parse failure.
-fn is_newer(latest: &str, current: &str) -> bool {
-    let lt = latest.trim_start_matches('v');
-    let cur = current.trim_start_matches('v');
-
-    let parse = |s: &str| -> Vec<u64> {
-        s.split('.')
-            .filter_map(|p| p.split('-').next().and_then(|n| n.parse().ok()))
-            .collect()
-    };
-
-    match (parse(lt), parse(cur)) {
-        (lt_parts, cur_parts) if !lt_parts.is_empty() && !cur_parts.is_empty() => {
-            lt_parts > cur_parts
-        }
-        _ => lt > cur,
-    }
-}
-
-/// Print update banner to stderr.
-fn print_banner(latest: &str, current: &str) {
-    eprintln!(
-        "\n⚠ Update available: {latest}\n  \
-         Run `uteke upgrade` to update (currently v{current})\n  \
-         https://github.com/codecoradev/uteke/releases/tag/{latest}\n"
-    );
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_newer_true() {
-        assert!(is_newer("v0.14.0", "0.13.0"));
-        assert!(is_newer("0.14.0", "0.13.0"));
-        assert!(is_newer("v1.0.0", "0.99.99"));
-    }
-
-    #[test]
-    fn test_is_newer_false() {
-        assert!(!is_newer("v0.13.0", "0.13.0"));
-        assert!(!is_newer("v0.12.0", "0.13.0"));
-    }
-
-    #[test]
-    fn test_is_newer_major() {
-        assert!(is_newer("v2.0.0", "1.9.9"));
-        assert!(!is_newer("v1.9.9", "2.0.0"));
-    }
+    crate::Config::load().update_check
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -30,6 +30,7 @@ mod rooms;
 pub mod salience_recency;
 mod timeline;
 mod types;
+pub mod update_check;
 
 pub use chunker::{
     CodeChunk, TextChunk, chunk_code, chunk_markdown, chunk_markdown_embed_aware, detect_language,

--- a/crates/uteke-core/src/update_check.rs
+++ b/crates/uteke-core/src/update_check.rs
@@ -1,0 +1,288 @@
+//! Update check — compare installed version against latest GitHub release.
+//!
+//! Shared by CLI, MCP server, and HTTP server. Each surface calls
+//! [`check_and_notify`] on startup (and periodically, for long-running servers).
+//!
+//! Uses a 24h cache file to avoid hammering GitHub. Network failures are
+//! silently swallowed — this is a notification, not a critical path.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Crate name on GitHub (`codecoradev/uteke`).
+const REPO: &str = "codecoradev/uteke";
+
+/// Seconds before re-checking GitHub (24 hours).
+const CACHE_TTL: u64 = 86_400;
+
+/// Cache payload persisted between runs.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Cache {
+    /// Unix timestamp (seconds) of last check.
+    checked_at: u64,
+    /// Latest version tag found (e.g. `v0.13.1`).
+    latest: String,
+}
+
+/// Result of an update check.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// Latest version tag from GitHub (e.g. `v0.14.0`).
+    pub latest: String,
+    /// Current installed version (e.g. `0.13.1`).
+    pub current: String,
+}
+
+impl UpdateInfo {
+    /// Returns `true` if `latest` is newer than `current`.
+    pub fn is_update_available(&self) -> bool {
+        is_newer(&self.latest, &self.current)
+    }
+
+    /// One-line banner for stderr/logs.
+    ///
+    /// ```text
+    /// ⚠ Update available: v0.14.0 (currently v0.13.1) — run `uteke upgrade`
+    /// ```
+    pub fn banner(&self) -> String {
+        format!(
+            "⚠ Update available: {} (currently v{}) — run `uteke upgrade` or visit https://github.com/{}/releases/tag/{}",
+            self.latest, self.current, REPO, self.latest
+        )
+    }
+}
+
+/// Check for updates using cached data (no network I/O).
+///
+/// Returns `Some(UpdateInfo)` if the cache is fresh (< 24h) and contains
+/// a version string. Returns `None` if cache is stale, missing, or corrupt.
+pub fn check_cached() -> Option<UpdateInfo> {
+    let latest = read_cache()?;
+    Some(UpdateInfo {
+        latest,
+        current: current_version().to_string(),
+    })
+}
+
+/// Synchronous network check. Fetches latest version from GitHub,
+/// updates the cache, and returns `UpdateInfo`.
+///
+/// # Errors
+/// Returns `Err` only on network failure. Callers should silently ignore.
+pub fn check_network() -> Result<UpdateInfo, String> {
+    let latest = get_latest_version()?;
+    write_cache(&latest);
+    Ok(UpdateInfo {
+        latest,
+        current: current_version().to_string(),
+    })
+}
+
+/// Convenience: check cached first, fall back to network.
+///
+/// If you need non-blocking behaviour, call [`check_cached`] yourself
+/// and spawn [`check_network`] in a background thread.
+pub fn check() -> Option<UpdateInfo> {
+    if let Some(info) = check_cached() {
+        return Some(info);
+    }
+    check_network().ok()
+}
+
+/// Check and print a banner to stderr if an update is available.
+///
+/// Tries cache first (instant). If cache is stale, spawns a background
+/// thread for the network check and returns a [`std::thread::JoinHandle`].
+/// The caller **must** `.join()` this handle before process exit to avoid
+/// the thread being killed prematurely.
+///
+/// If cache is fresh, prints immediately and returns `None`.
+/// If no update is available, returns `None`.
+pub fn check_and_notify() -> Option<std::thread::JoinHandle<()>> {
+    // Fast path: cache is fresh.
+    if let Some(info) = check_cached() {
+        if info.is_update_available() {
+            eprintln!("\n{}\n", info.banner());
+        }
+        return None;
+    }
+
+    // Slow path: spawn background thread.
+    let handle = std::thread::spawn(move || {
+        let _ = std::panic::catch_unwind(|| {
+            if let Some(info) = check_network().ok().filter(|i| i.is_update_available()) {
+                eprintln!("\n{}\n", info.banner());
+            }
+        });
+    });
+
+    Some(handle)
+}
+
+// ── Internals ───────────────────────────────────────────────────────────────
+
+/// Compile-time current version from `CARGO_PKG_VERSION`.
+fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Cache file path: `~/.config/uteke/update-cache.json` (or platform equivalent).
+fn cache_path() -> Option<std::path::PathBuf> {
+    dirs::config_dir().map(|d| d.join("uteke").join("update-cache.json"))
+}
+
+/// Read cache. Returns `Some(latest_version)` if cache is fresh (< 24h).
+fn read_cache() -> Option<String> {
+    let path = cache_path()?;
+    let data = std::fs::read_to_string(&path).ok()?;
+    let cache: Cache = serde_json::from_str(&data).ok()?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    if now.saturating_sub(cache.checked_at) < CACHE_TTL {
+        Some(cache.latest)
+    } else {
+        None
+    }
+}
+
+/// Persist cache to disk. Best-effort — ignores errors.
+fn write_cache(latest: &str) {
+    let Some(path) = cache_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let cache = Cache {
+        checked_at: now,
+        latest: latest.to_string(),
+    };
+
+    if let Ok(json) = serde_json::to_string(&cache) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Fetch latest release tag from GitHub.
+///
+/// Primary: follow the `/releases/latest` 302 redirect (no API call, no rate limit).
+/// Fallback: GitHub REST API.
+pub(crate) fn get_latest_version() -> Result<String, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("HTTP client build failed: {e}"))?;
+
+    // Primary: parse 302 redirect (no API call, no rate limit).
+    let resp = client
+        .head(format!("https://github.com/{REPO}/releases/latest"))
+        .send()
+        .map_err(|e| format!("Failed to check latest release: {e}"))?;
+
+    if let Some(location) = resp.headers().get("location") {
+        let loc = location.to_str().unwrap_or_default();
+        if let Some(tag) = loc.strip_prefix("/codecoradev/uteke/releases/tag/") {
+            return Ok(tag.trim_end_matches('?').to_string());
+        }
+        if let Some(tag) = loc.rsplit('/').next() {
+            if tag.starts_with('v') {
+                return Ok(tag.trim_end_matches('?').to_string());
+            }
+        }
+    }
+
+    // Fallback: GitHub API
+    let api_url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let resp = client
+        .get(&api_url)
+        .header("User-Agent", "uteke-update-check")
+        .send()
+        .map_err(|e| format!("GitHub API failed: {e}"))?;
+
+    if resp.status().is_success() {
+        let json: serde_json::Value = resp
+            .json()
+            .map_err(|e| format!("Failed to parse GitHub API response: {e}"))?;
+        if let Some(tag) = json["tag_name"].as_str() {
+            return Ok(tag.to_string());
+        }
+    }
+
+    Err(format!(
+        "Failed to determine latest version. Check https://github.com/{REPO}/releases"
+    ))
+}
+
+/// Compare semver-ish versions. Returns true if `latest` > `current`.
+///
+/// Strips leading `v` prefix. Falls back to string comparison on parse failure.
+fn is_newer(latest: &str, current: &str) -> bool {
+    let lt = latest.trim_start_matches('v');
+    let cur = current.trim_start_matches('v');
+
+    let parse = |s: &str| -> Vec<u64> {
+        s.split('.')
+            .filter_map(|p| p.split('-').next().and_then(|n| n.parse().ok()))
+            .collect()
+    };
+
+    match (parse(lt), parse(cur)) {
+        (lt_parts, cur_parts) if !lt_parts.is_empty() && !cur_parts.is_empty() => {
+            lt_parts > cur_parts
+        }
+        _ => lt > cur,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer_true() {
+        assert!(is_newer("v0.14.0", "0.13.0"));
+        assert!(is_newer("0.14.0", "0.13.0"));
+        assert!(is_newer("v1.0.0", "0.99.99"));
+        assert!(is_newer("v0.13.1", "0.13.0"));
+    }
+
+    #[test]
+    fn test_is_newer_false() {
+        assert!(!is_newer("v0.13.0", "0.13.0"));
+        assert!(!is_newer("v0.12.0", "0.13.0"));
+        assert!(!is_newer("v0.13.0", "0.13.1"));
+    }
+
+    #[test]
+    fn test_is_newer_major() {
+        assert!(is_newer("v2.0.0", "1.9.9"));
+        assert!(!is_newer("v1.9.9", "2.0.0"));
+    }
+
+    #[test]
+    fn test_update_info_banner() {
+        let info = UpdateInfo {
+            latest: "v0.14.0".to_string(),
+            current: "0.13.1".to_string(),
+        };
+        assert!(info.is_update_available());
+        assert!(info.banner().contains("v0.14.0"));
+        assert!(info.banner().contains("0.13.1"));
+    }
+
+    #[test]
+    fn test_update_info_no_update() {
+        let info = UpdateInfo {
+            latest: "v0.13.1".to_string(),
+            current: "0.13.1".to_string(),
+        };
+        assert!(!info.is_update_available());
+    }
+}

--- a/crates/uteke-core/src/update_check.rs
+++ b/crates/uteke-core/src/update_check.rs
@@ -188,7 +188,8 @@ pub(crate) fn get_latest_version() -> Result<String, String> {
 
     if let Some(location) = resp.headers().get("location") {
         let loc = location.to_str().unwrap_or_default();
-        if let Some(tag) = loc.strip_prefix("/codecoradev/uteke/releases/tag/") {
+        let prefix = format!("/{REPO}/releases/tag/");
+        if let Some(tag) = loc.strip_prefix(&prefix) {
             return Ok(tag.trim_end_matches('?').to_string());
         }
         if let Some(tag) = loc.rsplit('/').next() {

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -44,6 +44,20 @@ fn main() {
         }
     };
 
+    // Background update check — writes to stderr so it doesn't corrupt the
+    // JSON-RPC stdout channel. MCP clients capture stderr for logging.
+    // Cache is 24h so most runs skip network entirely.
+    // Detached thread — main loop blocks on stdin for hours, so join is impractical.
+    std::thread::spawn(|| {
+        let _ = std::panic::catch_unwind(|| {
+            if let Some(info) = uteke_core::update_check::check()
+                .filter(uteke_core::update_check::UpdateInfo::is_update_available)
+            {
+                eprintln!("\n{}\n", info.banner());
+            }
+        });
+    });
+
     // JSON-RPC over stdin/stdout (MCP stdio transport)
     for line in stdin.lock().lines() {
         let line = match line {

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -107,6 +107,10 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         (Method::Get, "/health") => {
             let total = uteke.count(None).unwrap_or(0);
             let namespaces = uteke.list_namespaces().unwrap_or_default().len();
+            // Populate update_available from cache (non-blocking, no network).
+            let update_available = uteke_core::update_check::check_cached()
+                .filter(|i| i.is_update_available())
+                .map(|i| i.latest);
             ctx.ok_response_for(
                 req,
                 &HealthResponse {
@@ -116,6 +120,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     namespaces,
                     api_versions: Some(API_VERSIONS.to_vec()),
                     api_latest: Some(API_LATEST),
+                    update_available,
                 },
             )
         }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -458,14 +458,15 @@ fn main() {
     // run our own. Logs via `warn!` so it's visible in structured logs.
     std::thread::spawn(move || {
         loop {
-            // Check on first iteration, then every 24h.
-            if let Ok(info) = uteke_core::update_check::check_network() {
-                if info.is_update_available() {
-                    warn!(
-                        "Uteke {} is available (currently v{}). Run `uteke upgrade` to update.",
-                        info.latest, info.current
-                    );
-                }
+            // Cache first — avoids hitting GitHub on every server restart
+            // within the 24h cache window.
+            let info = uteke_core::update_check::check_cached()
+                .or_else(|| uteke_core::update_check::check_network().ok());
+            if let Some(info) = info.filter(|i| i.is_update_available()) {
+                warn!(
+                    "Uteke {} is available (currently v{}). Run `uteke upgrade` to update.",
+                    info.latest, info.current
+                );
             }
             // Sleep 24h, checking shutdown flag hourly.
             for _ in 0..24 {

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -453,6 +453,30 @@ fn main() {
         info!("Auto-dream: disabled");
     }
 
+    // Update check — startup notification + periodic 24h re-check.
+    // Long-running server process won't see CLI's startup check, so we
+    // run our own. Logs via `warn!` so it's visible in structured logs.
+    std::thread::spawn(move || {
+        loop {
+            // Check on first iteration, then every 24h.
+            if let Ok(info) = uteke_core::update_check::check_network() {
+                if info.is_update_available() {
+                    warn!(
+                        "Uteke {} is available (currently v{}). Run `uteke upgrade` to update.",
+                        info.latest, info.current
+                    );
+                }
+            }
+            // Sleep 24h, checking shutdown flag hourly.
+            for _ in 0..24 {
+                std::thread::sleep(std::time::Duration::from_secs(3600));
+                if SHUTDOWN.load(Ordering::SeqCst) {
+                    return;
+                }
+            }
+        }
+    });
+
     // SIGINT handler
     ctrlc::set_handler(|| {
         if SHUTDOWN.load(Ordering::SeqCst) {

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -297,6 +297,10 @@ pub struct HealthResponse {
     /// Latest API version (#737).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_latest: Option<&'static str>,
+    /// Latest version available on GitHub, if newer than current.
+    /// Populated from cache (24h TTL) — may be `None` if cache is stale.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_available: Option<String>,
 }
 
 #[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -509,6 +509,8 @@ Detailed field definitions for each request type.
 | `memories` | `integer` | Yes |  |
 | `namespaces` | `integer` | Yes |  |
 | `status` | `string` | Yes |  |
+| `update_available` | any | No | Latest version available on GitHub, if newer than current.
+Populated from cache (24h TTL) — may be `None` if cache is stale. |
 | `version` | `string` | Yes | Server version (uteke-server crate version), so HTTP clients can gate
 features on the actual server capability rather than a local CLI probe. |
 


### PR DESCRIPTION
## What

Move update-check logic from uteke-cli to uteke-core so all three runtime surfaces (CLI, MCP server, HTTP server) share one code path. Each surface now notifies users when a newer version is available on GitHub.

## Why

Users running uteke via MCP (Claude Code, Cursor, Copilot) or HTTP server (Docker containers, long-running processes) had no way to know when a new version was released. Only CLI users got the startup notification. Now all surfaces check and notify.

## Changes

Core (uteke-core/src/update_check.rs) - new shared module with cached check + network check + banner formatting. 5 unit tests included.

MCP server - detached background thread at startup, writes to stderr.

HTTP server - background thread with cache-first check on startup + every 24h. Health endpoint gains update_available field.

CLI - thin wrapper over core. Config opt-out preserved.

## Testing

cargo test --workspace: 479 pass, 0 fail. Clippy: 0 warnings. Fmt: clean.
