### PR TITLE
fix: crates.io publish race condition + uteke-mcp metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,13 +269,22 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-core --allow-dirty
         continue-on-error: true
 
+      - name: Wait for crates.io index propagation
+        run: sleep 60
+
       - name: Publish uteke-mcp
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-mcp --allow-dirty
         continue-on-error: true
 
+      - name: Wait for crates.io index propagation
+        run: sleep 30
+
       - name: Publish uteke-cli
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-cli --allow-dirty
         continue-on-error: true
+
+      - name: Wait for crates.io index propagation
+        run: sleep 30
 
       - name: Publish uteke-server
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-server --allow-dirty

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -3,10 +3,14 @@ name = "uteke-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "MCP server for uteke — expose persistent memory to AI coding agents"
 readme = "README.md"
 keywords = ["mcp", "ai", "memory", "embedding", "agents"]
 categories = ["command-line-utilities", "development-tools"]
+documentation = "https://docs.rs/uteke-mcp"
+homepage = "https://github.com/codecoradev/uteke"
 
 [[bin]]
 name = "uteke-mcp"


### PR DESCRIPTION
## What

Fix dua masalah pada `publish-crates` job di release workflow:

1. **Race condition** — `uteke-core` published sukses tapi crates.io index belum propagate ketika mcp/cli/server langsung di-publish. Hasilnya: `failed to select a version for uteke-core = "^0.14.0"`.
2. **Missing metadata** — `uteke-mcp` tidak punya `repository`, `documentation`, `homepage`, `rust-version` fields → warning dari crates.io.

## Why

Tanpa fix ini, setiap release tag akan gagal publish mcp/cli/server ke crates.io. Hanya uteke-core yang sukses.

## Changes

- `release.yml`: Tambah `sleep 60` setelah publish core, `sleep 30` antara mcp→cli dan cli→server
- `uteke-mcp/Cargo.toml`: Tambah `repository.workspace`, `rust-version.workspace`, `documentation`, `homepage`

## Testing

- `cargo check` ✅
- Cora review ✅