### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.15.0] — 2026-08-19
+
+Minor release. The theme: memory you can trust across surfaces, and a store you can move.
+
+New memories now get UUIDv7 IDs — time-ordered at the front, so indexes and timelines sort naturally instead of jumping around. Existing v4 IDs keep working untouched.
+
+### Added
+
+- **Supersession workflow (#1069)** — mark a stale decision as superseded by a newer one. Recall flags superseded entries so agents stop acting on outdated decisions.
+- **Structural export (#1068)** — full-store round-trip: rooms, graph, edges, documents, and timeline export to a single file and import back without loss.
+- **MCP `uteke_get` + `uteke_update` (#1067)** — read and edit a single memory by ID, with short-ID resolution on every ID-taking tool.
+- **Richer MCP outputs (#1066)** — `uteke_stats` includes tier and namespace breakdowns, `uteke_doc_search` returns scores, room results carry room IDs.
+
+### Fixed
+
+- **`uteke_dream` no longer destructive by default (#1065)** — runs as dry-run first; destructive passes require explicit scope or confirmation.
+- **`/export` keeps namespace attribution (#1064)** — exported rows no longer lose which namespace they came from, and the deprecated-row delta is documented.
+- **Recall cache score parity (#1063)** — a cache hit used to skip salience and recency boosts, so the same query scored differently cold vs warm. Both paths now score identically.
+- **`search_content(None)` no longer collapses to the default namespace (#1062)** — keyword search without an explicit namespace now searches across namespaces as expected.
+- **Soft-forgotten memories stay hidden (#1061)** — they were leaking into list, search, and doctor counts.
+
+### Changed
+
+- **UUIDv4 → UUIDv7 for new IDs (#1060)** — time-sortable IDs. Existing v4 IDs are fully compatible; nothing migrates, nothing breaks.
+
 ## [0.14.3] — 2026-08-15
 
 Patch release: recall `strategy` now behaves the same everywhere. The CLI got the fix in #900; the HTTP API and MCP server never got the wiring, so the same request quietly returned different results depending on which surface you asked.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.3"
+version = "0.15.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "uteke"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.15.0", features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.15.0", features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -21,8 +21,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.14.3", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.14.3" }
+uteke-core = { path = "../uteke-core", version = "0.15.0", features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.15.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What
Version bump to 0.15.0 plus the CHANGELOG entry covering everything since v0.14.3 (13 commits).

## Why
Minor release: 3 new features (supersession workflow, structural export, MCP get/update tools), 5 fixes, and the UUIDv4 → UUIDv7 ID switch justify a minor bump.

## Changes
- Workspace version 0.14.3 → 0.15.0 (all crates)
- Internal path-dep versions aligned (uteke-core/mcp/cli/server)
- CHANGELOG entry for 0.15.0

## Testing
- Version-only + docs change; CI runs the full workspace suite. Release flow follows patch-release-flow (release branch to main comes after this merges).