### PR TITLE
fix(ci): release notes heredoc executed installer on runner — use template file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,54 +421,18 @@ jobs:
             cp RELEASE_NOTES.md release-notes.md
           else
             echo "::notice::No RELEASE_NOTES.md found, auto-generating from CHANGELOG"
-            echo "## What's New in ${VER}" > release-notes.md
-            echo "" >> release-notes.md
-            cat changelog-body.md >> release-notes.md
-            echo "" >> release-notes.md
-            cat >> release-notes.md << RELEASEEOF
-
-          ### 📦 Downloads
-
-          Each archive contains three binaries + ONNX Runtime shared library:
-
-          | Binary | Description |
-          |--------|-------------|
-          | `uteke` | CLI tool |
-          | `uteke-serve` | HTTP server daemon |
-          | `uteke-mcp` | MCP server (stdio + HTTP) |
-          | `libonnxruntime.so*` / `libonnxruntime*.dylib` / `onnxruntime*.dll` | ONNX Runtime |
-
-          | Platform | File |
-          |----------|------|
-          | Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-${VER}.tar.gz` |
-          | Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-${VER}.tar.gz` |
-          | Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-${VER}.tar.gz` |
-          | macOS Apple Silicon | `uteke-aarch64-apple-darwin-${VER}.tar.gz` |
-          | Windows x86_64 | `uteke-x86_64-pc-windows-msvc-${VER}.zip` |
-
-          > **Legacy Bundle (Linux only)** — Includes a SSE4.2-only ORT sidecar (`ort-legacy/`) for CPUs without AVX2 (Intel Celeron J4125/N4020). Use this bundle to avoid SIGILL crashes on older hardware.
-
-          ### 🚀 Quick Start
-
-          ```bash
-          # Quick install (Linux / macOS)
-          curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
-
-          # Pin a specific version
-          UTEKE_VERSION=${VER} curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
-
-          # Store a memory
-          uteke remember "Important context" --tags project
-
-          # Recall by meaning
-          uteke recall "what was that context?"
-
-          # Start server for fast AI agent access
-          uteke-serve --port 8767
-          ```
-
-          **Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md
-          RELEASEEOF
+            {
+              echo "## What's New in ${VER}"
+              echo ""
+              cat changelog-body.md
+              echo ""
+              # Static tail (downloads table + quick start) lives in a plain template
+              # file — NEVER inline it in a heredoc. Unquoted heredoc bodies undergo
+              # shell expansion: markdown backticks become command substitutions and
+              # get EXECUTED (v0.14.3: installer curl|sh ran on the runner, then
+              # uteke-serve blocked forever). Template file = zero expansion.
+              sed "s/__VER__/${VER#v}/g" scripts/release-notes-template.md
+            } > release-notes.md
           fi
 
       - name: Create GitHub Release

--- a/scripts/release-notes-template.md
+++ b/scripts/release-notes-template.md
@@ -1,0 +1,41 @@
+### 📦 Downloads
+
+Each archive contains three binaries + ONNX Runtime shared library:
+
+| Binary | Description |
+|--------|-------------|
+| `uteke` | CLI tool |
+| `uteke-serve` | HTTP server daemon |
+| `uteke-mcp` | MCP server (stdio + HTTP) |
+| `libonnxruntime.so*` / `libonnxruntime*.dylib` / `onnxruntime*.dll` | ONNX Runtime |
+
+| Platform | File |
+|----------|------|
+| Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-__VER__.tar.gz` |
+| Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-__VER__.tar.gz` |
+| Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-__VER__.tar.gz` |
+| macOS Apple Silicon | `uteke-aarch64-apple-darwin-__VER__.tar.gz` |
+| Windows x86_64 | `uteke-x86_64-pc-windows-msvc-__VER__.zip` |
+
+> **Legacy Bundle (Linux only)** — Includes a SSE4.2-only ORT sidecar (`ort-legacy/`) for CPUs without AVX2 (Intel Celeron J4125/N4020). Use this bundle to avoid SIGILL crashes on older hardware.
+
+### 🚀 Quick Start
+
+```bash
+# Quick install (Linux / macOS)
+curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+
+# Pin a specific version
+UTEKE_VERSION=__VER__ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+
+# Store a memory
+uteke remember "Important context" --tags project
+
+# Recall by meaning
+uteke recall "what was that context?"
+
+# Start server for fast AI agent access
+uteke-serve --port 8767
+```
+
+**Full changelog:** https://github.com/codecoradev/uteke/blob/main/CHANGELOG.md


### PR DESCRIPTION
## What

Unquoted heredoc `<< RELEASEEOF` in the release workflow's Generate release notes step underwent shell expansion. Markdown backticks in the downloads table and the ```bash fence turned into command substitutions — **executed on the CI runner**.

## Why

v0.14.3 release workflow hung for 48 minutes × 2 runs (deterministic). Log evidence (attempt 1):

- `line 22: uteke: command not found` ×12 — table cells executed as commands
- Odd backtick count → multi-line command substitution swallowed the entire Quick Start block
- `curl -fsSL …/install.sh | sh` — **installer ran on the runner**
- `uteke-serve --port 8767` — blocking server started, never exited → hang
- Cleanup: `Terminate orphan process: pid (2130) (uteke-serve)`

## Changes

- Static tail (downloads table + quick start) moved to `scripts/release-notes-template.md` with `__VER__` placeholder
- Workflow now: header + changelog body via grouped echo/cat, template via `sed "s/__VER__/…/g"`
- Zero shell expansion over markdown content — backticks can never execute again

## Testing

- Local dry-run of the new generate step: completes instantly, exit 0, output byte-correct (60 lines, version substituted in all 6 slots)
- `python3 -c yaml.safe_load`: workflow YAML parses
- Local repro of the bug (before fix): exit 124 timeout, same hang signature as CI