### PR TITLE
fix(docs): standardize recall latency to ~45ms

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,7 +237,7 @@ Protocol version: `2025-06-18` (Streamable HTTP spec). 1 MiB body limit enforced
 
 | Mode | Recall | Setup |
 |------|--------|-------|
-| **Library (Rust)** | **~30ms** | In-process, no startup |
+| **Library (Rust)** | **~45ms** | In-process, no startup |
 | **Server (HTTP)** | **~42ms** | One-time ~2s init |
 | **CLI (binary)** | **~3s** | Per-invocation (model load) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ features:
 | Install | 1 binary | pip + Docker + Qdrant | pip + Docker + Postgres | pip + Docker + Neo4j |
 | API Keys | ✅ None | ❌ OpenAI/LLM key | ❌ LLM key | ❌ LLM + vector DB |
 | Offline | ✅ Fully | ❌ Cloud embedding | ❌ Needs server | ❌ Needs LLM + DB |
-| Recall Speed | ~30ms | Network RTT | Network RTT | Network RTT |
+| Recall Speed | ~45ms | Network RTT | Network RTT | Network RTT |
 | Privacy | ✅ Local | ⚠️ Sent to LLM | ⚠️ Sent to LLM | ⚠️ Sent to LLM |
 
 [See full comparison →](/comparison)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -320,6 +320,6 @@ See [Docker guide — MCP](/docker#mcp-model-context-protocol) for full Docker-s
 | `Permission denied` | `chmod +x $(which uteke-mcp)` or ensure the binary is on your `PATH` |
 | `Connection refused` (HTTP) | Ensure `uteke-serve` is running: `uteke-serve` |
 | Client can't see tools | Verify the MCP config JSON is valid and the client has been restarted |
-| Slow first query | The embedding model (~188MB) downloads on first use — subsequent calls are ~30ms |
+| Slow first query | The embedding model (~188MB) downloads on first use — subsequent calls are ~45ms |
 
 See also: [Architecture — MCP Transport](/architecture#mcp-transport-381)


### PR DESCRIPTION
## What
3 docs files still referenced `~30ms` (stale from early benchmarks). Standardized to `~45ms` to match README, benchmarks.md, comparison.md, and config.ts.

## Why
The actual measured P50 recall latency at 1K–10K memories is **~45ms** per `benchmarks.md`. Three docs files had the old `~30ms` number from early development. Inconsistent latency claims across docs undermine credibility.

## How
Find-and-replace `~30ms` → `~45ms` in:
- `docs/architecture.md` — Library Rust row
- `docs/mcp.md` — Troubleshooting table
- `docs/index.md` — Comparison table

## Testing

- [x] `cargo test --workspace` passes *(docs-only change, no code touched)*
- [x] `cargo fmt --all -- --check` passes *(no Rust changes)*
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes *(no Rust changes)*
- [x] Cora review passed in CI
- [x] Manual verification: `grep -rn '30ms' docs/ README.md` → 0 results

## Related Issues
N/A

## Checklist

- [x] Branch name follows convention (`docs/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR (no mixed concerns)