### PR TITLE
test: use ORT_LIB_NAME in find_ort_in_dir exact-match test

### DIFF
--- a/crates/uteke-core/src/embed/ort_init.rs
+++ b/crates/uteke-core/src/embed/ort_init.rs
@@ -396,7 +396,7 @@ mod tests {
         let tmp = std::env::temp_dir();
         let dir = tmp.join("test_ort_exact");
         std::fs::create_dir_all(&dir).unwrap();
-        let lib = dir.join("libonnxruntime.so");
+        let lib = dir.join(ORT_LIB_NAME);
         std::fs::write(&lib, b"fake").unwrap();
 
         let result = find_ort_in_dir(&dir);


### PR DESCRIPTION
## What

`find_ort_in_dir_finds_exact_match` hardcoded `libonnxruntime.so` and asserted `find_ort_in_dir` finds it. On macOS `ORT_LIB_NAME` is `libonnxruntime.dylib`, so the exact-match path returned `None` and the test panicked:

```
assertion failed: result.is_some()
```

One-line fix: build the fixture from the `ORT_LIB_NAME` constant instead of the hardcoded `.so`.

## Why

The failure hid on every local macOS run (`cargo test --workspace` red) while CI ubuntu stayed green, masking real regressions in the workspace suite. The versioned-variant test already passes on macOS because the `.so.` prefix scan is unix-wide; only the exact-match fixture was platform-wrong.

## Testing

- `cargo test -p uteke-core find_ort_in_dir` → 3 passed (was 1 failed on macOS arm64)
- `cargo fmt --all -- --check` clean
- `cargo clippy -p uteke-core --all-targets -- -D warnings` clean
- Fixture dir still uniquely named (`test_ort_exact`), temp-dir cleanup unchanged

Closes #1054