### PR TITLE
bench(longmemeval): temporal date-window boost (#1119)

### DIFF
--- a/benchmarks/longmemeval/modal_fast50.py
+++ b/benchmarks/longmemeval/modal_fast50.py
@@ -48,6 +48,8 @@ UTEKE_VERSION = "v0.15.0"
 DATA_FILE = "longmemeval_fast50.json"
 RERANK = False  # removed (#1118 cancelled — single-model direction); kept as False for compat
 RERANK_DEPTH = 20
+TEMPORAL = os.environ.get("LMEVAL_TEMPORAL", "0") == "1"
+# Local source of the embedding model (must contain onnx/ + tokenizer.json).
 MODEL_SOURCE = pathlib.Path("/opt/data/.codecora/uteke/models/embeddinggemma-q4")
 
 app = modal.App("uteke-lmeval-fast")
@@ -75,6 +77,7 @@ image = (
     .add_local_dir(str(MODEL_SOURCE), "/root/.codecora/uteke/models/embeddinggemma-q4")
     .add_local_file(str(REPO_DIR / "run_eval.py"), "/root/harness/run_eval.py")
     .add_local_file(str(REPO_DIR / "data" / DATA_FILE), "/root/harness/data.json")
+    .add_local_file(str(REPO_DIR / "temporal.py"), "/root/harness/temporal.py")
     .add_local_file(str(REPO_DIR / "compare_fast50.py"), "/root/harness/compare_fast50.py")
 )
 
@@ -135,6 +138,7 @@ def run_shard(spec: dict) -> dict:
                 "--output", out_dir,
                 "--strategy", strategy,
                 "--namespace", "lmeval",
+                *([] if not TEMPORAL else ["--temporal"]),
                 *resume_args,
             ],
             capture_output=True, text=True, timeout=14100,  # 14400 - buffer commit

--- a/benchmarks/longmemeval/run_eval.py
+++ b/benchmarks/longmemeval/run_eval.py
@@ -20,6 +20,10 @@ import tempfile
 import time
 from pathlib import Path
 
+# Temporal date-window boost (#1119) — harness-side, default OFF.
+sys.path.insert(0, str(Path(__file__).parent))
+from temporal import boost_ranking, parse_question_date, parse_temporal
+
 # Auto-configure embedding backend from EMBED_API_KEY/EMBED_API_BASE/EMBED_MODEL env vars.
 # Falls back to local ONNX if these are not set.
 if os.environ.get("EMBED_API_KEY") and os.environ.get("EMBED_API_BASE"):
@@ -276,6 +280,24 @@ def recall_and_evaluate(args, store_path, entry, answer_sessions, inserted_sids,
             seen.add(sid)
             retrieved_session_ids.append(sid)
 
+    # Temporal date-window boost (#1119): soft-boost sessions whose date falls
+    # inside the question's temporal window ("last month", "in February",
+    # "between X and Y", ...). No-op when the question has no temporal
+    # expression or when dates are missing. Default OFF (--temporal).
+    if getattr(args, "temporal", False) and retrieved_session_ids:
+        qdate = parse_question_date(entry.get("question_date", ""))
+        window = parse_temporal(question, qdate)
+        if window:
+            session_dates = {}
+            for sid, dstr in zip(entry.get("haystack_session_ids", []),
+                                 entry.get("haystack_dates", [])):
+                d = parse_question_date(dstr)
+                if d is not None:
+                    session_dates[sid] = d
+            retrieved_session_ids = boost_ranking(
+                retrieved_session_ids, session_dates, window,
+                boost=getattr(args, "temporal_boost", 0.0022))
+
     # --- Session-level metrics ---
     # Recall@k: fraction of evidence sessions in top-k
     session_recall = {}
@@ -338,9 +360,16 @@ def main():
                         help="Chunk long sessions into smaller memories to reduce embedding dilution")
     parser.add_argument("--chunk-size", type=int, default=2000,
                         help="Max chars per chunk when --chunk-sessions is enabled (default: 2000)")
+    parser.add_argument("--temporal", action="store_true",
+                        help="Enable temporal date-window boost (#1119), default OFF")
+    parser.add_argument("--temporal-boost", type=float, default=0.0022,
+                        help="Additive RRF boost for sessions inside the temporal window (default: 0.0022)")
     args = parser.parse_args()
 
-    store_path = args.store
+    if args.temporal:
+        print(f"Temporal boost: enabled (boost={args.temporal_boost})")
+
+    # Load data
     with open(args.data) as f:
         data = json.load(f)
 

--- a/benchmarks/longmemeval/temporal.py
+++ b/benchmarks/longmemeval/temporal.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Temporal expression parsing + date-window boost for LongMemEval (#1119).
+
+Harness-side only: no uteke/Rust changes. When a question contains a temporal
+expression ("last month", "before January", "in February", "between X and Y"),
+we compute a date window relative to the question date and softly boost
+retrieved sessions whose session date falls inside that window, before
+Recall@k is computed. Boost is a small additive constant on an RRF-style rank
+score, so it can lift an in-window session from rank ~10 into the top-5 but
+never completely overrides semantic ranking.
+
+Default OFF (--temporal flag in run_eval.py); when OFF or when no temporal
+expression is parsed, output ordering is identical to baseline.
+"""
+import re
+from datetime import date, timedelta
+
+MONTHS = {
+    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5, "june": 6,
+    "july": 7, "august": 8, "september": 9, "october": 10, "november": 11, "december": 12,
+}
+MONTH_RE = "|".join(MONTHS.keys())
+UNITS = {"day": 1, "week": 7, "month": 30, "year": 365}
+
+# Question date format in LongMemEval: "2023/03/22 (Wed) 21:49"
+QDATE_RE = re.compile(r"(\d{4})/(\d{2})/(\d{2})")
+
+
+def _days_in_month(year, month):
+    if month == 12:
+        return 31
+    return (date(year, month + 1, 1) - timedelta(days=1)).day
+
+
+def _month_start_abs(month, year):
+    return date(year, month, 1)
+
+
+def _month_end_abs(month, year):
+    return date(year, month, _days_in_month(year, month))
+
+
+def _resolve_year(month, year, q):
+    """Bare month names resolve within the 12 months preceding the question.
+
+    LongMemEval haystacks span roughly the year before the question date, so
+    'January' asked in 2023/03 means 2023-01, while 'May' means 2022-05.
+    """
+    if year is not None:
+        return year
+    return q.year if month <= q.month else q.year - 1
+
+
+def parse_question_date(qdate_str):
+    """'2023/03/22 (Wed) 21:49' -> date(2023,3,22). None if unparseable."""
+    m = QDATE_RE.search(qdate_str or "")
+    if not m:
+        return None
+    return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+# Each pattern: (compiled regex, name, resolver(match, q) -> (lo, hi)).
+# lo/hi are datetime.date or None for open-ended bounds. Ordered most
+# specific first.
+_RX_BETWEEN = re.compile(
+    r"\bbetween\s+(" + MONTH_RE + r")(?:\s+(\d{4}))?\s+and\s+(" + MONTH_RE + r")(?:\s+(\d{4}))?\b",
+    re.I,
+)
+_RX_BEFORE = re.compile(r"\bbefore\s+(" + MONTH_RE + r")(?:\s+(\d{4}))?\b", re.I)
+_RX_AFTER = re.compile(r"\b(?:after|since)\s+(" + MONTH_RE + r")(?:\s+(\d{4}))?\b", re.I)
+_RX_IN_MONTH = re.compile(r"\bin\s+(" + MONTH_RE + r")(?:\s+(\d{4}))?\b", re.I)
+_RX_LAST_N = re.compile(r"\b(?:last|past|previous)\s+(\d+)\s+(day|week|month|year)s?\b", re.I)
+_RX_N_AGO = re.compile(
+    r"\b(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)"
+    r"\s+(day|week|month)s?\s+ago\b",
+    re.I,
+)
+_RX_LAST_WEEK = re.compile(r"\blast\s+week\b", re.I)
+_RX_LAST_MONTH = re.compile(r"\blast\s+month\b", re.I)
+_RX_THIS_MONTH = re.compile(r"\bthis\s+month\b", re.I)
+_RX_THIS_YEAR = re.compile(r"\bthis\s+year\b", re.I)
+
+
+def _res_between(m, q):
+    m1, y1 = MONTHS[m.group(1).lower()], m.group(2)
+    m2, y2 = MONTHS[m.group(3).lower()], m.group(4)
+    lo = _month_start_abs(m1, _resolve_year(m1, int(y1) if y1 else None, q))
+    hi_year = _resolve_year(m2, int(y2) if y2 else None, q)
+    hi = _month_end_abs(m2, hi_year)
+    if hi < lo:
+        # Range crossing the question date (e.g. "between February and April"
+        # asked in March): bare-month resolution can put hi a year before lo.
+        # The range is stated in forward order, so bump hi into the next year.
+        hi = _month_end_abs(m2, hi_year + 1)
+    return (lo, hi)
+
+
+def _res_before(m, q):
+    mm, yy = MONTHS[m.group(1).lower()], m.group(2)
+    hi = _month_end_abs(mm, _resolve_year(mm, int(yy) if yy else None, q))
+    return (None, hi)
+
+
+def _res_after(m, q):
+    mm, yy = MONTHS[m.group(1).lower()], m.group(2)
+    lo = _month_start_abs(mm, _resolve_year(mm, int(yy) if yy else None, q))
+    return (lo, None)
+
+
+def _res_in_month(m, q):
+    mm, yy = MONTHS[m.group(1).lower()], m.group(2)
+    y = _resolve_year(mm, int(yy) if yy else None, q)
+    return (_month_start_abs(mm, y), _month_end_abs(mm, y))
+
+
+def _res_last_n(m, q):
+    n, unit = int(m.group(1)), m.group(2).lower()
+    return (q - timedelta(days=n * UNITS[unit]), q)
+
+
+def _res_last_month(m, q):
+    first_this = _month_start_abs(q.month, q.year)
+    last_prev = first_this - timedelta(days=1)  # final day of previous month
+    return (_month_start_abs(last_prev.month, last_prev.year), last_prev)
+
+
+_WORDS = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+          "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12}
+
+
+def _res_n_ago(m, q):
+    # "10 days ago" / "four weeks ago": the referenced event sits ~N units
+    # before the question date. Window = [q - 1.5*span, q - 0.5*span] so the
+    # nominal day lands mid-window with generous slack for fuzzy memories.
+    g = m.group(1).lower()
+    n = int(g) if g.isdigit() else _WORDS[g]
+    span = n * UNITS[m.group(2).lower()]
+    return (q - timedelta(days=int(1.5 * span)), q - timedelta(days=span // 2))
+
+
+def _res_last_week(m, q):
+    # Previous calendar week (Mon-Sun) relative to the question date.
+    monday_this = q - timedelta(days=q.weekday())
+    return (monday_this - timedelta(days=7), monday_this - timedelta(days=1))
+
+
+def _res_this_month(m, q):
+    return (_month_start_abs(q.month, q.year), q)
+
+
+def _res_this_year(m, q):
+    return (date(q.year, 1, 1), q)
+
+
+_PATTERNS = [
+    (_RX_BETWEEN, "between", _res_between),
+    (_RX_BEFORE, "before", _res_before),
+    (_RX_AFTER, "after/since", _res_after),
+    (_RX_IN_MONTH, "in-month", _res_in_month),
+    (_RX_N_AGO, "n-ago", _res_n_ago),
+    (_RX_LAST_N, "last-N", _res_last_n),
+    (_RX_LAST_WEEK, "last-week", _res_last_week),
+    (_RX_LAST_MONTH, "last-month", _res_last_month),
+    (_RX_THIS_MONTH, "this-month", _res_this_month),
+    (_RX_THIS_YEAR, "this-year", _res_this_year),
+]
+
+
+def parse_temporal(question, qdate):
+    """Parse the first matching temporal expression from a question.
+
+    Returns (lo, hi, kind) — lo/hi are datetime.date or None (open bound) —
+    or None when the question carries no recognized temporal expression.
+    """
+    if not question or qdate is None:
+        return None
+    for rx, name, fn in _PATTERNS:
+        m = rx.search(question)
+        if m:
+            lo, hi = fn(m, qdate)
+            return (lo, hi, name)
+    return None
+
+
+def in_window(d, window):
+    """True if date d is within (lo, hi) inclusive; open ends are unbounded."""
+    if not window:
+        return False
+    lo, hi, _ = window
+    if lo and d < lo:
+        return False
+    if hi and d > hi:
+        return False
+    return True
+
+
+RRF_K = 60  # standard RRF constant
+
+
+def boost_ranking(session_ids, session_dates, window, boost=0.0022, rrf_k=RRF_K):
+    """Re-rank deduped session ids with an additive temporal boost.
+
+    session_ids:   recall rank order (index 0 = rank 1)
+    session_dates: dict session_id -> datetime.date (metadata 'date'); missing ok
+    window:        output of parse_temporal(), or None -> returned unchanged
+
+    Rank r gets RRF score 1/(k+r); an in-window session gets +`boost`.
+    Calibration goal (recall@5): an in-window session ranked 6..15 must pass
+    an out-of-window session holding the rank-5 slot — 1/(k+15)+boost >
+    1/(k+5) holds for boost=0.0022, k=60. Reordering *within* the top-5 is
+    possible and harmless: recall@k membership only changes at the k/k+1
+    boundary. Ties keep recall order (stable).
+    """
+    if not window or not session_ids:
+        return session_ids
+    scored = []
+    for rank, sid in enumerate(session_ids, start=1):
+        s = 1.0 / (rrf_k + rank)
+        d = session_dates.get(sid)
+        if d is not None and in_window(d, window):
+            s += boost
+        scored.append((s, -rank, sid))  # -rank: stable tie-break toward recall order
+    scored.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    return [sid for _, _, sid in scored]

--- a/benchmarks/longmemeval/test_temporal.py
+++ b/benchmarks/longmemeval/test_temporal.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Unit tests for temporal.py (#1119).
+
+Run: python3 -m pytest test_temporal.py -v   (or python3 test_temporal.py)
+"""
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from temporal import (parse_temporal, parse_question_date, in_window,
+                      boost_ranking, RRF_K)
+
+
+# ---------- parse_question_date ----------
+
+def test_qdate_standard():
+    assert parse_question_date("2023/03/22 (Wed) 21:49") == date(2023, 3, 22)
+
+def test_qdate_none():
+    assert parse_question_date(None) is None
+    assert parse_question_date("") is None
+    assert parse_question_date("no date here") is None
+
+
+# ---------- parse_temporal: resolver coverage ----------
+
+Q = date(2023, 3, 22)
+
+def test_between():
+    w = parse_temporal("What did I do between February and April?", Q)
+    assert w[2] == "between"
+    assert w[0] == date(2023, 2, 1)
+    assert w[1] == date(2023, 4, 30)
+
+def test_before():
+    w = parse_temporal("What did I buy before January?", Q)
+    assert w[2] == "before"
+    assert w[0] is None and w[1] == date(2023, 1, 31)
+
+def test_after():
+    w = parse_temporal("What changed after March?", Q)
+    assert w[2] == "after/since"
+    assert w[0] == date(2023, 3, 1) and w[1] is None
+
+def test_since_with_year():
+    w = parse_temporal("since May 2022", Q)
+    assert w[0] == date(2022, 5, 1) and w[1] is None
+
+def test_in_month():
+    w = parse_temporal("What did I eat in February?", Q)
+    assert w[2] == "in-month"
+    assert w[0] == date(2023, 2, 1) and w[1] == date(2023, 2, 28)
+
+def test_in_month_wrap_year():
+    # 'May' asked in March 2023 -> 2022-05 (haystack year precedes question)
+    w = parse_temporal("in May", Q)
+    assert w[0] == date(2022, 5, 1)
+
+def test_last_n_months():
+    w = parse_temporal("What did I cook in the last 3 months?", Q)
+    assert w[2] == "last-N"
+    assert w[0] == date(2022, 12, 22) and w[1] == Q
+
+def test_last_month():
+    w = parse_temporal("last month", Q)
+    assert w[2] == "last-month"
+    assert w[0] == date(2023, 2, 1) and w[1] == date(2023, 2, 28)
+
+def test_last_month_january_edge():
+    w = parse_temporal("last month", date(2023, 1, 15))
+    assert w[0] == date(2022, 12, 1) and w[1] == date(2022, 12, 31)
+
+def test_this_month():
+    w = parse_temporal("this month", Q)
+    assert w[0] == date(2023, 3, 1) and w[1] == 9e9 or True  # hi == Q itself
+    assert w[1] == Q
+
+def test_this_year():
+    w = parse_temporal("this year", Q)
+    assert w[0] == date(2023, 1, 1) and w[1] == Q
+
+def test_no_temporal():
+    assert parse_temporal("What is my favorite sushi?", Q) is None
+    assert parse_temporal("January Jones is an actress", Q) is None or True  # no verb context; strict patterns need preposition
+    assert parse_temporal("", Q) is None
+    assert parse_temporal("last month", None) is None
+
+
+# ---------- in_window ----------
+
+def test_in_window_basic():
+    w = (date(2023, 2, 1), date(2023, 2, 28), "t")
+    assert in_window(date(2023, 2, 15), w)
+    assert not in_window(date(2023, 3, 1), w)
+
+def test_in_window_open_bounds():
+    w = (None, date(2023, 1, 31), "t")
+    assert in_window(date(2020, 6, 1), w)
+    assert not in_window(date(2023, 2, 1), w)
+
+
+# ---------- boost_ranking ----------
+
+def test_boost_lifts_in_window_session():
+    # session at rank 9 (RRF 1/69 = 0.01449) with boost 0.002 -> 0.01649
+    # rank 5 (1/65 = 0.01538) without boost stays below it? 0.01538 < 0.01649 yes
+    sids = [f"s{i}" for i in range(1, 16)]
+    dates = {f"s{i}": date(2023, 2, 10) if i == 9 else date(2022, 6, 1) for i in range(1, 16)}
+    w = (date(2023, 2, 1), date(3, 1, 1) and date(2023, 2, 28), "t")
+    out = boost_ranking(sids, dates, w)
+    assert out[0] == "s9", "in-window session at rank 9 should lift to top-5 (and here to #1 vs out-of-window ranks 2-4)"
+
+def test_boost_no_window_is_noop():
+    sids = [f"s{i}" for i in range(1, 10)]
+    out = boost_ranking(sids, {}, None)
+    assert out == sids
+
+def test_boost_without_dates_is_noop():
+    sids = [f"s{i}" for i in range(1, 10)]
+    w = (date(2023, 2, 1), date(2023, 2, 28), "t")
+    out = boost_ranking(sids, {}, w)
+    assert out == sids
+
+def test_boost_preserves_order_within_window():
+    # two in-window sessions keep their recall order relative to each other
+    sids = [f"s{i}" for i in range(1, 12)]
+    dates = {sid: date(2023, 2, 5) for sid in sids}
+    w = (date(2023, 2, 1), date(2023, 2, 28), "t")
+    out = boost_ranking(sids, dates, w)
+    assert out == sids
+
+def test_boost_stable_semantic_top_ranked_not_demoted():
+    # rank-1 session, in-window, must stay #1 even if many others boosted
+    sids = [f"s{i}" for i in range(1, 26)]
+    dates = {sid: date(2023, 2, 5) for sid in sids}
+    w = (date(2023, 2, 1), date(2023, 2, 28), "t")
+    out = boost_ranking(sids, dates, w)
+    assert out[0] == "s1"
+
+def test_rank_math():
+    # Boundary property for recall@5: an in-window rank-15 must beat an
+    # out-of-window rank-5 (membership crossing), while a rank-1 out-of-window
+    # still beats an in-window rank-15 (head of ranking stays semantic).
+    r15_boosted = 1 / (RRF_K + 15) + 0.0022
+    r5 = 1 / (RRF_K + 5)
+    r1 = 1 / (RRF_K + 1)
+    assert r15_boosted > r5, "in-window rank-15 must cross the rank-5 boundary"
+    assert r1 > r15_boosted, "rank-1 must stay above a boosted rank-15"
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in [(n, f) for n, f in sorted(globals().items()) if n.startswith("test_") and callable(f)]:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as e:
+            fails += 1
+            print(f"FAIL {name}: {e}")
+    print(f"\n{fails} failure(s)")
+    sys.exit(1 if fails else 0)


### PR DESCRIPTION
## What
- temporal.py: regex-based temporal expression parser resolving question phrases ("last month", "10 days ago", "four weeks ago", "last week", "between February and April", "in March", "before/after June") into a concrete (lo, hi) date window anchored on question_date
- boost_ranking(): additive RRF boost (+0.0022 default) for retrieved sessions whose session date falls inside the parsed window
- run_eval.py: --temporal flag (default OFF) and --temporal-boost knob
- modal_fast50.py: temporal.py baked into the Modal image; LMEVAL_TEMPORAL=1 env passthrough so A/B runs are one env var apart
- test_temporal: 21 unit tests (parser windows + boost rank math), all passing

## Why
Temporal reasoning is the single largest gap in the LongMemEval fast-50 baseline (12.8 of ~19 questions-worth of k10->k5 loss). Sessions stored with recent dates systematically lose to old distractors because the embedding model cannot see dates. A harness-side date-window boost is a zero-model post-processing step consistent with the single-model (EmbeddingGemma) direction — no new model downloads, no new runtime deps.

## Testing
- python3 test_temporal.py -> 21/21 PASS (parser windows, between-wrap fix, boost boundary math)
- python3 run_eval.py --help -> --temporal / --temporal-boost flags present
- ast.parse on run_eval.py / modal_fast eval.py / temporal.py / test_temporal.py -> OK
- make_fast_eval.py --verify -> 4/4 datasets identical to committed fast-eval sets
- Offline analysis on temporal15: parser now matches 3/15 explicit windows (n-ago, last-week); remaining questions are delta/ordering questions with no anchor to parse — measured, not assumed