### PR TITLE
ci: bump actions/download-artifact v4 -> v8 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,13 +325,13 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Download standard Linux x64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: uteke-x86_64-unknown-linux-gnu-${{ steps.version.outputs.VERSION }}
           path: standard-artifact
 
       - name: Download legacy ORT artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ort-legacy-linux-x64
           path: ort-legacy
@@ -375,7 +375,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-artifacts
           pattern: uteke-*
@@ -480,7 +480,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download Linux binaries from build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: uteke-*-${{ github.ref_name }}
           path: release-artifacts


### PR DESCRIPTION
## What
Bump `actions/download-artifact` from v4 to v8 in `release.yml` (4 occurrences). `upload-artifact` is already at v7.

## Why
GitHub deprecated Node.js 20 on hosted runners — v0.15.0 release workflow emitted the deprecation annotation (`Node.js 20 is deprecated... actions/download-artifact@v4`). v8 targets Node 24.

Fixes #1079.

## Changes
- `.github/workflows/release.yml`: all `download-artifact@v4` → `@v8`

## Testing
- YAML validated locally (`yaml.safe_load`)
- CI on this PR exercises the same actions
- Final validation: next release run must show no Node 20 deprecation annotation