### PR TITLE
perf: Phase 2 — skip update check in batch mode + pre-truncate embedding text

### DIFF
--- a/benchmarks/longmemeval/run_eval.py
+++ b/benchmarks/longmemeval/run_eval.py
@@ -31,6 +31,9 @@ if os.environ.get("EMBED_API_KEY") and os.environ.get("EMBED_API_BASE"):
     if os.environ.get("EMBED_MODEL"):
         os.environ.setdefault("UTEKE_EMBEDDING_MODEL", os.environ["EMBED_MODEL"])
 
+# Skip CLI update check in subprocess calls — saves ~500ms per call (#1006).
+os.environ["UTEKE_NO_UPDATE_CHECK"] = "1"
+
 try:
     from tqdm import tqdm
 except ImportError:

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -35,7 +35,12 @@ fn main() {
             | Commands::Bench { .. }
             | Commands::Upgrade { .. }
     );
-    let update_handle = if !early_exit {
+    // Skip update check in subprocess/batch mode (e.g. benchmarks calling
+    // `uteke recall` 1000× via subprocess). Env var set by benchmark scripts
+    // and any automated pipeline (#1006).
+    let skip_update_check = std::env::var("UTEKE_NO_UPDATE_CHECK").is_ok();
+
+    let update_handle = if !early_exit && !skip_update_check {
         commands::update_check::spawn()
     } else {
         None

--- a/crates/uteke-core/src/embed/engine.rs
+++ b/crates/uteke-core/src/embed/engine.rs
@@ -229,8 +229,24 @@ impl OnnxEmbedder {
                 .as_ref()
                 .ok_or_else(|| Error::embed_msg("tokenizer not loaded after lazy_load"))?;
 
+            // Pre-truncate text to avoid tokenizing content beyond MAX_SEQ_LEN (#1002).
+            // ~4 chars per token is a conservative estimate; truncating slightly short
+            // is harmless because we discard tokens past MAX_SEQ_LEN anyway.
+            const CHARS_PER_TOKEN: usize = 4;
+            let max_chars = MAX_SEQ_LEN.saturating_mul(CHARS_PER_TOKEN);
+            let truncated_text: &str = if text.len() > max_chars {
+                // Find the nearest char boundary at or below max_chars (MSRV-safe).
+                let mut end = max_chars;
+                while end > 0 && !text.is_char_boundary(end) {
+                    end -= 1;
+                }
+                &text[..end]
+            } else {
+                text
+            };
+
             let encoding = tokenizer
-                .encode(text, true)
+                .encode(truncated_text, true)
                 .map_err(|e| Error::embed("tokenize text", e))?;
 
             let input_ids = encoding.get_ids();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -496,6 +496,14 @@ update_check = true    # Set to false to disable startup update notification
 
 When an update is available, a banner is printed to **stderr** (does not interfere with stdout pipes). The check is non-blocking: it runs in a background thread joined before process exit, so it never delays command execution.
 
+### Skipping in batch/subprocess mode (#1006)
+
+Set the `UTEKE_NO_UPDATE_CHECK=1` environment variable to skip the update check entirely. This is useful for benchmarks, scripts, or automated pipelines that invoke `uteke` many times via subprocess:
+
+```bash
+export UTEKE_NO_UPDATE_CHECK=1
+```
+
 ## Memory Lifecycle (#928–#937)
 
 Uteke uses a soft-delete lifecycle model. Memories are never hard-deleted directly by automated processes. They transition through a deprecated state before eventual pruning.


### PR DESCRIPTION
## What

Performance improvements addressing 4 issues from competitive analysis.

## Why

Phase 2 of hybrid-default rollout. Two real fixes + two issues verified as already resolved.

## Changes

- **#1006**: `UTEKE_NO_UPDATE_CHECK=1` env var skips background update check thread. Benchmark script sets this automatically — saves ~500ms × 1000 subprocess calls.
- **#1002**: Pre-truncate text before `tokenizer.encode()` using 4 chars/token heuristic with MSRV-safe char-boundary handling. Avoids tokenizing content beyond `MAX_SEQ_LEN` (2048) that gets discarded anyway.
- **#1003**: Already resolved — `idx_memories_namespace` index exists in `SCHEMA_INDEXES`. `memories_in_namespace()` query uses indexed lookup, not full scan.
- **#1004**: Already resolved — `compute_graph_signals` uses single batched SQL query (`WHERE source_id IN (...) OR target_id IN (...)`), not N+1.

## Testing

- `cargo check` ✅
- `cargo clippy --all-targets` ✅ zero warnings
- `cargo test` ✅ 479 pass, 0 fail, 25 ignored
- `cora review` ✅ no issues