### PR TITLE
fix(mcp): uteke_dream destructive defaults — dry-run first, scope or confirm to apply

### DIFF
--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -473,13 +473,14 @@ fn tool_context() -> Value {
 fn tool_dream() -> Value {
     serde_json::json!({
         "name": "uteke_dream",
-        "description": "Run the dream cycle maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify. Cleans up and optimizes the memory store. Safe to run periodically.",
+        "description": "Run the dream cycle maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify. DESTRUCTIVE when applied — defaults to dry_run (preview only). To apply changes you MUST pass dry_run=false, and ideally scope to a single namespace. Always dry-run first to preview projected changes.",
         "inputSchema": {
             "type": "object",
             "properties": {
-                "namespace": { "type": "string", "description": "Namespace to process (default: all)" },
-                "dry_run": { "type": "boolean", "description": "Preview changes without applying (default: false)" },
-                "phases": { "type": "array", "items": { "type": "string" }, "description": "Specific phases: lint, backlinks, dedup, orphans, compact, verify (default: all)" }
+                "namespace": { "type": "string", "description": "Namespace to process. STRONGLY RECOMMENDED — omitting processes ALL namespaces" },
+                "dry_run": { "type": "boolean", "description": "Preview changes without applying (default: TRUE — no mutations). Pass false explicitly to apply" },
+                "phases": { "type": "array", "items": { "type": "string" }, "description": "Specific phases: lint, backlinks, dedup, orphans, compact, verify (default: all)" },
+                "confirm_large": { "type": "boolean", "description": "Required when an APPLYING run projects more than 100 changes (default: false — run refuses instead)" }
             }
         }
     })
@@ -1345,7 +1346,11 @@ fn exec_context(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 
 fn exec_dream(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let namespace = args["namespace"].as_str();
-    let dry_run = args["dry_run"].as_bool().unwrap_or(false);
+    // #1050: dry_run defaults to TRUE — a no-args call must never mutate.
+    // Applying requires an explicit dry_run=false.
+    let dry_run = args["dry_run"].as_bool().unwrap_or(true);
+    let confirm_large = args["confirm_large"].as_bool().unwrap_or(false);
+    const LARGE_BATCH_THRESHOLD: usize = 100;
 
     // Parse phases if specified.
     let phases: Vec<uteke_core::DreamPhase> = args["phases"]
@@ -1366,17 +1371,94 @@ fn exec_dream(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         })
         .unwrap_or_default();
 
+    // Applying runs are guarded (#1050):
+    // 1. Unscoped (namespace=None) applying runs must announce the scope —
+    //    we require a namespace for applying runs unless confirm_large is
+    //    also set, making "accidental whole-store maintenance" a two-flag
+    //    decision instead of a default.
+    // 2. Large batches (>100 projected changes) need confirm_large=true,
+    //    else the run refuses and reports what it WOULD have done.
+    if !dry_run && namespace.is_none() && !confirm_large {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: "Refused: applying run without a namespace scope. Pass namespace=<ns> to scope the maintenance, or set confirm_large=true to apply across ALL namespaces.".to_string(),
+            }],
+            is_error: true,
+        });
+    }
+
+    // First pass: always compute the DRY report to learn projected changes.
+    let preview = uteke
+        .dream(namespace, true, &phases)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if !dry_run && preview.total_changes > LARGE_BATCH_THRESHOLD && !confirm_large {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: format!(
+                    "Refused: applying run projects {} changes (> {LARGE_BATCH_THRESHOLD}). Re-run with confirm_large=true to apply, or keep dry_run=true to preview.",
+                    preview.total_changes
+                ),
+            }],
+            is_error: true,
+        });
+    }
+
+    // Dry-run request (or nothing to apply) → return the preview report.
+    if dry_run || preview.total_changes == 0 {
+        let mut lines = vec![format!(
+            "Dream dry-run preview: {} changes, {} warnings, {} errors ({}ms){}",
+            preview.total_changes,
+            preview.total_warnings,
+            preview.total_errors,
+            preview.duration_ms,
+            if namespace.is_none() {
+                " [SCOPE: ALL NAMESPACES]"
+            } else {
+                ""
+            }
+        )];
+        for phase in &preview.phases {
+            lines.push(format!(
+                "  {}: {} changes, {} warnings",
+                phase.phase, phase.changes, phase.warnings
+            ));
+        }
+        if !dry_run && preview.total_changes == 0 {
+            lines.push("Nothing to apply — no changes projected.".to_string());
+        } else {
+            lines.push(
+                "To apply: dry_run=false (scope a namespace, or confirm_large=true for all-namespaces / >100 changes)."
+                    .to_string(),
+            );
+        }
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: lines.join("\n"),
+            }],
+            is_error: false,
+        });
+    }
+
+    // Applying run (scoped, or confirm_large, and under threshold / confirmed).
     let report = uteke
-        .dream(namespace, dry_run, &phases)
+        .dream(namespace, false, &phases)
         .map_err(|e| format!("Failed: {e}"))?;
 
     let mut lines = vec![format!(
-        "Dream cycle complete: {} changes, {} warnings, {} errors ({}ms{})",
+        "Dream cycle applied: {} changes, {} warnings, {} errors ({}ms){}",
         report.total_changes,
         report.total_warnings,
         report.total_errors,
         report.duration_ms,
-        if dry_run { " [DRY RUN]" } else { "" }
+        if namespace.is_none() {
+            " [SCOPE: ALL NAMESPACES]"
+        } else {
+            ""
+        }
     )];
 
     for phase in &report.phases {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -143,7 +143,7 @@ Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 | `uteke_forget` | Delete a memory |
 | `uteke_stats` | Memory store statistics |
 | `uteke_context` | AI-optimized context output for prompts |
-| `uteke_dream` | One-command maintenance pipeline (lint → backlinks → dedup → orphans) |
+| `uteke_dream` | Maintenance pipeline (lint → backlinks → dedup → orphans → compact → verify). **Dry-run by default** — pass `dry_run: false` to apply; scope `namespace` or `confirm_large` for whole-store / >100-change runs |
 | `uteke_doc_create` | Create a document (wiki/knowledge base entry) |
 | `uteke_doc_get` | Retrieve a document by ID |
 | `uteke_doc_list` | List all documents |


### PR DESCRIPTION
## What

`uteke_dream` MCP tool safety overhaul:

- **`dry_run` defaults to `true`** — a no-args call previews only, zero mutations. Applying requires explicit `dry_run: false`
- **Unscoped applying runs are refused** unless `confirm_large: true` — whole-store maintenance is now a deliberate two-flag decision, not an accident of omitted args
- **Large-batch guard** — the preview report is computed first; if an applying run projects >100 changes without `confirm_large: true`, the run refuses and reports the projected count
- **Scope announcement** — both preview and apply outputs state `[SCOPE: ALL NAMESPACES]` when unscoped
- **Honest description** — `"Safe to run periodically"` replaced with the destructive nature + dry-run-first guidance; new `confirm_large` schema param documented
- `docs/mcp.md` tool table updated

## Why

Closes #1050. Real incident (2026-08-17, production store via MCP): one exploratory `uteke_dream {}` call → **4,067 changes across the whole default namespace** + 850 contradict warnings. No preview, no scope, no confirmation. Core `dream(namespace, dry_run, phases)` already supported the knobs — this wires safe defaults into the MCP surface.

## Testing

- `cargo build/clippy/fmt` clean; workspace tests green (1 pre-existing macOS-only #1054, fixed in #1059)
- `cora review --staged`: no issues
- Behavior matrix walked by inspection: no-args → preview; `dry_run:false` + namespace → apply; `dry_run:false` no namespace → refused; `dry_run:false` + >100 changes → refused with count; `confirm_large:true` → apply unscoped

Closes #1050