### PR TITLE
fix(ci): keep v prefix in release notes download table + pinned install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-targets
 
+  release-notes-check:
+    name: Release Notes Template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Substituted names must match workflow asset names
+        run: |
+          # The release job archives "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}"
+          # where VERSION keeps the tag's `v` (refs/tags/vX.Y.Z). The notes template
+          # substitutes __VER__ with that same value, so rendered names must be
+          # exactly `<artifact>-v<semver>.<ext>` — no missing `v`, no double `v`.
+          set -euo pipefail
+          grep -oE 'uteke-[a-z0-9_-]+-__VER__\.(tar\.gz|zip)' scripts/release-notes-template.md \
+            | sed 's/__VER__/v0.0.0/' > rendered.txt
+          expected="uteke-aarch64-apple-darwin-v0.0.0.tar.gz
+          uteke-aarch64-unknown-linux-gnu-v0.0.0.tar.gz
+          uteke-x86_64-pc-windows-msvc-v0.0.0.zip
+          uteke-x86_64-unknown-linux-gnu-legacy-v0.0.0.tar.gz
+          uteke-x86_64-unknown-linux-gnu-v0.0.0.tar.gz"
+          sort_expected=$(printf '%s\n' "$expected" | sort)
+          if ! diff -u <(sort rendered.txt) <(printf '%s\n' "$sort_expected"); then
+            echo "::error::release-notes template renders asset names that do not match the release workflow artifact names (see diff above)"
+            exit 1
+          fi
+          # Pinned-install line: __VER__ is substituted WITH the `v`-prefixed tag,
+          # so the template must carry the bare placeholder — UTEKE_VERSION=__VER__
+          # renders as UTEKE_VERSION=vX.Y.Z (install.sh builds asset URLs from this).
+          grep -qE 'UTEKE_VERSION=__VER__ ' scripts/release-notes-template.md \
+            || { echo "::error::pinned-install line must use UTEKE_VERSION=__VER__ (the v comes from the tag)"; exit 1; }
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,18 @@ jobs:
           # exactly `<artifact>-v<semver>.<ext>` — no missing `v`, no double `v`.
           set -euo pipefail
           grep -oE 'uteke-[a-z0-9_-]+-__VER__\.(tar\.gz|zip)' scripts/release-notes-template.md \
-            | sed 's/__VER__/v0.0.0/' > rendered.txt
-          expected="uteke-aarch64-apple-darwin-v0.0.0.tar.gz
-          uteke-aarch64-unknown-linux-gnu-v0.0.0.tar.gz
-          uteke-x86_64-pc-windows-msvc-v0.0.0.zip
-          uteke-x86_64-unknown-linux-gnu-legacy-v0.0.0.tar.gz
-          uteke-x86_64-unknown-linux-gnu-v0.0.0.tar.gz"
-          sort_expected=$(printf '%s\n' "$expected" | sort)
-          if ! diff -u <(sort rendered.txt) <(printf '%s\n' "$sort_expected"); then
+            | sed 's/__VER__/v0.0.0/' | sort > rendered.txt
+          # Expected names mirror the release job's archive step:
+          #   tar czf "${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}"
+          # where VERSION keeps the tag's `v` (refs/tags/vX.Y.Z).
+          printf '%s\n' \
+            uteke-aarch64-apple-darwin-v0.0.0.tar.gz \
+            uteke-aarch64-unknown-linux-gnu-v0.0.0.tar.gz \
+            uteke-x86_64-pc-windows-msvc-v0.0.0.zip \
+            uteke-x86_64-unknown-linux-gnu-legacy-v0.0.0.tar.gz \
+            uteke-x86_64-unknown-linux-gnu-v0.0.0.tar.gz \
+            | sort > expected.txt
+          if ! diff -u expected.txt rendered.txt; then
             echo "::error::release-notes template renders asset names that do not match the release workflow artifact names (see diff above)"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,7 +431,7 @@ jobs:
               # shell expansion: markdown backticks become command substitutions and
               # get EXECUTED (v0.14.3: installer curl|sh ran on the runner, then
               # uteke-serve blocked forever). Template file = zero expansion.
-              sed "s/__VER__/${VER#v}/g" scripts/release-notes-template.md
+              sed "s/__VER__/${VER}/g" scripts/release-notes-template.md
             } > release-notes.md
           fi
 

--- a/scripts/release-notes-template.md
+++ b/scripts/release-notes-template.md
@@ -11,11 +11,11 @@ Each archive contains three binaries + ONNX Runtime shared library:
 
 | Platform | File |
 |----------|------|
-| Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-v__VER__.tar.gz` |
-| Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-v__VER__.tar.gz` |
-| Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-v__VER__.tar.gz` |
-| macOS Apple Silicon | `uteke-aarch64-apple-darwin-v__VER__.tar.gz` |
-| Windows x86_64 | `uteke-x86_64-pc-windows-msvc-v__VER__.zip` |
+| Linux x86_64 (AVX2) | `uteke-x86_64-unknown-linux-gnu-__VER__.tar.gz` |
+| Linux x86_64 (Legacy, SSE4.2) | `uteke-x86_64-unknown-linux-gnu-legacy-__VER__.tar.gz` |
+| Linux ARM64 | `uteke-aarch64-unknown-linux-gnu-__VER__.tar.gz` |
+| macOS Apple Silicon | `uteke-aarch64-apple-darwin-__VER__.tar.gz` |
+| Windows x86_64 | `uteke-x86_64-pc-windows-msvc-__VER__.zip` |
 
 > **Legacy Bundle (Linux only)** — Includes a SSE4.2-only ORT sidecar (`ort-legacy/`) for CPUs without AVX2 (Intel Celeron J4125/N4020). Use this bundle to avoid SIGILL crashes on older hardware.
 


### PR DESCRIPTION
## What (description of the change)

The release job substitutes `__VER__` in `scripts/release-notes-template.md` with `${VER#v}` — the tag **without** its `v` prefix — while the archived assets are named **with** it (`<artifact>-v<semver>.tar.gz`). Result: filenames copy-pasted from the notes table and the pinned-install line (`UTEKE_VERSION=0.15.0 ...`) both 404.

- `release.yml`: substitute `__VER__` with the full tag (v kept)
- `release-notes-template.md`: drop the literal `v` from the 5 download-table rows (the tag now supplies it), so rendered names stay byte-identical to the actual assets
- `ci.yml`: new **Release Notes Template** job — renders the template with a placeholder semver and asserts the names equal the workflow's `<artifact>-v<ver>.<ext>` pattern, plus the pinned-install line carries the `v`-prefixed tag. Catches this regression class **before** a tag is cut.

## Why

Users following the notes got 404s on download URLs (#1043). The v0.15.0 table rows were already correct (fixed in #1055); the remaining breakage was the pinned-install line and the risk of the substitution regressing again.

## Testing

- Rendered the template with `VER=v0.15.0`: all 5 names **diff-clean against the actual v0.15.0 release assets** (`gh release view`).
- The new CI step was extracted verbatim from `ci.yml` and passes locally (`bash /tmp/ci-step.sh`).
- `ci.yml` parses as valid YAML; full workflow suite unchanged otherwise.

Closes #1043

Reimplements the intent of #1046 (closed: wrong base branch, author unresponsive) — thanks @VIVAAN-DHAWAN for the original report.