### PR TITLE
fix(release): keep v prefix on download filenames and pinned install

### DIFF
--- a/scripts/release-notes-template.md
+++ b/scripts/release-notes-template.md
@@ -11,11 +11,11 @@ Each archive contains three binaries + ONNX Runtime shared library:
 
 | Platform | File |
 |----------|------|
-| Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-__VER__.tar.gz` |
-| Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-__VER__.tar.gz` |
-| Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-__VER__.tar.gz` |
-| macOS Apple Silicon | `uteke-aarch64-apple-darwin-__VER__.tar.gz` |
-| Windows x86_64 | `uteke-x86_64-pc-windows-msvc-__VER__.zip` |
+| Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-v__VER__.tar.gz` |
+| Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-v__VER__.tar.gz` |
+| Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-v__VER__.tar.gz` |
+| macOS Apple Silicon | `uteke-aarch64-apple-darwin-v__VER__.tar.gz` |
+| Windows x86_64 | `uteke-x86_64-pc-windows-msvc-v__VER__.zip` |
 
 > **Legacy Bundle (Linux only)** — Includes a SSE4.2-only ORT sidecar (`ort-legacy/`) for CPUs without AVX2 (Intel Celeron J4125/N4020). Use this bundle to avoid SIGILL crashes on older hardware.
 
@@ -26,7 +26,7 @@ Each archive contains three binaries + ONNX Runtime shared library:
 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 
 # Pin a specific version
-UTEKE_VERSION=__VER__ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v__VER__ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 
 # Store a memory
 uteke remember "Important context" --tags project


### PR DESCRIPTION
Closes #1043

## Why

The generated release-notes download table lists five filenames without the `v` prefix, but the built release assets keep it (`uteke-x86_64-unknown-linux-gnu-v0.14.3.tar.gz`). Copy-paste from the notes 404s.

Root cause: `release.yml` substitutes `__VER__` with `\${VER#v}` — the stripped version — so every filename loses its prefix.

## What

- Downloads table: filenames now use `-v__VER__.tar.gz` / `-v__VER__.zip`.
- Quick start pin: `UTEKE_VERSION=v__VER__`, matching what install.sh documents (`Set UTEKE_VERSION=vX.Y.Z to pin a version`). It previously expanded to a prefix-less pin, which install.sh resolves to a `v`-prefixed asset name (ARCHIVE_NAME already interpolates the version directly).

## Validation

- `sed "s/__VER__/${VER#v}/g"` run against the template with `VER=v0.14.3` yields exactly the v-prefixed filenames and a `UTEKE_VERSION=v0.14.3` pin.
- Live notes can be patched with `gh release edit v0.14.3 --notes-file <regenerated>` — no re-release needed.

## Surface area

`scripts/release-notes-template.md` only. No CI behavior change.
