### PR TITLE
chore: bump version to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.14.2] — 2026-08-14
+
+Patch release to restore the uteke-cli crates.io publish. The CLI crate embedded asset files from outside its package root, which `cargo publish` cannot bundle, so every publish attempt since June failed silently while the release workflow reported success. The crate was stuck at 0.4.3 on crates.io while the repo shipped 0.14.x.
+
+### Fixed
+
+- `uteke-cli` publishes again: the memory-skill and provider templates now live inside `crates/uteke-cli/assets/` and ship inside the `.crate` archive
+- The release workflow now verifies every crate reports the tagged version on crates.io and fails the job if a publish step was silently skipped
+
+### Note for `cargo install` users
+
+If you installed `uteke-cli` before this release, you have a build from June. Run `cargo install uteke-cli --version 0.14.2` to get the current CLI.
+
 ## [0.14.1] — 2026-08-14
 
 Patch release: two chunker bug fixes found by mutation testing, plus test-suite hardening. No API or behavior changes beyond the fixes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "dirs",
  "serde",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.1", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.2", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.1", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.2", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.1", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.14.1" }
+uteke-core = { path = "../uteke-core", version = "0.14.2", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.14.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What
Bump workspace version 0.14.1 → 0.14.2 and add the CHANGELOG entry.

## Why
v0.14.1 is already tagged and core/mcp/server are live on crates.io at 0.14.1, but uteke-cli failed to publish (assets outside package root, fixed in #1030). A version bump is required to republish uteke-cli — crates.io versions are immutable.

## Changes
- Cargo.toml + member crate versions: 0.14.1 → 0.14.2
- CHANGELOG entry for 0.14.2

## Testing
- cargo package -p uteke-cli verified locally in #1030 (exact failing command now passes)
- Release workflow will verify all four crates hit the tagged version on crates.io (new guard from #1030)