### PR TITLE
fix(ci): skip CLA check for bots (dependabot, renovate, github-actions)

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   cla-check:
     runs-on: ubuntu-latest
+    if: "!contains(fromJSON('[\"app/dependabot\", \"app/renovate\", \"github-actions[bot]\"]'), github.event.pull_request.user.login)"
     steps:
       - name: Fetch & check CLA signature
         id: check


### PR DESCRIPTION
## What
Skip the CLA check job for trusted bot accounts.

## Why
Bots cannot sign the CLA, so bot-authored PRs (e.g. dependabot bumps) always fail `cla-check` and are blocked. Same fix as skill-suites #11.

## How
Job-level `if` condition on `cla-check.yml`. Human PRs unaffected — full CLA enforcement still applies.

## Testing
- [x] YAML parses (yaml.safe_load)
- [x] Diff is a single line; human PRs unaffected (negative condition only matches bot logins)

## Checklist
- [x] Branch from `develop`, conventional commit, no secrets, single concern