### PR TITLE
fix(build): vecq binaries now buildable via forwarded backend features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       # Ensure the pure-Rust vecq vector backend (#1098) keeps compiling and
       # passing its unit tests on every PR.
       - run: cargo test -p uteke-core --no-default-features --features "onnx,vecq" --lib vector
+      # …and that it still builds into the shippable binaries (#1109). Testing
+      # only --lib let feature-unification break packaging silently.
+      - run: cargo build -p uteke-cli -p uteke-server -p uteke-mcp --no-default-features --features vecq
 
   docs-check:
     name: API Docs Fresh

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -13,8 +13,15 @@ categories = ["command-line-utilities", "development-tools"]
 name = "uteke"
 path = "src/main.rs"
 
+[features]
+default = ["usearch"]
+# Vector index backend forwarded to uteke-core. Exactly one must be enabled;
+# default is usearch (HNSW C++ FFI). vecq = pure-Rust 4-bit quantization (#1098).
+usearch = ["uteke-core/usearch"]
+vecq = ["uteke-core/vecq"]
+
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.15.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.15.0", default-features = false, features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -20,8 +20,15 @@ path = "src/main.rs"
 name = "uteke_mcp"
 path = "src/lib.rs"
 
+[features]
+default = ["usearch"]
+# Vector index backend forwarded to uteke-core. Exactly one must be enabled;
+# default is usearch (HNSW C++ FFI). vecq = pure-Rust 4-bit quantization (#1098).
+usearch = ["uteke-core/usearch"]
+vecq = ["uteke-core/vecq"]
+
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.15.0", features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.15.0", default-features = false, features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -10,7 +10,12 @@ keywords = ["server", "memory", "ai", "http", "embedding"]
 categories = ["web-programming::http-server", "development-tools"]
 
 [features]
+default = ["usearch"]
 docgen = ["dep:schemars"]
+# Vector index backend forwarded to uteke-core. Exactly one must be enabled;
+# default is usearch (HNSW, C++ FFI). vecq = pure-Rust 4-bit quantization (#1098).
+usearch = ["uteke-core/usearch", "uteke-mcp/usearch"]
+vecq = ["uteke-core/vecq", "uteke-mcp/vecq"]
 
 [lib]
 name = "uteke_server"
@@ -21,8 +26,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.15.0", features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.15.0" }
+uteke-core = { path = "../uteke-core", version = "0.15.0", default-features = false, features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What
- `uteke-cli`/`uteke-server`/`uteke-mcp` pulled `uteke-core` with **default features**, so requesting `vecq` always unified with default `usearch` → mutual-exclusion `compile_error!` guard fired. Feature unshippable as binary while CI stayed green.
- Fix: each downstream crate declares `usearch`/`vecq` features forwarding to `uteke-core` (`default = ["usearch"]`); `uteke-server` also forwards through its `uteke-mcp` dependency.
- CI vecq-check now builds all three binaries with vecq so packaging breaks fail the build.

## Why
Issue #1109 — the pure-Rust vecq backend (#1098) could not be built into a binary at all (`cargo build --no-default-features --features uteke-core/vecq` → compile_error). Root cause: Cargo feature unification — downstream default deps silently re-enabled usearch alongside vecq.

## Testing
```
cargo build -p uteke-cli -p uteke-server -p uteke-mcp --no-default-features --features vecq  → OK
cargo build --release (all 3, default usearch)                                               → OK (3m12s)
cargo test -p uteke-core --no-default-features --features "onnx,vecq" --lib vector         → 8 passed
cargo fmt --all --check / cargo clippy --workspace --all-targets                            → clean
```

Fixes #1109