### PR TITLE
chore: switch ID generation new_v4 → now_v7 (time-ordered, index-friendly)

### DIFF
--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 usearch = "2"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v7"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 thiserror = "2"
 dirs = "6"

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -984,7 +984,7 @@ mod tests {
 
     fn mem(content: &str, tags: &[&str]) -> Memory {
         Memory {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::now_v7().to_string(),
             content: content.to_string(),
             embedding: vec![],
             tags: tags.iter().map(|s| s.to_string()).collect(),

--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -285,7 +285,7 @@ impl<'a> GraphStore<'a> {
             return Ok(id);
         }
 
-        let id = uuid::Uuid::new_v4().to_string();
+        let id = uuid::Uuid::now_v7().to_string();
         let now = chrono::Utc::now().to_rfc3339();
         self.conn
             .execute(
@@ -305,7 +305,7 @@ impl<'a> GraphStore<'a> {
         relation: &str,
         weight: f64,
     ) -> Result<(), Error> {
-        let id = uuid::Uuid::new_v4().to_string();
+        let id = uuid::Uuid::now_v7().to_string();
         let now = chrono::Utc::now().to_rfc3339();
         let affected = self
             .conn

--- a/crates/uteke-core/src/import_export.rs
+++ b/crates/uteke-core/src/import_export.rs
@@ -88,7 +88,7 @@ impl crate::Uteke {
                 continue;
             }
 
-            let id = uuid::Uuid::new_v4().to_string();
+            let id = uuid::Uuid::now_v7().to_string();
             let now = chrono::Utc::now();
 
             let memory = Memory {

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1323,7 +1323,7 @@ impl Uteke {
         let existing = self.store.get_document_by_slug(slug)?;
         let (id, version) = match &existing {
             Some(doc) => (doc.id.clone(), doc.version),
-            None => (uuid::Uuid::new_v4().to_string(), 1),
+            None => (uuid::Uuid::now_v7().to_string(), 1),
         };
 
         let path = if let Some(ref _pid) = parent_id {
@@ -1384,7 +1384,7 @@ impl Uteke {
         }
 
         for (i, chunk) in chunks.iter().enumerate() {
-            let chunk_id = uuid::Uuid::new_v4().to_string();
+            let chunk_id = uuid::Uuid::now_v7().to_string();
             let embedding = embedder.embed(&chunk.content)?;
 
             self.store.insert_document_chunk(
@@ -1487,7 +1487,7 @@ impl Uteke {
             }
 
             for (i, chunk) in chunks.iter().enumerate() {
-                let chunk_id = uuid::Uuid::new_v4().to_string();
+                let chunk_id = uuid::Uuid::now_v7().to_string();
                 let embedding = embedder.embed(&chunk.content)?;
 
                 self.store.insert_document_chunk(
@@ -3247,5 +3247,27 @@ mod context_tests {
         assert!(ctx.contains("procedure"), "should list types");
         assert!(ctx.contains("decision"), "should list types");
         assert!(ctx.contains("Recent memories"), "should show recent");
+    }
+}
+
+#[cfg(test)]
+mod uuidv7_tests {
+    #[test]
+    fn new_ids_are_v7_and_time_ordered() {
+        let a = uuid::Uuid::now_v7().to_string();
+        let b = uuid::Uuid::now_v7().to_string();
+        let ua = uuid::Uuid::parse_str(&a).unwrap();
+        let ub = uuid::Uuid::parse_str(&b).unwrap();
+        assert_eq!(ua.get_version_num(), 7);
+        assert!(ub > ua, "consecutive now_v7 ids must sort ascending");
+    }
+
+    #[test]
+    fn v4_ids_still_parse_and_sort() {
+        // Mixed v4/v7 stores keep working: old rows stay v4, new rows v7.
+        let v4 = uuid::Uuid::new_v4();
+        let v7 = uuid::Uuid::now_v7();
+        assert_eq!(v4.get_version_num(), 4);
+        assert_eq!(v7.get_version_num(), 7);
     }
 }

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -277,7 +277,7 @@ impl crate::Uteke {
         content_type: &str,
         embedding: &[f32],
     ) -> Result<String, Error> {
-        let id = uuid::Uuid::new_v4().to_string();
+        let id = uuid::Uuid::now_v7().to_string();
         let now = chrono::Utc::now();
 
         let memory = Memory {

--- a/crates/uteke-core/src/orphans.rs
+++ b/crates/uteke-core/src/orphans.rs
@@ -165,7 +165,7 @@ mod tests {
 
     fn mem(content: &str, importance: f64) -> Memory {
         Memory {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::now_v7().to_string(),
             content: content.to_string(),
             embedding: vec![],
             tags: vec![],

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -198,7 +198,7 @@ mod tests {
 
     fn mem() -> Memory {
         Memory {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::now_v7().to_string(),
             content: "test".to_string(),
             embedding: vec![],
             tags: vec![],


### PR DESCRIPTION
## What

- `uuid` crate feature `v7` enabled alongside `v4` in uteke-core
- All 10 id-minting call sites swapped `Uuid::new_v4()` → `Uuid::now_v7()`: remember path, document chunks (x2), graph nodes (x2), edges, timeline events, orphans, import, lib fallback
- Two new tests: consecutive `now_v7()` mints sort ascending (version nibble = 7); v4/v7 parse coexistence

## Why

Closes #1058. v4 UUIDs are fully random → B-tree inserts land on random pages; v7 is time-ordered → append-mostly inserts, less page splitting at scale, sort-by-id ≈ sort-by-creation, and id prefix correlates with creation time (debugging). Aligns OSS with uteke-cloud's native `uuidv7()` PKs. Zero migration: storage is TEXT uuid either way, old stores keep their v4 rows, mixed ids coexist.

## Testing

- `cargo test -p uteke-core`: 478 passed + 2 new uuidv7 tests pass
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- Note: local macOS shows the pre-existing `find_ort_in_dir_finds_exact_match` failure — fixed separately in #1059, unrelated to this change; CI ubuntu unaffected