### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [0.14.0] — 2026-08-14
+
+Minor release: hybrid recall as default strategy, scene-segmented extraction, memory tools guide, lifecycle introspection, and source provenance. One behavior change (recall default).
+
+### ⚠️ Behavior Change
+
+- **Hybrid (RRF) is now the default recall strategy (#1005)** — Previously defaulted to vector-only. Hybrid combines vector similarity with FTS5 keyword matching via Reciprocal Rank Fusion, improving recall@5 from 85.4% to 98.0% on the internal benchmark. No action needed — existing setups automatically benefit. To revert to vector-only, set `strategy = "vector"` in `[recall]`.
+
+### Added
+
+- **Scene-segmented LLM extraction with priority scoring (#1009)** — When using `--extract` with an LLM, facts are now grouped by topic (scene) and assigned a priority score (0.0–1.0). Each fact gets a `scene:<topic>` tag for filtering, a semantic type (`decision`, `fact`, `preference`), and an importance value reflecting its priority. Offline extraction is unaffected. Backward compatible — flat string arrays from older models still parse correctly.
+
+- **List deprecated memories endpoint (#1007)** — `GET /lifecycle/deprecated` returns deprecated memories with TTL metadata (deprecated date, expiry date, remaining days). Useful for auditing what's slated for pruning before it's gone.
+
+- **Memory tools guide endpoint (#1010)** — `GET /guide` returns an agent-facing reference document covering all available memory operations. Designed for system-prompt injection — agents can discover capabilities without hardcoded instructions.
+
+- **Source provenance for extracted memories (#1012, #1013)** — Memories created via `--extract` now automatically record their source file path and extraction timestamp. CLI and server paths both covered.
+
+### Fixed
+
+- **Cross-compilation fails for Android/iOS targets (#1014)** — `ORT_LIB_NAME` environment variable was not cfg'd for mobile targets, breaking `cargo build --target aarch64-linux-android` and `aarch64-apple-ios`. Fixed with conditional compilation flags.
+
+- **Update check wastes API calls in batch mode (#1006)** — The startup update check ran even during `--batch-dir` imports, adding latency to batch operations. Now skipped when `--batch-dir` is active.
+
+- **Embedding text not pre-truncated before API call (#1002)** — Long content strings were sent to the embedding API untruncated, causing rejections from providers with token limits. Text is now pre-truncated to the configured `max_chunk_tokens`.
+
+### Contributors
+
+- [@ajianaz](https://github.com/ajianaz)
+
+---
+
 ## [0.13.2] — 2026-08-11
 
 Patch release with update notifications, a startup crash fix, and benchmark accuracy improvements. No breaking changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "dirs",
  "serde",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.2"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.13.2", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.13.2", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.13.2", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.13.2" }
+uteke-core = { path = "../uteke-core", version = "0.14.0", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.14.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -504,6 +504,18 @@ needs no duplicate key.
 See [configuration](#extraction) for the `[extraction]` config block and
 `UTEKE_EXTRACTION_*` environment variables.
 
+#### Scene-segmented output (#1009)
+
+When the LLM extracts facts, it groups them by topic (scene) and assigns
+a priority score (0.0–1.0) to each. This means:
+
+- **Scene tags** — each fact gets a `scene:<topic>` tag automatically, so you can filter by topic during recall.
+- **Priority** — important decisions get higher `importance` (0.7–0.9), routine facts get lower (0.3–0.5).
+- **Type** — facts are tagged with a semantic type (`decision`, `fact`, `preference`, etc.) when the model provides one.
+
+Offline extraction (no LLM) is unaffected — it continues to produce flat
+strings with default importance.
+
 ### Batch import (`--batch-dir`)
 
 Import all files from a directory in one command. Each file is processed

--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -71,6 +71,7 @@ See [CLI Reference → lifecycle](/cli-reference#uteke-lifecycle) for details.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/lifecycle/status` | Active vs deprecated counts |
+| `GET` | `/lifecycle/deprecated` | List deprecated memories with TTL metadata (#1007) |
 | `POST` | `/lifecycle/cycle` | Run lifecycle cycle |
 | `POST` | `/lifecycle/promote` | Promote deprecated → active |
 


### PR DESCRIPTION
## What

Version bump to 0.14.0 — hybrid default recall, scene-segmented extraction, lifecycle introspection, memory guide, provenance.

## Why

4 PRs merged since v0.13.2 (#1015, #1016, #1017, #1018) covering 8 issues. Minor version bump because of one behavior change (hybrid as default recall strategy).

## Changes

- Version: 0.13.2 → 0.14.0 (workspace + all crate deps + Cargo.lock)
- CHANGELOG.md: v0.14.0 entry
- docs/cli-reference.md: scene-segmented extraction section (#1009)
- docs/memory-lifecycle.md: /lifecycle/deprecated endpoint (#1007)

## Testing

- `cargo fmt` clean
- `cargo clippy` zero warnings
- `cargo test --all` — 547 tests, 0 failed
- `cargo run -p docgen` — API docs regenerated, fresh
- cora pre-commit review: no issues