### PR TITLE
feat(mcp): enrich tool outputs — stats tiers/namespaces, doc_search scores, room ids

### DIFF
--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -273,6 +273,23 @@ impl crate::Uteke {
         })
     }
 
+    /// Count PINNED (never-decay) memories, optionally per namespace (#1052).
+    /// Surfaced for MCP stats triage output.
+    pub fn count_pinned(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        self.store.count_pinned(namespace)
+    }
+
+    /// Count DEPRECATED (soft-deleted) memories, optionally per namespace.
+    /// Audit/triage counter — hidden from recall but restorable (#1052).
+    pub fn count_deprecated(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        self.store.count_deprecated(namespace)
+    }
+
+    /// Per-namespace memory counts for stats breakdown (#1052).
+    pub fn namespace_counts(&self) -> Result<Vec<(String, usize)>, Error> {
+        self.store.list_namespaces_with_counts()
+    }
+
     /// Get aging status — breakdown of memories by access tier.
     pub fn aging_status(&self, namespace: Option<&str>) -> Result<AgingStatus, Error> {
         let total = self.store.count(namespace)?;

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -804,6 +804,31 @@ impl super::Store {
     }
 }
 
+impl super::Store {
+    /// Count PINNED (never-decay) memories, optionally per namespace (#1052).
+    pub fn count_pinned(&self, namespace: Option<&str>) -> Result<usize, Error> {
+        let count: usize = match namespace {
+            Some(ns) => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND pinned = 1 AND deprecated = 0",
+                    params![ns],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|e| Error::db("count_pinned", e))? as usize,
+            None => self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE pinned = 1 AND deprecated = 0",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|e| Error::db("count_pinned", e))? as usize,
+        };
+        Ok(count)
+    }
+}
+
 #[cfg(test)]
 mod content_type_tests {
     use super::*;

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -488,7 +488,7 @@ fn tool_dream() -> Value {
 fn tool_room_recall() -> Value {
     serde_json::json!({
         "name": "uteke_room_recall",
-        "description": "Semantic recall within a room context. Searches across all namespaces in the room using hybrid RRF ranking.",
+        "description": "Semantic recall within a room context. Requires an EXISTING room_id (create via uteke_room_create first) — unknown room ids error at call time. Searches across all namespaces in the room using hybrid RRF ranking.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -965,13 +965,45 @@ fn exec_stats(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 
     let stats = uteke.stats(namespace).map_err(|e| format!("Failed: {e}"))?;
 
+    // #1052: agents need triage fields on one call — tiers, pinned/deprecated
+    // split, and (when unscoped) the per-namespace breakdown.
+    let pinned = uteke.count_pinned(namespace).unwrap_or(0);
+    let deprecated = uteke.count_deprecated(namespace).unwrap_or(0);
+
+    let mut lines = vec![
+        format!(
+            "Total: {} | Tags: {} | DB: {} bytes",
+            stats.total_memories, stats.unique_tags, stats.db_size_bytes
+        ),
+        format!(
+            "Tiers: hot {} | warm {} | cold {}",
+            stats.hot, stats.warm, stats.cold
+        ),
+        format!(
+            "Pinned: {} | Deprecated (soft-deleted): {}",
+            pinned, deprecated
+        ),
+        format!(
+            "Recall cache: {} hits / {} misses",
+            stats.cache_hits, stats.cache_misses
+        ),
+    ];
+
+    if namespace.is_none() {
+        if let Ok(ns_counts) = uteke.namespace_counts() {
+            if ns_counts.len() > 1 {
+                lines.push("Namespaces:".to_string());
+                for (ns, count) in ns_counts {
+                    lines.push(format!("  {ns}: {count}"));
+                }
+            }
+        }
+    }
+
     Ok(ToolResult {
         content: vec![McpContent::Text {
             r#type: "text".to_string(),
-            text: format!(
-                "Total: {} | Tags: {} | DB: {} bytes",
-                stats.total_memories, stats.unique_tags, stats.db_size_bytes
-            ),
+            text: lines.join("\n"),
         }],
         is_error: false,
     })
@@ -1159,7 +1191,22 @@ fn exec_doc_search(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 
     let lines: Vec<String> = results
         .iter()
-        .map(|d| format!("{} — {}", d.document.slug, d.document.title))
+        .map(|d| {
+            // #1052: score + chunk snippet make ranking visible and results
+            // actionable (was: bare "slug — title").
+            let mut line = format!(
+                "[{:.2}] {} — {}",
+                d.score, d.document.slug, d.document.title
+            );
+            if !d.chunk_heading.is_empty() {
+                line.push_str(&format!(" § {}", d.chunk_heading));
+            }
+            if !d.chunk_snippet.is_empty() {
+                let snip: String = d.chunk_snippet.chars().take(120).collect();
+                line.push_str(&format!(" \"{snip}…\""));
+            }
+            line
+        })
         .collect();
 
     Ok(ToolResult {
@@ -1450,8 +1497,11 @@ fn exec_room_memories(uteke: &Uteke, args: &Value) -> Result<ToolResult, String>
     let lines: Vec<String> = memories
         .iter()
         .map(|m| {
+            // #1052/#1048: include the short id so the next tool call
+            // (pin/forget/graph edges) can act on the row directly.
             let created = m.created_at.format("%Y-%m-%d %H:%M");
-            format!("[{created} | {}] {}", m.namespace, m.content)
+            let short_id: String = m.id.chars().take(8).collect();
+            format!("[{created} | {} | {}] {}", short_id, m.namespace, m.content)
         })
         .collect();
     Ok(ToolResult {


### PR DESCRIPTION
## What

Per #1052's acceptance list:

- **`uteke_stats`** — one-line output becomes a triage block: tiers (hot/warm/cold), pinned vs deprecated (soft-deleted) split, recall cache hits/misses, and a per-namespace breakdown when called unscoped on a multi-namespace store
- **`uteke_doc_search`** — each result line carries `[score] slug — title § heading "snippet…"` (120-char snippet); ranking is now visible instead of an unranked slug list
- **`uteke_room_memories`** — every line includes the 8-char short id (`[timestamp | id | ns] content`) so agents can act on rows with the next tool call
- **`uteke_room_recall`** — inputSchema description now states the existing-`room_id` precondition (was discovered only as a runtime error)
- Core additions: `Store::count_pinned()`, `Uteke::{count_pinned, count_deprecated, namespace_counts}()` — MCP consumes the public API surface, no private-field reach-through

## Why

Closes #1052. Agents driving uteke over MCP had to make follow-up calls (or drop to raw curl) for fields the engine already computes — stats hid tier/cache data, doc_search hid scores, room listings hid ids entirely (compounding #1048's short-id gap).

## Testing

- `cargo build/fmt/clippy` clean; workspace tests green (478 + pre-existing macOS-only #1054, fixed in #1059)
- `cora review --staged`: no issues
- Output formats walked by inspection against the acceptance table in the issue

Closes #1052