### PR TITLE
fix(cli): honor UTEKE_HOME as store path override

### DIFF
--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -39,12 +39,8 @@ pub(crate) fn run_repair(
     if rebuild {
         tracing::info!("Running repair --rebuild (deleting index files first)");
 
-        // Determine index path: cli --store override or config default.
-        let store_dir = cli
-            .store
-            .as_deref()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| crate::Config::expand_tilde(&config.store.path));
+        // Same resolution order as main (#1105): --store > UTEKE_HOME > config.
+        let store_dir = crate::resolve_store_path(cli, config);
 
         let index_path = std::path::PathBuf::from(&store_dir).join("uteke_index.usearch");
         let keys_path = std::path::PathBuf::from(&store_dir).join("uteke_index.keys");

--- a/crates/uteke-cli/src/main.rs
+++ b/crates/uteke-cli/src/main.rs
@@ -19,6 +19,23 @@ use uteke_core::Uteke;
 /// Global flag set by SIGINT handler.
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
+/// Store resolution order (#1105): `--store` flag > `UTEKE_HOME` env >
+/// `uteke.toml [store].path` > built-in default. `UTEKE_HOME` previously only
+/// affected models/config/logs while the DB silently stayed on the default
+/// (often production) path — an operator trap that could read/write the wrong
+/// database from an "isolated-looking" invocation.
+pub(crate) fn resolve_store_path(cli: &Cli, config: &Config) -> String {
+    if let Some(s) = cli.store.as_deref() {
+        return s.to_string();
+    }
+    if let Ok(home) = std::env::var("UTEKE_HOME") {
+        if !home.is_empty() {
+            return home;
+        }
+    }
+    Config::expand_tilde(&config.store.path)
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -130,11 +147,7 @@ fn main() {
         tracing::debug!("No server detected, using local store");
     }
 
-    let store_path = cli
-        .store
-        .as_deref()
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| Config::expand_tilde(&config.store.path));
+    let store_path = resolve_store_path(&cli, &config);
 
     tracing::debug!("Opening store at: {store_path}");
 
@@ -235,4 +248,38 @@ pub(crate) fn resolve_namespace(cli: &Cli, config: &Config) -> String {
         return config.store.namespace.clone();
     }
     "default".to_string()
+}
+
+#[cfg(test)]
+mod resolve_store_tests {
+    use super::*;
+
+    /// All four precedence cases mutate the process-global UTEKE_HOME, so
+    /// they run sequentially inside ONE #[test] — parallel #[test]s racing
+    /// on the same env var flake nondeterministically (same lesson as the
+    /// ort_init tests).
+    #[test]
+    fn store_resolution_precedence() {
+        let cfg = Config::default();
+        let expanded_default = Config::expand_tilde(&cfg.store.path);
+
+        // 1) --store flag beats everything
+        // SAFETY: single-threaded test section; no other test touches this var.
+        unsafe { std::env::set_var("UTEKE_HOME", "/tmp/env-home") };
+        let mut cli = Cli::try_parse_from(["uteke", "stats"]).unwrap();
+        cli.store = Some("/tmp/flag-store".to_string());
+        assert_eq!(resolve_store_path(&cli, &cfg), "/tmp/flag-store");
+
+        // 2) UTEKE_HOME beats config when flag absent
+        cli.store = None;
+        assert_eq!(resolve_store_path(&cli, &cfg), "/tmp/env-home");
+
+        // 3) empty env falls back to config
+        unsafe { std::env::set_var("UTEKE_HOME", "") };
+        assert_eq!(resolve_store_path(&cli, &cfg), expanded_default);
+
+        // 4) config default when no flag, no env
+        unsafe { std::env::remove_var("UTEKE_HOME") };
+        assert_eq!(resolve_store_path(&cli, &cfg), expanded_default);
+    }
 }


### PR DESCRIPTION
## What (description of the change)

The `uteke` CLI resolved its store from `--store` or `uteke.toml` only, **ignoring `UTEKE_HOME`** — so an isolated-looking invocation silently opened the default (often production) database:

```
$ UTEKE_HOME=/tmp/empty-home uteke doctor
  ✓ SQLite DB: 8045 memories  # <- opened ~/.codecora/uteke (prod), not the env home
```

- New resolution order: `--store` flag > `UTEKE_HOME` env > `uteke.toml [store].path` > default, implemented as a shared `resolve_store_path()` in the CLI crate
- Both call sites fixed: `main` and **`repair --rebuild`** (which resolved index paths independently — the most destructive command to mis-target)
- Sequential precedence test covering all four cases (env-var tests merged into one `#[test]` to avoid the parallel env-mutation race pattern seen in ort_init)

## Why

Operator trap with real consequences: during v0.16.0 pre-release QA this caused accidental v16+v17 schema migrations on a live DB (additive, non-destructive, but proves the risk). Also fixes an inconsistency: `uteke-serve` honors `UTEKE_HOME` for the DB while the CLI did not.

## Testing

- `cargo test --workspace` → **11/11 suites green** (55 uteke-cli tests, incl. the new precedence test, 3x stable)
- **Empirical isolation check**: `UTEKE_HOME=<empty dir> ./target/debug/uteke doctor` → `DB: 0 memories` in that dir (previously: 8045 from prod default)
- `cargo fmt` + `clippy --workspace --all-targets -D warnings` clean

Closes #1105