### PR TITLE
fix: soft-forgotten memories leak into list, search, and doctor counts

### DIFF
--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -454,7 +454,7 @@ impl super::Store {
                          created_at, updated_at, namespace, access_count, \
                          last_accessed, deprecated, valid_from, valid_until, \
                          memory_type, importance, pinned, content_type, slug \
-                         FROM memories WHERE namespace = ?1 AND EXISTS \
+                         FROM memories WHERE namespace = ?1 AND deprecated = 0 AND EXISTS \
                          (SELECT 1 FROM memory_tags WHERE memory_id = memories.id AND tag = ?2) \
                          ORDER BY created_at DESC LIMIT ?3 OFFSET ?4",
                     )
@@ -475,7 +475,7 @@ impl super::Store {
                          created_at, updated_at, namespace, access_count, \
                          last_accessed, deprecated, valid_from, valid_until, \
                          memory_type, importance, pinned, content_type, slug \
-                         FROM memories WHERE namespace = ?1 \
+                         FROM memories WHERE namespace = ?1 AND deprecated = 0 \
                          ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
                     )
                     .map_err(|e| Error::db("database operation", e))?;
@@ -495,7 +495,7 @@ impl super::Store {
                          created_at, updated_at, namespace, access_count, \
                          last_accessed, deprecated, valid_from, valid_until, \
                          memory_type, importance, pinned, content_type, slug \
-                         FROM memories WHERE EXISTS \
+                         FROM memories WHERE deprecated = 0 AND EXISTS \
                          (SELECT 1 FROM memory_tags WHERE memory_id = memories.id AND tag = ?1) \
                          ORDER BY created_at DESC LIMIT ?2 OFFSET ?3",
                     )
@@ -516,7 +516,7 @@ impl super::Store {
                          created_at, updated_at, namespace, access_count, \
                          last_accessed, deprecated, valid_from, valid_until, \
                          memory_type, importance, pinned, content_type, slug \
-                         FROM memories \
+                         FROM memories WHERE deprecated = 0 \
                          ORDER BY created_at DESC LIMIT ?1 OFFSET ?2",
                     )
                     .map_err(|e| Error::db("database operation", e))?;
@@ -550,7 +550,7 @@ impl super::Store {
             .conn
             .prepare(
                 "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug
-                 FROM memories WHERE namespace = ?1 AND content LIKE ?2 ESCAPE '!'
+                 FROM memories WHERE namespace = ?1 AND deprecated = 0 AND content LIKE ?2 ESCAPE '!'
                  ORDER BY created_at DESC LIMIT ?3",
             )
             .map_err(|e| Error::db("database operation", e))?;
@@ -571,12 +571,14 @@ impl super::Store {
     pub fn load_all(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
         // Filter out NULL embeddings — they cannot be inserted into the vector
         // index and cause dimension-mismatch crashes during build() (#992).
+        // Deprecated (soft-deleted) rows are excluded: they are hidden from
+        // recall and must not re-enter the vector index on repair/verify (#1047).
         let sql = match namespace {
             Some(_) => {
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE namespace = ?1 AND embedding IS NOT NULL ORDER BY created_at"
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE namespace = ?1 AND embedding IS NOT NULL AND deprecated = 0 ORDER BY created_at"
             }
             None => {
-                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE embedding IS NOT NULL ORDER BY created_at"
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug FROM memories WHERE embedding IS NOT NULL AND deprecated = 0 ORDER BY created_at"
             }
         };
 
@@ -613,7 +615,41 @@ impl super::Store {
     }
 
     /// Count total memories, optionally filtered by namespace.
+    /// Count ACTIVE (non-deprecated) memories, optionally filtered by namespace.
+    ///
+    /// Uniform contract: deprecated (soft-deleted) rows are excluded for both
+    /// the namespaced and un-namespaced paths. The vector index only ever holds
+    /// active rows (#1047), so counts from this method are directly comparable
+    /// against `index.len()` in doctor/verify.
+    ///
+    /// Callers that need totals INCLUDING deprecated rows (reporting, stats)
+    /// should use [`Store::count_all`].
     pub fn count(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let count: usize = match namespace {
+            Some(ns) => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND deprecated = 0",
+                    params![ns],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|e| Error::db("database operation", e))? as usize,
+            None => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE deprecated = 0",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|e| Error::db("database operation", e))? as usize,
+        };
+        Ok(count)
+    }
+
+    /// Count ALL memories including deprecated (soft-deleted) rows,
+    /// optionally filtered by namespace. For reporting/audit callers that
+    /// need raw totals; index comparisons should use [`Store::count`].
+    pub fn count_all(&self, namespace: Option<&str>) -> Result<usize, Error> {
         let count: usize = match namespace {
             Some(ns) => self
                 .conn

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -398,6 +398,12 @@ impl VectorIndex {
         self.index.size()
     }
 
+    /// Capacity of the underlying usearch index (diagnostics).
+    #[allow(dead_code)]
+    pub fn capacity(&self) -> usize {
+        self.index.capacity()
+    }
+
     /// Embedding dimensionality of this index.
     ///
     /// Used by backend dispatch to detect dim mismatch when the user swaps

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -1664,6 +1664,62 @@ mod forget_tests {
         let mem2 = uteke.get_by_id(&id2).unwrap().unwrap();
         assert!(!mem2.deprecated, "new memory should be active");
     }
+
+    /// #1047: after soft-forget, the deprecated row must vanish from list(),
+    /// load_all(), and the doctor/verify count — otherwise list shows ghosts
+    /// and doctor reports DB/Index mismatch forever.
+    #[test]
+    fn test_soft_forget_hides_from_list_and_doctor() {
+        // Isolated temp-dir store: ":memory:" stores still resolve the vector
+        // index to a file in the CWD, which cross-contaminates parallel runs.
+        let dir = std::env::temp_dir().join(format!("ghost-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
+        let embedding = vec![0.7_f32; 768];
+        let id = uteke
+            .remember_precomputed(
+                "ghost row after soft forget",
+                &[],
+                None,
+                Some("ghost-test"),
+                "fact",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+
+        uteke.forget(&id).unwrap();
+
+        // list() must not return the deprecated row
+        let listed = uteke.list(None, 100, 0, Some("ghost-test")).unwrap();
+        assert!(
+            listed.iter().all(|m| m.id != id),
+            "deprecated row must not appear in list()"
+        );
+
+        // store-level list filter
+        let rows = uteke.store.list(None, Some("ghost-test"), 100, 0).unwrap();
+        assert!(rows.iter().all(|m| m.id != id));
+
+        // load_all() (repair/verify source) must exclude it
+        let all = uteke.store.load_all(Some("ghost-test")).unwrap();
+        assert!(all.iter().all(|m| m.id != id));
+
+        // doctor: DB count (active-only now) must equal index count
+        let report = uteke.doctor().unwrap();
+        let consistency = report
+            .checks
+            .iter()
+            .find(|c| c.name == "Index consistency")
+            .expect("doctor reports index consistency");
+        assert!(
+            !consistency.detail.contains("MISMATCH"),
+            "doctor must not report mismatch after soft-forget, got: {}",
+            consistency.detail
+        );
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Read-side fixes so soft-deleted (deprecated) memories stop leaking after `uteke forget <id>`:

- `store.list()` — all four namespace/tag branches now `AND deprecated = 0`
- `store.search_content()` (LIKE fallback path) — same filter
- `store.load_all()` — same filter; this is the source for `repair()`/`verify()`, which previously **re-added soft-deleted vectors to the index**, resurrecting forgotten memories in recall
- `store.count()` — uniform active-only contract for both `None` and `Some(ns)`; doctor/verify counts are now directly comparable to `index.len()`
- New `store.count_all()` — explicit include-deprecated totals for reporting callers

## Why

Closes #1047. The reporter's diagnosis (pipe → partial delete) pointed at the wrong layer: `soft_forget()` itself is correct (row deprecated + vector removed). The ghosts came from read paths that never filtered `deprecated`:

- `uteke list` showed the forgotten memory forever
- `uteke doctor` reported `MISMATCH: DB=N Index=N-1 — run uteke repair` after every soft-forget (DB count included deprecated rows; index never does)
- `uteke repair` then rebuilt the index from `load_all()` which INCLUDED deprecated rows — pushing forgotten memories back into recall

## Testing

- New regression test `test_soft_forget_hides_from_list_and_doctor`: asserts soft-forgotten id absent from `list()`, namespaced list, `load_all()`, and doctor reports no MISMATCH
- Test uses an isolated temp-dir store — investigation found `:memory:` stores still resolve the vector index to a file in the CWD (`crates/uteke-core/uteke_index.usearch`), cross-contaminating parallel test runs and masking this class of bug; that polluted shared file is removed locally
- `cargo test -p uteke-core`: 479 passed (1 pre-existing macOS-only failure = #1054, fixed in #1059)
- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cora review --staged`: no issues (count() split-semantics finding resolved by making the active-only contract uniform + explicit `count_all()`)

Follow-up candidates (not in scope here): the `:memory:` → CWD index-file trap deserves its own guard so no future test reintroduces shared-state pollution.

Closes #1047