### PR TITLE
feat: Phase 3 — lifecycle/deprecated, memory tools guide, source provenance (#1007, #1010, #1012, #1013)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -211,6 +211,8 @@ pub enum Commands {
     },
     /// Show memory store statistics
     Stats,
+    /// Print agent-facing memory tools guide for system prompt injection (#1010)
+    Guide,
     /// Check system health (DB, index, model, consistency)
     Doctor,
     /// Verify DB and index consistency

--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -214,6 +214,9 @@ pub(crate) struct ExtractOpts<'a> {
     pub base_url: Option<String>,
     pub max_facts: Option<usize>,
     pub cfg: &'a crate::config::ExtractionConfig,
+    /// Auto-detected source label for provenance (#1013).
+    /// Set to the input filename/path, or None for stdin.
+    pub source_label: Option<&'a str>,
 }
 
 pub(crate) fn run_import(
@@ -241,8 +244,13 @@ pub(crate) fn run_import(
     // then store each fact as its own memory. Bypasses format detection because
     // the model handles arbitrary noisy text (transcripts, dumps, notes).
     if extract_opts.enabled {
+        // Auto-populate source label from input filename (#1013).
+        let mut opts = extract_opts;
+        if opts.source_label.is_none() && input != "-" {
+            opts.source_label = Some(input);
+        }
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
-        let result = import_with_extraction(uteke, &content, &tag_refs, ns, &extract_opts)?;
+        let result = import_with_extraction(uteke, &content, &tag_refs, ns, &opts)?;
         if cli.json {
             output::print_json(&result);
         } else {
@@ -376,7 +384,11 @@ fn import_with_extraction(
     let mut skipped = 0usize;
     for fact in &facts {
         match uteke.remember(fact, tags, None, ns) {
-            Ok(_) => imported += 1,
+            Ok(id) => {
+                // Auto-populate source provenance (#1013).
+                let _ = uteke.set_source(&id, opts.source_label, "extract");
+                imported += 1;
+            }
             Err(e) => {
                 tracing::warn!("Failed to store extracted fact: {e}");
                 skipped += 1;

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -167,6 +167,11 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
 
         Commands::Stats => list::run_stats(cli, uteke, ns),
 
+        Commands::Guide => {
+            println!("{}", uteke_core::guide::default_guide());
+            Ok(())
+        }
+
         Commands::Doctor => maintenance::run_doctor(cli, uteke),
 
         Commands::Verify => maintenance::run_verify(cli, uteke),
@@ -210,6 +215,7 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
                 base_url: extract_base_url.clone(),
                 max_facts: *extract_max_facts,
                 cfg: &config.extraction,
+                source_label: None, // Populated per-input in run_import (#1013)
             };
 
             // Batch mode: import entire directory

--- a/crates/uteke-cli/src/output.rs
+++ b/crates/uteke-cli/src/output.rs
@@ -83,7 +83,8 @@ pub(crate) fn print_unified_human(results: &[uteke_core::UnifiedSearchResult]) {
                     println!("     Type: {}", mt);
                 }
                 if let Some(src) = &r.source {
-                    println!("     Source: {}", src);
+                    let st = r.source_type.as_deref().unwrap_or("user");
+                    println!("     Source: {src} ({st})");
                 }
                 if let Some(imp) = r.importance {
                     println!("     Importance: {:.2}", imp);

--- a/crates/uteke-core/src/guide.rs
+++ b/crates/uteke-core/src/guide.rs
@@ -1,0 +1,128 @@
+//! Agent-facing memory tools guide (#1010).
+//!
+//! Provides a standardized guide string that can be injected into agent system
+//! prompts alongside recalled memories, teaching the agent how to actively
+//! retrieve deeper memories when injected context is insufficient.
+
+/// Available memory tools that an agent integration can expose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryTool {
+    /// Semantic hybrid search (vector + FTS5, ranked by RRF).
+    Recall,
+    /// FTS5 keyword-only search.
+    Search,
+    /// Scoped recall within a specific Room.
+    RoomRecall,
+    /// Store a new memory.
+    Remember,
+}
+
+impl MemoryTool {
+    /// Returns the tool name as it would appear in an MCP/API interface.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Recall => "uteke_recall",
+            Self::Search => "uteke_search",
+            Self::RoomRecall => "uteke_room_recall",
+            Self::Remember => "uteke_remember",
+        }
+    }
+
+    /// Short description for the guide.
+    fn description(self) -> &'static str {
+        match self {
+            Self::Recall => "Semantic hybrid search across all memory types. Use for most queries.",
+            Self::Search => "FTS5 keyword search. Use when you need exact term matches.",
+            Self::RoomRecall => "Scoped search within a specific Room namespace.",
+            Self::Remember => "Store a new memory (fact, decision, procedure, etc.).",
+        }
+    }
+}
+
+/// Returns a formatted guide for agent-facing memory tool usage.
+///
+/// Designed to be appended to a system prompt alongside recalled memories.
+/// Only documents the tools the integration actually exposes.
+///
+/// # Arguments
+/// * `available_tools` - Slice of tools the agent can call.
+/// * `max_searches` - Max recall/search calls recommended per turn.
+pub fn recall_guide(available_tools: &[MemoryTool], max_searches: u32) -> String {
+    let mut tools_section = String::new();
+    for tool in available_tools {
+        tools_section.push_str(&format!("- **{}**: {}\n", tool.name(), tool.description()));
+    }
+
+    format!(
+        r#"<memory-tools-guide>
+## Available Memory Tools
+
+{tools_section}## Guidelines
+
+- Injected context above was pre-fetched. If it fully answers the query, **do not search again**.
+- If context is insufficient, use `{recall_tool}` for deeper retrieval.
+- **Max {max} search call(s) per turn.** If {max} search(es) yield nothing relevant, the information is likely not stored — answer with available context.
+- Use `{remember_tool}` only for genuinely new facts, decisions, or preferences — not for re-stating what's already stored.
+</memory-tools-guide>"#,
+        tools_section = tools_section,
+        recall_tool = available_tools
+            .iter()
+            .find(|t| **t == MemoryTool::Recall)
+            .map(|t| t.name())
+            .unwrap_or("uteke_recall"),
+        remember_tool = available_tools
+            .iter()
+            .find(|t| **t == MemoryTool::Remember)
+            .map(|t| t.name())
+            .unwrap_or("uteke_remember"),
+        max = max_searches,
+    )
+}
+
+/// Convenience: the default guide with all four tools and max 3 searches.
+pub fn default_guide() -> String {
+    recall_guide(
+        &[
+            MemoryTool::Recall,
+            MemoryTool::Search,
+            MemoryTool::RoomRecall,
+            MemoryTool::Remember,
+        ],
+        3,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_guide_contains_all_tools() {
+        let guide = default_guide();
+        assert!(guide.contains("uteke_recall"));
+        assert!(guide.contains("uteke_search"));
+        assert!(guide.contains("uteke_room_recall"));
+        assert!(guide.contains("uteke_remember"));
+    }
+
+    #[test]
+    fn test_default_guide_has_max_searches() {
+        let guide = default_guide();
+        assert!(guide.contains("Max 3 search"));
+    }
+
+    #[test]
+    fn test_custom_tools_subset() {
+        let guide = recall_guide(&[MemoryTool::Recall], 2);
+        assert!(guide.contains("uteke_recall"));
+        assert!(!guide.contains("uteke_search"));
+        assert!(guide.contains("Max 2 search"));
+    }
+
+    #[test]
+    fn test_guide_is_wrapped_in_tags() {
+        let guide = default_guide();
+        assert!(guide.starts_with("<memory-tools-guide>"));
+        assert!(guide.ends_with("</memory-tools-guide>"));
+    }
+}

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -18,6 +18,7 @@ mod error;
 pub mod extraction;
 pub mod graph;
 pub mod graph_rerank;
+pub mod guide;
 mod import_export;
 mod jaccard;
 mod maintenance;
@@ -44,6 +45,7 @@ pub use edges::{
 pub use graph::{GraphEdge, GraphNode, GraphPath, GraphStats, GraphStore, GraphTriple};
 pub use graph::{Relationship, VALID_REL_TYPES, build_meta_relationship, is_relationship_meta};
 pub use graph_rerank::{GraphRerankConfig, GraphSignals, compute_graph_signals, rerank_with_graph};
+pub use memory::aging::DeprecatedMemoryInfo;
 pub use memory::types::{
     AgingStatus, BulkDeleteResult, CleanupResult, ConsolidationResult, ContradictionResult,
     DEFAULT_NAMESPACE, ExportEntry, ImportResult, Memory, MemoryTier, MemoryType, PruneResult,

--- a/crates/uteke-core/src/memory/aging.rs
+++ b/crates/uteke-core/src/memory/aging.rs
@@ -84,6 +84,51 @@ impl super::Store {
         Ok(count as usize)
     }
 
+    /// List deprecated memories with metadata for TTL display.
+    ///
+    /// Returns memories that are deprecated=1, ordered by most recently deprecated first.
+    /// Optionally filter by namespace.
+    pub fn list_deprecated(
+        &self,
+        namespace: Option<&str>,
+        limit: u32,
+    ) -> Result<Vec<DeprecatedMemoryInfo>, Error> {
+        let limit = limit.max(1) as i64;
+        let sql = if namespace.is_some() {
+            r#"SELECT id, content, memory_type, namespace, tags, importance,
+                      valid_until, deprecate_reason, updated_at
+               FROM memories
+               WHERE deprecated = 1 AND namespace = ?1
+               ORDER BY updated_at DESC
+               LIMIT ?2"#
+        } else {
+            r#"SELECT id, content, memory_type, namespace, tags, importance,
+                      valid_until, deprecate_reason, updated_at
+               FROM memories
+               WHERE deprecated = 1
+               ORDER BY updated_at DESC
+               LIMIT ?1"#
+        };
+
+        let ns = namespace.map(|s| s.to_string());
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| Error::db("prepare list_deprecated", e))?;
+
+        let rows = match &ns {
+            Some(ns_val) => stmt.query_map(params![ns_val, limit], dep_row_to_info),
+            None => stmt.query_map(params![limit], dep_row_to_info),
+        }
+        .map_err(|e| Error::db("query list_deprecated", e))?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row.map_err(|e| Error::db("row list_deprecated", e))?);
+        }
+        Ok(results)
+    }
+
     /// Find aged memories eligible for cleanup.
     ///
     /// Returns memories matching: older than `older_than_days`, access_count <= max_access_count,
@@ -239,4 +284,47 @@ impl super::Store {
 
         Ok((hot, warm, cold))
     }
+}
+
+/// Lightweight info about a deprecated memory, for lifecycle UI display.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DeprecatedMemoryInfo {
+    pub id: String,
+    pub content: String,
+    pub memory_type: String,
+    pub namespace: String,
+    pub tags: Vec<String>,
+    pub importance: f64,
+    pub deprecated_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub deprecate_reason: Option<String>,
+}
+
+fn dep_row_to_info(row: &rusqlite::Row<'_>) -> Result<DeprecatedMemoryInfo, rusqlite::Error> {
+    let id: String = row.get(0)?;
+    let content: String = row.get(1)?;
+    let memory_type: String = row.get(2).unwrap_or_else(|_| "fact".to_string());
+    let namespace: String = row.get(3).unwrap_or_else(|_| "default".to_string());
+    let tags_str: Option<String> = row.get(4).ok().flatten();
+    let tags = tags_str
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<Vec<String>>(s).ok())
+        .unwrap_or_default();
+    let importance: f64 = row.get(5).unwrap_or(0.5);
+    let valid_until_str: Option<String> = row.get(6).ok().flatten();
+    let deprecated_at = valid_until_str
+        .as_deref()
+        .and_then(super::store::parse_datetime_opt);
+    let deprecate_reason: Option<String> = row.get(7).ok().flatten();
+    let _updated_at_str: Option<String> = row.get(8).ok().flatten();
+
+    Ok(DeprecatedMemoryInfo {
+        id,
+        content,
+        memory_type,
+        namespace,
+        tags,
+        importance,
+        deprecated_at,
+        deprecate_reason,
+    })
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -386,7 +386,7 @@ fn parse_datetime_flexible(
 
 /// Optional variant of [parse_datetime_flexible] — returns None on parse failure
 /// instead of an error. Used for nullable datetime columns (last_accessed, valid_from, etc).
-fn parse_datetime_opt(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+pub(crate) fn parse_datetime_opt(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     parse_datetime_flexible(s, 0).ok()
 }
 

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -48,6 +48,15 @@ pub const ENDPOINTS: &[Endpoint] = &[
     },
     Endpoint {
         method: "GET",
+        path: "/guide",
+        description: "Returns the agent-facing memory tools guide for system prompt injection (#1010).",
+        request_type: None,
+        response_type: Some("GuideResponse"),
+        excludes_deprecated: false,
+        issues: &["#1010"],
+    },
+    Endpoint {
+        method: "GET",
         path: "/namespaces",
         description: "List all namespaces in the memory store",
         request_type: None,
@@ -616,6 +625,15 @@ pub const ENDPOINTS: &[Endpoint] = &[
         response_type: None,
         excludes_deprecated: false,
         issues: &["#935"],
+    },
+    Endpoint {
+        method: "GET",
+        path: "/lifecycle/deprecated",
+        description: "List deprecated memories with TTL metadata.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#1007"],
     },
 ];
 

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -125,6 +125,20 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             )
         }
 
+        // ── Memory Tools Guide (#1010) ──────────────────────────────────
+        (Method::Get, "/guide") => {
+            #[derive(serde::Serialize)]
+            struct GuideResponse<'a> {
+                guide: &'a str,
+            }
+            ctx.ok_response_for(
+                req,
+                &GuideResponse {
+                    guide: &uteke_core::guide::default_guide(),
+                },
+            )
+        }
+
         // ── Remember ───────────────────────────────────────────────────
         (Method::Post, "/remember") => match read_body::<RememberRequest>(req.as_reader()) {
             Ok(req_data) => {
@@ -637,6 +651,43 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 deprecated: usize,
             }
             ctx.ok_response_for(req, &LifecycleStatusResponse { active, deprecated })
+        }
+
+        (Method::Get, "/lifecycle/deprecated") => {
+            let query = req.url().split('?').nth(1).unwrap_or("");
+            let params: std::collections::HashMap<String, String> = query
+                .split('&')
+                .filter_map(|pair| {
+                    let mut kv = pair.splitn(2, '=');
+                    Some((kv.next()?.to_string(), kv.next()?.to_string()))
+                })
+                .collect();
+            let ns_param = params.get("namespace").map(|s| s.as_str());
+            let limit: u32 = params
+                .get("limit")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(100);
+            match uteke.store().list_deprecated(ns_param, limit) {
+                Ok(items) => {
+                    #[derive(serde::Serialize)]
+                    struct DeprecatedListResponse {
+                        deprecated: Vec<uteke_core::DeprecatedMemoryInfo>,
+                        count: usize,
+                    }
+                    let count = items.len();
+                    ctx.ok_response_for(
+                        req,
+                        &DeprecatedListResponse {
+                            deprecated: items,
+                            count,
+                        },
+                    )
+                }
+                Err(e) => {
+                    error!("lifecycle deprecated list error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
+            }
         }
 
         (Method::Post, "/lifecycle/cycle") => {
@@ -1913,6 +1964,8 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                     };
 
                     if let Ok(id) = uteke.remember(fact, &tag_refs, metadata, fact_ns) {
+                        // Auto-populate source provenance (#1013).
+                        let _ = uteke.set_source(&id, Some("api:extraction"), "extract");
                         stored_ids.push(id);
                     }
                 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,6 +18,7 @@ export default createConfig({
       items: [
         { text: 'Installation', link: '/install' },
         { text: 'Quick Start', link: '/getting-started' },
+        { text: 'Organizing Memories', link: '/organizing-memories' },
         { text: 'Configuration', link: '/configuration' },
         { text: 'Docker', link: '/docker' },
       ],

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -42,6 +42,14 @@ Unpin a memory by ID (legacy — prefer /memory/pin with pin=false).
 
 ## 📝 Other
 
+#### 🟢 `GET` `/guide`
+
+Returns the agent-facing memory tools guide for system prompt injection (#1010).
+
+**Response**: [`GuideResponse`](#guideresponse)
+
+*Related: `#1010`*
+
 #### 🟢 `GET` `/namespaces`
 
 List all namespaces in the memory store
@@ -91,6 +99,12 @@ Restore a deprecated memory back to active status.
 Get lifecycle status: active/deprecated counts and current configuration.
 
 *Related: `#935`*
+
+#### 🟢 `GET` `/lifecycle/deprecated`
+
+List deprecated memories with TTL metadata.
+
+*Related: `#1007`*
 
 
 ## 📦 Import/Export

--- a/docs/organizing-memories.md
+++ b/docs/organizing-memories.md
@@ -1,0 +1,120 @@
+---
+title: Organizing Memories
+---
+
+# Organizing Memories
+
+Uteke stores all memories in a **flat structure** — there are no rigid L0–L3 layers or forced hierarchies. Instead, an **implicit hierarchy** emerges naturally from three existing fields:
+
+| Field | Purpose | Range |
+|---|---|---|
+| `memory_type` | What kind of knowledge this is | `fact`, `procedure`, `preference`, `decision`, `context`, `event` |
+| `importance` | How much weight this carries in recall scoring | `0.0` – `1.0` |
+| `pinned` | Protect from aging/pruning | `true` / `false` |
+
+Combined with built-in **recency decay** (type-based half-life) and **salience scoring** (access frequency), these fields create a practical hierarchy without the complexity of explicit layers.
+
+## Implicit Layer Mapping
+
+| Layer | `memory_type` | `importance` | `pinned` | Example |
+|---|---|---|---|---|
+| **Long-term core** | `decision`, `preference` | 0.9+ | ✅ | "User prefers dark mode", "Decided on OAuth 2.1" |
+| **Scenario context** | `procedure`, `context` | 0.5–0.8 | ❌ | "Auth middleware runs before route handler" |
+| **Atomic facts** | `fact` | 0.3–0.7 | ❌ | "Migration 0042 adds indexes on users.email" |
+| **Ephemeral** | `fact`, `event` | 0.1–0.3 | ❌ | "Today's meeting was at 2pm" (ages out via recency decay) |
+
+## How Decay Works
+
+Each `memory_type` has a configurable **half-life** (`type_half_life_days` in config):
+
+- **Decisions** and **preferences** are evergreen — slow decay (default: 365 days)
+- **Procedures** and **context** decay moderately (default: 90 days)
+- **Facts** and **events** decay faster (default: 30 days)
+
+Memories that are frequently recalled drift **upward** in salience. Cold memories drift **downward** and eventually get deprecated → pruned.
+
+**Pinned** memories are excluded from aging entirely.
+
+## Recommended Usage Patterns
+
+### Store a long-term decision
+
+```bash
+uteke remember "We chose PostgreSQL for ACID compliance and JSONB support" \
+  --type decision --importance 0.95 --pinned
+```
+
+### Store a preference
+
+```bash
+uteke remember "User prefers concise responses without filler" \
+  --type preference --importance 0.9 --pinned
+```
+
+### Store a procedure
+
+```bash
+uteke remember "To deploy: push to main, CI builds Docker image, auto-deploy to prod" \
+  --type procedure --importance 0.6
+```
+
+### Store an ephemeral fact
+
+```bash
+uteke remember "Standup moved to 9:30am today" \
+  --type event --importance 0.2
+```
+
+This will naturally age out — no manual cleanup needed.
+
+### Store an atomic fact
+
+```bash
+uteke remember "The config file is at ~/.codecora/uteke/uteke.toml" \
+  --type fact --importance 0.5
+```
+
+## When to Pin
+
+Pin only what you **never want to lose**:
+
+- Core architectural decisions
+- User preferences that define behavior
+- Critical procedure steps
+- Anything that would be expensive to re-derive
+
+Do **not** pin:
+- Ephemeral facts (today's meeting time)
+- Contextual information (current sprint goals)
+- Anything that will become stale
+
+## Configuring Decay
+
+Customize half-life per type in `uteke.toml`:
+
+```toml
+[aging]
+enabled = true
+
+[aging.type_half_life_days]
+decision = 365
+preference = 365
+procedure = 90
+context = 90
+fact = 30
+event = 14
+```
+
+Shorter half-life = faster decay. Set very high values (e.g. `9999`) for types you want to keep indefinitely without pinning.
+
+## Summary
+
+| Mechanism | Handles |
+|---|---|
+| `memory_type` | What kind of knowledge (affects decay rate) |
+| `importance` | How much weight in recall scoring |
+| `pinned` | Protect from aging entirely |
+| Recency decay | Temporal relevance (old → forgotten) |
+| Salience scoring | Access frequency (popular → boosted) |
+
+No explicit layers needed. The combination of these fields gives you a **self-organizing hierarchy** that adapts to usage patterns automatically.


### PR DESCRIPTION
## What

Four Phase 3 improvements to make uteke more self-documenting and auditable:

- **GET /lifecycle/deprecated** (#1007) — new endpoint listing deprecated memories with sunset dates and reasons
- **Memory tools guide** (#1010) — agent-facing guide string for system prompt injection, available via CLI and HTTP API
- **Implicit memory hierarchy docs** (#1012) — new `docs/organizing-memories.md` documenting the type + importance + pinning pattern
- **Auto-populate source provenance** (#1013) — extracted and imported memories now track where they came from

## Why

These are all observability and usability improvements. No algorithm changes, no perf impact.

Deprecated memories were only visible as a count in /lifecycle/status. Now you can actually see *which* memories are deprecated and why — critical for debugging contradiction resolution.

The guide gives agent integrators a ready-made system prompt fragment so their LLM knows how to use recall/search properly instead of guessing.

Provenance was the biggest gap: extracted facts had zero traceability. You could not answer "where did this memory come from?" without manual investigation. Now every extraction path tags its output.

## Changes

| Area | Files | What |
|------|-------|------|
| **#1007** | aging.rs, handlers.rs, api_registry.rs, lib.rs | `list_deprecated()` + `DeprecatedMemoryInfo` struct, handler + route + registry |
| **#1010** | guide.rs (new), lib.rs, cli.rs, mod.rs, handlers.rs, api_registry.rs | `default_guide()` module, `uteke guide` CLI command, `GET /guide` endpoint |
| **#1012** | organizing-memories.md (new), config.ts | New docs page, VitePress nav entry |
| **#1013** | maintenance.rs, mod.rs, output.rs, handlers.rs | CLI extraction auto-sets source_label + source_type="extract", server extraction calls set_source, verbose output shows source_type |

## Testing

```
cargo fmt --all          # ✅ clean
cargo clippy --all-targets  # ✅ 0 warnings
cargo test --all         # ✅ 483 passed, 0 failed (was 479, +4 new tests)
```

Manual verification:
- `uteke guide` — prints memory tools guide ✅
- `/lifecycle/deprecated` — registered in API registry ✅
- `/guide` — registered in API registry ✅
- `registry_covers_handler_routes` test passes (validates all routes have registry entries) ✅

Closes #1007, closes #1010, closes #1012, closes #1013