### PR TITLE
docs(server): document deprecation time-travel limitation (#1086)

### DIFF
--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -2310,6 +2310,10 @@ fn resolve_extraction_config(
 /// Mirrors the core `recall_at_time` temporal rules: memory must have been
 /// created at or before `pit`, not yet invalidated (valid_until), not
 /// deprecated, and valid_from must not be in the future relative to `pit`.
+///
+/// Known limitation (#1086): the schema stores no deprecation timestamp,
+/// so a memory deprecated *after* `pit` is also excluded here — time-travel
+/// treats `deprecated` as "never existed". Same rule as core `recall_at_time`.
 fn memory_exists_at(
     memory: &uteke_core::memory::types::Memory,
     pit: chrono::DateTime<chrono::Utc>,


### PR DESCRIPTION
## What
Documents the known time-travel limitation flagged by cora review on #1085.

## Why
Cora correctly flagged that `memory_exists_at` excludes deprecated memories regardless of *when* they were deprecated. The fix requires a schema migration (`deprecated_at` column) — tracked in #1086. Per the review's own recommendation (`At minimum this limitation should be documented`), this adds the doc comment now so the behavior is explicit.

## Changes
- Doc comment on `memory_exists_at` explaining the limitation and linking #1086.

## Testing
- Docs-only change; `cargo fmt` + existing tests unaffected.