### PR TITLE
feat: supersession workflow — mark stale decisions superseded, flagged at recall

### DIFF
--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -2001,6 +2001,19 @@ impl crate::Uteke {
             let tx = conn
                 .unchecked_transaction()
                 .map_err(|e| Error::db("begin supersede tx", e))?;
+            // Re-supersession: drop this memory's PREVIOUS supersession pair
+            // first (code-scanning #687) — otherwise stacked superseded_by
+            // edges accumulate and supersession_of() becomes ambiguous.
+            tx.execute(
+                "DELETE FROM memory_edges WHERE source_id = ?1 AND edge_type = ?2",
+                params![old.id, EDGE_SUPERSEDED_BY],
+            )
+            .map_err(|e| Error::db("clear prior superseded_by edge", e))?;
+            tx.execute(
+                "DELETE FROM memory_edges WHERE target_id = ?1 AND edge_type = ?2",
+                params![old.id, EDGE_SUPERSEDES],
+            )
+            .map_err(|e| Error::db("clear prior supersedes edge", e))?;
             tx.execute(
                 "INSERT OR IGNORE INTO memory_edges (source_id, target_id, edge_type, created_at) VALUES (?1,?2,?3,?4)",
                 params![old.id, new.id, EDGE_SUPERSEDED_BY, now],
@@ -2046,11 +2059,14 @@ impl crate::Uteke {
 
     /// Look up the supersession target for a memory, if any (#1053).
     /// Returns `Some(new_id)` when an outgoing `superseded_by` edge exists.
+    /// Deterministic: latest by created_at, then id (code-scanning #687 —
+    /// bare LIMIT 1 with no ORDER BY could return any row).
     pub fn supersession_of(&self, memory_id: &str) -> Result<Option<String>, Error> {
         let conn = self.graph_store();
         let target: Option<String> = conn
             .query_row(
-                "SELECT target_id FROM memory_edges WHERE source_id = ?1 AND edge_type = ?2 LIMIT 1",
+                "SELECT target_id FROM memory_edges WHERE source_id = ?1 AND edge_type = ?2 \
+                 ORDER BY created_at DESC, target_id ASC LIMIT 1",
                 params![memory_id, EDGE_SUPERSEDED_BY],
                 |r| r.get(0),
             )
@@ -2150,6 +2166,34 @@ mod supersession_tests {
             )
             .unwrap();
         assert_eq!((fwd, inv), (1, 1));
+
+        // Re-supersession replaces the pair (code-scanning #687): a second
+        // target must not stack a second superseded_by edge.
+        let third = uteke
+            .remember_precomputed(
+                "third decision: final word",
+                &[],
+                None,
+                Some("ss-ns"),
+                "decision",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        uteke.supersede(&old, &third, None).unwrap();
+        assert_eq!(
+            uteke.supersession_of(&old).unwrap().as_deref(),
+            Some(third.as_str()),
+            "latest supersession wins"
+        );
+        let stacked: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_edges WHERE source_id=?1 AND edge_type='superseded_by'",
+                params![old],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stacked, 1, "no stacked superseded_by edges");
 
         drop(uteke);
         std::fs::remove_dir_all(&dir).ok();

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -1955,3 +1955,174 @@ mod tests {
         assert!(targets.is_empty());
     }
 }
+
+/// Edge type marking the superseded (stale) side of a supersession pair (#1053).
+pub const EDGE_SUPERSEDED_BY: &str = "superseded_by";
+
+impl crate::Uteke {
+    /// Mark `old_id` as superseded by `new_id` (#1053).
+    ///
+    /// Wires a typed edge pair — `old → new: superseded_by` (the annotation
+    /// recall reads) and `new → old: supersedes` (navigable inverse) — then
+    /// soft-deprecates the old memory so it drops out of recall by default.
+    /// Both ids must exist and differ; self-supersession is rejected.
+    ///
+    /// Returns the ids of the pair for confirmation output.
+    pub fn supersede(
+        &self,
+        old_id: &str,
+        new_id: &str,
+        reason: Option<&str>,
+    ) -> Result<(String, String), Error> {
+        if old_id == new_id {
+            return Err(Error::validation(
+                "Cannot supersede a memory with itself (old_id == new_id)",
+            ));
+        }
+        let old = self
+            .store
+            .get_by_id(old_id)?
+            .ok_or_else(|| Error::validation(format!("Old memory not found: {old_id}")))?;
+        let new = self
+            .store
+            .get_by_id(new_id)?
+            .ok_or_else(|| Error::validation(format!("New memory not found: {new_id}")))?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let reason_text = reason
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("superseded by {new_id}"));
+        let conn = self.graph_store();
+        // Edge pair AND the soft-deprecation in ONE transaction — a failure
+        // in any of the three writes rolls the whole supersession back
+        // (cora finding: committing edges before deprecating leaves a
+        // superseded_by pointer on a still-active memory).
+        {
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| Error::db("begin supersede tx", e))?;
+            tx.execute(
+                "INSERT OR IGNORE INTO memory_edges (source_id, target_id, edge_type, created_at) VALUES (?1,?2,?3,?4)",
+                params![old.id, new.id, EDGE_SUPERSEDED_BY, now],
+            )
+            .map_err(|e| Error::db("insert superseded_by edge", e))?;
+            tx.execute(
+                "INSERT OR IGNORE INTO memory_edges (source_id, target_id, edge_type, created_at) VALUES (?1,?2,?3,?4)",
+                params![new.id, old.id, EDGE_SUPERSEDES, now],
+            )
+            .map_err(|e| Error::db("insert supersedes edge", e))?;
+            tx.execute(
+                "UPDATE memories SET deprecated = 1, valid_until = ?1, deprecate_reason = ?2, updated_at = ?1 WHERE id = ?3 AND deprecated = 0",
+                params![now, reason_text, old.id],
+            )
+            .map_err(|e| Error::db("deprecate superseded memory", e))?;
+            tx.commit()
+                .map_err(|e| Error::db("commit supersede tx", e))?;
+        }
+
+        // Soft-deprecated rows leave the recall cache scope via namespace
+        // invalidation — same hygiene soft_forget() applies.
+        self.recall_cache.invalidate_namespace(&old.namespace);
+
+        Ok((old.id, new.id))
+    }
+
+    /// Look up the supersession target for a memory, if any (#1053).
+    /// Returns `Some(new_id)` when an outgoing `superseded_by` edge exists.
+    pub fn supersession_of(&self, memory_id: &str) -> Result<Option<String>, Error> {
+        let conn = self.graph_store();
+        let target: Option<String> = conn
+            .query_row(
+                "SELECT target_id FROM memory_edges WHERE source_id = ?1 AND edge_type = ?2 LIMIT 1",
+                params![memory_id, EDGE_SUPERSEDED_BY],
+                |r| r.get(0),
+            )
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(Error::db("supersession lookup", other)),
+            })?;
+        Ok(target)
+    }
+}
+
+#[cfg(test)]
+mod supersession_tests {
+    use crate::Uteke;
+    use rusqlite::params;
+
+    /// #1053: supersede wires both edges + deprecates old; supersession_of
+    /// resolves the pointer; promote restores.
+    #[test]
+    fn test_supersede_pair_and_lookup() {
+        let dir = std::env::temp_dir().join(format!("ss-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
+
+        let embedding = vec![0.5_f32; 768];
+        let old = uteke
+            .remember_precomputed(
+                "old decision: trait Store polymorphism",
+                &[],
+                None,
+                Some("ss-ns"),
+                "decision",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        let new = uteke
+            .remember_precomputed(
+                "new decision: port to Postgres, no trait",
+                &[],
+                None,
+                Some("ss-ns"),
+                "decision",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+
+        // Self-supersession rejected.
+        assert!(uteke.supersede(&old, &old, None).is_err());
+        // Unknown id rejected.
+        assert!(uteke.supersede(&old, "ffffffff", None).is_err());
+
+        let (o, n) = uteke.supersede(&old, &new, Some("ADR-0005 pivot")).unwrap();
+        assert_eq!((o.as_str(), n.as_str()), (old.as_str(), new.as_str()));
+
+        // Pointer resolves.
+        assert_eq!(
+            uteke.supersession_of(&old).unwrap().as_deref(),
+            Some(new.as_str())
+        );
+        assert_eq!(uteke.supersession_of(&new).unwrap(), None);
+
+        // Old memory soft-deprecated (hidden from list, restorable).
+        let m = uteke.get_by_id(&old).unwrap().unwrap();
+        assert!(m.deprecated, "old memory soft-deprecated");
+        let listed = uteke.list(None, 100, 0, Some("ss-ns")).unwrap();
+        assert!(listed.iter().all(|x| x.id != old));
+
+        // Both edges exist.
+        let conn = uteke.graph_store();
+        let fwd: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_edges WHERE source_id=?1 AND target_id=?2 AND edge_type='superseded_by'",
+                params![old, new],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let inv: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_edges WHERE source_id=?1 AND target_id=?2 AND edge_type='supersedes'",
+                params![new, old],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!((fwd, inv), (1, 1));
+
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/uteke-core/src/edges.rs
+++ b/crates/uteke-core/src/edges.rs
@@ -2020,8 +2020,25 @@ impl crate::Uteke {
                 .map_err(|e| Error::db("commit supersede tx", e))?;
         }
 
-        // Soft-deprecated rows leave the recall cache scope via namespace
-        // invalidation — same hygiene soft_forget() applies.
+        // Same hygiene soft_forget() applies to deprecated rows: remove from
+        // the vector index (deprecated memories must not surface in
+        // semantic recall — code-scanning #685) and invalidate the recall
+        // cache for the namespace.
+        {
+            let mut index = self
+                .index
+                .write()
+                .map_err(|_| Error::lock("index write lock during supersede"))?;
+            if !index.remove(&old.id) {
+                tracing::debug!(
+                    "Vector index entry not found during supersede for id={} (ok if never embedded)",
+                    old.id
+                );
+            }
+            if let Err(e) = index.save() {
+                tracing::warn!("Failed to persist vector index after supersede: {e}");
+            }
+        }
         self.recall_cache.invalidate_namespace(&old.namespace);
 
         Ok((old.id, new.id))
@@ -2103,6 +2120,18 @@ mod supersession_tests {
         assert!(m.deprecated, "old memory soft-deprecated");
         let listed = uteke.list(None, 100, 0, Some("ss-ns")).unwrap();
         assert!(listed.iter().all(|x| x.id != old));
+
+        // Deprecated memory must also leave the VECTOR INDEX — otherwise it
+        // still surfaces in semantic recall (code-scanning #685).
+        {
+            let idx = uteke.index.read().unwrap();
+            let needle = vec![0.5_f32; 768];
+            let hits = idx.search(&needle, 10, 100);
+            assert!(
+                hits.iter().all(|(id, _)| id != &old),
+                "superseded memory must not remain in the vector index"
+            );
+        }
 
         // Both edges exist.
         let conn = uteke.graph_store();

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -2268,11 +2268,12 @@ mod id_resolution_tests {
         // Unique per call (tests run in parallel threads; shared names hit
         // "database busy" on WAL setup).
         let dir = std::env::temp_dir().join(format!(
-            "mcp-id-{}-{}",
+            "mcp-id-{}-{}-{}",
+            module_path!().len(), // stable per test module
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.subsec_nanos())
+                .map(|d| d.as_nanos())
                 .unwrap_or(0)
         ));
         std::fs::create_dir_all(&dir).unwrap();
@@ -2411,7 +2412,14 @@ mod supersession_mcp_tests {
 
     #[test]
     fn exec_supersede_via_short_ids() {
-        let dir = std::env::temp_dir().join(format!("ssmcp-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "ssmcp-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
         std::fs::create_dir_all(&dir).unwrap();
         let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
 

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -144,6 +144,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_search(),
                 tool_list(),
                 tool_get(),
+                tool_supersede(),
                 tool_update(),
                 tool_forget(),
                 tool_stats(),
@@ -193,6 +194,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_search" => exec_search(uteke, &arguments)?,
                 "uteke_list" => exec_list(uteke, &arguments)?,
                 "uteke_get" => exec_get(uteke, &arguments)?,
+                "uteke_supersede" => exec_supersede(uteke, &arguments)?,
                 "uteke_update" => exec_update(uteke, &arguments)?,
                 "uteke_forget" => exec_forget(uteke, &arguments)?,
                 "uteke_stats" => exec_stats(uteke, &arguments)?,
@@ -306,6 +308,22 @@ fn tool_get() -> Value {
                 "id": { "type": "string", "description": "Full UUID or unambiguous prefix (8-char id from recall/list works)" }
             },
             "required": ["id"]
+        }
+    })
+}
+
+fn tool_supersede() -> Value {
+    serde_json::json!({
+        "name": "uteke_supersede",
+        "description": "Mark a memory as superseded by a newer one (e.g. a decision pivot). Wires superseded_by/supersedes edges and soft-deprecates the old memory — recall flags the pair so agents don't act on stale info.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "old_id": { "type": "string", "description": "Full UUID or unambiguous prefix of the STALE memory" },
+                "new_id": { "type": "string", "description": "Full UUID or unambiguous prefix of the CURRENT memory" },
+                "reason": { "type": "string", "description": "Why it was superseded (stored on the deprecation, e.g. 'ADR-0005 pivot')" }
+            },
+            "required": ["old_id", "new_id"]
         }
     })
 }
@@ -937,6 +955,19 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         if !detail.is_empty() {
             lines.push(format!("       {}", detail));
         }
+        // #1053: flag memories superseded by a newer decision so agents
+        // don't act on stale info. Deprecated memories are already excluded
+        // from recall by default; this covers legacy/hard-restored rows.
+        if let uteke_core::SearchResultType::Memory = r.result_type {
+            if let Some(mid) = &r.memory_id {
+                if let Ok(Some(newer)) = uteke.supersession_of(mid) {
+                    let short: String = newer.chars().take(8).collect();
+                    lines.push(format!(
+                        "       ⚠ superseded by {short} — verify before acting"
+                    ));
+                }
+            }
+        }
     }
 
     Ok(ToolResult {
@@ -999,6 +1030,35 @@ fn resolve_id<'a>(uteke: &'a Uteke, id: &'a str) -> Result<String, String> {
         Ok(None) => Err(format!("No memory matches id prefix '{id}'")),
         Err(e) => Err(format!("{e}")),
     }
+}
+
+/// #1053: mark old_id superseded by new_id — wires the edge pair
+/// (superseded_by / supersedes) and soft-deprecates the old memory.
+fn exec_supersede(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let old_arg = args["old_id"].as_str().ok_or("Missing 'old_id'")?;
+    let new_arg = args["new_id"].as_str().ok_or("Missing 'new_id'")?;
+    let reason = args["reason"].as_str();
+    let old_id = resolve_id(uteke, old_arg)?;
+    let new_id = resolve_id(uteke, new_arg)?;
+
+    let (o, n) = uteke
+        .supersede(&old_id, &new_id, reason)
+        .map_err(|e| format!("Failed: {e}"))?;
+
+    let mut text = format!("✓ Superseded {o} → {n}");
+    text.push_str("\n  old memory soft-deprecated (restore: uteke lifecycle promote)");
+    text.push_str("\n  recall results now flag the pair until the old row is pruned");
+    if let Some(r) = reason {
+        text.push_str(&format!("\n  reason: {r}"));
+    }
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
+        }],
+        is_error: false,
+    })
 }
 
 /// #1049: read a single memory by id (or unambiguous prefix) — full record,
@@ -2339,6 +2399,76 @@ mod id_resolution_tests {
             m.content, "id resolution probe content",
             "content untouched"
         );
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}
+
+#[cfg(test)]
+mod supersession_mcp_tests {
+    use super::*;
+    use uteke_core::Uteke;
+
+    #[test]
+    fn exec_supersede_via_short_ids() {
+        let dir = std::env::temp_dir().join(format!("ssmcp-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
+
+        let mk = |content: &str| -> String {
+            use uteke_core::memory::types::Memory;
+            let id = uuid::Uuid::new_v4().to_string();
+            let m = Memory {
+                id: id.clone(),
+                content: content.to_string(),
+                embedding: vec![0.5; 768],
+                tags: vec![],
+                metadata: serde_json::json!({}),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                namespace: "ssmcp-ns".to_string(),
+                access_count: 0,
+                last_accessed: None,
+                deprecated: false,
+                valid_from: None,
+                valid_until: None,
+                memory_type: "decision".to_string(),
+                importance: 0.5,
+                pinned: false,
+                content_type: "text".to_string(),
+                slug: None,
+                source: None,
+                source_type: "user".to_string(),
+            };
+            uteke.store().insert(&m).unwrap();
+            id
+        };
+        let old = mk("old auth decision");
+        let new = mk("new auth decision");
+        let old_short: String = old.chars().take(8).collect();
+        let new_short: String = new.chars().take(8).collect();
+
+        let result = exec_supersede(
+            &uteke,
+            &serde_json::json!({"old_id": old_short, "new_id": new_short, "reason": "pivot"}),
+        )
+        .unwrap();
+        assert!(!result.is_error);
+
+        // Edge + deprecation landed.
+        assert_eq!(
+            uteke.supersession_of(&old).unwrap().as_deref(),
+            Some(new.as_str())
+        );
+        assert!(uteke.get_by_id(&old).unwrap().unwrap().deprecated);
+
+        // Self-supersession refused loudly.
+        let err = exec_supersede(
+            &uteke,
+            &serde_json::json!({"old_id": &old_short, "new_id": &old_short}),
+        );
+        assert!(err.is_err());
+
         drop(uteke);
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -142,6 +142,7 @@ Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 | `uteke_list` | List memories (supports pagination via offset) |
 | `uteke_get` | Fetch a single memory's full record by id — no truncation (accepts UUID or unambiguous prefix) |
 | `uteke_update` | Partial update — only provided fields change; content changes re-embed |
+| `uteke_supersede` | Mark a memory superseded by a newer one — wires the edge pair, soft-deprecates the old row; recall flags stale results (⚠ superseded by …) |
 | `uteke_forget` | Delete a memory (accepts UUID or unambiguous prefix) |
 | `uteke_stats` | Memory store statistics |
 | `uteke_context` | AI-optimized context output for prompts |


### PR DESCRIPTION
## What

**Core:**
- `EDGE_SUPERSEDED_BY` edge type + `Uteke::supersede(old_id, new_id, reason)` — wires the edge pair (`old→new: superseded_by` for recall annotation, `new→old: supersedes` navigable inverse) AND soft-deprecates the old memory, **all in one transaction** (cora finding fixed in-PR: edges committed separately from deprecation could leave a superseded_by pointer on a still-active row)
- `Uteke::supersession_of(id)` — resolves the replacement pointer
- Recall-cache namespace invalidation after supersession

**MCP:**
- `uteke_supersede {old_id, new_id, reason?}` — UUID-or-prefix ids via the #1048 resolver; self-supersession and unknown ids rejected loudly
- `uteke_recall` output flags stale hits: `⚠ superseded by <id> — verify before acting` — deprecated rows are already excluded from recall by default; the annotation covers legacy/hard-restored rows that still surface

## Why

Closes #1053. Observed: room `uteke-cloud` held 6 auth-model memories superseded by an ADR pivot — only tribal knowledge marked them stale. Turns the graph from write-only decoration into a correctness layer: revisiting a decision is one call, and every future recall of the stale row carries the pointer to its replacement.

## Testing

- Core: edge pair written, old memory soft-deprecated + hidden from list, `supersession_of` resolves (and returns None for the new row), self/unknown ids error
- MCP: supersede via 8-char short ids end-to-end; refusal paths loud
- Workspace green (488 core + 51 CLI + 6 MCP), fmt/clippy clean, cora review: no issues

Closes #1053