### PR TITLE
fix: keyword search misses non-default namespaces when namespace omitted

### DIFF
--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -1,7 +1,7 @@
 //! Core CRUD operations — insert, get, delete, update, list, search, count.
 
 use crate::Error;
-use crate::memory::types::{DEFAULT_NAMESPACE, Memory};
+use crate::memory::types::Memory;
 use rusqlite::{OptionalExtension, params};
 
 use super::store::{row_to_memory, serialize_embedding};
@@ -532,13 +532,18 @@ impl super::Store {
     }
 
     /// Search memories by content using LIKE (simple full-text for v2).
+    /// Search memories by content using LIKE (simple full-text for v2).
+    ///
+    /// `namespace=None` searches ACROSS all namespaces (matches list(None)
+    /// semantics, #526) — previously it coerced None to the default namespace,
+    /// hiding results from other namespaces from cross-namespace callers
+    /// such as MCP `uteke_search` invoked without a namespace argument (#1051).
     pub fn search_content(
         &self,
         query: &str,
         namespace: Option<&str>,
         limit: usize,
     ) -> Result<Vec<Memory>, Error> {
-        let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);
         // Escape SQL LIKE wildcards so user input is treated as literal text
         // Using '!' as escape character — unambiguous on all platforms
         let escaped = query
@@ -546,18 +551,31 @@ impl super::Store {
             .replace('%', "!%")
             .replace('_', "!_");
         let pattern = format!("%{escaped}%");
-        let mut stmt = self
-            .conn
-            .prepare(
+        let sql = match namespace {
+            Some(_) => {
                 "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug
                  FROM memories WHERE namespace = ?1 AND deprecated = 0 AND content LIKE ?2 ESCAPE '!'
-                 ORDER BY created_at DESC LIMIT ?3",
-            )
+                 ORDER BY created_at DESC LIMIT ?3"
+            }
+            None => {
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug
+                 FROM memories WHERE deprecated = 0 AND content LIKE ?1 ESCAPE '!'
+                 ORDER BY created_at DESC LIMIT ?2"
+            }
+        };
+        let mut stmt = self
+            .conn
+            .prepare(sql)
             .map_err(|e| Error::db("database operation", e))?;
 
-        let rows = stmt
-            .query_map(params![ns, pattern, limit as i64], row_to_memory)
-            .map_err(|e| Error::db("database operation", e))?;
+        let rows = match namespace {
+            Some(ns) => stmt
+                .query_map(params![ns, pattern, limit as i64], row_to_memory)
+                .map_err(|e| Error::db("database operation", e))?,
+            None => stmt
+                .query_map(params![pattern, limit as i64], row_to_memory)
+                .map_err(|e| Error::db("database operation", e))?,
+        };
 
         let mut memories = Vec::new();
         for row in rows {

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -1121,6 +1121,42 @@ mod tests {
         assert_eq!(lower.len(), 2);
     }
 
+    /// #1051: search_content(None) must search ACROSS namespaces — it used to
+    /// coerce None to the default namespace, hiding hits from other namespaces
+    /// (e.g. MCP uteke_search without a namespace argument). Also pins
+    /// hyphenated-identifier matching on the LIKE path.
+    #[test]
+    fn test_search_content_cross_namespace_and_hyphen() {
+        let store = Store::open(":memory:").unwrap();
+
+        let mut m = make_test_memory("x1", "uteke-cloud-dev is the private repo", &[]);
+        m.namespace = "repo-uteke".to_string();
+        store.insert(&m).unwrap();
+
+        let mut m2 = make_test_memory("x2", "unrelated note", &[]);
+        m2.namespace = "default".to_string();
+        store.insert(&m2).unwrap();
+
+        // Cross-namespace: None must find the non-default-namespace hit
+        let across = store.search_content("uteke-cloud-dev", None, 10).unwrap();
+        assert_eq!(across.len(), 1, "None must search across namespaces");
+        assert_eq!(across[0].id, "x1");
+
+        // Scoped search still works
+        let scoped = store
+            .search_content("uteke-cloud-dev", Some("repo-uteke"), 10)
+            .unwrap();
+        assert_eq!(scoped.len(), 1);
+
+        // Hyphenated identifier matches as literal substring
+        let hyphen = store.search_content("uteke-cloud-dev", None, 10).unwrap();
+        assert!(!hyphen.is_empty());
+
+        // Partial hyphen prefix also matches (substring semantics)
+        let partial = store.search_content("uteke-cloud", None, 10).unwrap();
+        assert_eq!(partial.len(), 1);
+    }
+
     #[test]
     fn test_search_content_namespace_scoped() {
         let store = Store::open(":memory:").unwrap();


### PR DESCRIPTION
## What

`store.search_content()` (the LIKE-substring path behind CLI `uteke search` and MCP `uteke_search`) mapped `namespace=None` to the literal `default` namespace instead of searching across all namespaces:

```rust
let ns = namespace.unwrap_or(DEFAULT_NAMESPACE);   // before
```

Now `None` searches across all namespaces — same semantics `list(None)` already has (#526). Deprecated rows are excluded on both paths. Namespaced queries unchanged.

Also adds a regression test pinning hyphenated-identifier behavior (`uteke-cloud-dev`, full and partial) on the LIKE path.

## Why

Closes #1051. Investigation notes for the record:

- The issue's title points at FTS5 tokenization, but the tool the reporter used (`uteke_search`) never touches FTS5 — it goes through `Uteke::search()` → `search_content()` → SQL LIKE, which matches literal substrings regardless of hyphens (verified in-test and against SQLite 3.51 phrase queries)
- The reproducible miss: any memory outside the `default` namespace is invisible to a namespace-less keyword search. A store like the production instance (10K+ rows, multiple namespaces) hits this constantly
- The FTS5 phrase path (`recall_fts5_only`, `recall_rrf`) already handles hyphenated identifiers correctly — unicode61 keeps adjacency in phrase queries; probed and pinned

## Testing

- New `test_search_content_cross_namespace_and_hyphen`: cross-namespace hit via `None`, scoped via `Some(ns)`, full + partial hyphen match
- `cargo test -p uteke-core test_search_content`: 5/5 pass; full workspace suite green except the pre-existing macOS-only #1054 failure (fixed in #1059)
- `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cora review --staged`: no issues

Closes #1051