### PR TITLE
feat(core): semantic segments in room_summary (#1088)

### DIFF
--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -41,6 +41,10 @@ pub struct RoomSummary {
     /// Document slugs linked to this room via the room_documents junction table.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub referenced_documents: Option<Vec<String>>,
+    /// Semantic segments (embedding-distance boundaries, #1088).
+    /// Computed on demand; absent when the room has no embeddings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segments: Option<Vec<crate::rooms_segments::Segment>>,
 }
 
 /// Time range of memories in a room.
@@ -490,6 +494,7 @@ impl super::Store {
                 recent_decisions: vec![],
                 pinned_highlights: vec![],
                 referenced_documents: None,
+                segments: None,
             }));
         }
 
@@ -734,6 +739,7 @@ impl super::Store {
             recent_decisions,
             pinned_highlights: pinned,
             referenced_documents: None,
+            segments: None,
         }))
     }
 

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -191,8 +191,23 @@ impl crate::Uteke {
     }
 
     /// Generate a summary of room discussion (topic clustering, no LLM needed).
+    /// Enriched with embedding-distance semantic segments (#1088) when
+    /// embeddings exist — these are the batching units for future
+    /// segment-level LLM consolidation.
     pub fn room_summary(&self, room_id: &str) -> Result<Option<RoomSummary>, Error> {
-        self.store.room_summary(room_id)
+        let mut summary = match self.store.room_summary(room_id)? {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        if summary.total_memories > 0 && summary.segments.is_none() {
+            // Segment only when embeddings are present; otherwise keep None.
+            let memories = self.store.recall_room(room_id, None, 0)?;
+            if memories.iter().any(|m| !m.embedding.is_empty()) {
+                let segmentation = self.room_segments_inner(room_id, &memories, 0.45, 12, 3)?;
+                summary.segments = Some(segmentation.segments);
+            }
+        }
+        Ok(Some(summary))
     }
 
     /// Get room summary with referenced documents populated.

--- a/crates/uteke-core/src/rooms_segments.rs
+++ b/crates/uteke-core/src/rooms_segments.rs
@@ -107,7 +107,21 @@ impl crate::Uteke {
         min_size: usize,
     ) -> Result<SegmentationResult, Error> {
         // Bulk-fetch room memories in one query, chronological order.
-        let mut memories: Vec<Memory> = self.store.recall_room(room_id, None, 0)?;
+        let memories = self.store.recall_room(room_id, None, 0)?;
+        self.room_segments_inner(room_id, &memories, threshold, max_size, min_size)
+    }
+
+    /// Segmentation over caller-supplied memories (already fetched — avoids
+    /// a second query when the caller already holds the room's memories).
+    pub fn room_segments_inner(
+        &self,
+        room_id: &str,
+        memories: &[Memory],
+        threshold: f32,
+        max_size: usize,
+        min_size: usize,
+    ) -> Result<SegmentationResult, Error> {
+        let mut memories: Vec<Memory> = memories.to_vec();
         if memories.is_empty() {
             return Ok(SegmentationResult {
                 room_id: room_id.to_string(),
@@ -420,5 +434,46 @@ mod tests {
             sizes.iter().skip(1).all(|&s| s >= 3),
             "tail segments below min_size: {sizes:?}"
         );
+    }
+
+    #[test]
+    fn room_summary_includes_segments_when_embeddings_exist() {
+        let uteke = crate::Uteke::open(":memory:").unwrap();
+        uteke.store.create_room("r4", None, "default").unwrap();
+        let a = vec![1.0, 0.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0, 0.0];
+        let embs = [
+            a.clone(),
+            a.clone(),
+            a.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+        ];
+        for (i, e) in embs.into_iter().enumerate() {
+            let id = format!("m{i}");
+            let m = make_memory(&id, &id, e);
+            uteke.store.insert(&m).unwrap();
+            uteke
+                .store
+                .link_memory_to_room("r4", &id, "tester", "participant")
+                .unwrap();
+        }
+        let summary = uteke.room_summary("r4").unwrap().expect("summary exists");
+        let segs = summary.segments.expect("segments present");
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].memory_ids.len(), 3);
+        assert_eq!(segs[1].memory_ids.len(), 3);
+
+        // No embeddings -> segments stay None.
+        uteke.store.create_room("r5", None, "default").unwrap();
+        let m = make_memory("plain", "plain", vec![]);
+        uteke.store.insert(&m).unwrap();
+        uteke
+            .store
+            .link_memory_to_room("r5", "plain", "tester", "participant")
+            .unwrap();
+        let s5 = uteke.room_summary("r5").unwrap().expect("summary exists");
+        assert!(s5.segments.is_none());
     }
 }


### PR DESCRIPTION
## What
- `Uteke::room_summary` now includes `segments` (serde-optional `Vec<Segment>`) computed via `room_segments_inner` when room memories have embeddings
- `room_segments` refactored into public fetch wrapper + `room_segments_inner` taking caller-supplied memories (avoids a second `recall_room` query in the summary path)

## Why
Segments are the batching units for segment-level LLM consolidation (LycheeMemory V2 granularity, #1088). Exposing them in the summary gives API consumers the same unit boundaries without an extra call. Tag-based topic clusters remain untouched; segments are additive and None for rooms without embeddings (backward compatible).

## Testing
- 6/6 `rooms_segments` tests pass, incl. new `room_summary_includes_segments_when_embeddings_exist` (segments present with embeddings, None without)
- Full `uteke-core` lib suite: 499 passed, 0 failed
- cargo fmt + clippy clean