### PR TITLE
ci: source-branch-check allows chore/release-* release branches

### DIFF
--- a/.github/workflows/source-branch-check.yml
+++ b/.github/workflows/source-branch-check.yml
@@ -22,13 +22,20 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           echo "PR: $HEAD_REF -> $BASE_REF"
-          case "$HEAD_REF" in
-            develop|chore/release-*)
-              echo "OK: source branch allowed ($HEAD_REF)."
-              ;;
-            *)
-              echo "::error::PRs into 'main' are only accepted from 'develop' (or a 'chore/release-*' release branch)."
-              echo "::error::Please change the base branch of this PR to 'develop' and open a new PR from there."
-              exit 1
-              ;;
-          esac
+          # The `on.pull_request.branches: [main]` filter already limits this
+          # workflow to PRs targeting main; the explicit guard below keeps the
+          # check correct even if that trigger filter is ever loosened.
+          if [ "$BASE_REF" = "main" ]; then
+            case "$HEAD_REF" in
+              develop|chore/release-*)
+                echo "OK: source branch allowed ($HEAD_REF)."
+                ;;
+              *)
+                echo "::error::PRs into 'main' are only accepted from 'develop' (or a 'chore/release-*' release branch)."
+                echo "::error::Please change the base branch of this PR to 'develop' and open a new PR from there."
+                exit 1
+                ;;
+            esac
+          else
+            echo "OK: base branch is not 'main' — source branch check not applicable."
+          fi

--- a/.github/workflows/source-branch-check.yml
+++ b/.github/workflows/source-branch-check.yml
@@ -1,7 +1,8 @@
 name: Source Branch Check
 
 # Enforces contribution flow: PRs into `main` must come from `develop`
-# (release chore branches). PRs targeting any other branch are unaffected.
+# or a `chore/release-*` release branch (release flow). PRs targeting
+# any other branch are unaffected.
 
 on:
   pull_request:
@@ -21,9 +22,13 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           echo "PR: $HEAD_REF -> $BASE_REF"
-          if [ "$BASE_REF" = "main" ] && [ "$HEAD_REF" != "develop" ]; then
-            echo "::error::PRs into 'main' are only accepted from 'develop' (release flow)."
-            echo "::error::Please change the base branch of this PR to 'develop' and open a new PR from there."
-            exit 1
-          fi
-          echo "OK: source branch allowed."
+          case "$HEAD_REF" in
+            develop|chore/release-*)
+              echo "OK: source branch allowed ($HEAD_REF)."
+              ;;
+            *)
+              echo "::error::PRs into 'main' are only accepted from 'develop' (or a 'chore/release-*' release branch)."
+              echo "::error::Please change the base branch of this PR to 'develop' and open a new PR from there."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## What
Extend source-branch-check to allow `chore/release-*` branches as PR sources into main, in addition to develop.

## Why
The release flow cuts a `chore/release-vX.Y.Z` branch from main and merges develop into it — that PR targets main but legitimately does not come from develop (#1074 was blocked). External contribution flow is unchanged: everything else must still target develop first.

## Changes
- Replace the strict `!= develop` check with a case pattern: `develop|chore/release-*` allowed, everything else rejected with the same actionable error.

## Testing
- #1074 (chore/release-v0.15.0) will pass Source Branch once this lands on main via the release merge.
- Feature branches (e.g. fix/foo) targeting main are still rejected.