### PR TITLE
chore: bump version to 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.14.3] — 2026-08-15
+
+Patch release: recall `strategy` now behaves the same everywhere. The CLI got the fix in #900; the HTTP API and MCP server never got the wiring, so the same request quietly returned different results depending on which surface you asked.
+
+### Fixed
+
+- **HTTP recall strategy: default is hybrid, not legacy vector (#1034)** — A request without `strategy` silently fell back to the legacy vector path, and `strategy: "bogus"` returned 200 OK with vector results behind it. Strategy is now resolved once per request (request > `[recall] default_strategy` from uteke.toml > hybrid) and invalid values return HTTP 400 on every path — bare recall, unified search, and v1. The eager legacy recall that ran before strategy resolution is gone, which also removes a wasted query on every memory recall.
+- **MCP `uteke_recall` exposes `strategy` (#1035)** — The tool schema didn't list a `strategy` parameter, silently hardcoded vector, and ignored invalid values. The schema now documents `vector | fts5 | hybrid | graph`, the default resolves to hybrid, and invalid values return a loud JSON-RPC error instead of a quiet vector search.
+- **Server honors `[recall] default_strategy`** — The HTTP server now reads the config key the CLI has documented all along. A typo'd value is caught at startup with a warning and falls back to hybrid, so one bad config line can't 400 every request with a message blaming the request.
+- **Memory recall with entity/category filters** now routes through the hybrid engine with the same 3× over-fetch post-filter the unified path uses, instead of a vector-only path that could miss FTS5 matches.
+
+### Verified
+
+Empirically, against a scratch store with a release build: HTTP matrix 10/10 (default hybrid, all four strategies, 400 on invalid across all three paths, config override, startup sanitization), MCP harness 8/8 (schema, defaults, loud errors, engine parity default == hybrid on warm cache). Workspace suite 538/538.
+
+Known issues filed during this work: #1036 (export drops namespace), #1037 (recall cache-hit skips salience/recency boosts).
+
 ## [0.14.2] — 2026-08-14
 
 Patch release to restore the uteke-cli crates.io publish. The CLI crate embedded asset files from outside its package root, which `cargo publish` cannot bundle, so every publish attempt since June failed silently while the release workflow reported success. The crate was stuck at 0.4.3 on crates.io while the repo shipped 0.14.x.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "dirs",
  "serde",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.2", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.2", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.2", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.14.2" }
+uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.14.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What

Version bump 0.14.2 → 0.14.3 plus the CHANGELOG entry for this patch release.

## Why

Ships fix #1034 (HTTP recall strategy: default hybrid, 400 on invalid) and #1035 (MCP `uteke_recall` exposes `strategy`, loud validation) merged in #1038.

## Changes

- Root workspace version → `0.14.3` (all crates inherit via `version.workspace = true`), `Cargo.lock` regenerated
- `CHANGELOG.md` — 0.14.3 entry: fixed sections for #1034/#1035, config startup sanitization, empirical verification summary

## Testing

- `cargo update -w` clean, workspace builds
- CHANGELOG content mirrors PR #1038 verification (HTTP 10/10, MCP 8/8, 538/538 tests)