### PR TITLE
feat(mcp): uteke_get + uteke_update; short-ID resolution for all ID-taking tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,8 +214,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2815,10 +2817,12 @@ dependencies = [
 name = "uteke-mcp"
 version = "0.14.3"
 dependencies = [
+ "chrono",
  "dirs",
  "serde",
  "serde_json",
  "uteke-core",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -25,3 +25,7 @@ uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"
+
+[dev-dependencies]
+uuid = { version = "1", features = ["v4"] }
+chrono = "0.4"

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -143,6 +143,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_recall(),
                 tool_search(),
                 tool_list(),
+                tool_get(),
+                tool_update(),
                 tool_forget(),
                 tool_stats(),
                 tool_context(),
@@ -190,6 +192,8 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_recall" => exec_recall(uteke, &arguments)?,
                 "uteke_search" => exec_search(uteke, &arguments)?,
                 "uteke_list" => exec_list(uteke, &arguments)?,
+                "uteke_get" => exec_get(uteke, &arguments)?,
+                "uteke_update" => exec_update(uteke, &arguments)?,
                 "uteke_forget" => exec_forget(uteke, &arguments)?,
                 "uteke_stats" => exec_stats(uteke, &arguments)?,
                 "uteke_context" => exec_context(uteke, &arguments)?,
@@ -292,6 +296,40 @@ fn tool_list() -> Value {
     })
 }
 
+fn tool_get() -> Value {
+    serde_json::json!({
+        "name": "uteke_get",
+        "description": "Fetch a single memory's FULL record by id — content, tags, metadata, timestamps, importance, no truncation. Use after recall/search when you need the complete entry.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "Full UUID or unambiguous prefix (8-char id from recall/list works)" }
+            },
+            "required": ["id"]
+        }
+    })
+}
+
+fn tool_update() -> Value {
+    serde_json::json!({
+        "name": "uteke_update",
+        "description": "Partially update a memory — only provided fields change (same semantics as HTTP PUT /memory). Changing content regenerates its embedding.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "Full UUID or unambiguous prefix" },
+                "content": { "type": "string", "description": "New content (triggers re-embed)" },
+                "tags": { "type": "array", "items": { "type": "string" }, "description": "Replacement tag set" },
+                "metadata": { "type": "object", "description": "Replacement metadata JSON" },
+                "importance": { "type": "number", "description": "0.0–1.0" },
+                "pinned": { "type": "boolean", "description": "Pin (never decays) or unpin" },
+                "memory_type": { "type": "string", "description": "fact | procedure | preference | decision | context | note | insight | reference | event" }
+            },
+            "required": ["id"]
+        }
+    })
+}
+
 fn tool_forget() -> Value {
     serde_json::json!({
         "name": "uteke_forget",
@@ -299,7 +337,7 @@ fn tool_forget() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
-                "id": { "type": "string", "description": "The memory ID (UUID)" }
+                "id": { "type": "string", "description": "Full UUID or unambiguous prefix (8-char id from recall/list works)" }
             },
             "required": ["id"]
         }
@@ -712,7 +750,7 @@ fn tool_pin() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
-                "id": { "type": "string", "description": "The memory ID (UUID)" }
+                "id": { "type": "string", "description": "Full UUID or unambiguous prefix (8-char id from recall/list works)" }
             },
             "required": ["id"]
         }
@@ -726,7 +764,7 @@ fn tool_unpin() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
-                "id": { "type": "string", "description": "The memory ID (UUID)" }
+                "id": { "type": "string", "description": "Full UUID or unambiguous prefix (8-char id from recall/list works)" }
             },
             "required": ["id"]
         }
@@ -946,10 +984,114 @@ fn exec_list(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     })
 }
 
-fn exec_forget(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let id = args["id"].as_str().ok_or("Missing 'id'")?;
+/// Resolve an id argument to a full UUID (#1048).
+///
+/// Accepts the full UUID or any unambiguous prefix (e.g. the 8-char ids
+/// printed by recall/list). Errors loudly on ambiguous prefixes instead of
+/// silently no-oping. Exact UUIDs skip the prefix scan.
+fn resolve_id<'a>(uteke: &'a Uteke, id: &'a str) -> Result<String, String> {
+    if id.len() == 36 {
+        return Ok(id.to_string());
+    }
+    match uteke.resolve_id_prefix(id) {
+        Ok(Some(full)) => Ok(full),
+        Ok(None) => Err(format!("No memory matches id prefix '{id}'")),
+        Err(e) => Err(format!("{e}")),
+    }
+}
 
-    uteke.forget(id).map_err(|e| format!("Failed: {e}"))?;
+/// #1049: read a single memory by id (or unambiguous prefix) — full record,
+/// no truncation. recall/search return ranked excerpts; list truncates.
+fn exec_get(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let id_arg = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id = resolve_id(uteke, id_arg)?;
+
+    let m = uteke
+        .get_by_id(&id)
+        .map_err(|e| format!("Failed: {e}"))?
+        .ok_or_else(|| format!("Memory not found: {id}"))?;
+
+    let body = serde_json::json!({
+        "id": m.id,
+        "content": m.content,
+        "tags": m.tags,
+        "metadata": m.metadata,
+        "namespace": m.namespace,
+        "memory_type": m.memory_type,
+        "importance": m.importance,
+        "pinned": m.pinned,
+        "deprecated": m.deprecated,
+        "created_at": m.created_at,
+        "updated_at": m.updated_at,
+        "last_accessed": m.last_accessed,
+        "access_count": m.access_count,
+        "source": m.source,
+    });
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: serde_json::to_string_pretty(&body)
+                .map_err(|e| format!("Serialization failed: {e}"))?,
+        }],
+        is_error: false,
+    })
+}
+
+/// #1049: partial update — same semantics as HTTP PUT /memory (#659):
+/// only provided fields change; content changes regenerate the embedding.
+fn exec_update(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let id_arg = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id = resolve_id(uteke, id_arg)?;
+
+    let content = args["content"].as_str();
+    let importance = args["importance"].as_f64();
+    let pinned = args["pinned"].as_bool();
+    let memory_type = args["memory_type"].as_str();
+    let tags: Option<Vec<String>> = args["tags"].as_array().map(|a| {
+        a.iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect()
+    });
+    let tags_ref = tags.as_deref();
+    let metadata = args.get("metadata").filter(|m| !m.is_null());
+
+    let updated = uteke
+        .update_memory(
+            &id,
+            content,
+            tags_ref,
+            metadata,
+            importance,
+            pinned,
+            memory_type,
+        )
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    if !updated {
+        return Ok(ToolResult {
+            content: vec![McpContent::Text {
+                r#type: "text".to_string(),
+                text: format!("Memory not found: {id}"),
+            }],
+            is_error: true,
+        });
+    }
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("✓ Updated memory {id}"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_forget(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let id_arg = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id = resolve_id(uteke, id_arg)?;
+
+    uteke.forget(&id).map_err(|e| format!("Failed: {e}"))?;
 
     Ok(ToolResult {
         content: vec![McpContent::Text {
@@ -1241,8 +1383,10 @@ fn exec_graph(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 }
 
 fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let source = args["source"].as_str().ok_or("Missing 'source'")?;
-    let target = args["target"].as_str().ok_or("Missing 'target'")?;
+    let source_arg = args["source"].as_str().ok_or("Missing 'source'")?;
+    let source = resolve_id(uteke, source_arg)?;
+    let target_arg = args["target"].as_str().ok_or("Missing 'target'")?;
+    let target = resolve_id(uteke, target_arg)?;
     let edge_type = args["edge_type"].as_str().unwrap_or("related");
     let weight = args["weight"].as_f64().unwrap_or(1.0);
 
@@ -1257,7 +1401,7 @@ fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String
     }
 
     // Validate both memories exist
-    match uteke.get_by_id(source) {
+    match uteke.get_by_id(&source) {
         Ok(Some(_)) => {}
         Ok(None) => {
             return Ok(ToolResult {
@@ -1270,7 +1414,7 @@ fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String
         }
         Err(e) => return Err(format!("Failed: {e}")),
     }
-    match uteke.get_by_id(target) {
+    match uteke.get_by_id(&target) {
         Ok(Some(_)) => {}
         Ok(None) => {
             return Ok(ToolResult {
@@ -1286,7 +1430,7 @@ fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String
 
     let conn = uteke.graph_store();
     let gs = uteke_core::graph::GraphStore::new(conn);
-    gs.add_edge(source, target, edge_type, weight)
+    gs.add_edge(&source, &target, edge_type, weight)
         .map_err(|e| format!("Failed: {e}"))?;
 
     Ok(ToolResult {
@@ -1299,13 +1443,15 @@ fn exec_graph_add_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String
 }
 
 fn exec_graph_remove_edge(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let source = args["source"].as_str().ok_or("Missing 'source'")?;
-    let target = args["target"].as_str().ok_or("Missing 'target'")?;
+    let source_arg = args["source"].as_str().ok_or("Missing 'source'")?;
+    let source = resolve_id(uteke, source_arg)?;
+    let target_arg = args["target"].as_str().ok_or("Missing 'target'")?;
+    let target = resolve_id(uteke, target_arg)?;
 
     let conn = uteke.graph_store();
     let gs = uteke_core::graph::GraphStore::new(conn);
     let removed = gs
-        .remove_edge(source, target)
+        .remove_edge(&source, &target)
         .map_err(|e| format!("Failed: {e}"))?;
 
     if removed {
@@ -1875,9 +2021,10 @@ fn exec_tags_delete(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 }
 
 fn exec_pin(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let id = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id_arg = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id = resolve_id(uteke, id_arg)?;
 
-    match uteke.pin(id) {
+    match uteke.pin(&id) {
         Ok(true) => Ok(ToolResult {
             content: vec![McpContent::Text {
                 r#type: "text".to_string(),
@@ -1897,9 +2044,10 @@ fn exec_pin(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 }
 
 fn exec_unpin(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
-    let id = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id_arg = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id = resolve_id(uteke, id_arg)?;
 
-    match uteke.unpin(id) {
+    match uteke.unpin(&id) {
         Ok(true) => Ok(ToolResult {
             content: vec![McpContent::Text {
                 r#type: "text".to_string(),
@@ -1915,5 +2063,151 @@ fn exec_unpin(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
             is_error: true,
         }),
         Err(e) => Err(format!("Failed: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod id_resolution_tests {
+    use super::*;
+    use uteke_core::Uteke;
+    use uteke_core::memory::types::Memory;
+
+    fn scratch() -> (Uteke, std::path::PathBuf) {
+        // Unique per call (tests run in parallel threads; shared names hit
+        // "database busy" on WAL setup).
+        let dir = std::env::temp_dir().join(format!(
+            "mcp-id-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
+        (uteke, dir)
+    }
+
+    fn seed(uteke: &Uteke) -> String {
+        // Direct store insert (remember_precomputed is pub(crate)); the MCP
+        // executor under test only reads/resolves/updates, which is the
+        // behavior under test here.
+        let id = uuid::Uuid::new_v4().to_string();
+        let m = Memory {
+            id: id.clone(),
+            content: "id resolution probe content".to_string(),
+            embedding: vec![0.21; 768],
+            tags: vec!["probe".to_string()],
+            metadata: serde_json::json!({}),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            namespace: "mcp-id-ns".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+            slug: None,
+            source: None,
+            source_type: "user".to_string(),
+        };
+        uteke.store().insert(&m).unwrap();
+        id
+    }
+
+    #[test]
+    fn resolve_id_accepts_prefix_and_full() {
+        let (uteke, dir) = scratch();
+        let id = seed(&uteke);
+        let short: String = id.chars().take(8).collect();
+
+        assert_eq!(resolve_id(&uteke, &id).unwrap(), id);
+        assert_eq!(resolve_id(&uteke, &short).unwrap(), id);
+        assert!(
+            resolve_id(&uteke, "00000000").is_err(),
+            "unknown prefix errors"
+        );
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn exec_get_returns_full_record() {
+        let (uteke, dir) = scratch();
+        let id = seed(&uteke);
+        let short: String = id.chars().take(8).collect();
+
+        let result = exec_get(&uteke, &serde_json::json!({"id": short})).unwrap();
+        assert!(!result.is_error);
+        let text = match &result.content[0] {
+            McpContent::Text { text, .. } => text.clone(),
+        };
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["id"].as_str().unwrap(), id);
+        assert_eq!(
+            v["content"].as_str().unwrap(),
+            "id resolution probe content"
+        );
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn exec_pin_accepts_short_id() {
+        let (uteke, dir) = scratch();
+        let id = seed(&uteke);
+        let short: String = id.chars().take(8).collect();
+
+        let result = exec_pin(&uteke, &serde_json::json!({"id": short})).unwrap();
+        assert!(!result.is_error, "short id must pin");
+        let m = uteke.get_by_id(&id).unwrap().unwrap();
+        assert!(m.pinned);
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn exec_forget_short_id_no_longer_silent_noop() {
+        let (uteke, dir) = scratch();
+        let id = seed(&uteke);
+        let short: String = id.chars().take(8).collect();
+
+        // Happy path: short id resolves and forgets.
+        let result = exec_forget(&uteke, &serde_json::json!({"id": short})).unwrap();
+        assert!(!result.is_error);
+
+        // Bogus prefix must now ERROR (was: silent "not found" no-op pre-fix).
+        let err = exec_forget(&uteke, &serde_json::json!({"id": "ffffffff"}));
+        assert!(err.is_err(), "unknown prefix must error loudly");
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn exec_update_partial_fields() {
+        let (uteke, dir) = scratch();
+        let id = seed(&uteke);
+        let short: String = id.chars().take(8).collect();
+
+        // metadata-only update: content unchanged
+        let result = exec_update(
+            &uteke,
+            &serde_json::json!({"id": short, "importance": 0.9, "pinned": true}),
+        )
+        .unwrap();
+        assert!(!result.is_error);
+        let m = uteke.get_by_id(&id).unwrap().unwrap();
+        assert!((m.importance - 0.9).abs() < 1e-9);
+        assert!(m.pinned);
+        assert_eq!(
+            m.content, "id resolution probe content",
+            "content untouched"
+        );
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -140,7 +140,9 @@ Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 | `uteke_recall` | Semantic search (supports tags filter, min_score, strategy: hybrid/vector/fts5/graph — default hybrid) |
 | `uteke_search` | Text search with optional tag filter |
 | `uteke_list` | List memories (supports pagination via offset) |
-| `uteke_forget` | Delete a memory |
+| `uteke_get` | Fetch a single memory's full record by id — no truncation (accepts UUID or unambiguous prefix) |
+| `uteke_update` | Partial update — only provided fields change; content changes re-embed |
+| `uteke_forget` | Delete a memory (accepts UUID or unambiguous prefix) |
 | `uteke_stats` | Memory store statistics |
 | `uteke_context` | AI-optimized context output for prompts |
 | `uteke_dream` | One-command maintenance pipeline (lint → backlinks → dedup → orphans) |


### PR DESCRIPTION
## What

**#1048 — short IDs become usable:**
- `resolve_id()` executor helper: full UUIDs pass through; shorter prefixes resolve via core `resolve_id_prefix()` (#794); ambiguous prefixes error with match count; unknown prefixes error instead of silent not-found
- Wired into `uteke_forget`, `uteke_pin`, `uteke_unpin`, `uteke_graph_add_edge`, `uteke_graph_remove_edge` — the id printed by recall/list is now directly usable by the next tool call

**#1049 — the missing read/edit pair:**
- `uteke_get {id}` — full memory record (content, tags, metadata, timestamps, importance, source), no truncation; recall/search return ranked excerpts and `uteke_list` is a browsing view — MCP-only consumers previously had to drop to raw curl for full-content verification
- `uteke_update {id, content?, tags?, metadata?, importance?, pinned?, memory_type?}` — partial-update semantics identical to HTTP `PUT /memory` (#659); content changes regenerate the embedding; completes the create→read→edit→delete loop over MCP

Tool schemas + `docs/mcp.md` updated (id params documented as UUID-or-prefix).

## Why

Closes #1048, closes #1049. The repro in #1048: `uteke_remember` returns a full UUID, `uteke_recall` prints 8 chars, `uteke_pin {short}` → "Memory not found". Both gaps were pure wiring — core APIs existed.

## Testing

5 new tests on isolated temp-dir stores (unique per call — parallel WAL setup collides on shared names):
- prefix + full + unknown-prefix resolution behavior
- `uteke_get` returns the full record via short id
- pin via short id pins the right memory
- forget via short id succeeds; bogus prefix errors loudly (was silent no-op)
- partial update (importance + pinned) leaves content byte-identical

fmt/clippy clean, `cora review --staged` no issues, workspace green except pre-existing macOS-only #1054 (fixed in #1059).

Closes #1048
Closes #1049