### PR TITLE
feat: wire consolidation pipeline into core, CLI, and HTTP (#1088)

### DIFF
--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -776,6 +776,21 @@ pub enum RoomCommands {
         /// Document slug
         doc_slug: String,
     },
+    /// Consolidate a room's memories into fewer, denser records (#1088).
+    ///
+    /// Dry-run by default: shows the batching plan and estimated LLM calls
+    /// without contacting any API. Pass --apply to execute (requires
+    /// extraction LLM config in uteke.toml or UTEKE_* env vars).
+    Consolidate {
+        /// Room ID
+        room_id: String,
+        /// Execute the plan (LLM calls + store writes). Omit for dry-run.
+        #[arg(long)]
+        apply: bool,
+        /// Max LLM requests for this run (default 10, failed calls count too)
+        #[arg(long, default_value_t = 10)]
+        max_calls: usize,
+    },
 }
 
 /// Subcommands for memory aging operations.

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -330,5 +330,70 @@ pub(crate) fn run(
             }
             Ok(())
         }
+        RoomCommands::Consolidate {
+            room_id,
+            apply,
+            max_calls,
+        } => {
+            let dry = uteke_core::consolidation_api::plan_room(uteke, room_id)
+                .map_err(|e| format!("Failed to plan consolidation: {e}"))?;
+
+            if !apply {
+                if cli.json {
+                    println!("{}", serde_json::to_string_pretty(&dry).unwrap());
+                } else {
+                    println!("Consolidation plan for room '{room_id}' (dry-run, no LLM calls):");
+                    println!("  Memories: {}", dry.plan.total_memories);
+                    println!("  Batches:  {}", dry.plan.batches.len());
+                    println!(
+                        "  Estimated LLM calls: {}",
+                        dry.plan.batches.len().min(*max_calls)
+                    );
+                    if dry.plan.batches.len() > *max_calls {
+                        println!(
+                            "  ⚠ {} batches exceed --max-calls {max_calls}; run with higher --max-calls or in parts.",
+                            dry.plan.batches.len() - max_calls
+                        );
+                    }
+                    println!("  Pass --apply to execute.");
+                }
+                return Ok(());
+            }
+
+            // Apply: requires extraction LLM setup (shared with import --extract).
+            let ext = &config.extraction;
+            if ext.api_key.is_empty() {
+                return Err(
+                    "Consolidation --apply needs LLM config: set [extraction] in uteke.toml \
+                     or UTEKE_EXTRACTION_API_KEY (same setup as `import --extract`)."
+                        .to_string(),
+                );
+            }
+            let result =
+                uteke_core::consolidation_api::consolidate_room(uteke, room_id, ext, *max_calls)
+                    .map_err(|e| format!("Consolidation failed: {e}"))?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+            } else {
+                println!("Consolidation of room '{room_id}' complete:");
+                println!("  Batches processed: {}", result.batches_processed);
+                println!("  Records written:   {}", result.records_written);
+                println!("  Sources deprecated: {}", result.sources_deprecated);
+                if result.budget_skipped > 0 {
+                    println!("  Budget-skipped:    {}", result.budget_skipped);
+                }
+                if result.rejected_by_policy > 0 {
+                    println!("  Rejected (policy): {}", result.rejected_by_policy);
+                }
+                if !result.batch_errors.is_empty() {
+                    println!("  ⚠ Batch errors (isolated, run continued):");
+                    for e in &result.batch_errors {
+                        println!("    - {e}");
+                    }
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/uteke-core/src/consolidation_api.rs
+++ b/crates/uteke-core/src/consolidation_api.rs
@@ -35,21 +35,31 @@ impl ConsolidationStore for Uteke {
         // Persist (transactional insert, mirrors crud flow).
         self.store().insert(memory)?;
 
-        // Insert into the vector index so recall finds it.
+        // Insert into the vector index so recall finds it; roll back the row
+        // if indexing fails so we never leave an un-searchable memory behind.
         if !memory.embedding.is_empty() {
             let key = memory.id.clone();
             let embedding = memory.embedding.clone();
-            self.add_to_index(&key, &embedding)?;
+            if let Err(e) = self.add_to_index(&key, &embedding) {
+                let _ = self.store().delete(&memory.id);
+                return Err(e);
+            }
         }
 
-        // Keep the record linked to its room so recall_room returns it.
+        // Keep the record linked to its room so recall_room returns it;
+        // roll back the row + index entry on failure (no room links to a
+        // memory the room cannot see).
         if let Some(room_id) = room_id {
-            self.store().link_memory_to_room(
+            if let Err(e) = self.store().link_memory_to_room(
                 &room_id,
                 &memory.id,
                 CONSOLIDATOR_AUTHOR,
                 "consolidated",
-            )?;
+            ) {
+                self.remove_from_index(&memory.id);
+                let _ = self.store().delete(&memory.id);
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/crates/uteke-core/src/consolidation_api.rs
+++ b/crates/uteke-core/src/consolidation_api.rs
@@ -1,0 +1,195 @@
+//! High-level consolidation API wiring the executor to a real `Uteke` store.
+//!
+//! Implements `ConsolidationStore` for `Uteke` (SQLite + lazy embedder) and
+//! exposes a single entry point [`consolidate_room`] used by the CLI and the
+//! HTTP server. The executor itself stays store-agnostic and testable with
+//! a mock store (see `consolidation_exec`).
+//!
+//! All operations are opt-in: nothing in the dream pipeline calls this
+//! automatically. Rooms are consolidated only when explicitly requested
+//! via CLI (`uteke consolidate`) or HTTP (`POST /room/{id}/consolidate`).
+
+use crate::Error;
+use crate::Uteke;
+use crate::consolidation_exec::{self, ConsolidationExecution, ConsolidationStore};
+use crate::consolidation_plan::{self, ConsolidationPlan};
+use crate::extraction::ExtractionConfig;
+use crate::memory::types::Memory;
+
+/// System author tag for consolidated records.
+const CONSOLIDATOR_AUTHOR: &str = "uteke-consolidator";
+
+impl ConsolidationStore for Uteke {
+    fn room_memories(&self, room_id: &str) -> Result<Vec<Memory>, Error> {
+        // author=None → cross-namespace; limit=0 → all; active only (#784).
+        self.store().recall_room(room_id, None, 0)
+    }
+
+    fn insert_memory(&self, memory: &mut Memory) -> Result<(), Error> {
+        let room_id = memory
+            .metadata
+            .get("room_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        // Persist (transactional insert, mirrors crud flow).
+        self.store().insert(memory)?;
+
+        // Insert into the vector index so recall finds it.
+        if !memory.embedding.is_empty() {
+            let key = memory.id.clone();
+            let embedding = memory.embedding.clone();
+            self.add_to_index(&key, &embedding)?;
+        }
+
+        // Keep the record linked to its room so recall_room returns it.
+        if let Some(room_id) = room_id {
+            self.store().link_memory_to_room(
+                &room_id,
+                &memory.id,
+                CONSOLIDATOR_AUTHOR,
+                "consolidated",
+            )?;
+        }
+        Ok(())
+    }
+
+    fn deprecate_memory(&self, id: &str, reason: &str) -> Result<(), Error> {
+        self.store().deprecate_with_reason(id, reason)
+    }
+
+    fn embed_content(&self, content: &str) -> Result<Vec<f32>, Error> {
+        self.embed_text(content)
+    }
+}
+
+/// Outcome of a dry-run (plan only, no LLM calls, no writes).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ConsolidationDryRun {
+    pub plan: ConsolidationPlan,
+}
+
+/// Plan consolidation for a room without any side effects.
+///
+/// Costs nothing: no LLM call, no store write. The returned plan carries
+/// per-batch payloads and cost estimates the caller can inspect first.
+pub fn plan_room(uteke: &Uteke, room_id: &str) -> Result<ConsolidationDryRun, Error> {
+    let plan = uteke.room_consolidation_plan(
+        room_id,
+        consolidation_plan::DEFAULT_THRESHOLD,
+        consolidation_plan::DEFAULT_MAX_SIZE,
+        consolidation_plan::DEFAULT_MIN_SIZE,
+    )?;
+    Ok(ConsolidationDryRun { plan })
+}
+
+/// Execute consolidation for a room: plan → LLM batches → provenance gate →
+/// write consolidated records and deprecate sources.
+///
+/// `max_llm_calls` caps the number of LLM requests for this run (failed
+/// calls count against the budget too). Uses the shared extraction endpoint
+/// setup — same model/key/base URL as import extraction ("1 setup, many uses").
+pub fn consolidate_room(
+    uteke: &Uteke,
+    room_id: &str,
+    config: &ExtractionConfig,
+    max_llm_calls: usize,
+) -> Result<ConsolidationExecution, Error> {
+    let dry = plan_room(uteke, room_id)?;
+    consolidation_exec::execute_plan(uteke, room_id, &dry.plan, config, max_llm_calls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dry_run_makes_no_changes() {
+        let uteke = Uteke::open(":memory:").unwrap();
+        let dry = plan_room(&uteke, "r1").expect("plan empty room");
+        assert!(dry.plan.batches.is_empty());
+        assert_eq!(dry.plan.total_memories, 0);
+    }
+
+    #[test]
+    fn trait_impl_reads_room() {
+        // Trait dispatch through &Uteke — catches signature drift between
+        // the trait and the store API at compile time.
+        fn takes_store<S: ConsolidationStore>(_s: &S) {}
+        let uteke = Uteke::open(":memory:").unwrap();
+        takes_store(&uteke);
+        let mems = ConsolidationStore::room_memories(&uteke, "nope").unwrap();
+        assert!(mems.is_empty());
+    }
+
+    fn mem(id: &str, content: &str) -> crate::memory::types::Memory {
+        use crate::memory::types::Memory;
+        use chrono::Utc;
+        Memory {
+            id: id.to_string(),
+            content: content.to_string(),
+            embedding: vec![0.1; 768],
+            tags: vec!["test".into()],
+            metadata: serde_json::json!({}),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            namespace: crate::memory::types::DEFAULT_NAMESPACE.to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            valid_from: None,
+            valid_until: None,
+            memory_type: "fact".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+            slug: None,
+            source: None,
+            source_type: "unknown".to_string(),
+            author_type: "agent".to_string(),
+        }
+    }
+
+    #[test]
+    fn plan_room_batches_real_memories() {
+        let uteke = Uteke::open(":memory:").unwrap();
+        uteke.store.create_room("r1", None, "default").unwrap();
+        for i in 0..6 {
+            let id = format!("m{i}");
+            uteke
+                .store
+                .insert(&mem(&id, &format!("Fact {i} about caching")))
+                .unwrap();
+            uteke
+                .store
+                .link_memory_to_room("r1", &id, "tester", "member")
+                .unwrap();
+        }
+        let dry = plan_room(&uteke, "r1").unwrap();
+        assert_eq!(dry.plan.total_memories, 6);
+        assert!(
+            !dry.plan.batches.is_empty(),
+            "6 similar memories should form at least one batch"
+        );
+    }
+
+    #[test]
+    fn deprecate_and_insert_via_trait() {
+        // Exercises the two write paths the executor relies on.
+        let uteke = Uteke::open(":memory:").unwrap();
+        uteke.store.create_room("r1", None, "default").unwrap();
+        let mut m = mem("m1", "caching fact");
+        ConsolidationStore::insert_memory(&uteke, &mut m).unwrap();
+        assert!(!m.id.is_empty());
+        uteke
+            .store
+            .link_memory_to_room("r1", &m.id, "tester", "member")
+            .unwrap();
+        ConsolidationStore::deprecate_memory(&uteke, &m.id, "consolidated").unwrap();
+        let after = ConsolidationStore::room_memories(&uteke, "r1").unwrap();
+        assert!(
+            after.is_empty(),
+            "deprecated memory must not appear in room recall"
+        );
+    }
+}

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod chunker;
 mod consolidate;
+pub mod consolidation_api;
 pub mod consolidation_exec;
 pub mod consolidation_plan;
 pub mod dream;
@@ -591,6 +592,33 @@ impl Uteke {
     /// Borrow lifecycle configuration (read-only).
     pub fn get_lifecycle_config(&self) -> &LifecycleConfig {
         &self.lifecycle_config
+    }
+
+    /// Embed an arbitrary text with the configured backend (lazy init).
+    /// Used by the consolidation executor to embed consolidated records
+    /// before writing them so they stay vector-searchable.
+    pub fn embed_text(&self, text: &str) -> Result<Vec<f32>, Error> {
+        self.ensure_embedder()?;
+        self.embedder
+            .lock()
+            .map_err(|_| Error::lock("embedder lock during embed_text"))?
+            .as_ref()
+            .expect("embedder ensured above")
+            .embed(text)
+    }
+
+    /// Add an already-persisted memory's embedding to the vector index.
+    /// Used by the consolidation write path so new records are searchable.
+    pub(crate) fn add_to_index(&self, id: &str, embedding: &[f32]) -> Result<(), Error> {
+        let mut index = self
+            .index
+            .write()
+            .map_err(|_| Error::lock("index write lock during consolidation insert"))?;
+        index.insert(id, embedding)?;
+        if let Err(e) = index.save() {
+            tracing::warn!("failed to persist vector index after insert id={id}: {e}");
+        }
+        Ok(())
     }
 
     /// Open or create a Uteke memory store.

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -621,6 +621,20 @@ impl Uteke {
         Ok(())
     }
 
+    /// Remove an entry from the vector index (compensating action for a
+    /// failed consolidation insert). Persistence failure is logged, not
+    /// fatal — the caller is already unwinding an error.
+    pub(crate) fn remove_from_index(&self, id: &str) {
+        let Ok(mut index) = self.index.write() else {
+            return;
+        };
+        if index.remove(id) {
+            if let Err(e) = index.save() {
+                tracing::warn!("failed to persist vector index after remove id={id}: {e}");
+            }
+        }
+    }
+
     /// Open or create a Uteke memory store.
     ///
     /// `path` can be a directory path (will create `uteke.db` inside)

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -286,6 +286,15 @@ pub const ENDPOINTS: &[Endpoint] = &[
     },
     Endpoint {
         method: "POST",
+        path: "/room/consolidate",
+        description: "Plan or execute segment-level LLM consolidation of room memories (#1088). Dry-run by default; `apply: true` executes with a hard budget cap. Write op — blocked for read-only tokens.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#1088"],
+    },
+    Endpoint {
+        method: "POST",
         path: "/room/stats",
         description: "Get memory count for a room. Includes deprecated memories (known discrepancy vs /room/summary).",
         request_type: Some("serde_json::Value"),

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -994,6 +994,69 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // ── Room Consolidation (#1088) ───────────────────────────────────
+        // Dry-run by default; `apply: true` executes with a hard budget cap.
+        // Blocked for read-only tokens (not in read_only_post_paths).
+        (Method::Post, "/room/consolidate") => {
+            #[derive(Deserialize)]
+            struct RoomConsolidateRequest {
+                room_id: String,
+                /// Execute the plan (LLM calls + writes). Default false = dry-run.
+                #[serde(default)]
+                apply: bool,
+                /// Max LLM requests for this run. Default 10, hard cap 100.
+                #[serde(default = "default_max_calls")]
+                max_calls: usize,
+            }
+            fn default_max_calls() -> usize {
+                10
+            }
+            match read_body::<RoomConsolidateRequest>(req.as_reader()) {
+                Ok(req_data) => {
+                    let max_calls = req_data.max_calls.min(100);
+                    let result = if req_data.apply {
+                        let ext = resolve_extraction_config(ctx, None, None, None);
+                        if ext.api_key.is_empty() {
+                            return ctx.error_response_for(
+                                req,
+                                503,
+                                "Consolidation apply requires server-side extraction LLM config",
+                            );
+                        }
+                        match uteke_core::consolidation_api::consolidate_room(
+                            &uteke,
+                            &req_data.room_id,
+                            &ext,
+                            max_calls,
+                        ) {
+                            Ok(exec) => serde_json::to_value(&exec).unwrap_or_default(),
+                            Err(e) => {
+                                error!("Internal error: {e}");
+                                return ctx.error_response_for(req, 500, "Internal server error");
+                            }
+                        }
+                    } else {
+                        match uteke_core::consolidation_api::plan_room(&uteke, &req_data.room_id) {
+                            Ok(dry) => serde_json::json!({
+                                "room_id": req_data.room_id,
+                                "dry_run": true,
+                                "total_memories": dry.plan.total_memories,
+                                "batches": dry.plan.batches.len(),
+                                "estimated_llm_calls": dry.plan.batches.len().min(max_calls),
+                                "plan": dry.plan,
+                            }),
+                            Err(e) => {
+                                error!("Internal error: {e}");
+                                return ctx.error_response_for(req, 500, "Internal server error");
+                            }
+                        }
+                    };
+                    ctx.ok_response_for(req, &result)
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
         // ── DEPRECATED: POST /room/document → /room/summary-document (#735)
         (Method::Post, "/room/document") => {
             warn!(

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -331,6 +331,17 @@ Get room summary focused on document-type memories.
 
 **Request body**: JSON object (see handler source for fields)
 
+#### 🟡 `POST` `/room/consolidate`
+
+Plan or execute segment-level LLM consolidation of room memories (#1088).
+
+- Dry-run by default (`{"room_id": "..."}`) — returns plan + estimated LLM calls, zero API calls.
+- `{"room_id": "...", "apply": true, "max_calls": 20}` executes with a hard budget cap (default 10, hard cap 100; failed calls count).
+- Apply requires server-side extraction LLM config, otherwise **503**.
+- Write operation — blocked for read-only tokens.
+
+**Request body**: `{"room_id": string, "apply"?: boolean, "max_calls"?: number}`
+
 #### 🟢 `GET` `/room/list`
 
 List all rooms.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -394,7 +394,21 @@ uteke room list-documents "project-kickoff"
 
 # List rooms that reference a document (#859, positional slug)
 uteke room list-rooms "architecture-spec"
+
+# Consolidate a room's memories (#1088) — dry-run by default, no LLM calls
+uteke room consolidate "project-kickoff"
+
+# Execute consolidation (LLM calls + writes; budget-capped)
+uteke room consolidate "project-kickoff" --apply --max-calls 20
 ```
+
+### Room consolidation notes (#1088)
+
+- **Dry-run default**: shows memory count, batches, and estimated LLM calls — zero API calls.
+- **`--apply`** requires LLM config (same `[extraction]` setup as `import --extract`).
+- **`--max-calls`** (default 10) is a hard budget: failed LLM calls count too, batches beyond the cap are skipped.
+- Source memories are **soft-deprecated** (never deleted), each carrying a `consolidated into <id>` reason.
+- New consolidated records pass a provenance policy gate (hedging language, trust tier) before being written.
 
 ## uteke bench
 


### PR DESCRIPTION
## What
- Implement `ConsolidationStore` for `Uteke` (SQLite + lazy embedder) in new `consolidation_api` module
- Add `embed_text` / `add_to_index` helpers on `Uteke` for the consolidation write path
- CLI: `uteke room consolidate <room_id> [--apply] [--max-calls N]` — dry-run by default, zero LLM calls
- HTTP: `POST /room/consolidate` — dry-run default; `apply: true` gated on server-side extraction LLM config (503 without it), hard budget cap (default 10, max 100)
- Register endpoint in API registry (`#1088`); document CLI + API in docs/

## Why
Closes the integration gap from #1090–#1094: the pipeline was library-only (mock-tested). This wires it to the real store so rooms can actually be consolidated via CLI/HTTP. Rooms are only consolidated when explicitly requested — never automatic.

## Testing
- Layered: unit (trait dispatch, plan batching on real SQLite, deprecate+insert write paths) → cargo test workspace **585 passed / 0 failed** → clippy `-D warnings` clean → cora review (no major+ findings; println! findings are FP — CLI output convention) → CLI smoke on real DB (room create → 5 remembers → dry-run shows 1 batch/1 call) → HTTP live smoke (dry-run 200 JSON; apply without LLM config → 503)