### PR TITLE
fix: HTTP & MCP recall strategy — default hybrid, loud validation (#1034, #1035)

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -222,8 +222,8 @@ pub struct RecallConfig {
     pub min_score_strict: f64,
     /// Default recall strategy for the `recall` command when `--strategy` is
     /// not given. One of: `vector`, `fts5`, `hybrid`, `graph`. Default
-    /// `vector` preserves the original CLI behavior; `graph` enables
-    /// graph-augmented reranking (#378).
+    /// `hybrid` (RRF: vector + FTS5, R@5 98.0% vs vector-only 85.4% on
+    /// LongMemEval-S); `graph` enables graph-augmented reranking (#378).
     pub default_strategy: String,
     /// Weight for the edge-density boost applied by the `graph` strategy.
     /// 0.0 disables; 0.1 is subtle (default).

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -268,7 +268,8 @@ fn tool_recall() -> Value {
                 "namespace": { "type": "string", "description": "Namespace to search (default: 'default')" },
                 "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter by tags (optional)" },
                 "min_score": { "type": "number", "description": "Minimum similarity score 0..1 (default: 0.0)" },
-                "type": { "type": "string", "enum": ["all", "memory", "doc"], "description": "Search type: 'all' (default, unified), 'memory', or 'doc'" }
+                "type": { "type": "string", "enum": ["all", "memory", "doc"], "description": "Search type: 'all' (default, unified), 'memory', or 'doc'" },
+                "strategy": { "type": "string", "enum": ["hybrid", "vector", "fts5", "graph"], "description": "Recall strategy: 'hybrid' (default, vector+FTS5 via RRF), 'vector' (similarity only), 'fts5' (keyword only), or 'graph' (hybrid + graph-signal reranking)", "default": "hybrid" }
             },
             "required": ["query"]
         }
@@ -827,6 +828,21 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         }
     };
 
+    // Parse optional recall strategy (#1035): default hybrid, matching the
+    // CLI and HTTP defaults. Unknown values are a loud error (JSON-RPC -32603),
+    // never a silent fallback.
+    let strategy = match args["strategy"].as_str() {
+        Some(name) => match uteke_core::RecallStrategy::from_str_opt(name) {
+            Some(s) => s,
+            None => {
+                return Err(format!(
+                    "Invalid strategy: '{name}'. Use 'vector', 'fts5', 'hybrid', or 'graph'."
+                ));
+            }
+        },
+        None => uteke_core::RecallStrategy::Hybrid,
+    };
+
     // Use unified search when type is specified or default (all).
     // Fall back to legacy recall only for backward compat with existing MCP consumers.
     let results = uteke
@@ -840,7 +856,7 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
             None,
             None,
             false,
-            uteke_core::RecallStrategy::Vector, // #900: default vector, MCP doesn't expose strategy yet
+            strategy,
         )
         .map_err(|e| format!("Failed: {e}"))?;
 

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -316,27 +316,29 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 };
                 let has_temporal = after_ts.is_some() || before_ts.is_some();
 
-                let recall_result = if let Some(pit) = point_in_time {
-                    uteke.recall_at_time(
-                        &req_data.query,
-                        limit,
-                        tags_filter,
-                        ns(&req_data.namespace),
-                        pit,
-                        min_score,
-                        entity_filter,
-                        category_filter,
-                    )
-                } else {
-                    uteke.recall(
-                        &req_data.query,
-                        limit,
-                        tags_filter,
-                        ns(&req_data.namespace),
-                        min_score,
-                        entity_filter,
-                        category_filter,
-                    )
+                // Resolve recall strategy ONCE for every path (#1034):
+                // request `strategy` > config `[recall] default_strategy` >
+                // Hybrid — matching the CLI default. Unknown values are a
+                // loud 400 on all paths, never a silent no-op.
+                let strategy_name = req_data.strategy.as_deref().or_else(|| {
+                    ctx.recall_config
+                        .as_ref()
+                        .and_then(|r| r.default_strategy.as_deref())
+                });
+                let strategy = match strategy_name {
+                    Some(name) => match uteke_core::RecallStrategy::from_str_opt(name) {
+                        Some(s) => s,
+                        None => {
+                            return ctx.error_response_for(
+                                req,
+                                400,
+                                format!(
+                                    "Invalid strategy: '{name}'. Use 'vector', 'fts5', 'hybrid', or 'graph'."
+                                ),
+                            );
+                        }
+                    },
+                    None => uteke_core::RecallStrategy::Hybrid,
                 };
 
                 // Unified search path (#531): when search_type is specified,
@@ -353,22 +355,6 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                                 400,
                                 format!(
                                     "Invalid search_type: '{other}'. Use 'all', 'memory', or 'doc'."
-                                ),
-                            );
-                        }
-                    };
-                    // Parse strategy (#900)
-                    let strategy = match req_data.strategy.as_deref() {
-                        Some("fts5") => uteke_core::RecallStrategy::Fts5,
-                        Some("hybrid") => uteke_core::RecallStrategy::Hybrid,
-                        Some("graph") => uteke_core::RecallStrategy::Graph,
-                        Some("vector") | None => uteke_core::RecallStrategy::Vector,
-                        Some(other) => {
-                            return ctx.error_response_for(
-                                req,
-                                400,
-                                format!(
-                                    "Invalid strategy: '{other}'. Use 'vector', 'fts5', 'hybrid', or 'graph'."
                                 ),
                             );
                         }
@@ -416,10 +402,65 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                         ctx.error_response_for(req, 500, "Internal server error")
                     }
                     None => {
-                        // Memory-only recall path — entity/category filtering
-                        // is already applied in the core recall candidate loop (#663).
+                        // Memory-only recall path (#1034): route through
+                        // recall_hybrid so the resolved strategy applies to
+                        // the default path too — not just when search_type is
+                        // present. recall_hybrid has no native entity/category
+                        // support, so apply them as post-filters with 3×
+                        // over-fetch (same pattern as recall_unified_memories).
+                        let needs_post_filter =
+                            entity_filter.is_some() || category_filter.is_some();
+                        let fetch_limit = if needs_post_filter {
+                            (limit.saturating_mul(3)).max(limit + 10)
+                        } else {
+                            limit
+                        };
+                        let recall_result = if let Some(pit) = point_in_time {
+                            // Time-travel: strategy doesn't apply to
+                            // recall_at_time (point-in-time semantics).
+                            uteke.recall_at_time(
+                                &req_data.query,
+                                limit,
+                                tags_filter,
+                                ns(&req_data.namespace),
+                                pit,
+                                min_score,
+                                entity_filter,
+                                category_filter,
+                            )
+                        } else {
+                            uteke.recall_hybrid(
+                                &req_data.query,
+                                fetch_limit,
+                                tags_filter,
+                                ns(&req_data.namespace),
+                                strategy,
+                                min_score,
+                            )
+                        };
+                        // Entity/category post-filter (memory results only) —
+                        // mirrors the CLI recall post-filter and core
+                        // recall_unified_memories (#663, #900).
                         match recall_result {
                             Ok(mut results) => {
+                                if needs_post_filter && point_in_time.is_none() {
+                                    results.retain(|sr| {
+                                        entity_filter.is_none_or(|ent| {
+                                            sr.memory
+                                                .metadata
+                                                .get("entity")
+                                                .and_then(|v| v.as_str())
+                                                .is_some_and(|e| e == ent)
+                                        }) && category_filter.is_none_or(|cat| {
+                                            sr.memory
+                                                .metadata
+                                                .get("category")
+                                                .and_then(|v| v.as_str())
+                                                .is_some_and(|c| c == cat)
+                                        })
+                                    });
+                                    results.truncate(limit);
+                                }
                                 // #902: Post-filter by temporal range (before/after).
                                 if has_temporal {
                                     results.retain(|r| {

--- a/crates/uteke-server/src/main.rs
+++ b/crates/uteke-server/src/main.rs
@@ -326,7 +326,28 @@ fn main() {
         auth_token_hash,
         read_only_token_hash,
         cors_origins: cors_origins.clone(),
-        recall_config: config.recall.clone(),
+        recall_config: {
+            // Sanitize [recall] default_strategy at startup (#1034): the
+            // server only recently started honoring this key. An invalid
+            // value (typo in uteke.toml) must not 400 every recall request
+            // with a message blaming the request — warn loudly and fall
+            // back to hybrid instead. Explicit request-level `strategy`
+            // values remain strictly validated (HTTP 400).
+            let mut recall = config.recall.clone();
+            if let Some(r) = recall.as_mut() {
+                if let Some(s) = r.default_strategy.as_deref() {
+                    if uteke_core::RecallStrategy::from_str_opt(s).is_none() {
+                        warn!(
+                            "Invalid [recall] default_strategy='{s}' in config — \
+                             falling back to 'hybrid'. \
+                             Expected: vector | fts5 | hybrid | graph."
+                        );
+                        r.default_strategy = Some("hybrid".to_string());
+                    }
+                }
+            }
+            recall
+        },
         extraction_config: config.extraction.clone(),
     };
 

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -245,6 +245,7 @@ pub struct RecallRequest {
     /// Recall strategy: "hybrid" (default), "vector", "fts5", or "graph" (#900, #1034).
     /// When absent, the server falls back to `[recall] default_strategy` from
     /// uteke.toml, then to "hybrid" — matching the CLI default.
+    /// Invalid values return HTTP 400.
     #[serde(default)]
     pub strategy: Option<String>,
     /// Temporal range filter: only return memories created at or after this

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -242,7 +242,9 @@ pub struct RecallRequest {
     /// `linked_memory_ids` on document results.
     #[serde(default)]
     pub enrich: bool,
-    /// Recall strategy: "vector" (default), "fts5", "hybrid", or "graph" (#900).
+    /// Recall strategy: "hybrid" (default), "vector", "fts5", or "graph" (#900, #1034).
+    /// When absent, the server falls back to `[recall] default_strategy` from
+    /// uteke.toml, then to "hybrid" — matching the CLI default.
     #[serde(default)]
     pub strategy: Option<String>,
     /// Temporal range filter: only return memories created at or after this
@@ -428,6 +430,9 @@ pub struct RecallFileSection {
     pub min_score: Option<f64>,
     /// Strict mode threshold (higher, for critical queries).
     pub min_score_strict: Option<f64>,
+    /// Default recall strategy when a request omits `strategy` (#1034).
+    /// One of: vector | fts5 | hybrid | graph. Server-side default: hybrid.
+    pub default_strategy: Option<String>,
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -640,7 +640,10 @@ Default: 0.0 (no filtering). Use `strict=true` for 0.5 default (#995). |
 | `namespace` | any | No |  |
 | `query` | `string` | Yes |  |
 | `search_type` | any | No | Search type filter: "all" (default, unified), "memory", or "doc" (#531). |
-| `strategy` | any | No | Recall strategy: "hybrid" (default, RRF: vector + FTS5), "vector", "fts5", or "graph". Invalid values return HTTP 400. When absent, falls back to `[recall] default_strategy` from uteke.toml (#900, #1034). |
+| `strategy` | any | No | Recall strategy: "hybrid" (default), "vector", "fts5", or "graph" (#900, #1034).
+When absent, the server falls back to `[recall] default_strategy` from
+uteke.toml, then to "hybrid" — matching the CLI default.
+Invalid values return HTTP 400. |
 | `strict` | `boolean` | No | Use strict threshold (defaults to 0.5 if min_score not set). |
 | `tags` | ``string``[] | No |  |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -640,7 +640,7 @@ Default: 0.0 (no filtering). Use `strict=true` for 0.5 default (#995). |
 | `namespace` | any | No |  |
 | `query` | `string` | Yes |  |
 | `search_type` | any | No | Search type filter: "all" (default, unified), "memory", or "doc" (#531). |
-| `strategy` | any | No | Recall strategy: "vector" (default), "fts5", "hybrid", or "graph" (#900). |
+| `strategy` | any | No | Recall strategy: "hybrid" (default, RRF: vector + FTS5), "vector", "fts5", or "graph". Invalid values return HTTP 400. When absent, falls back to `[recall] default_strategy` from uteke.toml (#900, #1034). |
 | `strict` | `boolean` | No | Use strict threshold (defaults to 0.5 if min_score not set). |
 | `tags` | ``string``[] | No |  |
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -137,7 +137,7 @@ Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 | Tool | Description |
 |------|-------------|
 | `uteke_remember` | Store a memory (supports type, room, author, tags) |
-| `uteke_recall` | Semantic search (supports tags filter, min_score) |
+| `uteke_recall` | Semantic search (supports tags filter, min_score, strategy: hybrid/vector/fts5/graph — default hybrid) |
 | `uteke_search` | Text search with optional tag filter |
 | `uteke_list` | List memories (supports pagination via offset) |
 | `uteke_forget` | Delete a memory |


### PR DESCRIPTION
## What

Recall `strategy` now behaves identically across CLI, HTTP API, and MCP:

- **Default is hybrid** everywhere (request `strategy` > `[recall] default_strategy` config > built-in hybrid). The HTTP server silently fell back to legacy vector when no `strategy` was sent — the same class of bug the CLI fixed in #900.
- **Invalid values fail loud**: HTTP returns 400 on every path (bare recall, unified search, v1); MCP returns a JSON-RPC `-32603` error. Previously HTTP returned 200 OK and MCP silently used vector.
- **MCP schema exposes `strategy`** (vector|fts5|hybrid|graph) so agents can select a strategy at all.

## Why

Issues #1034 and #1035: the CLI got the strategy fix in #900, but the HTTP and MCP surfaces never got the wiring. Three surfaces, three behaviors — the worst kind of inconsistency because it is invisible until results quietly differ.

Also closes a footgun this fix would have introduced: the server now honors `[recall] default_strategy` from uteke.toml, so an invalid value (typo) is sanitized at startup (warn + fallback hybrid) instead of 400-ing every request with a message blaming the request.

## Changes

- `uteke-server/src/handlers.rs` — strategy resolved once per request (request > config > hybrid); invalid → 400; eager legacy recall before resolution removed; memory-only path routes through `recall_hybrid` + 3× over-fetch post-filter for entity/category (same pattern as `recall_unified_memories`)
- `uteke-server/src/types.rs` — `RecallRequest.strategy` docs (hybrid default, fallback chain); `RecallFileSection` gains `default_strategy`
- `uteke-server/src/main.rs` — startup sanitization of `[recall] default_strategy`
- `uteke-mcp/src/lib.rs` — schema exposes `strategy`; default hybrid; invalid → `-32603`
- `uteke-cli/src/config.rs` — doc comment aligns with hybrid default
- `docs/api-reference.md`, `docs/mcp.md` — hybrid default, 400 on invalid, fallback chain

## Testing

Empirical verification against a scratch store (isolated UTEKE_HOME, 6 seeded memories, release build):

- **HTTP matrix 10/10 PASS**: default → 200 hybrid; all four strategies explicit → 200; `bogus` → 400 (bare + unified + v1); config `default_strategy = "vector"` overrides built-in default; server with typo'd config boots + WARN + 200 (not 400-everything)
- **MCP harness 8/8 PASS**: schema exposes strategy; default `isError=false`; `bogus` → `-32603` with clear message; **engine parity proven**: default == explicit hybrid on warm cache (identical score vectors)
- `cargo fmt` clean, `cargo clippy --workspace --all-targets` clean, `cargo test --workspace` **538 passed / 0 failed**, cora pre-commit review: no issues

Out of scope (filed separately): #1036 (export drops namespace), #1037 (recall cache-hit skips salience/recency boosts — discovered during this verification).

Closes #1034. Closes #1035.