### PR TITLE
fix(cli): repair report compares against memories + chunks

### DIFF
--- a/crates/uteke-cli/src/output.rs
+++ b/crates/uteke-cli/src/output.rs
@@ -243,7 +243,7 @@ pub(crate) fn print_repair_human(report: &uteke_core::RepairReport) {
     println!("  SQLite DB:     {} memories", report.db_count);
     println!("  Index before:  {} vectors", report.index_before);
     println!("  Index after:   {} vectors", report.index_after);
-    if report.index_after == report.db_count {
+    if report.index_after == report.db_count + report.chunk_count {
         println!("  ✓ Index rebuilt successfully");
     } else {
         println!("  ⚠ Index count still differs from DB");

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -176,6 +176,7 @@ impl crate::Uteke {
             db_count: before_db,
             index_before: before_index,
             index_after: items.len(),
+            chunk_count,
         })
     }
 

--- a/crates/uteke-core/src/types.rs
+++ b/crates/uteke-core/src/types.rs
@@ -51,6 +51,10 @@ pub struct RepairReport {
     pub index_before: usize,
     /// Index count after repair.
     pub index_after: usize,
+    /// Document chunks included in the rebuilt index (#1110).
+    /// Defaults to 0 when deserializing reports from older binaries.
+    #[serde(default)]
+    pub chunk_count: usize,
 }
 
 /// Result of `uteke repair --reembed`.
@@ -110,9 +114,11 @@ mod tests {
             db_count: 10,
             index_before: 5,
             index_after: 10,
+            chunk_count: 2,
         };
         let json = serde_json::to_string(&report).unwrap();
         let restored: RepairReport = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.index_after, 10);
+        assert_eq!(restored.chunk_count, 2);
     }
 }


### PR DESCRIPTION
## What
- CLI repair summary compared `index_after` (memories + chunk vectors) against `db_count` (memories only) → false "⚠ Index count still differs from DB" warning on any store with documents.
- `RepairReport` now carries `chunk_count` (`#[serde(default)]`, backward-compatible); CLI compares `index_after == db_count + chunk_count`.

## Why
Follow-up to #1110/#1111, caught during post-merge E2E retest: repair on a doc-only store correctly preserved the chunk vector (doc search still found it post-repair) but printed a misleading failure warning. Same stale comparison logic that #1111 fixed in verify/doctor, missed in the repair display path.

## Testing
Post-merge E2E retest (isolated QA home):
```
doc/create raft-consensus → chunk indexed (score 0.0328)
repair → "✓ Index rebuilt successfully" (was "⚠ Index count still differs")
doc/search post-repair → 1 result, same score (chunk preserved)
doctor → Index consistency: DB=0 (+1 chunks) Index=1 — all checks passed
```
`cargo test -p uteke-core --lib` → 518 passed (serialization test extended with `chunk_count`); clippy clean.

Related: #1110 #1111