### PR TITLE
chore: bump version to 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Changelog
+
+## [0.14.1] — 2026-08-14
+
+Patch release: two chunker bug fixes found by mutation testing, plus test-suite hardening. No API or behavior changes beyond the fixes.
+
+### Fixed
+
+- **Markdown heading duplicated in oversized sections** — When a markdown section exceeded `max_chunk_chars`, its heading appeared twice in the first sub-chunk: once from `split_by_headings`, then again from the sub-chunking loop. Every oversized markdown document was quietly producing corrupted chunk content, which flows directly into embedding input and degrades retrieval quality. The dead re-prepend path is removed entirely (#1024).
+
+- **Infinite loop on multi-byte text with small chunk sizes** — The zero-progress guard in `split_long_text` advanced by raw byte offsets that could land inside multi-byte UTF-8 characters (CJK, emoji), flooring back to the start position forever. `chunk_markdown("日本語", 2)` would hang. The guard now advances to the next valid character boundary (#1024).
+
+### Changed
+
+- **cargo-mutants configuration moved to `.cargo/mutants.toml`** — The previous config at `crates/uteke-core/mutants.toml` used the key `exclude_files`, which is not a valid field in cargo-mutants v27 and was silently never applied. Migration to `.cargo/mutants.toml` (the location cargo-mutants actually reads) with the correct v27 schema (`exclude_globs`, `exclude_re` as arrays) and workspace-root-relative glob paths. This release is the first where mutant exclusions actually work.
+
+- **Chunker test suite grew from 20 to 60 tests** — Mutation score improved from 50% to 97% (149/164 mutants caught, 0 missed non-equivalent). 3 proven-equivalent mutants are excluded with documented reasoning.
+
 ## [0.14.0] — 2026-08-14
 
 Minor release: hybrid recall as default strategy, scene-segmented extraction, memory tools guide, lifecycle introspection, and source provenance. One behavior change (recall default).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "dirs",
  "serde",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.1", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.1", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.14.0" }
+uteke-core = { path = "../uteke-core", version = "0.14.1", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.14.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What
Bump workspace version 0.14.0 → 0.14.1 and add the CHANGELOG entry for the upcoming patch release.

## Why
Two chunker bug fixes landed in #1024 (heading duplication in oversized markdown sections, infinite loop on multi-byte text) and need to ship as v0.14.1. This is the version-bump half of the release flow.

## Changes
- Root `Cargo.toml` workspace version → 0.14.1
- Intra-workspace dependency versions (cli/mcp/server → uteke-core) → 0.14.1
- `Cargo.lock` synced via `cargo update -w`
- CHANGELOG entry: Fixed (2 bugs), Changed (mutants.toml migration + test suite growth)

## Testing
- `cargo update -w` clean, zero stale 0.14.0 refs in workspace Cargo.toml files
- Docs verified version-agnostic (no hardcoded version strings to update)
- Runtime validation happens post-tag via release workflow binaries