### PR TITLE
fix(core): handle absolute URLs in update check redirect parser

### DIFF
--- a/crates/uteke-core/src/update_check.rs
+++ b/crates/uteke-core/src/update_check.rs
@@ -189,10 +189,9 @@ pub(crate) fn get_latest_version() -> Result<String, String> {
     if let Some(location) = resp.headers().get("location") {
         let loc = location.to_str().unwrap_or_default();
         // GitHub returns absolute URLs (https://github.com/codecoradev/uteke/releases/tag/v0.13.1).
-        // Use contains() to handle both absolute and relative formats.
+        // split_after the tag marker handles both absolute and relative formats safely.
         let tag_marker = format!("/{REPO}/releases/tag/");
-        if let Some(idx) = loc.find(&tag_marker) {
-            let tag = &loc[idx + tag_marker.len()..];
+        if let Some((_, tag)) = loc.split_once(&tag_marker) {
             return Ok(tag.trim_end_matches('?').to_string());
         }
         // Fallback: last path segment (works for any URL format).

--- a/crates/uteke-core/src/update_check.rs
+++ b/crates/uteke-core/src/update_check.rs
@@ -188,12 +188,16 @@ pub(crate) fn get_latest_version() -> Result<String, String> {
 
     if let Some(location) = resp.headers().get("location") {
         let loc = location.to_str().unwrap_or_default();
-        let prefix = format!("/{REPO}/releases/tag/");
-        if let Some(tag) = loc.strip_prefix(&prefix) {
+        // GitHub returns absolute URLs (https://github.com/codecoradev/uteke/releases/tag/v0.13.1).
+        // Use contains() to handle both absolute and relative formats.
+        let tag_marker = format!("/{REPO}/releases/tag/");
+        if let Some(idx) = loc.find(&tag_marker) {
+            let tag = &loc[idx + tag_marker.len()..];
             return Ok(tag.trim_end_matches('?').to_string());
         }
+        // Fallback: last path segment (works for any URL format).
         if let Some(tag) = loc.rsplit('/').next() {
-            if tag.starts_with('v') {
+            if !tag.is_empty() {
                 return Ok(tag.trim_end_matches('?').to_string());
             }
         }


### PR DESCRIPTION
## What

Fix Cora finding on PR #990: `strip_prefix` used relative path but GitHub returns absolute URLs in 302 redirects.

## Why

GitHub's 302 redirect returns `Location: https://github.com/codecoradev/uteke/releases/tag/v0.13.1` (absolute URL). The previous code used `strip_prefix("/codecoradev/uteke/releases/tag/")` which always failed on absolute URLs, falling through to the `rsplit('/')` fallback that required a `v` prefix.

## Changes

- Primary path: `strip_prefix` → `find()` to locate tag marker anywhere in URL
- Fallback: relaxed `starts_with('v')` check → `!tag.is_empty()` (accept any valid tag format)

## Testing

- `cargo fmt` ✅
- `cargo clippy --workspace --all-targets` ✅
- `cargo test --workspace` ✅ — 480 pass, 0 fail
