### PR TITLE
fix(cli): uteke-cli crates.io publish failure + release verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,29 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p uteke-server --allow-dirty
         continue-on-error: true
 
+      - name: Wait for crates.io index
+        run: sleep 30
+
+      - name: Verify crates.io versions
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          fail=0
+          for crate in uteke-core uteke-mcp uteke-cli uteke-server; do
+            for attempt in 1 2 3 4 5; do
+              MAX=$(curl -sf -A "uteke-release-verify" "https://crates.io/api/v1/crates/$crate" | jq -r '.crate.max_version') || MAX=""
+              [ "$MAX" = "$VERSION" ] && break
+              echo "attempt $attempt: $crate at $MAX (want $VERSION), waiting..."
+              sleep 30
+            done
+            if [ "$MAX" = "$VERSION" ]; then
+              echo "✓ $crate $VERSION live on crates.io"
+            else
+              echo "::error::$crate not at $VERSION on crates.io (found: $MAX) — publish step failed silently"
+              fail=1
+            fi
+          done
+          exit $fail
+
   package-legacy:
     name: Package Linux x64 legacy bundle
     needs: [build-release, build-ort-legacy]

--- a/crates/uteke-cli/assets/hermes-memory-provider/__init__.py.tmpl
+++ b/crates/uteke-cli/assets/hermes-memory-provider/__init__.py.tmpl
@@ -1,0 +1,364 @@
+"""Uteke memory plugin — pre_llm_call auto-recall hook.
+
+Offline-first local memory backed by the `uteke` CLI (single Rust binary) or
+`uteke-serve` HTTP daemon. Every turn, before the LLM call, this plugin
+recalls relevant memories via semantic search and injects them into the
+user message.
+
+This replaces the old Mode B (MemoryProvider, removed 2026-06-29) and the
+Mode C (shell hook). Both are now unified into a single Python plugin.
+
+Transport:
+  - subprocess (default): talks to the `uteke` binary directly.
+    Requires the binary on PATH or set UTEKE_BIN.
+  - HTTP (optional): talks to `uteke-serve` via HTTP. Set UTEKE_SERVER_URL
+    to enable. Useful when the binary is unavailable, hangs, or runs as a
+    container (e.g., http://uteke:8767).
+
+Config via $HERMES_HOME/uteke.json (preferred) or environment variables:
+  UTEKE_BIN           — path to the uteke binary (default: search PATH)
+  UTEKE_HOME          — HOME dir uteke runs under (holds ~/.codecora/uteke store)
+  UTEKE_NAMESPACE     — memory namespace (default: agent profile name)
+  UTEKE_SERVER_URL    — uteke-serve HTTP URL (default: http://127.0.0.1:8767)
+  UTEKE_TOKEN         — auth token for uteke-serve (Bearer token)
+  UTEKE_RECALL_LIMIT  — number of memories to prefetch (default: 5)
+  UTEKE_RECALL_MIN_SCORE — drop recall hits below this score (default: 0.40)
+  UTEKE_RECALL_TIMEOUT — max seconds for recall per turn (default: 15)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker: after this many consecutive failures, pause calls
+# for _BREAKER_COOLDOWN_SECS to avoid hammering a broken binary/endpoint.
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+# Subprocess timeout (seconds)
+_DEFAULT_RECALL_TIMEOUT = 15
+
+# HTTP timeout (seconds)
+_HTTP_RECALL_TIMEOUT = 10
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    """Load config from env vars, overridden by $HERMES_HOME/uteke.json."""
+    try:
+        from hermes_constants import get_hermes_home
+    except ImportError:
+        get_hermes_home = lambda: None  # type: ignore[assignment]
+
+    hermes_home = get_hermes_home() if get_hermes_home else os.environ.get("HERMES_HOME", "")
+
+    def _envbool(key: str, default: bool) -> bool:
+        v = os.environ.get(key)
+        if v is None:
+            return default
+        return v.strip().lower() in ("1", "true", "yes", "on")
+
+    def _envfloat(key: str, default: float) -> float:
+        v = os.environ.get(key)
+        if v is None:
+            return default
+        try:
+            return float(v)
+        except ValueError:
+            return default
+
+    def _envint(key: str, default: int) -> int:
+        v = os.environ.get(key)
+        if v is None:
+            return default
+        try:
+            return int(v)
+        except ValueError:
+            return default
+
+    config = {
+        "bin": os.environ.get("UTEKE_BIN", ""),
+        "uteke_home": os.environ.get("UTEKE_HOME", ""),
+        "namespace": os.environ.get("UTEKE_NAMESPACE", ""),
+        "server_url": os.environ.get("UTEKE_SERVER_URL", ""),
+        "token": os.environ.get("UTEKE_TOKEN", ""),
+        "recall_limit": _envint("UTEKE_RECALL_LIMIT", 5),
+        "recall_min_score": _envfloat("UTEKE_RECALL_MIN_SCORE", 0.40),
+        "recall_timeout": _envint("UTEKE_RECALL_TIMEOUT", _DEFAULT_RECALL_TIMEOUT),
+    }
+
+    if hermes_home:
+        config_path = os.path.join(hermes_home, "uteke.json")
+        if os.path.exists(config_path):
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    file_cfg = json.loads(f.read())
+                config.update({k: v for k, v in file_cfg.items()
+                               if v is not None and v != ""})
+            except Exception:
+                pass
+
+    return config
+
+
+def _resolve_agent_name() -> str:
+    """Determine the calling agent's name from environment.
+
+    Tries HERMES_HOME path basename (profile name), falls back to
+    HERMES_AGENT_NAME, then "default".
+    """
+    try:
+        home = os.environ.get("HERMES_HOME", "")
+        if home:
+            basename = os.path.basename(home)
+            if basename and basename != "data":
+                return basename.lower()
+        return os.environ.get("HERMES_AGENT_NAME", "default")
+    except Exception:
+        return "default"
+
+
+def _resolve_bin(config: dict) -> str:
+    """Find the uteke binary."""
+    b = config.get("bin") or ""
+    if b and os.path.exists(b):
+        return b
+    found = shutil.which("uteke")
+    return found or ""
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+def _http_request(url: str, method: str = "GET", data: dict = None,
+                  token: str = "", timeout: int = 10) -> dict:
+    """Make an HTTP request to uteke-serve. Returns parsed JSON or error dict."""
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        return {"error": e.read().decode()[:200], "status": e.code}
+    except urllib.error.URLError as e:
+        return {"error": f"uteke-serve not reachable: {e.reason}"}
+
+
+# ---------------------------------------------------------------------------
+# Recall (dual transport)
+# ---------------------------------------------------------------------------
+
+def _recall_subprocess(bin_path: str, env: dict, query: str,
+                        namespace: str, limit: int, timeout: int) -> List[Dict[str, Any]]:
+    """Recall via subprocess (uteke binary)."""
+    cmd = [bin_path, "recall", query, "--namespace", namespace,
+           "--limit", str(limit), "--json"]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(f"recall exit {proc.returncode}: {proc.stderr.strip()[:200]}")
+    return _parse_recall_results(json.loads(proc.stdout or "[]"))
+
+
+def _recall_http(server_url: str, token: str, query: str,
+                 namespace: str, limit: int) -> List[Dict[str, Any]]:
+    """Recall via HTTP (uteke-serve)."""
+    result = _http_request(
+        f"{server_url}/recall",
+        method="POST",
+        data={"query": query, "namespace": namespace, "limit": limit},
+        token=token,
+        timeout=_HTTP_RECALL_TIMEOUT,
+    )
+    if "error" in result:
+        raise RuntimeError(f"recall HTTP error: {result['error']}")
+    if not isinstance(result, list):
+        return []
+    return _parse_recall_results(result)
+
+
+def _parse_recall_results(data: list) -> List[Dict[str, Any]]:
+    """Parse recall results from both subprocess JSON and HTTP API."""
+    out = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        mem = item.get("memory", {})
+        score = item.get("score", 0.0)
+        content = mem.get("content", "")
+        if content and score >= 0:
+            out.append({"content": content, "score": score, "tags": mem.get("tags", [])})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Recall manager (thread-safe, circuit breaker)
+# ---------------------------------------------------------------------------
+
+class _RecallManager:
+    """Manages recall state with circuit breaker and thread safety."""
+
+    def __init__(self):
+        self._config: dict = {}
+        self._bin = ""
+        self._env = dict(os.environ)
+        self._namespace = "default"
+        self._server_url = ""
+        self._token = ""
+        self._use_http = False
+        self._recall_limit = 5
+        self._recall_min_score = 0.40
+        self._recall_timeout = _DEFAULT_RECALL_TIMEOUT
+
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+        self._lock = threading.Lock()
+
+    def initialize(self) -> None:
+        """Load config and resolve transport. Called once at plugin load."""
+        cfg = _load_config()
+        self._config = cfg
+        self._bin = _resolve_bin(cfg)
+        self._namespace = cfg.get("namespace", "") or _resolve_agent_name()
+        self._server_url = cfg.get("server_url", "").rstrip("/")
+        self._token = cfg.get("token", "")
+        self._use_http = bool(self._server_url)
+        self._recall_limit = int(cfg.get("recall_limit", 5) or 5)
+        self._recall_min_score = float(cfg.get("recall_min_score", 0.40) or 0.40)
+        self._recall_timeout = int(cfg.get("recall_timeout", _DEFAULT_RECALL_TIMEOUT) or _DEFAULT_RECALL_TIMEOUT)
+
+        # uteke stores under $HOME/.uteke; let the user point it at a fixed home.
+        self._env = dict(os.environ)
+        uteke_home = cfg.get("uteke_home")
+        if uteke_home:
+            self._env["HOME"] = uteke_home
+
+        transport = "HTTP" if self._use_http else "subprocess"
+        logger.info(
+            "uteke-memory plugin initialized: transport=%s bin=%s ns=%s server=%s limit=%d min_score=%.2f",
+            transport, self._bin or "(PATH)", self._namespace, self._server_url or "(none)",
+            self._recall_limit, self._recall_min_score,
+        )
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            with self._lock:
+                self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        with self._lock:
+            self._consecutive_failures = 0
+
+    def _record_failure(self):
+        with self._lock:
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= _BREAKER_THRESHOLD:
+                self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+                logger.warning("uteke circuit breaker tripped after %d failures; pausing %ds.",
+                               self._consecutive_failures, _BREAKER_COOLDOWN_SECS)
+
+    def recall(self, query: str) -> List[Dict[str, Any]]:
+        """Recall memories, applying circuit breaker and score filtering."""
+        if self._is_breaker_open():
+            return []
+
+        try:
+            if self._use_http:
+                hits = _recall_http(self._server_url, self._token, query,
+                                   self._namespace, self._recall_limit)
+            else:
+                if not self._bin:
+                    logger.warning("uteke binary not found on PATH and UTEKE_BIN not set.")
+                    return []
+                hits = _recall_subprocess(self._bin, self._env, query,
+                                          self._namespace, self._recall_limit,
+                                          self._recall_timeout)
+
+            # Apply min_score filtering
+            hits = [h for h in hits if h.get("score", 0) >= self._recall_min_score]
+            self._record_success()
+            return hits
+        except Exception as e:
+            self._record_failure()
+            logger.debug("uteke recall failed: %s", e)
+            return []
+
+
+# Process-wide singleton
+_manager = _RecallManager()
+
+
+def _pre_llm_call(
+    session_id: str = "",
+    user_message: str = "",
+    conversation_history: list = None,
+    is_first_turn: bool = False,
+    model: str = "",
+    platform: str = "",
+    **kwargs,
+) -> dict:
+    """pre_llm_call plugin hook — auto-recall relevant memories.
+
+    Runs in-process (same Python runtime as the gateway). Has full access
+    to contextvars. Returns {"context": "..."} to inject into the user
+    message before the LLM call.
+
+    This runs synchronously in the turn prologue (turn_context.py). Keep it
+    fast — the recall is bounded by UTEKE_RECALL_TIMEOUT (default 15s).
+    """
+    if not user_message or not isinstance(user_message, str):
+        return {}
+    if len(user_message.strip()) < 5:
+        return {}
+
+    # Truncate long messages to save embedding time
+    query = user_message.strip()[:500]
+
+    hits = _manager.recall(query)
+    if not hits:
+        return {}
+
+    lines = []
+    for i, mem in enumerate(hits, 1):
+        content = mem["content"]
+        if len(content) > 200:
+            content = content[:200] + "..."
+        score_str = f"{mem['score']:.2f}"
+        tags = mem.get("tags", [])
+        tag_str = f" [{', '.join(tags)}]" if tags else ""
+        lines.append(f"{i}. [{score_str}]{tag_str} {content}")
+
+    return {"context": f"<recalled-memories>\n" + "\n".join(lines) + "\n</recalled-memories>"}
+
+
+def register(ctx) -> None:
+    """Register the uteke auto-recall plugin.
+
+    1. Initialize the recall manager (load config, resolve transport).
+    2. Register a pre_llm_call hook that runs uteke recall before every
+       LLM call and injects relevant memories into the user message.
+    """
+    _manager.initialize()
+    ctx.register_hook("pre_llm_call", _pre_llm_call)
+    logger.info("uteke-memory plugin registered: pre_llm_call hook active.")

--- a/crates/uteke-cli/assets/hermes-memory-provider/plugin.yaml.tmpl
+++ b/crates/uteke-cli/assets/hermes-memory-provider/plugin.yaml.tmpl
@@ -1,0 +1,8 @@
+name: uteke-memory
+version: 2.0.0
+description: "Uteke — offline-first local memory with auto-recall. Registers a pre_llm_call plugin hook for automatic memory injection every turn. Requires uteke binary on PATH or UTEKE_BIN env var."
+author: CodeCoraDev
+pip_dependencies: []
+requires_env: []
+provides_hooks:
+  - pre_llm_call

--- a/crates/uteke-cli/assets/pi-memory-provider/index.ts
+++ b/crates/uteke-cli/assets/pi-memory-provider/index.ts
@@ -1,0 +1,272 @@
+/**
+ * Uteke Memory Provider Extension for Pi
+ *
+ * Automatic persistent memory integration — mirrors the Hermes memory-provider
+ * experience. Hooks `before_agent_start` to inject relevant memories into
+ * every agent turn without manual tool calls.
+ *
+ * Project-aware: auto-detects project name from the current working directory
+ * and tags all memories with `project:<name>` for noise-free recall.
+ *
+ * Install:
+ *   Global:  ~/.pi/agent/extensions/uteke-memory-provider/index.ts
+ *   Project: .pi/extensions/uteke-memory-provider/index.ts
+ *
+ * Requires: `uteke` binary on PATH (same binary as the CLI).
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execSync, execFileSync } from "node:child_process";
+import { basename, resolve } from "node:path";
+import { existsSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Config (reads from env, can be extended)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_NAMESPACE = "default";
+const RECALL_LIMIT = 6;
+const RECALL_MIN_SCORE = 0.45;
+const RECALL_TIMEOUT_MS = 15_000;
+
+// Known project root directories to scan for project detection
+const KNOWN_PROJECT_DIRS = [
+	"/opt/data/repos",
+	"/home",
+	process.env.HOME || "",
+].filter(Boolean);
+
+// ---------------------------------------------------------------------------
+// Project Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect project name from the current working directory.
+ * Walks up from cwd to find a known project root, then extracts the folder name.
+ * Returns lowercase project name or empty string.
+ */
+function detectProjectFromCwd(): string {
+	const cwd = process.cwd();
+
+	for (const root of KNOWN_PROJECT_DIRS) {
+		if (!root || !existsSync(root)) continue;
+		const resolved = resolve(root);
+
+		// Check if cwd is inside or equal to this project root
+		if (cwd.startsWith(resolved + "/") || cwd === resolved) {
+			// Extract the immediate subdirectory name
+			const relative = cwd.slice(resolved.length + 1);
+			const firstSegment = relative.split("/")[0];
+			if (firstSegment && !firstSegment.startsWith(".")) {
+				return firstSegment.toLowerCase();
+			}
+		}
+	}
+
+	return "";
+}
+
+/**
+ * Detect project name from text (file paths, mentions).
+ * Falls back to cwd detection if nothing found in text.
+ */
+function detectProject(text: string, fallbackToCwd = false): string {
+	if (!text) return fallbackToCwd ? detectProjectFromCwd() : "";
+
+	// Strategy 1: file paths containing known project roots
+	for (const root of KNOWN_PROJECT_DIRS) {
+		if (!root) continue;
+		const escaped = root.replace(/\//g, "\\/");
+		const match = text.match(new RegExp(`${escaped}/([a-zA-Z0-9_.-]+)`));
+		if (match && match[1] && !match[1].startsWith(".")) {
+			return match[1].toLowerCase();
+		}
+	}
+
+	return fallbackToCwd ? detectProjectFromCwd() : "";
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess helpers
+// ---------------------------------------------------------------------------
+
+function utekeBin(): string {
+	const envBin = process.env.UTEKE_BIN;
+	if (envBin) return envBin;
+	// pi extensions run as Node.js — use which-compatible lookup
+	try {
+		return execSync("which uteke", { encoding: "utf-8", timeout: 3000 }).trim();
+	} catch {
+		return "uteke";
+	}
+}
+
+function runUteke(args: string[], timeout = RECALL_TIMEOUT_MS): string {
+	const bin = utekeBin();
+	const env = { ...process.env };
+	// Allow pointing uteke at a different home directory
+	if (process.env.UTEKE_HOME) {
+		env.HOME = process.env.UTEKE_HOME;
+	}
+	try {
+		return execFileSync(bin, args, {
+			encoding: "utf-8",
+			timeout,
+			env,
+		});
+	} catch {
+		return "";
+	}
+}
+
+function recallMemories(query: string, project: string): string[] {
+	const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
+	const limit = process.env.UTEKE_RECALL_LIMIT || String(RECALL_LIMIT);
+	const minScore = process.env.UTEKE_RECALL_MIN_SCORE || String(RECALL_MIN_SCORE);
+
+	const args: string[] = [
+		"recall", query,
+		"--namespace", ns,
+		"--limit", limit,
+		"--min-score", minScore,
+		"--json",
+	];
+
+	// Filter by project tag if detected
+	if (project) {
+		args.push("--tags", `project:${project}`);
+	}
+
+	const raw = runUteke(args);
+
+	if (!raw.trim()) return [];
+
+	try {
+		const items = JSON.parse(raw);
+		const results: string[] = [];
+		for (const item of items) {
+			const mem = item.memory || item;
+			const content = mem.content || "";
+			if (content) {
+				results.push(content);
+			}
+		}
+		return results;
+	} catch {
+		return [];
+	}
+}
+
+function formatMemories(memories: string[], project: string): string {
+	if (!memories.length) return "";
+	const projectHint = project ? ` [project: ${project}]` : "";
+	const lines = memories.map((m, i) => `${i + 1}. ${m}`).join("\n");
+	return (
+		`\n\n## Relevant Memories (uteke)${projectHint}\n\n` +
+		lines +
+		"\n\nUse `uteke remember` to store new facts, `uteke recall` to search more."
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+	let available = false;
+
+	// Check uteke availability on session start
+	pi.on("session_start", async (_event, ctx) => {
+		const out = runUteke(["stats"], 3000);
+		available = out.trim().length > 0;
+
+		const project = detectProjectFromCwd();
+		const status = project
+			? `🧠 uteke: active (${project})`
+			: available
+				? "🧠 uteke: active"
+				: "🧠 uteke: not found";
+
+		ctx.ui.setStatus("uteke", status);
+	});
+
+	// Core hook: inject relevant memories before every agent turn
+	pi.on("before_agent_start", async (event) => {
+		if (!available) return;
+
+		const prompt = (event.prompt || "").trim();
+		if (!prompt || prompt.length < 3) return;
+
+		// Detect project from prompt text, fallback to cwd
+		const project = detectProject(prompt, true);
+		const memories = recallMemories(prompt, project);
+		if (!memories.length) return;
+
+		const injection = formatMemories(memories, project);
+
+		return {
+			systemPrompt: event.systemPrompt + injection,
+		};
+	});
+
+	// Slash commands for manual control
+	pi.registerCommand("uteke-recall", {
+		description: "Manually recall memories for a topic",
+		handler: async (args, _ctx) => {
+			const query = args.join(" ").trim();
+			if (!query) return "Usage: /uteke-recall <topic>";
+			const project = detectProject(query, true);
+			const memories = recallMemories(query, project);
+			if (!memories.length) return "No relevant memories found.";
+			return formatMemories(memories, project);
+		},
+	});
+
+	pi.registerCommand("uteke-save", {
+		description: "Save a memory to uteke (auto-tagged with project)",
+		handler: async (args, _ctx) => {
+			const content = args.join(" ").trim();
+			if (!content) return "Usage: /uteke-save <content>";
+
+			const ns = process.env.UTEKE_NAMESPACE || DEFAULT_NAMESPACE;
+			const project = detectProjectFromCwd();
+			const cmdArgs: string[] = [
+				"remember", content,
+				"--namespace", ns,
+			];
+			if (project) {
+				cmdArgs.push("--tags", `project:${project}`);
+			}
+
+			runUteke(cmdArgs, RECALL_TIMEOUT_MS);
+			const projectNote = project ? ` [project: ${project}]` : "";
+			return `✓ Memory saved.${projectNote}`;
+		},
+	});
+
+	pi.registerCommand("uteke-stats", {
+		description: "Show uteke memory stats",
+		handler: async (_args, ctx) => {
+			const out = runUteke(["stats"], 5000);
+			available = out.trim().length > 0;
+			ctx.ui.setStatus("uteke", available ? "🧠 uteke: active" : "🧠 uteke: not found");
+			return out.trim() || "uteke: not available";
+		},
+	});
+
+	pi.registerCommand("uteke-on", {
+		description: "Enable automatic memory recall",
+		handler: async () => {
+			available = true;
+			return "✓ Automatic uteke recall enabled.";
+		},
+	});
+
+	pi.registerCommand("uteke-off", {
+		description: "Disable automatic memory recall",
+		handler: async () => {
+			available = false;
+			return "✓ Automatic uteke recall disabled.";
+		},
+	});
+}

--- a/crates/uteke-cli/assets/pi-memory-provider/package.json
+++ b/crates/uteke-cli/assets/pi-memory-provider/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uteke-memory-provider",
+  "version": "0.1.0",
+  "description": "Pi extension — automatic uteke memory recall injected into every turn",
+  "main": "index.ts",
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "keywords": ["pi-extension", "uteke", "memory", "memory-provider"],
+  "license": "Apache-2.0"
+}

--- a/crates/uteke-cli/assets/uteke-memory-skill.md
+++ b/crates/uteke-cli/assets/uteke-memory-skill.md
@@ -1,0 +1,299 @@
+---
+description: "Persistent memory engine for AI agents via the uteke CLI — remember, recall, search, forget with semantic + FTS5 hybrid search, documents, knowledge graph, rooms, tiered memory, and multi-agent namespaces."
+---
+
+# Uteke Memory Skill
+
+Persistent memory engine for AI agents via the `uteke` CLI.
+Version: **0.10.0** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Zero unsafe code.
+
+> **Hermes integration:** Install the `uteke-memory` plugin for automatic recall
+> on every turn via the `pre_llm_call` hook. No shell hook or daemon needed.
+> See `extensions/hermes-memory-provider/` for the plugin source.
+> Manual tool calls via `uteke-tool` plugin remain available for explicit
+> remember/forget/room operations.
+
+## Global Flags (all commands)
+
+| Flag | Description |
+|------|-------------|
+| `--store <PATH>` | Override store path (default: `~/.uteke`) |
+| `--namespace <NS>` | Multi-agent isolation (default: `"default"`) |
+| `--json` | Machine-readable JSON output |
+| `--verbose` | Debug logging |
+
+## Commands
+
+### Core Memory Operations
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke remember <TEXT>` | Store a new memory | `--tags`, `--type`, `--entity`, `--category`, `--meta`, `--room`, `--author`, `--source`, `--source-type`, `--detect-contradiction` |
+| `uteke recall <QUERY>` | Hybrid search (vector + FTS5, RRF) | `--limit`, `--tags`, `--entity`, `--category`, `--min`, `--strategy` (vector/fts5/hybrid/graph), `--salience`, `--recency`, `--related`, `--depth`, `--context`, `--at` (time-travel), `--type` (all/memory/doc), `--where` (JSON field filter) |
+| `uteke search <QUERY>` | Keyword text search | `--limit`, `--tags` |
+| `uteke list` | List memories with filters | `--tag`, `--entity`, `--category`, `--limit`, `--offset`, `--at` |
+| `uteke get <ID>` | Get single memory by UUID | |
+| `uteke forget <ID>` | Delete memory by ID, tag, tier, or all | `--tag`, `--cold`, `--all`, `--confirm` |
+
+### Documents (Wiki / Knowledge Base)
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke doc create <SLUG>` | Create document from file/stdin | `--title`, `--file`, `--content`, `--tags`, `--parent` |
+| `uteke doc get <ID_OR_SLUG>` | Get a document | |
+| `uteke doc update <ID_OR_SLUG>` | Partial update — only provided fields change | `--title`, `--content`, `--file`, `--tags`, `--metadata` |
+| `uteke doc delete <ID>` | Delete document (cascades to children) | |
+| `uteke doc list` | List documents | `--limit`, `--tree` (hierarchy) |
+| `uteke doc search <QUERY>` | Search documents (semantic + FTS5) | `--limit`, `--mode` (semantic/fts/hybrid) |
+| `uteke doc children <PARENT>` | List child documents | `--limit` |
+| `uteke doc move <ID_OR_SLUG>` | Move to new parent or root | `--parent` |
+| `uteke doc breadcrumbs <ID_OR_SLUG>` | Show path from root | |
+| `uteke doc descendants <ID_OR_SLUG>` | List all descendants | `--max-depth`, `--limit` |
+| `uteke doc export` | Export all documents as JSON | `--output` |
+
+### Knowledge Graph
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke graph nodes` | List all graph nodes | `--entity-type` |
+| `uteke graph edges` | List all graph edges | `--relation` |
+| `uteke graph neighbors <LABEL>` | Find neighbors (BFS) | `--depth` |
+| `uteke graph path <SRC> <TGT>` | Shortest path (BFS) | `--max-depth` |
+| `uteke graph query <RELATION>` | Query edges by relation type | |
+| `uteke graph stats` | Graph statistics | |
+
+### Memory Relationships
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke edges <ID>` | List edges for a memory (auto-wired backlinks/forward links) | `--deep` (BFS depth), `--direction` (incoming/outgoing/both) |
+| `uteke rebuild-backlinks` | Rebuild `referenced_by` from forward edges | `--quiet` |
+
+### Rooms (Collaborative Memory)
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke room create <ID>` | Create a room | `--title` |
+| `uteke room list` | List all rooms | `--namespace` |
+| `uteke room stats <ID>` | Room statistics and participants | |
+| `uteke room recall <ID>` | Recall room memories | `--query`, `--author`, `--limit`, `--min` |
+| `uteke room summary <ID>` | Topic clustering summary | |
+| `uteke room document <ID>` | Generate structured document from room | |
+| `uteke room delete <ID>` | Delete room (memories preserved) | `--confirm` |
+
+### Pinning & Importance
+
+| Command | Description |
+|---------|-------------|
+| `uteke pin <ID>` | Pin a memory (never decays) |
+| `uteke unpin <ID>` | Unpin a memory |
+| `uteke importance` | Recalculate importance scores for all memories |
+| `uteke orphans` | Find disconnected memories with low importance | `--threshold` (default 0.3), `--limit` (default 50) |
+
+### Maintenance
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke dream` | Full maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify | `--phases`, `--skip`, `--dry-run`, `--quiet` |
+| `uteke consolidate` | Merge near-duplicate memories | `--threshold` (default 0.90), `--dry-run` |
+| `uteke prune` | Remove deprecated/expired memories | `--ttl` (default 30), `--dry-run` |
+| `uteke timeline <ID>` | Show audit log events for a memory | `--limit` (default 20) |
+
+### Tags & Namespaces
+
+| Command | Description |
+|---------|-------------|
+| `uteke tags list` | List all tags with counts (`--by-count`) |
+| `uteke tags rename <old> <new>` | Rename a tag across all memories |
+| `uteke tags delete <tag>` | Delete a tag from all memories (`--confirm`) |
+| `uteke namespace list` | List all namespaces with counts |
+| `uteke namespace stats <name>` | Stats for a specific namespace |
+| `uteke namespace switch <name>` | Set default namespace in config |
+
+### Memory Aging
+
+| Command | Description | Key Options |
+|---------|-------------|-------------|
+| `uteke aging status` | Hot/warm/cold/never-accessed breakdown | |
+| `uteke aging preview` | Preview stale memories | `--older-than-days` (default 180), `--max-access-count` (default 1) |
+| `uteke aging cleanup` | Delete aged memories | `--older-than-days`, `--max-access-count`, `--yes` |
+
+### Health, Stats & Data
+
+| Command | Description |
+|---------|-------------|
+| `uteke stats` | Memory store statistics + tier breakdown |
+| `uteke doctor` | Full health check: DB, index, embedding model, consistency |
+| `uteke verify` | Compare DB count vs vector index count |
+| `uteke verify-checksums` | Verify binary integrity against SHA256 checksums |
+| `uteke repair` | Rebuild vector index from SQLite |
+| `uteke export [FILE]` | Export to JSONL (no embeddings). Default: stdout |
+| `uteke import [FILE]` | Import from JSONL/Markdown/text. Default: stdin |
+| `uteke bench` | Performance benchmarks | `--counts`, `--json` |
+
+### Setup & Upgrade
+
+| Command | Description |
+|---------|-------------|
+| `uteke init --agent <TYPE>` | Initialize integration (pi/claude/cursor/opencode/hermes) |
+| `uteke hook install <SHELL>` | Install shell hook (bash/zsh/fish) |
+| `uteke completions <SHELL>` | Generate shell completions (bash/zsh/fish/powershell) |
+| `uteke upgrade` | Check for updates and upgrade | `-y` (skip confirmation) |
+
+## Architecture
+
+- **Storage:** SQLite (WAL mode) with namespace column + FTS5 virtual table
+- **Vector index:** usearch persistent HNSW (768d, cosine similarity)
+- **Hybrid search:** RRF (k=60) merges vector + FTS5 results; graph strategy adds graph-signal reranking
+- **Embedding:** ONNX EmbeddingGemma Q4 (768d), auto-downloaded
+- **Tiered memory:** Hot (<7d, +0.1 boost), Warm (<30d), Cold (>30d)
+- **Schema versioning:** Integer counter, auto-migration on upgrade
+- **Zero unsafe code** (`unsafe_code = "forbid"`)
+- **Project-scoped stores:** `uteke --store .uteke remember "..."`
+
+## Usage Patterns
+
+### Session lifecycle
+```bash
+uteke recall "project architecture decisions" --namespace pi-agent
+uteke remember "Use WAL mode for concurrent reads" --tags architecture,db --entity db-layer
+uteke recall "last session state" --namespace pi-agent
+```
+
+### Metadata-enriched storage
+```bash
+uteke remember "Deploy staging to AWS us-east-1" \
+  --tags deploy,aws --entity staging-server --category infrastructure \
+  --source "meeting-notes.md" --source-type file
+```
+
+### Time-travel queries
+```bash
+uteke recall "auth flow" --at 2026-06-01T12:00:00Z
+uteke list --at 2026-06-01T12:00:00Z
+```
+
+### Graph-enhanced recall
+```bash
+uteke recall "database design" --strategy graph --related --depth 2
+uteke graph neighbors "auth-service" --depth 3
+uteke graph path "api-gateway" "database"
+```
+
+### Document wiki
+```bash
+uteke doc create architecture/overview --title "Architecture Overview" --file overview.md --parent docs
+uteke doc search "authentication" --mode hybrid
+uteke doc list --tree
+```
+
+### Room collaboration
+```bash
+uteke remember "Decision: use PostgreSQL" --room design-review --author alice
+uteke room recall design-review --query "database"
+uteke room summary design-review
+```
+
+### Programmatic (JSON)
+```bash
+uteke recall "auth flow" --json --limit 3
+uteke stats --json
+uteke list --tag architecture --json --limit 50
+```
+
+### Maintenance pipeline
+```bash
+uteke dream                           # Full pipeline
+uteke dream --phases lint,verify --dry-run  # Selective, safe
+uteke importance                      # Recompute scores
+uteke orphans --threshold 0.2         # Find disconnected
+```
+
+## Project-Aware Memory (MANDATORY)
+
+**Always tag memories with `project:<name>` when working in a project.** This prevents noise when recalling — you only see memories relevant to the current project.
+
+### How to detect the project name
+
+1. From `workdir` / `cwd` — extract the repo folder name:
+   - `/home/user/repos/bond/` → `project:bond`
+   - `/home/user/repos/uteke/` → `project:uteke`
+   - `/home/user/repos/my-saas-app/` → `project:my-saas-app`
+2. From file paths mentioned in the conversation
+3. From the project name the user mentions
+
+### Rules
+
+| Rule | Details |
+|------|---------|
+| **REMEMBER** | Always include `project:<name>` in `--tags` when the memory is project-specific |
+| **RECALL** | Always include `--tags project:<name>` to scope recall to the current project |
+| **NO PROJECT** | If the conversation is not about any specific project (e.g., general chat), do NOT add a `project:` tag |
+| **TAG FORMAT** | Always lowercase: `project:bond`, `project:uteke` (not `project:Bond`) |
+
+### Examples
+
+```bash
+# Working on the "bond" project
+uteke recall "auth flow" --tags project:bond
+uteke remember "JWT rotation implemented with refresh tokens" --tags project:bond,decision,auth
+uteke remember "DB schema uses UUID v7 for primary keys" --tags project:bond,architecture,db
+
+# Working on the "uteke" project
+uteke recall "vector index corruption" --tags project:uteke
+uteke remember "Fixed usearch rebuild race condition" --tags project:uteke,bugfix,index
+
+# General conversation — no project tag
+uteke remember "User prefers concise responses" --tags preference
+
+# Cross-project recall (explicitly requested)
+uteke recall "shared auth pattern" --tags project:bond,project:corin
+```
+
+### Why this matters
+
+Without project tags, memories from all projects mix together. When you recall "fix auth bug" while working on project Bond, you might get results from project Corin's auth system — causing confusion and wasted context. Project tags ensure recall is scoped and noise-free.
+
+## When to Use
+
+| Trigger | Action |
+|---------|--------|
+| Before starting work | `uteke recall "<project context>" --tags project:<name>` |
+| After making decisions | `uteke remember "<decision>" --tags project:<name>,<other tags>` |
+| Important documents | `uteke doc create <slug> --file <path> --parent <slug>` |
+| Collaborative decisions | `uteke remember "..." --room <room> --author <name>` |
+| Memory feels stale | `uteke dream` or `uteke importance` |
+| Index feels corrupt | `uteke doctor` → `uteke repair` |
+
+## Hermes Auto-Recall Plugin
+
+The `uteke-memory` plugin registers a `pre_llm_call` hook that automatically
+recalls relevant memories on every turn and injects them into the user message.
+No shell hook, no daemon required (subprocess transport). Supports HTTP transport
+to `uteke-serve` for container deployments.
+
+```bash
+# Generate and install the plugin
+uteke init --agent hermes
+# → writes to ~/.hermes/plugins/uteke-memory/
+
+# Enable in config.yaml
+# plugins:
+#   enabled:
+#     - uteke-memory
+```
+
+Config via `~/.hermes/uteke.json` or env vars:
+`UTEKE_BIN`, `UTEKE_NAMESPACE`, `UTEKE_SERVER_URL`, `UTEKE_TOKEN`,
+`UTEKE_RECALL_LIMIT` (default 5), `UTEKE_RECALL_MIN_SCORE` (default 0.40).
+
+## Server Mode (uteke-serve)
+
+HTTP daemon with REST API for all operations + monitoring/maintenance endpoints.
+
+```bash
+uteke-serve --port 8767
+# CLI auto-routes to server when running: ~42ms recall vs ~3s cold start
+```
+
+Endpoints mirror CLI commands (e.g., `POST /remember`, `POST /recall`). Supports read-only API tokens for restricted access.

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -68,7 +68,7 @@ fn install_skill_md(cwd: &std::path::Path) -> Result<std::path::PathBuf, String>
     // Bundled SKILL.md is in .agents/skills/uteke-memory/ relative to repo root.
     // For `cargo install` builds it's embedded; for `cargo run` it lives in the
     // crate's CWD.  We embed the content at compile time to always have it.
-    let bundled = include_str!("../../../.agents/skills/uteke-memory/SKILL.md");
+    let bundled = include_str!("../assets/uteke-memory-skill.md");
     std::fs::write(&dest, bundled).map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
     Ok(dest)
 }
@@ -232,8 +232,8 @@ fn init_pi_memory_provider(json: bool) -> Result<(), String> {
         .map_err(|e| format!("Failed to create extension dir: {e}"))?;
 
     // Templates embedded from extensions/pi-memory-provider/ at build time.
-    let index_ts = include_str!("../../../extensions/pi-memory-provider/index.ts");
-    let package_json = include_str!("../../../extensions/pi-memory-provider/package.json");
+    let index_ts = include_str!("../assets/pi-memory-provider/index.ts");
+    let package_json = include_str!("../assets/pi-memory-provider/package.json");
 
     std::fs::write(ext_dir.join("index.ts"), index_ts)
         .map_err(|e| format!("Failed to write index.ts: {e}"))?;
@@ -652,8 +652,8 @@ fn init_hermes_memory_provider(json: bool) -> Result<(), String> {
         .map_err(|e| format!("Failed to create plugin dir: {e}"))?;
 
     // Templates embedded from extensions/hermes-memory-provider/ at build time.
-    let init_py = include_str!("../../../extensions/hermes-memory-provider/__init__.py.tmpl");
-    let plugin_yaml = include_str!("../../../extensions/hermes-memory-provider/plugin.yaml.tmpl");
+    let init_py = include_str!("../assets/hermes-memory-provider/__init__.py.tmpl");
+    let plugin_yaml = include_str!("../assets/hermes-memory-provider/plugin.yaml.tmpl");
 
     std::fs::write(plugin_dir.join("__init__.py"), init_py)
         .map_err(|e| format!("Failed to write __init__.py: {e}"))?;
@@ -696,9 +696,9 @@ mod tests {
     /// The Hermes memory-provider templates are embedded at build time. Guard
     /// against them going missing or losing their entry points.
     const INIT_PY: &str =
-        include_str!("../../../extensions/hermes-memory-provider/__init__.py.tmpl");
+        include_str!("../assets/hermes-memory-provider/__init__.py.tmpl");
     const PLUGIN_YAML: &str =
-        include_str!("../../../extensions/hermes-memory-provider/plugin.yaml.tmpl");
+        include_str!("../assets/hermes-memory-provider/plugin.yaml.tmpl");
 
     #[test]
     fn memory_provider_template_has_register_entrypoint() {
@@ -722,9 +722,9 @@ mod tests {
     }
 
     // Pi memory-provider template guards (#575).
-    const PI_INDEX_TS: &str = include_str!("../../../extensions/pi-memory-provider/index.ts");
+    const PI_INDEX_TS: &str = include_str!("../assets/pi-memory-provider/index.ts");
     const PI_PACKAGE_JSON: &str =
-        include_str!("../../../extensions/pi-memory-provider/package.json");
+        include_str!("../assets/pi-memory-provider/package.json");
 
     #[test]
     fn pi_memory_provider_has_before_agent_start_hook() {

--- a/crates/uteke-cli/src/init.rs
+++ b/crates/uteke-cli/src/init.rs
@@ -695,10 +695,8 @@ fn init_hermes_memory_provider(json: bool) -> Result<(), String> {
 mod tests {
     /// The Hermes memory-provider templates are embedded at build time. Guard
     /// against them going missing or losing their entry points.
-    const INIT_PY: &str =
-        include_str!("../assets/hermes-memory-provider/__init__.py.tmpl");
-    const PLUGIN_YAML: &str =
-        include_str!("../assets/hermes-memory-provider/plugin.yaml.tmpl");
+    const INIT_PY: &str = include_str!("../assets/hermes-memory-provider/__init__.py.tmpl");
+    const PLUGIN_YAML: &str = include_str!("../assets/hermes-memory-provider/plugin.yaml.tmpl");
 
     #[test]
     fn memory_provider_template_has_register_entrypoint() {
@@ -723,8 +721,7 @@ mod tests {
 
     // Pi memory-provider template guards (#575).
     const PI_INDEX_TS: &str = include_str!("../assets/pi-memory-provider/index.ts");
-    const PI_PACKAGE_JSON: &str =
-        include_str!("../assets/pi-memory-provider/package.json");
+    const PI_PACKAGE_JSON: &str = include_str!("../assets/pi-memory-provider/package.json");
 
     #[test]
     fn pi_memory_provider_has_before_agent_start_hook() {


### PR DESCRIPTION
## What
- Move embedded assets (`SKILL.md`, pi/hermes memory provider templates) from repo root (`.agents/`, `extensions/`) into `crates/uteke-cli/assets/`, update 9 `include_str!` paths
- Add a Verify crates.io versions step to the release workflow that fails the job if any crate's `max_version` on crates.io does not match the tag after publish

## Why
`cargo publish` cannot bundle files referenced outside the package root. uteke-cli has silently failed to publish since June (crates.io stuck at 0.4.3 while the repo is at 0.14.1) since the release workflow's `continue-on-error: true` on publish steps masked the failure. `cargo install uteke-cli` gives users a binary two months stale. Fixes the gap surfaced by the v0.14.1 release validation.

## Changes
- `crates/uteke-cli/assets/` — 5 new asset files (skill md, provider templates)
- `crates/uteke-cli/src/init.rs` — 9 include_str! path updates
- `.github/workflows/release.yml` — post-publish verification with retries

## Testing
- `cargo build -p uteke-cli` clean
- `cargo test -p uteke-cli`: 51 passed, 0 failed
- `cargo package -p uteke-cli` (full verify incl. compile from packaged .crate): passes — this exact command failed in CI before the fix
- Verified asset files present inside the packaged `.crate` archive