### PR TITLE
merge: develop → main v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## [0.13.2] — 2026-08-11
+
+Patch release with update notifications, a startup crash fix, and benchmark accuracy improvements. No breaking changes.
+
+### Added
+
+- **Update check across all surfaces (#990)** — Uteke now checks GitHub for newer releases on startup (CLI, MCP, HTTP). Uses a 302 redirect as primary source (no API rate limit), REST API as fallback, with a 24-hour cache (`~/.config/uteke/update-cache.json`). MCP server runs the check in a detached background thread to avoid blocking JSON-RPC.
+
+### Fixed
+
+- **NULL embedding rows crash vector index build on startup (#992, #993)** — `load_all()` returned rows with NULL embedding blobs, which `row_to_memory()` silently converted to `vec![]`. When these reached `index.build()`, the dimension validator rejected them (0 ≠ 768), crashing the server on startup and blocking `repair_index`. Fixed with a SQL filter (`WHERE embedding IS NOT NULL`) plus defense-in-depth guards at call sites.
+
+- **Update check redirect parser fails on absolute URLs (#994)** — GitHub 302 redirects return absolute URLs (`https://github.com/.../v0.13.1`), not relative paths. The previous `strip_prefix('/codecoradev/...')` always failed on absolute URLs, falling through to a fallback that required a `v` prefix. Fixed with `find()` to locate the tag marker anywhere in the URL. Also fixed a UTF-8 safety issue: byte-indexed slicing replaced with `split_once()`.
+
+- **LongMemEval benchmark false negatives from CLI score threshold (#995, #996)** — The benchmark harness called `uteke recall` without `--min`, inheriting the CLI default threshold of 0.3. Relevant evidence sessions scoring 0.30–0.40 were silently filtered, causing 8/500 false negatives in the Oracle subset. Fixed by passing `--min 0.0` to evaluate raw ranking quality. Also documented the threshold chain inconsistency: CLI defaults to 0.3 (UX), HTTP API and MCP default to 0.0.
+
+### Changed
+
+- **Branding refresh (#991)** — Tagline updated to "One memory. Every agent. Zero cloud." Install URL changed to `codecora.dev/uteke/install`. MCP compatibility (Claude, Cursor, Copilot) now mentioned in subtitle.
+
+### Contributors
+
+- [@ajianaz](https://github.com/ajianaz)
+
+---
+
 ## [0.13.1] — 2026-08-10
 
 Patch release focused on security hardening, data integrity, and query performance. No breaking changes. 13 commits across 32 files.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/README.id.md
+++ b/README.id.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img src="docs/assets/uteke-banner.png" alt="Uteke — Kasih AI kamu memori" width="640" />
+  <img src="docs/assets/uteke-banner.png" alt="Uteke — Satu memori. Semua agent. Tanpa cloud." width="640" />
 </p>
 
 <h1 align="center">Uteke</h1>
-<p align="center"><strong>Beri AI kamu memori yang nggak pernah keluar dari laptop kamu.</strong></p>
+<p align="center"><strong>Satu memori. Semua agent. Tanpa cloud.</strong></p>
 <p align="center">
-  AI kamu lupa semuanya antar sesi. Uteke fix ini — satu binary, fully offline, recall ~45ms.
+  Beri AI kamu memori yang nggak pernah keluar dari laptop kamu. Mendukung Claude, Cursor, Copilot, dan semua agent yang kompatibel MCP.
 </p>
 
 <p align="center">
@@ -28,7 +28,7 @@
 
 ```bash
 # Install (macOS, Linux, Windows)
-curl -sSL codecora.dev/install | sh
+curl -sSL codecora.dev/uteke/install | sh
 
 # Simpan ingatan
 uteke remember "Deploy v2.1 ke staging jam 3 sore"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img src="docs/assets/uteke-banner.png" alt="Uteke: Give your AI a memory" width="640" />
+  <img src="docs/assets/uteke-banner.png" alt="Uteke: One memory. Every agent. Zero cloud." width="640" />
 </p>
 
 <h1 align="center">Uteke</h1>
-<p align="center"><strong>Give your AI a memory that never leaves your machine.</strong></p>
+<p align="center"><strong>One memory. Every agent. Zero cloud.</strong></p>
 <p align="center">
-  Local-first by default. One binary, fully offline, ~45ms recall. Want cloud or team deployments? Docker ready.
+  Give your AI a memory that never leaves your machine. Works with Claude, Cursor, Copilot, and any MCP-compatible agent.
 </p>
 
 <p align="center">
@@ -28,7 +28,7 @@
 
 ```bash
 # Install (macOS, Linux, Windows)
-curl -sSL codecora.dev/install | sh
+curl -sSL codecora.dev/uteke/install | sh
 
 # Store a memory
 uteke remember "Deploy v2.1 to staging at 3pm"
@@ -269,7 +269,7 @@ Uteke runs the same everywhere. Pick the mode that fits your setup.
 Single binary, zero infrastructure. Everything runs in-process on your machine:
 
 ```bash
-curl -sSL codecora.dev/install | sh
+curl -sSL codecora.dev/uteke/install | sh
 uteke remember "first memory"
 ```
 

--- a/benchmarks/longmemeval/run_eval.py
+++ b/benchmarks/longmemeval/run_eval.py
@@ -134,6 +134,7 @@ def recall_and_evaluate(args, store_path, entry, answer_sessions, inserted_sids,
             "recall", question,
             "--limit", "50",
             "--tags", "longmemeval",
+            "--min", "0.0",  # Disable threshold — evaluate raw retrieval ranking (#995)
         ])
     except RuntimeError as e:
         print(f"  Warning: recall failed: {e}", file=sys.stderr)

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.13.1", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.13.2", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/commands/update_check.rs
+++ b/crates/uteke-cli/src/commands/update_check.rs
@@ -1,29 +1,8 @@
-//! Background startup update notification.
+//! Background startup update notification — thin wrapper over `uteke_core::update_check`.
 //!
-//! Checks GitHub for a newer release at most once per 24h.
-//! Prints a banner to stderr if an update is available.
-//! Never auto-upgrades — notification only.
-
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use crate::Config;
-
-/// Cache file path: `~/.config/uteke/update-cache.json` (or platform equivalent).
-fn cache_path() -> Option<std::path::PathBuf> {
-    dirs::config_dir().map(|d| d.join("uteke").join("update-cache.json"))
-}
-
-/// Cache payload persisted between runs.
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Cache {
-    /// Unix timestamp (seconds) of last check.
-    checked_at: u64,
-    /// Latest version tag found (e.g. `v0.14.0`).
-    latest: String,
-}
-
-/// Seconds before re-checking GitHub (24 hours).
-const CACHE_TTL: u64 = 86_400;
+//! Delegates all logic (fetch, cache, compare, banner) to core so MCP and HTTP
+//! servers share the same code path. The config opt-out (`update_check = false`
+//! in `uteke.toml`) is CLI-specific — core doesn't know about user config.
 
 /// Entry point: returns a `JoinHandle` that the caller should `.join()`
 /// at the end of `main()` to ensure the thread isn't killed prematurely.
@@ -31,15 +10,12 @@ const CACHE_TTL: u64 = 86_400;
 /// - If cache is fresh, prints immediately and returns `None` (no thread).
 /// - If cache is stale/missing, spawns a background thread and returns
 ///   `Some(handle)`.
+/// - Respects `update_check = false` from `uteke.toml` (CLI-only).
 pub fn spawn() -> Option<std::thread::JoinHandle<()>> {
     // Try cache first — if fresh, print immediately and skip network.
-    // No config load needed for cached path (zero disk I/O for opt-out
-    // users who have no cache file either — they fall through to thread
-    // which checks config asynchronously).
-    if let Some(latest) = read_cache() {
-        let current = env!("CARGO_PKG_VERSION");
-        if is_newer(&latest, current) {
-            print_banner(&latest, current);
+    if let Some(info) = uteke_core::update_check::check_cached() {
+        if info.is_update_available() {
+            eprintln!("\n{}\n", info.banner());
         }
         return None;
     }
@@ -47,15 +23,17 @@ pub fn spawn() -> Option<std::thread::JoinHandle<()>> {
     // Cache stale or missing — spawn background check.
     // Config opt-out check happens inside the thread to avoid
     // synchronous disk I/O on the main thread.
-    // Caller MUST join() this handle before process exit so the thread
-    // isn't killed before the network request completes.
     let handle = std::thread::spawn(move || {
         let _ = std::panic::catch_unwind(|| {
             // Respect config opt-out (checked in background thread).
             if !enabled() {
                 return;
             }
-            run_check();
+            if let Ok(info) = uteke_core::update_check::check_network() {
+                if info.is_update_available() {
+                    eprintln!("\n{}\n", info.banner());
+                }
+            }
         });
     });
 
@@ -65,115 +43,5 @@ pub fn spawn() -> Option<std::thread::JoinHandle<()>> {
 /// Read config to determine if update check is enabled.
 /// Defaults to `true` when config field is unset.
 fn enabled() -> bool {
-    Config::load().update_check
-}
-
-/// Background thread body: fetch latest version, update cache, print banner.
-fn run_check() {
-    let latest = match crate::commands::upgrade::get_latest_version() {
-        Ok(tag) => tag,
-        Err(_) => return, // network failure — silently skip
-    };
-
-    write_cache(&latest);
-
-    let current = env!("CARGO_PKG_VERSION");
-    if is_newer(&latest, current) {
-        print_banner(&latest, current);
-    }
-}
-
-/// Read cache. Returns `Some(latest_version)` if cache is fresh (< 24h).
-fn read_cache() -> Option<String> {
-    let path = cache_path()?;
-    let data = std::fs::read_to_string(&path).ok()?;
-    let cache: Cache = serde_json::from_str(&data).ok()?;
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    if now.saturating_sub(cache.checked_at) < CACHE_TTL {
-        Some(cache.latest)
-    } else {
-        None
-    }
-}
-
-/// Persist cache to disk. Best-effort — ignores errors.
-fn write_cache(latest: &str) {
-    let Some(path) = cache_path() else { return };
-
-    // Ensure parent dir exists.
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    let cache = Cache {
-        checked_at: now,
-        latest: latest.to_string(),
-    };
-
-    if let Ok(json) = serde_json::to_string(&cache) {
-        let _ = std::fs::write(&path, json);
-    }
-}
-
-/// Compare semver-ish versions. Returns true if `latest` > `current`.
-/// Strips leading `v` prefix. Falls back to string comparison on parse failure.
-fn is_newer(latest: &str, current: &str) -> bool {
-    let lt = latest.trim_start_matches('v');
-    let cur = current.trim_start_matches('v');
-
-    let parse = |s: &str| -> Vec<u64> {
-        s.split('.')
-            .filter_map(|p| p.split('-').next().and_then(|n| n.parse().ok()))
-            .collect()
-    };
-
-    match (parse(lt), parse(cur)) {
-        (lt_parts, cur_parts) if !lt_parts.is_empty() && !cur_parts.is_empty() => {
-            lt_parts > cur_parts
-        }
-        _ => lt > cur,
-    }
-}
-
-/// Print update banner to stderr.
-fn print_banner(latest: &str, current: &str) {
-    eprintln!(
-        "\n⚠ Update available: {latest}\n  \
-         Run `uteke upgrade` to update (currently v{current})\n  \
-         https://github.com/codecoradev/uteke/releases/tag/{latest}\n"
-    );
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_newer_true() {
-        assert!(is_newer("v0.14.0", "0.13.0"));
-        assert!(is_newer("0.14.0", "0.13.0"));
-        assert!(is_newer("v1.0.0", "0.99.99"));
-    }
-
-    #[test]
-    fn test_is_newer_false() {
-        assert!(!is_newer("v0.13.0", "0.13.0"));
-        assert!(!is_newer("v0.12.0", "0.13.0"));
-    }
-
-    #[test]
-    fn test_is_newer_major() {
-        assert!(is_newer("v2.0.0", "1.9.9"));
-        assert!(!is_newer("v1.9.9", "2.0.0"));
-    }
+    crate::Config::load().update_check
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -30,6 +30,7 @@ mod rooms;
 pub mod salience_recency;
 mod timeline;
 mod types;
+pub mod update_check;
 
 pub use chunker::{
     CodeChunk, TextChunk, chunk_code, chunk_markdown, chunk_markdown_embed_aware, detect_language,

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -730,12 +730,17 @@ impl Uteke {
         if index.is_empty() {
             let all_memories = store.load_all(None)?;
             if !all_memories.is_empty() {
+                // Defense-in-depth: skip any memories with empty embeddings
+                // (NULL rows already filtered in load_all SQL, but guard here too).
                 let items: Vec<(String, Vec<f32>)> = all_memories
                     .into_iter()
+                    .filter(|m| !m.embedding.is_empty())
                     .map(|m| (m.id, m.embedding))
                     .collect();
-                index.build(&items)?;
-                index.save().ok(); // Persist after migration build
+                if !items.is_empty() {
+                    index.build(&items)?;
+                    index.save().ok(); // Persist after migration build
+                }
             }
         }
 

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -121,10 +121,11 @@ impl crate::Uteke {
             index.len()
         };
 
-        // Load all from SQLite and rebuild index
+        // Load all from SQLite and rebuild index (NULL embeddings filtered in load_all)
         let all_memories = self.store.load_all(None)?;
         let items: Vec<(String, Vec<f32>)> = all_memories
             .iter()
+            .filter(|m| !m.embedding.is_empty())
             .map(|m| (m.id.clone(), m.embedding.clone()))
             .collect();
 

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -569,12 +569,14 @@ impl super::Store {
 
     /// Load all memories for index rebuilding, optionally filtered by namespace.
     pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
+        // Filter out NULL embeddings — they cannot be inserted into the vector
+        // index and cause dimension-mismatch crashes during build() (#992).
         let sql = match namespace {
             Some(_) => {
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE namespace = ?1 ORDER BY created_at"
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE namespace = ?1 AND embedding IS NOT NULL ORDER BY created_at"
             }
             None => {
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories ORDER BY created_at"
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE embedding IS NOT NULL ORDER BY created_at"
             }
         };
 
@@ -935,5 +937,54 @@ mod content_type_tests {
         assert!(store.column_exists("content_type"));
         let version = store.schema_version().unwrap();
         assert_eq!(version, 15); // v15 = room_documents junction (#689); v14 = FTS5 memory_type column (#662); v13 = global docs no namespace (#614); v12 = hierarchical docs (#438); v11 = document engine (#406); v10 = source columns (#348); v9 = timeline (#347); v8 = edges + slug; v7 = graph
+    }
+
+    #[test]
+    fn test_load_all_excludes_null_embeddings() {
+        // Regression test for #992: load_all() must filter out NULL embeddings.
+        use crate::memory::types::Memory;
+        use chrono::Utc;
+
+        let store = super::super::store::Store::open(":memory:").unwrap();
+
+        // Insert a valid memory with embedding
+        let m1 = Memory {
+            id: "valid-1".to_string(),
+            content: "has embedding".to_string(),
+            embedding: vec![0.1; 4],
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            namespace: "default".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+            slug: None,
+            source: None,
+            source_type: "user".to_string(),
+        };
+        store.insert(&m1).unwrap();
+
+        // Insert a memory with NULL embedding (direct SQL to simulate corrupted data)
+        store
+            .conn
+            .execute(
+                "INSERT INTO memories (id, content, embedding, tags, metadata, created_at, updated_at, namespace, memory_type)
+                 VALUES ('null-emb-1', 'no embedding', NULL, '[]', '{}', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'default', 'fact')",
+                [],
+            )
+            .unwrap();
+
+        // load_all must exclude the NULL embedding row
+        let all = store.load_all(None).unwrap();
+        assert_eq!(all.len(), 1, "load_all should exclude NULL embeddings");
+        assert_eq!(all[0].id, "valid-1");
     }
 }

--- a/crates/uteke-core/src/update_check.rs
+++ b/crates/uteke-core/src/update_check.rs
@@ -188,12 +188,15 @@ pub(crate) fn get_latest_version() -> Result<String, String> {
 
     if let Some(location) = resp.headers().get("location") {
         let loc = location.to_str().unwrap_or_default();
-        let prefix = format!("/{REPO}/releases/tag/");
-        if let Some(tag) = loc.strip_prefix(&prefix) {
+        // GitHub returns absolute URLs (https://github.com/codecoradev/uteke/releases/tag/v0.13.1).
+        // split_after the tag marker handles both absolute and relative formats safely.
+        let tag_marker = format!("/{REPO}/releases/tag/");
+        if let Some((_, tag)) = loc.split_once(&tag_marker) {
             return Ok(tag.trim_end_matches('?').to_string());
         }
+        // Fallback: last path segment (works for any URL format).
         if let Some(tag) = loc.rsplit('/').next() {
-            if tag.starts_with('v') {
+            if !tag.is_empty() {
                 return Ok(tag.trim_end_matches('?').to_string());
             }
         }

--- a/crates/uteke-core/src/update_check.rs
+++ b/crates/uteke-core/src/update_check.rs
@@ -1,0 +1,289 @@
+//! Update check — compare installed version against latest GitHub release.
+//!
+//! Shared by CLI, MCP server, and HTTP server. Each surface calls
+//! [`check_and_notify`] on startup (and periodically, for long-running servers).
+//!
+//! Uses a 24h cache file to avoid hammering GitHub. Network failures are
+//! silently swallowed — this is a notification, not a critical path.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Crate name on GitHub (`codecoradev/uteke`).
+const REPO: &str = "codecoradev/uteke";
+
+/// Seconds before re-checking GitHub (24 hours).
+const CACHE_TTL: u64 = 86_400;
+
+/// Cache payload persisted between runs.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Cache {
+    /// Unix timestamp (seconds) of last check.
+    checked_at: u64,
+    /// Latest version tag found (e.g. `v0.13.1`).
+    latest: String,
+}
+
+/// Result of an update check.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// Latest version tag from GitHub (e.g. `v0.14.0`).
+    pub latest: String,
+    /// Current installed version (e.g. `0.13.1`).
+    pub current: String,
+}
+
+impl UpdateInfo {
+    /// Returns `true` if `latest` is newer than `current`.
+    pub fn is_update_available(&self) -> bool {
+        is_newer(&self.latest, &self.current)
+    }
+
+    /// One-line banner for stderr/logs.
+    ///
+    /// ```text
+    /// ⚠ Update available: v0.14.0 (currently v0.13.1) — run `uteke upgrade`
+    /// ```
+    pub fn banner(&self) -> String {
+        format!(
+            "⚠ Update available: {} (currently v{}) — run `uteke upgrade` or visit https://github.com/{}/releases/tag/{}",
+            self.latest, self.current, REPO, self.latest
+        )
+    }
+}
+
+/// Check for updates using cached data (no network I/O).
+///
+/// Returns `Some(UpdateInfo)` if the cache is fresh (< 24h) and contains
+/// a version string. Returns `None` if cache is stale, missing, or corrupt.
+pub fn check_cached() -> Option<UpdateInfo> {
+    let latest = read_cache()?;
+    Some(UpdateInfo {
+        latest,
+        current: current_version().to_string(),
+    })
+}
+
+/// Synchronous network check. Fetches latest version from GitHub,
+/// updates the cache, and returns `UpdateInfo`.
+///
+/// # Errors
+/// Returns `Err` only on network failure. Callers should silently ignore.
+pub fn check_network() -> Result<UpdateInfo, String> {
+    let latest = get_latest_version()?;
+    write_cache(&latest);
+    Ok(UpdateInfo {
+        latest,
+        current: current_version().to_string(),
+    })
+}
+
+/// Convenience: check cached first, fall back to network.
+///
+/// If you need non-blocking behaviour, call [`check_cached`] yourself
+/// and spawn [`check_network`] in a background thread.
+pub fn check() -> Option<UpdateInfo> {
+    if let Some(info) = check_cached() {
+        return Some(info);
+    }
+    check_network().ok()
+}
+
+/// Check and print a banner to stderr if an update is available.
+///
+/// Tries cache first (instant). If cache is stale, spawns a background
+/// thread for the network check and returns a [`std::thread::JoinHandle`].
+/// The caller **must** `.join()` this handle before process exit to avoid
+/// the thread being killed prematurely.
+///
+/// If cache is fresh, prints immediately and returns `None`.
+/// If no update is available, returns `None`.
+pub fn check_and_notify() -> Option<std::thread::JoinHandle<()>> {
+    // Fast path: cache is fresh.
+    if let Some(info) = check_cached() {
+        if info.is_update_available() {
+            eprintln!("\n{}\n", info.banner());
+        }
+        return None;
+    }
+
+    // Slow path: spawn background thread.
+    let handle = std::thread::spawn(move || {
+        let _ = std::panic::catch_unwind(|| {
+            if let Some(info) = check_network().ok().filter(|i| i.is_update_available()) {
+                eprintln!("\n{}\n", info.banner());
+            }
+        });
+    });
+
+    Some(handle)
+}
+
+// ── Internals ───────────────────────────────────────────────────────────────
+
+/// Compile-time current version from `CARGO_PKG_VERSION`.
+fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Cache file path: `~/.config/uteke/update-cache.json` (or platform equivalent).
+fn cache_path() -> Option<std::path::PathBuf> {
+    dirs::config_dir().map(|d| d.join("uteke").join("update-cache.json"))
+}
+
+/// Read cache. Returns `Some(latest_version)` if cache is fresh (< 24h).
+fn read_cache() -> Option<String> {
+    let path = cache_path()?;
+    let data = std::fs::read_to_string(&path).ok()?;
+    let cache: Cache = serde_json::from_str(&data).ok()?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    if now.saturating_sub(cache.checked_at) < CACHE_TTL {
+        Some(cache.latest)
+    } else {
+        None
+    }
+}
+
+/// Persist cache to disk. Best-effort — ignores errors.
+fn write_cache(latest: &str) {
+    let Some(path) = cache_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let cache = Cache {
+        checked_at: now,
+        latest: latest.to_string(),
+    };
+
+    if let Ok(json) = serde_json::to_string(&cache) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Fetch latest release tag from GitHub.
+///
+/// Primary: follow the `/releases/latest` 302 redirect (no API call, no rate limit).
+/// Fallback: GitHub REST API.
+pub(crate) fn get_latest_version() -> Result<String, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("HTTP client build failed: {e}"))?;
+
+    // Primary: parse 302 redirect (no API call, no rate limit).
+    let resp = client
+        .head(format!("https://github.com/{REPO}/releases/latest"))
+        .send()
+        .map_err(|e| format!("Failed to check latest release: {e}"))?;
+
+    if let Some(location) = resp.headers().get("location") {
+        let loc = location.to_str().unwrap_or_default();
+        let prefix = format!("/{REPO}/releases/tag/");
+        if let Some(tag) = loc.strip_prefix(&prefix) {
+            return Ok(tag.trim_end_matches('?').to_string());
+        }
+        if let Some(tag) = loc.rsplit('/').next() {
+            if tag.starts_with('v') {
+                return Ok(tag.trim_end_matches('?').to_string());
+            }
+        }
+    }
+
+    // Fallback: GitHub API
+    let api_url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let resp = client
+        .get(&api_url)
+        .header("User-Agent", "uteke-update-check")
+        .send()
+        .map_err(|e| format!("GitHub API failed: {e}"))?;
+
+    if resp.status().is_success() {
+        let json: serde_json::Value = resp
+            .json()
+            .map_err(|e| format!("Failed to parse GitHub API response: {e}"))?;
+        if let Some(tag) = json["tag_name"].as_str() {
+            return Ok(tag.to_string());
+        }
+    }
+
+    Err(format!(
+        "Failed to determine latest version. Check https://github.com/{REPO}/releases"
+    ))
+}
+
+/// Compare semver-ish versions. Returns true if `latest` > `current`.
+///
+/// Strips leading `v` prefix. Falls back to string comparison on parse failure.
+fn is_newer(latest: &str, current: &str) -> bool {
+    let lt = latest.trim_start_matches('v');
+    let cur = current.trim_start_matches('v');
+
+    let parse = |s: &str| -> Vec<u64> {
+        s.split('.')
+            .filter_map(|p| p.split('-').next().and_then(|n| n.parse().ok()))
+            .collect()
+    };
+
+    match (parse(lt), parse(cur)) {
+        (lt_parts, cur_parts) if !lt_parts.is_empty() && !cur_parts.is_empty() => {
+            lt_parts > cur_parts
+        }
+        _ => lt > cur,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer_true() {
+        assert!(is_newer("v0.14.0", "0.13.0"));
+        assert!(is_newer("0.14.0", "0.13.0"));
+        assert!(is_newer("v1.0.0", "0.99.99"));
+        assert!(is_newer("v0.13.1", "0.13.0"));
+    }
+
+    #[test]
+    fn test_is_newer_false() {
+        assert!(!is_newer("v0.13.0", "0.13.0"));
+        assert!(!is_newer("v0.12.0", "0.13.0"));
+        assert!(!is_newer("v0.13.0", "0.13.1"));
+    }
+
+    #[test]
+    fn test_is_newer_major() {
+        assert!(is_newer("v2.0.0", "1.9.9"));
+        assert!(!is_newer("v1.9.9", "2.0.0"));
+    }
+
+    #[test]
+    fn test_update_info_banner() {
+        let info = UpdateInfo {
+            latest: "v0.14.0".to_string(),
+            current: "0.13.1".to_string(),
+        };
+        assert!(info.is_update_available());
+        assert!(info.banner().contains("v0.14.0"));
+        assert!(info.banner().contains("0.13.1"));
+    }
+
+    #[test]
+    fn test_update_info_no_update() {
+        let info = UpdateInfo {
+            latest: "v0.13.1".to_string(),
+            current: "0.13.1".to_string(),
+        };
+        assert!(!info.is_update_available());
+    }
+}

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.13.1", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.13.2", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-mcp/src/main.rs
+++ b/crates/uteke-mcp/src/main.rs
@@ -44,6 +44,20 @@ fn main() {
         }
     };
 
+    // Background update check — writes to stderr so it doesn't corrupt the
+    // JSON-RPC stdout channel. MCP clients capture stderr for logging.
+    // Cache is 24h so most runs skip network entirely.
+    // Detached thread — main loop blocks on stdin for hours, so join is impractical.
+    std::thread::spawn(|| {
+        let _ = std::panic::catch_unwind(|| {
+            if let Some(info) = uteke_core::update_check::check()
+                .filter(uteke_core::update_check::UpdateInfo::is_update_available)
+            {
+                eprintln!("\n{}\n", info.banner());
+            }
+        });
+    });
+
     // JSON-RPC over stdin/stdout (MCP stdio transport)
     for line in stdin.lock().lines() {
         let line = match line {

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.13.1", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.13.1" }
+uteke-core = { path = "../uteke-core", version = "0.13.2", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.13.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -107,6 +107,10 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
         (Method::Get, "/health") => {
             let total = uteke.count(None).unwrap_or(0);
             let namespaces = uteke.list_namespaces().unwrap_or_default().len();
+            // Populate update_available from cache (non-blocking, no network).
+            let update_available = uteke_core::update_check::check_cached()
+                .filter(|i| i.is_update_available())
+                .map(|i| i.latest);
             ctx.ok_response_for(
                 req,
                 &HealthResponse {
@@ -116,6 +120,7 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     namespaces,
                     api_versions: Some(API_VERSIONS.to_vec()),
                     api_latest: Some(API_LATEST),
+                    update_available,
                 },
             )
         }

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -453,6 +453,31 @@ fn main() {
         info!("Auto-dream: disabled");
     }
 
+    // Update check — startup notification + periodic 24h re-check.
+    // Long-running server process won't see CLI's startup check, so we
+    // run our own. Logs via `warn!` so it's visible in structured logs.
+    std::thread::spawn(move || {
+        loop {
+            // Cache first — avoids hitting GitHub on every server restart
+            // within the 24h cache window.
+            let info = uteke_core::update_check::check_cached()
+                .or_else(|| uteke_core::update_check::check_network().ok());
+            if let Some(info) = info.filter(|i| i.is_update_available()) {
+                warn!(
+                    "Uteke {} is available (currently v{}). Run `uteke upgrade` to update.",
+                    info.latest, info.current
+                );
+            }
+            // Sleep 24h, checking shutdown flag hourly.
+            for _ in 0..24 {
+                std::thread::sleep(std::time::Duration::from_secs(3600));
+                if SHUTDOWN.load(Ordering::SeqCst) {
+                    return;
+                }
+            }
+        }
+    });
+
     // SIGINT handler
     ctrlc::set_handler(|| {
         if SHUTDOWN.load(Ordering::SeqCst) {

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -297,6 +297,10 @@ pub struct HealthResponse {
     /// Latest API version (#737).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_latest: Option<&'static str>,
+    /// Latest version available on GitHub, if newer than current.
+    /// Populated from cache (24h TTL) — may be `None` if cache is stale.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_available: Option<String>,
 }
 
 #[cfg_attr(feature = "docgen", derive(schemars::JsonSchema))]

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -224,7 +224,8 @@ pub struct RecallRequest {
     /// Filter by category metadata.
     #[serde(default)]
     pub category: Option<String>,
-    /// Minimum similarity score. Results below are filtered.
+    /// Minimum similarity score (0.0-1.0). Results below are filtered.
+    /// Default: 0.0 (no filtering). Use `strict=true` for 0.5 default (#995).
     #[serde(default)]
     pub min_score: Option<f32>,
     /// Use strict threshold (defaults to 0.5 if min_score not set).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,12 +3,12 @@ import { createConfig } from '@codecora/theme/vitepress/config'
 export default createConfig({
   product: 'uteke',
   title: 'Uteke',
-  description: 'Local-first semantic memory engine. Single binary, zero infrastructure, 30ms recall.',
+  description: 'Offline semantic memory for AI agents. One binary, every MCP client, zero cloud. ~45ms recall.',
   accent: 'green',
   repo: 'uteke',
   head: [
-    ['meta', { property: 'og:title', content: 'Uteke — Give Your AI a Memory' }],
-    ['meta', { property: 'og:description', content: 'Offline-first semantic memory. Single binary. Zero config. 30ms recall.' }],
+    ['meta', { property: 'og:title', content: 'Uteke — One Memory. Every Agent. Zero Cloud.' }],
+    ['meta', { property: 'og:description', content: 'Offline semantic memory for AI agents. One binary, every MCP client, zero cloud. ~45ms recall.' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
   ],
   ignoreDeadLinks: true,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -509,6 +509,8 @@ Detailed field definitions for each request type.
 | `memories` | `integer` | Yes |  |
 | `namespaces` | `integer` | Yes |  |
 | `status` | `string` | Yes |  |
+| `update_available` | any | No | Latest version available on GitHub, if newer than current.
+Populated from cache (24h TTL) — may be `None` if cache is stale. |
 | `version` | `string` | Yes | Server version (uteke-server crate version), so HTTP clients can gate
 features on the actual server capability rather than a local CLI probe. |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -621,7 +621,8 @@ When true, populates `linked_doc_slugs` on memory results and
 `linked_memory_ids` on document results. |
 | `entity` | any | No | Filter by entity metadata. |
 | `limit` | `integer` | No |  |
-| `min_score` | any | No | Minimum similarity score. Results below are filtered. |
+| `min_score` | any | No | Minimum similarity score (0.0-1.0). Results below are filtered.
+Default: 0.0 (no filtering). Use `strict=true` for 0.5 default (#995). |
 | `namespace` | any | No |  |
 | `query` | `string` | Yes |  |
 | `search_type` | any | No | Search type filter: "all" (default, unified), "memory", or "doc" (#531). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,12 +213,24 @@ graph_rerank_enabled = true   # master switch; false → graph acts like hybrid
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `min_score` | 0.3 | Minimum similarity score (0.0-1.0) |
-| `min_score_strict` | 0.5 | Strict-mode threshold (used with `--strict`) |
+| `min_score` | 0.3 | Minimum similarity score (0.0-1.0). **CLI only.** |
+| `min_score_strict` | 0.5 | Strict-mode threshold (used with `--strict`). **CLI only.** |
 | `default_strategy` | `vector` | Default recall strategy (`vector\|fts5\|hybrid\|graph`) |
 | `graph_density_weight` | 0.1 | Edge-density boost weight (graph strategy only) |
 | `graph_authority_weight` | 0.1 | Incoming-edge authority boost weight (graph strategy only) |
 | `graph_rerank_enabled` | true | Master switch for graph reranking |
+
+> **⚠️ Threshold defaults differ across interfaces (#995)**
+>
+> | Interface | Default `min_score` | Notes |
+> |-----------|---------------------|-------|
+> | **CLI** | `0.3` (from `[recall] min_score`) | Reads from `uteke.toml`. `--min 0.0` to disable. |
+> | **HTTP API / Server** | `0.0` (`DEFAULT_MIN_SCORE`) | Server has its own constant, ignores `[recall] min_score`. |
+> | **MCP** | `0.0` | MCP server hardcodes 0.0. |
+>
+> This means a score of 0.25 is returned by API/MCP but **filtered out** by CLI.
+> For benchmark/retrieval evaluation, always pass `--min 0.0` explicitly to
+> evaluate raw ranking quality without UX threshold filtering.
 
 ### Salience + Recency Boost (#352)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: uteke
-  text: Give Your AI a Memory
-  tagline: Local-first semantic memory engine. Single Rust binary, zero infrastructure, 30ms recall, fully offline.
+  text: One Memory. Every Agent. Zero Cloud.
+  tagline: Give your AI a memory that never leaves your machine. Works with Claude, Cursor, Copilot, and any MCP-compatible agent.
   actions:
     - theme: brand
       text: Get Started


### PR DESCRIPTION
## What

Sync develop → main for v0.13.2 release.

## Why

All changes since v0.13.1 have been merged to develop and CI-verified. This PR promotes them to main for tagging.

## Changes

All commits from v0.13.1..develop (5 commits):
- feat: update check (#990)
- fix: NULL embeddings crash (#992, #993)
- chore: branding refresh (#991)
- fix: absolute URL redirect parser (#994)
- fix: benchmark threshold (#995, #996)
- chore: version bump + CHANGELOG (#997)

## Testing

CI will run full suite on this PR.