### PR TITLE
fix(core): filter NULL embeddings from vector index build

### DIFF
--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -730,12 +730,17 @@ impl Uteke {
         if index.is_empty() {
             let all_memories = store.load_all(None)?;
             if !all_memories.is_empty() {
+                // Defense-in-depth: skip any memories with empty embeddings
+                // (NULL rows already filtered in load_all SQL, but guard here too).
                 let items: Vec<(String, Vec<f32>)> = all_memories
                     .into_iter()
+                    .filter(|m| !m.embedding.is_empty())
                     .map(|m| (m.id, m.embedding))
                     .collect();
-                index.build(&items)?;
-                index.save().ok(); // Persist after migration build
+                if !items.is_empty() {
+                    index.build(&items)?;
+                    index.save().ok(); // Persist after migration build
+                }
             }
         }
 

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -121,10 +121,11 @@ impl crate::Uteke {
             index.len()
         };
 
-        // Load all from SQLite and rebuild index
+        // Load all from SQLite and rebuild index (NULL embeddings filtered in load_all)
         let all_memories = self.store.load_all(None)?;
         let items: Vec<(String, Vec<f32>)> = all_memories
             .iter()
+            .filter(|m| !m.embedding.is_empty())
             .map(|m| (m.id.clone(), m.embedding.clone()))
             .collect();
 

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -569,12 +569,14 @@ impl super::Store {
 
     /// Load all memories for index rebuilding, optionally filtered by namespace.
     pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
+        // Filter out NULL embeddings — they cannot be inserted into the vector
+        // index and cause dimension-mismatch crashes during build() (#992).
         let sql = match namespace {
             Some(_) => {
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE namespace = ?1 ORDER BY created_at"
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE namespace = ?1 AND embedding IS NOT NULL ORDER BY created_at"
             }
             None => {
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories ORDER BY created_at"
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE embedding IS NOT NULL ORDER BY created_at"
             }
         };
 
@@ -935,5 +937,54 @@ mod content_type_tests {
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
         assert_eq!(version, 15); // v15 = room_documents junction (#689); v14 = FTS5 memory_type column (#662); v13 = global docs no namespace (#614); v12 = hierarchical docs (#438); v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
+    }
+
+    #[test]
+    fn test_load_all_excludes_null_embeddings() {
+        // Regression test for #992: load_all() must filter out NULL embeddings.
+        use crate::memory::types::Memory;
+        use chrono::Utc;
+
+        let store = super::super::store::Store::open(":memory:").unwrap();
+
+        // Insert a valid memory with embedding
+        let m1 = Memory {
+            id: "valid-1".to_string(),
+            content: "has embedding".to_string(),
+            embedding: vec![0.1; 4],
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            namespace: "default".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+            slug: None,
+            source: None,
+            source_type: "user".to_string(),
+        };
+        store.insert(&m1).unwrap();
+
+        // Insert a memory with NULL embedding (direct SQL to simulate corrupted data)
+        store
+            .conn
+            .execute(
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, memory_type)
+                 VALUES ('null-emb-1', 'no embedding', NULL, '[]', '{}', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'default', 'fact')",
+                [],
+            )
+            .unwrap();
+
+        // load_all must exclude the NULL embedding row
+        let all = store.load_all(None).unwrap();
+        assert_eq!(all.len(), 1, "load_all should exclude NULL embeddings");
+        assert_eq!(all[0].id, "valid-1");
     }
 }


### PR DESCRIPTION
## What

Fix crash where NULL embedding rows in SQLite cause `vector_index.build()` to fail with dimension mismatch error, blocking server startup and `repair_index`.

Closes #992.

## Why

Memories with `NULL` embedding silently convert to `vec![]` via `row_to_memory()`. When `load_all()` returns these rows and they reach `index.build()`, the validator rejects them (0 ≠ 768 dims), crashing the server.

Production data confirmed: 19 NULL embedding rows out of 596 memories (~3.2%).

## Changes

- **`crud.rs` — `load_all()` SQL query:** Added `WHERE embedding IS NOT NULL` to both namespace-filtered and unfiltered variants. This is the primary fix — NULL rows never enter the build pipeline.
- **`lib.rs:731-737` — startup index build:** Added `.filter(|m| !m.embedding.is_empty())` guard before `index.build()`. Also added `if !items.is_empty()` check to skip build entirely when all memories have NULL embeddings.
- **`maintenance.rs:125-136` — `repair_index`:** Same defense-in-depth filter applied.
- **`crud.rs` — regression test:** `test_load_all_excludes_null_embeddings` inserts one valid + one NULL embedding row, asserts `load_all()` returns only the valid row.

## Testing

- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets` ✅ (0 warnings)
- `cargo test --workspace` ✅ — **480 pass, 0 fail, 26 ignored** (was 479, +1 new test)
