### PR TITLE
chore(docs): regenerate api-reference via docgen (#1095 follow-up)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -331,20 +331,17 @@ Get room summary focused on document-type memories.
 
 **Request body**: JSON object (see handler source for fields)
 
-#### 🟡 `POST` `/room/consolidate`
-
-Plan or execute segment-level LLM consolidation of room memories (#1088).
-
-- Dry-run by default (`{"room_id": "..."}`) — returns plan + estimated LLM calls, zero API calls.
-- `{"room_id": "...", "apply": true, "max_calls": 20}` executes with a hard budget cap (default 10, hard cap 100; failed calls count).
-- Apply requires server-side extraction LLM config, otherwise **503**.
-- Write operation — blocked for read-only tokens.
-
-**Request body**: `{"room_id": string, "apply"?: boolean, "max_calls"?: number}`
-
 #### 🟢 `GET` `/room/list`
 
 List all rooms.
+
+#### 🟡 `POST` `/room/consolidate`
+
+Plan or execute segment-level LLM consolidation of room memories (#1088). Dry-run by default; `apply: true` executes with a hard budget cap. Write op — blocked for read-only tokens.
+
+**Request body**: JSON object (see handler source for fields)
+
+*Related: `#1088`*
 
 #### 🟡 `POST` `/room/stats`
 


### PR DESCRIPTION
## What
- Re-run `cargo run -p docgen` so `docs/api-reference.md` matches the API registry.

## Why
#1095 added a hand-written `/room/consolidate` section; the `API Docs Fresh` CI job correctly flagged the file as stale. docgen now renders the endpoint from the registry (correct ordering + `#1088` related-tag) instead of manual prose.

## Testing
- `cargo run -p docgen` output committed verbatim (6+/9- vs develop)
- `API Docs Fresh` job will verify freshness in CI