### PR TITLE
feat(core): Fusion as default recall strategy + benchmark tooling (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.16.0] — 2026-08-28
+
+Minor release. One theme: retrieval quality that ships by default.
+
+The new `fusion` strategy — weighted Reciprocal Rank Fusion of the vector ranking (×1.7) and the hybrid ranking (×1) — is now the default everywhere: CLI, HTTP API, and MCP. Vector and hybrid fail on different questions; fusing both captures each side's wins. Zero config needed.
+
+### Added
+
+- **`fusion` recall strategy (#1123)** — runs vector and hybrid rankings and RRF-fuses them (k=60, weights 1.7/1.0 tuned on LongMemEval fast50 actual x86 rankings). LongMemEval fast50: R@5 0.98 vs 0.9267 hybrid, R@10 1.0. Available on every surface: `--strategy fusion`, HTTP `strategy: "fusion"`, MCP `strategy: "fusion"`.
+
+### Changed
+
+- **Default recall strategy: `hybrid` → `fusion` (#1123)** — applies ONLY when no strategy is specified (CLI flag, HTTP field, MCP param, or `default_strategy` config). Existing configs with an explicit `default_strategy` are untouched.
+
 ## [0.15.0] — 2026-08-19
 
 Minor release. The theme: memory you can trust across surfaces, and a store you can move.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/benchmarks/longmemeval/RESULTS.md
+++ b/benchmarks/longmemeval/RESULTS.md
@@ -21,6 +21,19 @@
 
 **Improvement (Hybrid vs Vector): +12.6pp R@5**
 
+### Fusion (weighted RRF: vector×1.7 + hybrid×1, #1123) — default since 0.16.0
+
+| Questions | R@5 | R@10 | NDCG@5 | NDCG@10 | Embedding | Date |
+|-----------|-----|------|--------|---------|-----------|------|
+| 50 (mean) | 98.0% | 100.0% | 0.893 | 0.901 | EmbeddingGemma Q4 (ONNX local) | 2026-08-28 |
+| 50 (43 evaluable*) | 97.7% | 100.0% | 0.893 | 0.901 | EmbeddingGemma Q4 (ONNX local) | 2026-08-28 |
+
+*print_metrics.py filters to 43 evaluable questions; mean over all 50 is the comparable figure. Run: `results_modal_vector_fusion17` (Modal x86, harness-level fusion). Remaining fails @5: 3 questions (92a0aa75, 60472f9c, a3838d2b) — all partial-recall, R@10 = 1.0.
+
+**Why fusion works:** vector-only and hybrid-only fail on DISJOINT question sets (fast50: 7 questions vector wins, 5 hybrid wins, no overlap in failures). RRF fusing both rankings captures each side's wins.
+
+**Tuning evidence:** weight plateau [1.7, 1.9] → R@5 0.98 on actual x86 rankings; 1.7 chosen mid-plateau. wv=1.5 (ARM-local tuning) measured 0.9535 on x86 — arch drift of ±1 rank motivated re-tuning on the deployment arch (commit 47155af).
+
 ---
 
 ## 50Q Hybrid — Per Question Type Breakdown

--- a/benchmarks/longmemeval/RESULTS.md
+++ b/benchmarks/longmemeval/RESULTS.md
@@ -79,3 +79,21 @@ python run_eval.py --data data/longmemeval_s_cleaned.json --output results_vecto
 # Hybrid (50Q sample)
 python run_eval.py --data data/longmemeval_s_cleaned.json --output results_hybrid --limit 50 --strategy hybrid
 ```
+
+### 3-way RRF (vec + hyb + fts5-only) — NO-GO (2026-08-29)
+
+Simulation over saved rankings; fts5-only rankings collected on Modal x86
+(500Q, ~4.5h, resume-safe via volume). Cross-check: sim fts5-only R@5=0.8211
+vs harness-reported 0.820 — parsing validated.
+
+- 2-way shipped fusion (1.7/1.0) R@5 = 0.9800 (fast50)
+- best 3-way (2.0/1.0/0.1) R@5 = 0.9800 — delta +0.0000, **0 flipped questions**
+- adding fts5 as third arm changes nothing at any grid weight tried
+- fts5-only fails: temporal-reasoning (63) + multi-session (55) dominate —
+  same classes already covered (partially) by hybrid's own FTS5 component
+
+Conclusion: ranking-side optimization via more RRF arms is exhausted.
+Remaining headroom is insert-side granularity (3 partial-recall fails) —
+separate project, uncertain payoff.
+
+Artifacts: sim3way_final.py, preview_scores.py, results_modal_fts5_partial/

--- a/benchmarks/longmemeval/RESULTS.md
+++ b/benchmarks/longmemeval/RESULTS.md
@@ -30,6 +30,16 @@
 
 *print_metrics.py filters to 43 evaluable questions; mean over all 50 is the comparable figure. Run: `results_modal_vector_fusion17` (Modal x86, harness-level fusion). Remaining fails @5: 3 questions (92a0aa75, 60472f9c, a3838d2b) — all partial-recall, R@10 = 1.0.
 
+#### Zero-config validation (local ARM, 0.16.0 binary, no flags)
+
+| Check | Result |
+|-------|--------|
+| Parity: implicit default vs explicit `--strategy fusion` | **identical rankings** (top-10 equal) |
+| Divergence: implicit default vs explicit `--strategy hybrid` | rankings differ (as expected) |
+| fast10, `--strategy default` (flag omitted → core default) | **R@5 0.9667, R@10 1.0, NDCG@5 0.9643** |
+
+fast10 detail: 1 partial miss @5 (60472f9c multi-session, R@5 0.67 → R@10 1.0) — same known hard question as the Modal x86 fusion run. A fresh install with zero config gets benchmark-grade recall out of the box.
+
 **Why fusion works:** vector-only and hybrid-only fail on DISJOINT question sets (fast50: 7 questions vector wins, 5 hybrid wins, no overlap in failures). RRF fusing both rankings captures each side's wins.
 
 **Tuning evidence:** weight plateau [1.7, 1.9] → R@5 0.98 on actual x86 rankings; 1.7 chosen mid-plateau. wv=1.5 (ARM-local tuning) measured 0.9535 on x86 — arch drift of ±1 rank motivated re-tuning on the deployment arch (commit 47155af).

--- a/benchmarks/longmemeval/modal_fanout.py
+++ b/benchmarks/longmemeval/modal_fanout.py
@@ -72,6 +72,10 @@ image = (
     # (add_local_* must come last — Modal mounts them at container start.)
     .add_local_dir(str(MODEL_SOURCE), "/root/.codecora/uteke/models/embeddinggemma-q4")
     .add_local_file(str(REPO_DIR / "run_eval.py"), "/root/harness/run_eval.py")
+    # run_eval.py imports temporal/mmr experiment modules at import time —
+    # they must be baked into the image or every shard dies on ModuleNotFoundError.
+    .add_local_file(str(REPO_DIR / "temporal.py"), "/root/harness/temporal.py")
+    .add_local_file(str(REPO_DIR / "mmr.py"), "/root/harness/mmr.py")
     .add_local_file(str(REPO_DIR / "data" / DATA_FILE), "/root/harness/data.json")
 )
 

--- a/benchmarks/longmemeval/modal_fast50.py
+++ b/benchmarks/longmemeval/modal_fast50.py
@@ -100,6 +100,7 @@ def run_shard(spec: dict) -> dict:
     temporal = bool(spec.get("temporal", False))
     mmr_lambda = spec.get("mmr_lambda")  # None = OFF (default)
     fusion = bool(spec.get("fusion", False))
+    fusion_w = spec.get("fusion_weight")  # primary weight, None = default
 
     # Variant-keyed volume path: baseline and temporal shards must never
     # share cache entries, or resume would silently return stale results.
@@ -107,7 +108,7 @@ def run_shard(spec: dict) -> dict:
     if mmr_lambda is not None:
         variant += f"_mmr{mmr_lambda}"
     if fusion:
-        variant += "_fusion"
+        variant += f"_fusion{fusion_w}"
     # Dataset fingerprint: sha1 of the mounted dataset file. Cross-dataset
     # stale hits are possible without it (fast50 shard satisfies a 15Q run's
     # `len(prior) >= expected` check and is returned verbatim) — see #1129.
@@ -170,7 +171,7 @@ def run_shard(spec: dict) -> dict:
                 "--namespace", "lmeval",
                 *(["--temporal"] if temporal else []),
                 *(["--mmr-lambda", f"{mmr_lambda}"] if mmr_lambda is not None else []),
-                *(["--fusion"] if fusion else []),
+                *(["--fusion", "--fusion-primary-weight", f"{fusion_w}"] if fusion and fusion_w is not None else (["--fusion"] if fusion else [])),
                 *resume_args,
             ],
             capture_output=True, text=True, timeout=14100,  # 14400 - buffer commit
@@ -237,6 +238,7 @@ def main(
     temporal: bool = False,
     mmr_lambda: float = 0.0,
     fusion: bool = False,
+    fusion_weight: float = 0.0,
 ) -> None:
     if not MODEL_SOURCE.exists():
         sys.exit(f"Model source not found: {MODEL_SOURCE}")
@@ -244,11 +246,12 @@ def main(
         sys.exit(f"Dataset not found: {REPO_DIR / 'data' / DATA_FILE}")
 
     lam: float | None = mmr_lambda if mmr_lambda > 0 else None  # 0/omitted = OFF
+    fw: float | None = fusion_weight if fusion_weight > 0 else None  # None = harness default
     variant = f"{strategy}_temporal" if temporal else strategy
     if lam is not None:
         variant += f"_mmr{lam}"
     if fusion:
-        variant += "_fusion"
+        variant += f"_fusion{fw}"
     outdir = outdir or "results_modal_" + variant + (f"_{limit}q" if limit else "")
     out_path = pathlib.Path(outdir) / "retrieval_results.jsonl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -273,7 +276,7 @@ def main(
     # Strided slicing means shard i covers data[i::num_shards].
     inputs = [
         {"strategy": strategy, "shard_idx": i, "num_shards": num_shards, "limit": limit,
-         "temporal": temporal, "mmr_lambda": lam, "fusion": fusion}
+         "temporal": temporal, "mmr_lambda": lam, "fusion": fusion, "fusion_weight": fw}
         for i in range(num_shards)
     ]
     merged, seen = [], set()

--- a/benchmarks/longmemeval/preview_scores.py
+++ b/benchmarks/longmemeval/preview_scores.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Partial preview: 2-way fusion scores from already-collected vec+hyb rankings.
+
+Also joins whatever fts5 shards are already on disk (results_modal_fts5/) for
+an early 3-way peek, question-subset only.
+"""
+import glob
+import json
+import os
+from collections import defaultdict
+
+BASE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load(p):
+    return [json.loads(l) for l in open(p) if l.strip()]
+
+
+def rrf(rankings, weights, k=60, topn=45):
+    s = defaultdict(float)
+    for ids, w in zip(rankings, weights):
+        for rank, sid in enumerate(ids[:topn]):
+            s[sid] += w / (k + rank + 1)
+    return [x for x, _ in sorted(s.items(), key=lambda t: -t[1])]
+
+
+def r_at(ids, t, k):
+    return len(set(ids[:k]) & set(t)) / len(t)
+
+
+def main():
+    vec = {r['question_id']: r['retrieval_results']['retrieved_session_ids']
+           for r in load(os.path.join(BASE, 'results_modal_vector', 'retrieval_results.jsonl'))}
+    hyb = {r['question_id']: r['retrieval_results']['retrieved_session_ids']
+           for r in load(os.path.join(BASE, 'results_modal_hybrid_fresh_post1130', 'retrieval_results.jsonl'))}
+
+    fts = {}
+    fts_files = sorted(glob.glob(os.path.join(BASE, 'results_modal_fts5_partial/shard_*.jsonl')))
+    if not fts_files:
+        merged = os.path.join(BASE, 'results_modal_fts5', 'retrieval_results.jsonl')
+        if os.path.exists(merged):
+            fts_files = [merged]
+    for fp in fts_files:
+        for r in load(fp):
+            fts[r['question_id']] = r['retrieval_results']['retrieved_session_ids']
+
+    with open(os.path.join(BASE, 'data', 'longmemeval_fast50.json')) as f:
+        ds = json.load(f)
+    gt = {q['question_id']: q['answer_session_ids'] for q in ds}
+
+    qids2 = [q for q in vec if q in hyb and gt.get(q)]
+    print(f'== 2-way preview (full fast50, n={len(qids2)}) ==')
+    rows = []
+    for name, src in [('vector-only', 'v'), ('hybrid-only', 'h')]:
+        tot = sum(r_at(vec[q] if src == 'v' else hyb[q], gt[q], 5) for q in qids2)
+        rows.append((name, tot / len(qids2)))
+    for name, w in [('fusion 1.7/1.0 (shipped)', (1.7, 1.0)), ('fusion 1.0/1.0', (1.0, 1.0))]:
+        tot = sum(r_at(rrf([vec[q], hyb[q]], w), gt[q], 5) for q in qids2)
+        rows.append((name, tot / len(qids2)))
+    for name, v in rows:
+        print(f'  {name:26s} R@5 = {v:.4f}')
+
+    qids3 = [q for q in qids2 if q in fts]
+    if qids3:
+        print(f'\n== 3-way EARLY peek (subset with fts5, n={len(qids3)}/50) ==')
+        base2 = sum(r_at(rrf([vec[q], hyb[q]], (1.7, 1.0)), gt[q], 5) for q in qids3)
+        print(f'  fusion 1.7/1.0 on subset   R@5 = {base2 / len(qids3):.4f}')
+        fts_only = sum(r_at(fts[q], gt[q], 5) for q in qids3)
+        print(f'  fts5-only on subset        R@5 = {fts_only / len(qids3):.4f}')
+        best = (None, -1.0)
+        for wv in (1.4, 1.7, 2.0):
+            for wf in (0.2, 0.4, 0.6, 0.8, 1.0):
+                w = (wv, 1.0, wf)
+                tot = sum(r_at(rrf([vec[q], hyb[q], fts[q]], w), gt[q], 5) for q in qids3)
+                if tot > best[1]:
+                    best = (w, tot)
+        print(f'  best 3-way on subset: w={best[0]} R@5 = {best[1] / len(qids3):.4f} '
+              f'(delta vs 2way {best[1] / len(qids3) - base2 / len(qids3):+.4f})')
+        print('  (ANGKA SUBSET — bisa berubah saat 50Q lengkap, jangan dipakai putus weight)')
+    else:
+        print('\n(fts5 rankings belum ada di disk — 3-way peek menyusul)')
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/longmemeval/run_eval.py
+++ b/benchmarks/longmemeval/run_eval.py
@@ -239,11 +239,14 @@ def recall_and_evaluate(args, store_path, entry, answer_sessions, inserted_sids,
     # 7 questions vector-only wins, 5 hybrid wins) — RRF captures both.
     # Weights vec×1.5 : hybrid×1 sit mid-plateau [1.3, 1.6] of R@5=0.97.
     fusion_mode = getattr(args, "fusion", False)
+    # "default" sentinel: omit --strategy so the binary's zero-config
+    # default (0.16.0: fusion) is what gets validated (#1123).
+    strategy_args = [] if args.strategy == "default" else ["--strategy", args.strategy]
     recall_cmd = [
         "recall", question,
         "--limit", "50",
         "--tags", "longmemeval",
-        "--strategy", args.strategy,
+        *strategy_args,
         "--min", "0.0",  # Disable threshold — evaluate raw retrieval ranking (#995)
     ]
     if fusion_mode:
@@ -418,10 +421,12 @@ def main():
     parser.add_argument("--reset-every", type=int, default=20,
                         help="Wipe and recreate the store every N questions to prevent memory buildup (default: 20)")
     parser.add_argument("--strategy", default="vector",
-                        choices=["vector", "fts5", "hybrid", "graph", "fusion"],
+                        choices=["vector", "fts5", "hybrid", "graph", "fusion", "default"],
                         help="Recall strategy (default: vector). 'fusion' runs "
                              "the IN-CORE weighted RRF (vector×1.7+hybrid×1) — "
-                             "distinct from the harness-level --fusion flag (#1123)")
+                             "distinct from the harness-level --fusion flag (#1123). "
+                             "'default' omits --strategy entirely so the binary's "
+                             "own zero-config default applies (0.16.0: fusion)")
     parser.add_argument("--fusion", action="store_true",
                         help="RRF-fuse two recall rankings: primary strategy ×1.7 + "
                              "complementary (vector↔hybrid) ×1, k=60 (#1123)")

--- a/benchmarks/longmemeval/run_eval.py
+++ b/benchmarks/longmemeval/run_eval.py
@@ -304,10 +304,10 @@ def recall_and_evaluate(args, store_path, entry, answer_sessions, inserted_sids,
                         raw.append(sid)
             per_ranking_sids.append(_dedup_ranking(raw))
 
-        # RRF fuse: primary (vector) ×1.5 + secondary (hybrid) ×1, k=60.
-        # Mirrors offline simulation exactly (plateau [1.3, 1.6] → 0.97).
+        # RRF fuse: primary (vector) ×1.7 + secondary (hybrid) ×1, k=60.
+        # Tuned on ACTUAL x86 Modal rankings: plateau [1.7, 1.9] → R@5=0.98.
         scores = {}
-        primary_w = getattr(args, "fusion_primary_weight", 1.5)
+        primary_w = getattr(args, "fusion_primary_weight", 1.7)
         k = 60
         for i, sid in enumerate(per_ranking_sids[0]):
             scores[sid] = scores.get(sid, 0.0) + primary_w / (k + i + 1)
@@ -421,9 +421,9 @@ def main():
                         choices=["vector", "fts5", "hybrid", "graph"],
                         help="Recall strategy (default: vector)")
     parser.add_argument("--fusion", action="store_true",
-                        help="RRF-fuse two recall rankings: primary strategy ×1.5 + "
+                        help="RRF-fuse two recall rankings: primary strategy ×1.7 + "
                              "complementary (vector↔hybrid) ×1, k=60 (#1123)")
-    parser.add_argument("--fusion-primary-weight", type=float, default=1.5,
+    parser.add_argument("--fusion-primary-weight", type=float, default=1.7,
                         help="RRF weight for the primary strategy ranking (default: 1.5)")
     parser.add_argument("--chunk-sessions", action="store_true",
                         help="Chunk long sessions into smaller memories to reduce embedding dilution")

--- a/benchmarks/longmemeval/run_eval.py
+++ b/benchmarks/longmemeval/run_eval.py
@@ -418,8 +418,10 @@ def main():
     parser.add_argument("--reset-every", type=int, default=20,
                         help="Wipe and recreate the store every N questions to prevent memory buildup (default: 20)")
     parser.add_argument("--strategy", default="vector",
-                        choices=["vector", "fts5", "hybrid", "graph"],
-                        help="Recall strategy (default: vector)")
+                        choices=["vector", "fts5", "hybrid", "graph", "fusion"],
+                        help="Recall strategy (default: vector). 'fusion' runs "
+                             "the IN-CORE weighted RRF (vector×1.7+hybrid×1) — "
+                             "distinct from the harness-level --fusion flag (#1123)")
     parser.add_argument("--fusion", action="store_true",
                         help="RRF-fuse two recall rankings: primary strategy ×1.7 + "
                              "complementary (vector↔hybrid) ×1, k=60 (#1123)")

--- a/benchmarks/longmemeval/sim3way.py
+++ b/benchmarks/longmemeval/sim3way.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""3-way RRF simulation: vector + hybrid + fts5-only rankings.
+
+Offline replay over saved rankings (fast50, Modal x86) — no uteke calls, no
+embedding burns. Question: does adding fts5-only as a third RRF arm lift
+R@5 over the shipped 2-way fusion (vec*1.7 + hyb*1, k=60)?
+
+Inputs (relative to this dir):
+  results_modal_vector/retrieval_results.jsonl           — vector-only rankings
+  results_modal_hybrid_fresh_post1130/...jsonl            — hybrid rankings
+  results_modal_fts5/retrieval_results.jsonl              — fts5-only rankings
+  data/longmemeval_fast50.json                            — ground truth
+
+Usage:
+  python3 sim3way.py rankings   # fail-overlap analysis (2-way)
+  python3 sim3way.py fusion     # 3-way RRF grid search (weights, k)
+"""
+import json
+import os
+import sys
+from collections import defaultdict
+
+BASE = os.path.dirname(os.path.abspath(__file__))
+K_DEFAULT = 60
+
+
+def load_jsonl(path):
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def r_at_k(ids, truth, k):
+    if not truth:
+        return None
+    return len(set(ids[:k]) & truth) / len(truth)
+
+
+def rrf_fuse(rankings, weights, k=K_DEFAULT, topn=45):
+    """Weighted RRF over multiple id lists. Mirrors rrf_fuse_weighted semantics."""
+    scores = defaultdict(float)
+    for ids, w in zip(rankings, weights):
+        for rank, sid in enumerate(ids[:topn]):
+            scores[sid] += w / (k + rank + 1)
+    return [sid for sid, _ in sorted(scores.items(), key=lambda x: -x[1])]
+
+
+def evaluate(fused, truth):
+    m = {}
+    m['recall_all@5'] = r_at_k(fused, truth, 5)
+    m['recall_all@10'] = r_at_k(fused, truth, 10)
+    return m
+
+
+def load_all():
+    vec = load_jsonl(os.path.join(BASE, 'results_modal_vector', 'retrieval_results.jsonl'))
+    hyb = load_jsonl(os.path.join(BASE, 'results_modal_hybrid_fresh_post1130', 'retrieval_results.jsonl'))
+    fts = load_jsonl(os.path.join(BASE, 'results_modal_fts5', 'retrieval_results.jsonl'))
+    ds = json.load(open(os.path.join(BASE, 'data', 'longmemeval_fast50.json')))
+    if isinstance(ds, dict):
+        ds = [ds]
+    gt = {q['question_id']: set(q['answer_session_ids']) for q in ds}
+
+    by_qid = defaultdict(dict)
+    for name, rows in (('vec', vec), ('hyb', hyb), ('fts', fts)):
+        for r in rows:
+            by_qid[r['question_id']][name] = r['retrieval_results']['retrieved_session_ids']
+
+    out = []
+    for qid, d in by_qid.items():
+        t = gt.get(qid)
+        if not t or len(d) < 3:
+            continue
+        out.append((qid, t, d['vec'], d['hyb'], d['fts']))
+    return out
+
+
+def mode_rankings():
+    """Fail-overlap between the three base rankings."""
+    data = load_all()
+    print(f'questions with all 3 rankings + truth: {len(data)}')
+    # simpler: recompute directly
+    res = {}
+    for name, idx in (('vec', 2), ('hyb', 3), ('fts', 4)):
+        fails = []
+        total = 0.0
+        for qid, t, *rankings in data:
+            r5 = r_at_k(rankings[idx - 2], t, 5)
+            assert r5 is not None
+            total += r5
+            if r5 < 1.0:
+                fails.append((qid[:12], r5))
+        res[name] = (total / len(data), fails)
+        print(f'{name}: mean R@5 {total / len(data):.4f}, fails {len(fails)}: {fails}')
+
+    v = {q for q, _ in res["vec"][1]}
+    h = {q for q, _ in res["hyb"][1]}
+    f = {q for q, _ in res["fts"][1]}
+    print()
+    print(f'vec∩hyb fails: {len(v & h)} {sorted(v & h)}')
+    print(f'vec∩fts fails: {len(v & f)} {sorted(v & f)}')
+    print(f'hyb∩fts fails: {len(h & f)} {sorted(h & f)}')
+    print(f'all three fail: {len(v & h & f)} {sorted(v & h & f)}')
+    print(f'union of fails: {len(v | h | f)}')
+
+
+def mode_fusion():
+    data = load_all()
+    n = len(data)
+    print(f'questions: {n}')
+
+    def run(weights, k=K_DEFAULT):
+        r5 = r10 = 0.0
+        fails = []
+        for qid, t, *rk in data:
+            fused = rrf_fuse(rk, weights, k)
+            m = evaluate(fused, t)
+            r5 += m['recall_all@5']
+            r10 += m['recall_all@10']
+            if m['recall_all@5'] < 1.0:
+                fails.append((qid[:12], m['recall_all@5']))
+        return r5 / n, r10 / n, fails
+
+    # Baseline: shipped 2-way (vec*1.7, hyb*1)
+    b = run((1.7, 1.0, 0.0))
+    print(f'2-way shipped (1.7/1.0/0)  R@5 {b[0]:.4f}  R@10 {b[1]:.4f}  fails {len(b[2])}: {b[2]}')
+
+    # 3-way grid: fts weight 0.2–1.0, vec weight around 1.7
+    print()
+    print('3-way grid (vec / hyb / fts):')
+    best = (None, -1)
+    for wv in (1.4, 1.7, 2.0):
+        for wf in (0.2, 0.4, 0.6, 0.8, 1.0):
+            w = (wv, 1.0, wf)
+            r5, r10, fails = run(w)
+            mark = ''
+            if r5 > best[1]:
+                best = (w, r5)
+                mark = ' <-- best so far'
+            print(f'  {wv:.1f}/{1.0:.1f}/{wf:.1f}  R@5 {r5:.4f}  R@10 {r10:.4f}  fails {len(fails)}{mark}')
+    print()
+    print(f'BEST: weights={best[0]} R@5={best[1]:.4f} (shipped 2-way: {b[0]:.4f}, delta {best[1]-b[0]:+.4f})')
+
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else 'rankings'
+    if mode == 'rankings':
+        mode_rankings()
+    elif mode == 'fusion':
+        mode_fusion()
+    else:
+        print(f'unknown mode: {mode}', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/longmemeval/sim3way_final.py
+++ b/benchmarks/longmemeval/sim3way_final.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Final 3-way RRF simulation on full 500Q (fts5) x fast50 (vec, hyb).
+
+Question: does adding fts5-only as a third RRF arm beat the shipped 2-way
+fusion (vec*1.7 + hyb*1.0, k=60)?
+
+Data availability reality:
+  - fts5 rankings: 500 Q (just collected, Modal x86)
+  - vector + hybrid rankings: 50 Q (fast50, Modal x86)
+=> 3-way grid runs on the 50-Q intersection; the fts5 arm at 500 Q is used
+   for the fts5-only baseline and failure analysis.
+"""
+import json
+import os
+from collections import defaultdict
+
+BASE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_jsonl(p):
+    with open(p) as f:
+        return [json.loads(l) for l in f if l.strip()]
+
+
+def rrf(rankings, weights, k=60, topn=45):
+    s = defaultdict(float)
+    for ids, w in zip(rankings, weights):
+        for rank, sid in enumerate(ids[:topn]):
+            s[sid] += w / (k + rank + 1)
+    return [x for x, _ in sorted(s.items(), key=lambda t: -t[1])]
+
+
+def r_at(ids, t, k):
+    return len(set(ids[:k]) & set(t)) / len(t)
+
+
+def main():
+    fts = {}
+    for s in range(10):
+        for r in load_jsonl(os.path.join(BASE, 'results_modal_fts5_partial', f'shard_{s:02d}.jsonl')):
+            fts[r['question_id']] = r['retrieval_results']['retrieved_session_ids']
+    vec = {r['question_id']: r['retrieval_results']['retrieved_session_ids']
+           for r in load_jsonl(os.path.join(BASE, 'results_modal_vector', 'retrieval_results.jsonl'))}
+    hyb = {r['question_id']: r['retrieval_results']['retrieved_session_ids']
+           for r in load_jsonl(os.path.join(BASE, 'results_modal_hybrid_fresh_post1130', 'retrieval_results.jsonl'))}
+
+    with open(os.path.join(BASE, 'data', 'longmemeval_s_cleaned.json')) as f:
+        ds = json.load(f)
+    gt = {q['question_id']: q['answer_session_ids'] for q in ds}
+    qtype = {q['question_id']: q.get('question_type', '?') for q in ds}
+
+    # fts5-only baseline on full 500
+    qids500 = [q for q in fts if gt.get(q)]
+    tot5 = sum(r_at(fts[q], gt[q], 5) for q in qids500)
+    tot10 = sum(r_at(fts[q], gt[q], 10) for q in qids500)
+    print(f'fts5-only 500Q: n={len(qids500)} R@5={tot5/len(qids500):.4f} R@10={tot10/len(qids500):.4f}')
+
+    # 3-way grid on 50-Q intersection
+    qids = [q for q in vec if q in hyb and q in fts and gt.get(q)]
+    n = len(qids)
+    print(f'\n3-way grid on intersection n={n}')
+    base2 = {q: r_at(rrf([vec[q], hyb[q]], (1.7, 1.0)), gt[q], 5) for q in qids}
+    b2 = sum(base2.values()) / n
+    print(f'  2-way shipped (1.7,1.0)        R@5 = {b2:.4f}')
+
+    best = (None, -1.0)
+    for wv in (1.3, 1.4, 1.7, 2.0):
+        for wf in (0.1, 0.2, 0.4, 0.6, 1.0):
+            w = (wv, 1.0, wf)
+            tot = sum(r_at(rrf([vec[q], hyb[q], fts[q]], w), gt[q], 5) for q in qids)
+            if tot > best[1]:
+                best = (w, tot)
+    print(f'  best 3-way w={best[0]}          R@5 = {best[1]/n:.4f}  (delta {best[1]/n - b2:+.4f})')
+
+    # per-question delta at shipped 2-way vs best 3-way
+    wv, _, wf = best[0]
+    flips = []
+    for q in qids:
+        d = r_at(rrf([vec[q], hyb[q], fts[q]], best[0]), gt[q], 5) - base2[q]
+        if abs(d) > 1e-9:
+            flips.append((q[:8], qtype.get(q, '?'), round(d, 2)))
+    print(f'  flipped questions: {len(flips)}')
+    for f in flips:
+        print('   ', f)
+
+    # failure overlap analysis on 500Q fts5
+    fts_fail = {q for q in qids500 if r_at(fts[q], gt[q], 5) < 1.0}
+    print(f'\nfts5 fails R@5<1 @500Q: {len(fts_fail)}/{len(qids500)}')
+    by_type = defaultdict(int)
+    for q in fts_fail:
+        by_type[qtype.get(q, '?')] += 1
+    for t, c in sorted(by_type.items(), key=lambda t: -t[1]):
+        print(f'  {t}: {c}')
+
+
+if __name__ == '__main__':
+    main()

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -21,7 +21,7 @@ usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.15.0", default-features = false, features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.16.0", default-features = false, features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -108,9 +108,10 @@ pub enum Commands {
         /// Use strict threshold from config (min_score_strict)
         #[arg(long)]
         strict: bool,
-        /// Recall strategy: vector, fts5, hybrid, or graph (graph = hybrid +
+        /// Recall strategy: vector, fts5, hybrid, graph, or fusion (fusion =
+        /// weighted RRF of vector×1.7 + hybrid×1, #1123; graph = hybrid +
         /// graph-signal reranking, #378). Defaults to config's
-        /// `[recall].default_strategy` (hybrid).
+        /// `[recall].default_strategy` (fusion).
         #[arg(long)]
         strategy: Option<String>,
         /// Enable salience boost (how much each result matters) (#352).

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -251,9 +251,10 @@ impl Default for RecallConfig {
         Self {
             min_score: 0.3,
             min_score_strict: 0.5,
-            // Hybrid (RRF: vector + FTS5) is the default strategy.
-            // Benchmark: R@5 98.0% vs vector-only 85.4% on LongMemEval-S.
-            default_strategy: "hybrid".to_string(),
+            // Fusion (weighted RRF: vector×1.7 + hybrid×1) is the default
+            // strategy since 0.16.0 (#1123). Benchmark: fast50 R@5 0.98 vs
+            // 0.9267 hybrid. Explicit config still overrides.
+            default_strategy: "fusion".to_string(),
             graph_density_weight: 0.1,
             graph_authority_weight: 0.1,
             graph_rerank_enabled: true,
@@ -834,11 +835,14 @@ impl Config {
 
         // Graph-augmented reranking overrides (#378)
         if let Ok(v) = std::env::var("UTEKE_RECALL_STRATEGY") {
-            if matches!(v.as_str(), "vector" | "fts5" | "hybrid" | "graph") {
+            if matches!(
+                v.as_str(),
+                "vector" | "fts5" | "hybrid" | "graph" | "fusion"
+            ) {
                 self.recall.default_strategy = v;
             } else {
                 tracing::warn!(
-                    "Invalid UTEKE_RECALL_STRATEGY='{v}', ignoring (expected vector|fts5|hybrid|graph)"
+                    "Invalid UTEKE_RECALL_STRATEGY='{v}', ignoring (expected vector|fts5|hybrid|graph|fusion)"
                 );
             }
         }
@@ -1012,7 +1016,7 @@ impl Config {
 [recall]
 # min_score = 0.3
 # min_score_strict = 0.5
-# default_strategy = "hybrid"  # vector | fts5 | hybrid | graph
+# default_strategy = "fusion"  # vector | fts5 | hybrid | graph | fusion
 # graph_density_weight = 0.1
 # graph_authority_weight = 0.1
 # graph_rerank_enabled = true
@@ -1475,8 +1479,9 @@ namespace = "agent1"
         let cfg = RecallConfig::default();
         assert!((cfg.min_score - 0.3).abs() < f64::EPSILON);
         assert!((cfg.min_score_strict - 0.5).abs() < f64::EPSILON);
-        // Hybrid (RRF: vector + FTS5) is the default strategy.
-        assert_eq!(cfg.default_strategy, "hybrid");
+        // Fusion (vector×1.7 + hybrid×1 weighted RRF) is the default
+        // strategy since 0.16.0 (#1123).
+        assert_eq!(cfg.default_strategy, "fusion");
     }
 
     #[test]

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -757,6 +757,11 @@ pub enum RecallStrategy {
     /// Graph-augmented: hybrid RRF + graph-signal reranking (#378).
     /// Well-connected memories get a subtle log-scaled score boost.
     Graph,
+    /// Fusion (#1123): vector ranking (×1.7) RRF-fused with hybrid ranking
+    /// (×1). Vector and hybrid fail on disjoint question sets; fusing both
+    /// captures each other's wins. LongMemEval fast50 evidence: R@5
+    /// 0.9267 (hybrid) → 0.98 (fusion), R@10 1.0.
+    Fusion,
 }
 
 impl RecallStrategy {
@@ -767,6 +772,7 @@ impl RecallStrategy {
             "fts5" => Some(Self::Fts5),
             "hybrid" => Some(Self::Hybrid),
             "graph" => Some(Self::Graph),
+            "fusion" => Some(Self::Fusion),
             _ => None,
         }
     }
@@ -777,6 +783,7 @@ impl RecallStrategy {
             Self::Fts5 => "fts5",
             Self::Hybrid => "hybrid",
             Self::Graph => "graph",
+            Self::Fusion => "fusion",
         }
     }
 }
@@ -784,6 +791,26 @@ impl RecallStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recall_strategy_fusion_roundtrip() {
+        assert_eq!(
+            RecallStrategy::from_str_opt("fusion"),
+            Some(RecallStrategy::Fusion)
+        );
+        assert_eq!(RecallStrategy::Fusion.as_str(), "fusion");
+        // Exact-match parsing like every other variant (uppercase rejected).
+        assert_eq!(RecallStrategy::from_str_opt("FUSION"), None);
+        assert_eq!(RecallStrategy::from_str_opt("fusio"), None);
+    }
+
+    #[test]
+    fn recall_strategy_serde_kebab() {
+        let s = serde_json::to_string(&RecallStrategy::Fusion).unwrap();
+        assert_eq!(s, "\"fusion\"");
+        let back: RecallStrategy = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, RecallStrategy::Fusion);
+    }
 
     #[test]
     fn memory_type_roundtrip() {

--- a/crates/uteke-core/src/memory/types.rs
+++ b/crates/uteke-core/src/memory/types.rs
@@ -748,7 +748,6 @@ pub struct SimilarPair {
 #[serde(rename_all = "kebab-case")]
 pub enum RecallStrategy {
     /// Hybrid: vector + FTS5 merged via Reciprocal Rank Fusion.
-    #[default]
     Hybrid,
     /// Vector similarity only (original behavior).
     Vector,
@@ -761,6 +760,9 @@ pub enum RecallStrategy {
     /// (×1). Vector and hybrid fail on disjoint question sets; fusing both
     /// captures each other's wins. LongMemEval fast50 evidence: R@5
     /// 0.9267 (hybrid) → 0.98 (fusion), R@10 1.0.
+    ///
+    /// DEFAULT since 0.16.0: the zero-config recall strategy.
+    #[default]
     Fusion,
 }
 
@@ -802,6 +804,12 @@ mod tests {
         // Exact-match parsing like every other variant (uppercase rejected).
         assert_eq!(RecallStrategy::from_str_opt("FUSION"), None);
         assert_eq!(RecallStrategy::from_str_opt("fusio"), None);
+    }
+
+    #[test]
+    fn recall_strategy_default_is_fusion() {
+        // #1123: Fusion is the zero-config default since 0.16.0.
+        assert_eq!(RecallStrategy::default(), RecallStrategy::Fusion);
     }
 
     #[test]

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -602,43 +602,14 @@ impl crate::Uteke {
         // min_score is passed as 0.0 to the underlying paths: thresholding
         // happens AFTER boosts (on both cache-miss and cache-hit reads) so
         // cold and warm calls filter identical boosted score sets.
-        let results = match strategy {
-            RecallStrategy::Vector => {
-                self.recall(query, boost_window, tags_filter, namespace, 0.0, None, None)?
-            }
-            RecallStrategy::Fts5 => {
-                self.recall_fts5_only(query, boost_window, tags_filter, namespace, 0.0)?
-            }
-            // Hybrid (RRF): min_score is passed but not used for filtering.
-            // RRF scores are rank-based, not cosine similarity. Applying a
-            // cosine threshold to RRF scores would incorrectly filter results.
-            RecallStrategy::Hybrid => {
-                self.recall_rrf(query, boost_window, tags_filter, namespace, min_score)?
-            }
-            // Graph (#378): hybrid RRF, then fuse graph-signal boosts.
-            // The boost is additive + log-scaled, so isolated memories are
-            // untouched and well-connected memories drift upward. Reranking
-            // happens *before* caching so cache entries store the final scores.
-            RecallStrategy::Graph => {
-                let rrf =
-                    self.recall_rrf(query, boost_window, tags_filter, namespace, min_score)?;
-                if self.graph_rerank_config.enabled && !rrf.is_empty() {
-                    let ids: Vec<String> = rrf.iter().map(|r| r.memory.id.clone()).collect();
-                    let signals =
-                        crate::graph_rerank::compute_graph_signals(&self.store.conn, &ids)?;
-                    crate::graph_rerank::rerank_with_graph(rrf, &signals, &self.graph_rerank_config)
-                } else {
-                    rrf
-                }
-            }
-            // Fusion (#1123): wired in a follow-up commit; parse/serde first.
-            // Loud error (never a silent fallback to another strategy).
-            RecallStrategy::Fusion => {
-                return Err(Error::Validation(
-                    "fusion strategy is not wired yet (#1123)".to_string(),
-                ));
-            }
-        };
+        let results = self.compute_recall(
+            strategy,
+            query,
+            boost_window,
+            tags_filter,
+            namespace,
+            min_score,
+        )?;
 
         // Cache results for future queries (without min_score filtering,
         // so cached results are reusable for any threshold). The cached set
@@ -661,6 +632,62 @@ impl crate::Uteke {
         }
         results.truncate(limit);
         Ok(results)
+    }
+
+    /// Raw strategy computation below the cache layer. Shared by the
+    /// dispatch path (cache-miss) and by Fusion, which runs two
+    /// sub-strategies and fuses their rankings (#1123).
+    ///
+    /// Callers must NOT cache inside this method — the dispatcher owns the
+    /// cache put and applies salience/recency boosts exactly once.
+    fn compute_recall(
+        &self,
+        strategy: RecallStrategy,
+        query: &str,
+        boost_window: usize,
+        tags_filter: Option<&[&str]>,
+        namespace: Option<&str>,
+        min_score: f32,
+    ) -> Result<Vec<SearchResult>, Error> {
+        match strategy {
+            RecallStrategy::Vector => {
+                self.recall(query, boost_window, tags_filter, namespace, 0.0, None, None)
+            }
+            RecallStrategy::Fts5 => {
+                self.recall_fts5_only(query, boost_window, tags_filter, namespace, 0.0)
+            }
+            // Hybrid (RRF): min_score is passed but not used for filtering.
+            // RRF scores are rank-based, not cosine similarity. Applying a
+            // cosine threshold to RRF scores would incorrectly filter results.
+            RecallStrategy::Hybrid => {
+                self.recall_rrf(query, boost_window, tags_filter, namespace, min_score)
+            }
+            // Graph (#378): hybrid RRF, then fuse graph-signal boosts.
+            // The boost is additive + log-scaled, so isolated memories are
+            // untouched and well-connected memories drift upward. Reranking
+            // happens *before* caching so cache entries store the final scores.
+            RecallStrategy::Graph => {
+                let rrf =
+                    self.recall_rrf(query, boost_window, tags_filter, namespace, min_score)?;
+                if self.graph_rerank_config.enabled && !rrf.is_empty() {
+                    let ids: Vec<String> = rrf.iter().map(|r| r.memory.id.clone()).collect();
+                    let signals =
+                        crate::graph_rerank::compute_graph_signals(&self.store.conn, &ids)?;
+                    Ok(crate::graph_rerank::rerank_with_graph(
+                        rrf,
+                        &signals,
+                        &self.graph_rerank_config,
+                    ))
+                } else {
+                    Ok(rrf)
+                }
+            }
+            // Fusion (#1123): wired in a follow-up commit; parse/serde first.
+            // Loud error (never a silent fallback to another strategy).
+            RecallStrategy::Fusion => Err(Error::Validation(
+                "fusion strategy is not wired yet (#1123)".to_string(),
+            )),
+        }
     }
 
     /// Apply salience/recency boosts in place, then re-sort and truncate.

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -631,6 +631,13 @@ impl crate::Uteke {
                     rrf
                 }
             }
+            // Fusion (#1123): wired in a follow-up commit; parse/serde first.
+            // Loud error (never a silent fallback to another strategy).
+            RecallStrategy::Fusion => {
+                return Err(Error::Validation(
+                    "fusion strategy is not wired yet (#1123)".to_string(),
+                ));
+            }
         };
 
         // Cache results for future queries (without min_score filtering,

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -682,11 +682,36 @@ impl crate::Uteke {
                     Ok(rrf)
                 }
             }
-            // Fusion (#1123): wired in a follow-up commit; parse/serde first.
-            // Loud error (never a silent fallback to another strategy).
-            RecallStrategy::Fusion => Err(Error::Validation(
-                "fusion strategy is not wired yet (#1123)".to_string(),
-            )),
+            // Fusion (#1123): run vector and hybrid rankings at boost_window
+            // depth, then weighted-RRF fuse them. Vector and hybrid fail on
+            // disjoint question sets; the fused ranking captures both sides'
+            // wins (fast50 R@5 0.9267 hybrid → 0.98 fusion). Sub-calls bypass
+            // the cache/boost layer — THIS dispatcher applies boosts once and
+            // caches the fused set, mirroring harness semantics.
+            RecallStrategy::Fusion => {
+                let vec_res = self.compute_recall(
+                    RecallStrategy::Vector,
+                    query,
+                    boost_window,
+                    tags_filter,
+                    namespace,
+                    0.0,
+                )?;
+                let hyb_res = self.compute_recall(
+                    RecallStrategy::Hybrid,
+                    query,
+                    boost_window,
+                    tags_filter,
+                    namespace,
+                    min_score,
+                )?;
+                Ok(rrf_fuse_weighted(
+                    vec_res,
+                    hyb_res,
+                    FUSION_W_VECTOR,
+                    FUSION_W_HYBRID,
+                ))
+            }
         }
     }
 
@@ -1983,6 +2008,242 @@ mod recall_cache_parity_tests {
             assert_eq!(c.memory.id, w.memory.id, "same ids in same order");
         }
 
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}
+
+/// Fusion weights benchmark-tuned on LongMemEval fast50 (#1123):
+/// plateau [1.7, 1.9] → R@5 0.98; 1.7 chosen mid-plateau.
+/// k=60 matches the k used by recall_rrf.
+const FUSION_W_VECTOR: f64 = 1.7;
+const FUSION_W_HYBRID: f64 = 1.0;
+const FUSION_RRF_K: f64 = 60.0;
+
+/// Weighted RRF fuse of two complete SearchResult rankings (#1123).
+///
+/// Deduplicates by memory id (first occurrence keeps the Memory payload),
+/// sorts by fused score descending, and rewrites each result's score to the
+/// fused RRF score. No truncation — the caller truncates to its window.
+fn rrf_fuse_weighted(
+    primary: Vec<SearchResult>,
+    secondary: Vec<SearchResult>,
+    w_primary: f64,
+    w_secondary: f64,
+) -> Vec<SearchResult> {
+    use std::collections::HashMap;
+    let mut scores: HashMap<String, f64> = HashMap::new();
+    for (rank, r) in primary.iter().enumerate() {
+        *scores.entry(r.memory.id.clone()).or_default() +=
+            w_primary / (FUSION_RRF_K + rank as f64 + 1.0);
+    }
+    for (rank, r) in secondary.iter().enumerate() {
+        *scores.entry(r.memory.id.clone()).or_default() +=
+            w_secondary / (FUSION_RRF_K + rank as f64 + 1.0);
+    }
+
+    // Chain both rankings, dedup by id (first occurrence wins the payload),
+    // then stable-sort by fused score descending.
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<SearchResult> = primary
+        .into_iter()
+        .chain(secondary)
+        .filter(|r| seen.insert(r.memory.id.clone()))
+        .collect();
+    out.sort_by(|a, b| {
+        let sb = scores.get(&b.memory.id).copied().unwrap_or(0.0);
+        let sa = scores.get(&a.memory.id).copied().unwrap_or(0.0);
+        sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for r in out.iter_mut() {
+        r.score = scores.get(&r.memory.id).copied().unwrap_or(0.0) as f32;
+    }
+    out
+}
+
+#[cfg(test)]
+mod rrf_fuse_weighted_tests {
+    use super::rrf_fuse_weighted;
+    use crate::memory::types::{Memory, SearchResult};
+
+    fn sr(id: &str, score: f32) -> SearchResult {
+        let now = chrono::Utc::now();
+        let memory = Memory {
+            id: id.to_string(),
+            content: format!("content {id}"),
+            embedding: vec![0.1_f32; 4],
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            created_at: now,
+            updated_at: now,
+            namespace: "test".to_string(),
+            access_count: 0,
+            last_accessed: None,
+            deprecated: false,
+            deprecated_at: None,
+            valid_from: Some(now),
+            valid_until: None,
+            memory_type: "note".to_string(),
+            importance: 0.5,
+            pinned: false,
+            content_type: "text".to_string(),
+            slug: None,
+            source: None,
+            source_type: "user".to_string(),
+            author_type: "agent".to_string(),
+        };
+        SearchResult { memory, score }
+    }
+
+    #[test]
+    fn overlap_wins_and_ids_dedup() {
+        // 'both' appears in BOTH rankings; 'gold' only in secondary.
+        let primary = vec![sr("a", 0.9), sr("b", 0.8), sr("both", 0.7)];
+        let secondary = vec![sr("gold", 0.95), sr("both", 0.85), sr("c", 0.6)];
+        let fused = rrf_fuse_weighted(primary, secondary, 1.7, 1.0);
+        // 'both' ranks 3rd primary + 2nd secondary → highest fused score.
+        assert_eq!(fused[0].memory.id, "both");
+        // No duplicate ids survive.
+        let n = fused.len();
+        let uniq = fused
+            .iter()
+            .map(|r| r.memory.id.as_str())
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        assert_eq!(n, uniq);
+        // Scores are fused RRF scores (small positive), not the originals.
+        assert!(fused[0].score > 0.0 && fused[0].score < 0.1);
+    }
+
+    #[test]
+    fn primary_weight_orders_disagreeing_rankings() {
+        let primary = vec![sr("x", 0.9), sr("y", 0.8)];
+        let secondary = vec![sr("y", 0.95), sr("x", 0.85)];
+        // x: 1st primary + 2nd secondary; y: mirrored. Higher primary weight
+        // must lift x; higher secondary weight must lift y.
+        let f1 = rrf_fuse_weighted(primary.clone(), secondary.clone(), 2.0, 1.0);
+        assert_eq!(f1[0].memory.id, "x");
+        let f2 = rrf_fuse_weighted(primary, secondary, 0.5, 2.0);
+        assert_eq!(f2[0].memory.id, "y");
+    }
+
+    #[test]
+    fn empty_inputs_yield_empty() {
+        let fused = rrf_fuse_weighted(vec![], vec![], 1.7, 1.0);
+        assert!(fused.is_empty());
+        let fused = rrf_fuse_weighted(vec![sr("only", 0.9)], vec![], 1.7, 1.0);
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].memory.id, "only");
+    }
+}
+
+#[cfg(test)]
+mod fusion_strategy_tests {
+    use crate::Uteke;
+    use crate::memory::types::RecallStrategy;
+
+    /// #1123: Fusion strategy end-to-end — seeds a store, runs recall with
+    /// the explicit Fusion strategy, and asserts the on-topic memory surfaces
+    /// in the top results. Also asserts cold/warm parity through the cache.
+    #[test]
+    fn fusion_recall_finds_on_topic_memory() {
+        let dir = std::env::temp_dir().join(format!("fusion-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
+
+        let base = vec![0.1_f32; 768];
+        // On-topic memory: near-parallel to the probe direction.
+        let mut on_topic = base.clone();
+        for v in on_topic.iter_mut().take(384) {
+            *v = 0.9;
+        }
+        // Off-topic memories: anti-parallel.
+        let mut off = base.clone();
+        for v in off.iter_mut().take(384) {
+            *v = -0.9;
+        }
+
+        uteke
+            .remember_precomputed(
+                "quarterly revenue projections for the board meeting",
+                &["finance"],
+                None,
+                Some("fusion-ns"),
+                "fact",
+                "text",
+                &on_topic,
+            )
+            .unwrap();
+        for i in 0..4 {
+            uteke
+                .remember_precomputed(
+                    &format!("unrelated filler note {i} about gardening"),
+                    &["misc"],
+                    None,
+                    Some("fusion-ns"),
+                    "note",
+                    "text",
+                    &off,
+                )
+                .unwrap();
+        }
+
+        let ns = Some("fusion-ns");
+        let cold = uteke
+            .recall_hybrid(
+                "board meeting revenue projections",
+                3,
+                None,
+                ns,
+                RecallStrategy::Fusion,
+                0.0,
+            )
+            .unwrap();
+        assert!(!cold.is_empty(), "fusion must return results");
+        assert_eq!(
+            cold[0].memory.content, "quarterly revenue projections for the board meeting",
+            "on-topic memory must rank first under fusion"
+        );
+        assert!(cold.len() <= 3);
+
+        // Cold/warm parity through the recall cache (#1037 invariant).
+        let warm = uteke
+            .recall_hybrid(
+                "board meeting revenue projections",
+                3,
+                None,
+                ns,
+                RecallStrategy::Fusion,
+                0.0,
+            )
+            .unwrap();
+        let cold_ids: Vec<_> = cold.iter().map(|r| r.memory.id.clone()).collect();
+        let warm_ids: Vec<_> = warm.iter().map(|r| r.memory.id.clone()).collect();
+        assert_eq!(cold_ids, warm_ids, "cold and warm fusion must match");
+
+        drop(uteke);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Fusion must not silently degrade: an explicit Fusion call on an empty
+    /// store returns empty results (both sub-rankings empty), NOT an error
+    /// and NOT a fallback ranking.
+    #[test]
+    fn fusion_recall_empty_store_returns_empty() {
+        let dir = std::env::temp_dir().join(format!("fusion-e-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let uteke = Uteke::open(dir.join("t.db").to_str().unwrap()).unwrap();
+        let res = uteke
+            .recall_hybrid(
+                "anything",
+                5,
+                None,
+                Some("empty-ns"),
+                RecallStrategy::Fusion,
+                0.0,
+            )
+            .unwrap();
+        assert!(res.is_empty());
         drop(uteke);
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -28,7 +28,7 @@ usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.15.0", default-features = false, features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.16.0", default-features = false, features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -275,7 +275,7 @@ fn tool_recall() -> Value {
                 "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter by tags (optional)" },
                 "min_score": { "type": "number", "description": "Minimum similarity score 0..1 (default: 0.0)" },
                 "type": { "type": "string", "enum": ["all", "memory", "doc"], "description": "Search type: 'all' (default, unified), 'memory', or 'doc'" },
-                "strategy": { "type": "string", "enum": ["hybrid", "vector", "fts5", "graph"], "description": "Recall strategy: 'hybrid' (default, vector+FTS5 via RRF), 'vector' (similarity only), 'fts5' (keyword only), or 'graph' (hybrid + graph-signal reranking)", "default": "hybrid" }
+                "strategy": { "type": "string", "enum": ["fusion", "hybrid", "vector", "fts5", "graph"], "description": "Recall strategy: 'fusion' (default since 0.16.0, weighted RRF of vector×1.7 + hybrid×1, #1123), 'hybrid' (vector+FTS5 via RRF), 'vector' (similarity only), 'fts5' (keyword only), or 'graph' (hybrid + graph-signal reranking)", "default": "fusion" }
             },
             "required": ["query"]
         }
@@ -885,19 +885,19 @@ fn exec_recall(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         }
     };
 
-    // Parse optional recall strategy (#1035): default hybrid, matching the
-    // CLI and HTTP defaults. Unknown values are a loud error (JSON-RPC -32603),
-    // never a silent fallback.
+    // Parse optional recall strategy (#1035): default fusion since 0.16.0
+    // (#1123), matching the CLI and HTTP defaults. Unknown values are a loud
+    // error (JSON-RPC -32603), never a silent fallback.
     let strategy = match args["strategy"].as_str() {
         Some(name) => match uteke_core::RecallStrategy::from_str_opt(name) {
             Some(s) => s,
             None => {
                 return Err(format!(
-                    "Invalid strategy: '{name}'. Use 'vector', 'fts5', 'hybrid', or 'graph'."
+                    "Invalid strategy: '{name}'. Use 'vector', 'fts5', 'hybrid', 'graph', or 'fusion'."
                 ));
             }
         },
-        None => uteke_core::RecallStrategy::Hybrid,
+        None => uteke_core::RecallStrategy::Fusion,
     };
 
     // Use unified search when type is specified or default (all).

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -26,8 +26,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.15.0", default-features = false, features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.15.0", default-features = false }
+uteke-core = { path = "../uteke-core", version = "0.16.0", default-features = false, features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.16.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -360,12 +360,14 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                                 req,
                                 400,
                                 format!(
-                                    "Invalid strategy: '{name}'. Use 'vector', 'fts5', 'hybrid', or 'graph'."
+                                    "Invalid strategy: '{name}'. Use 'vector', 'fts5', 'hybrid', 'graph', or 'fusion'."
                                 ),
                             );
                         }
                     },
-                    None => uteke_core::RecallStrategy::Hybrid,
+                    // Implicit default since 0.16.0 (#1123): fusion.
+                    // Matches the core enum default and CLI default_strategy.
+                    None => uteke_core::RecallStrategy::Fusion,
                 };
 
                 // Unified search path (#531): when search_type is specified,

--- a/crates/uteke-server/src/types.rs
+++ b/crates/uteke-server/src/types.rs
@@ -245,9 +245,10 @@ pub struct RecallRequest {
     /// `linked_memory_ids` on document results.
     #[serde(default)]
     pub enrich: bool,
-    /// Recall strategy: "hybrid" (default), "vector", "fts5", or "graph" (#900, #1034).
+    /// Recall strategy: "fusion" (default since 0.16.0), "vector", "fts5",
+    /// "hybrid", or "graph" (#900, #1034, #1123).
     /// When absent, the server falls back to `[recall] default_strategy` from
-    /// uteke.toml, then to "hybrid" — matching the CLI default.
+    /// uteke.toml, then to "fusion" — matching the CLI default.
     /// Invalid values return HTTP 400.
     #[serde(default)]
     pub strategy: Option<String>,
@@ -439,7 +440,8 @@ pub struct RecallFileSection {
     /// Strict mode threshold (higher, for critical queries).
     pub min_score_strict: Option<f64>,
     /// Default recall strategy when a request omits `strategy` (#1034).
-    /// One of: vector | fts5 | hybrid | graph. Server-side default: hybrid.
+    /// One of: vector | fts5 | hybrid | graph | fusion. Server-side default:
+    /// fusion (#1123).
     pub default_strategy: Option<String>,
 }
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -28,11 +28,15 @@ The killer stat: recall latency barely changes as the store grows.
 HNSW search is O(log N), so even at 10K memories, the vector index adds <1ms.
 The ~40ms floor is dominated by ONNX embedding inference, not search.
 
-The full pipeline:
+The full pipeline (fusion strategy, default since 0.16.0):
 1. Query → ONNX embedding generation
-2. HNSW vector search
-3. FTS5 full-text search
-4. Reciprocal Rank Fusion (k=60)
+2. HNSW vector search → vector ranking
+3. FTS5 full-text search + RRF (k=60) → hybrid ranking
+4. Weighted RRF fusion of the two rankings (vector×1.7 + hybrid×1, #1123)
+
+Retrieval quality (LongMemEval fast50, session-level): fusion R@5 0.98
+vs hybrid 0.9267 vs vector-only 0.854. Vector and hybrid fail on
+disjoint question sets — fusing captures both sides' wins.
 
 No network round-trip. No API call. Everything in-process.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,7 +202,7 @@ min_score_strict = 0.5
 #   hybrid — vector + FTS5 fused via Reciprocal Rank Fusion (default)
 #   graph  — hybrid + graph-signal reranking (#378): well-connected memories
 #            get a subtle log-scaled score boost
-default_strategy = "hybrid"
+default_strategy = "fusion"
 
 # Graph-augmented reranking weights (only affect the `graph` strategy).
 # Boosts are additive + log-scaled, so 0.1 is subtle and saturates quickly.
@@ -215,7 +215,7 @@ graph_rerank_enabled = true   # master switch; false → graph acts like hybrid
 |---------|---------|-------------|
 | `min_score` | 0.3 | Minimum similarity score (0.0-1.0). **CLI only.** |
 | `min_score_strict` | 0.5 | Strict-mode threshold (used with `--strict`). **CLI only.** |
-| `default_strategy` | `hybrid` | Default recall strategy (`vector\|fts5\|hybrid\|graph`) |
+| `default_strategy` | `fusion` | Default recall strategy (`vector\|fts5\|hybrid\|graph\|fusion`). Since 0.16.0 `fusion` (weighted RRF: vector×1.7 + hybrid×1, #1123) is the default — LongMemEval fast50 R@5 0.98 vs 0.9267 hybrid |
 | `graph_density_weight` | 0.1 | Edge-density boost weight (graph strategy only) |
 | `graph_authority_weight` | 0.1 | Incoming-edge authority boost weight (graph strategy only) |
 | `graph_rerank_enabled` | true | Master switch for graph reranking |
@@ -269,7 +269,7 @@ Resolution order (highest priority first):
 | `UTEKE_SERVER_PORT` | `[server] port` | `8767` | Server port |
 | `UTEKE_RECALL_MIN_SCORE` | `[recall] min_score` | `0.3` | Default similarity threshold |
 | `UTEKE_RECALL_MIN_SCORE_STRICT` | `[recall] min_score_strict` | `0.5` | Strict threshold |
-| `UTEKE_RECALL_STRATEGY` | `[recall] default_strategy` | `hybrid` | Default recall strategy (`vector\|fts5\|hybrid\|graph`) |
+| `UTEKE_RECALL_STRATEGY` | `[recall] default_strategy` | `fusion` | Default recall strategy (`vector\|fts5\|hybrid\|graph\|fusion`) |
 | `UTEKE_GRAPH_DENSITY_WEIGHT` | `[recall] graph_density_weight` | `0.1` | Edge-density boost weight |
 | `UTEKE_GRAPH_AUTHORITY_WEIGHT` | `[recall] graph_authority_weight` | `0.1` | Incoming-edge authority boost weight |
 | `UTEKE_GRAPH_RERANK_ENABLED` | `[recall] graph_rerank_enabled` | `true` | Master switch for graph reranking |


### PR DESCRIPTION
## What

- Promote **Fusion** (weighted RRF of the vector and hybrid rankings (k=60, weights benchmark-tuned)) to the default recall strategy across core/CLI/server/MCP
- Benchmark harness: `--strategy default` sentinel, `fusion` first-class, 3-way RRF simulation tooling
- Docs + CHANGELOG for 0.16.0

## Why

- Fusion default delivers benchmark-grade recall out of the box (zero-config): fast50 R@5 = **0.9800** vs hybrid 0.9200 / vector 0.9267
- 3-way RRF (+fts5 arm) simulated on full 500Q fts5 rankings: **no-go** — 0 flipped questions at any grid weight; ranking-side optimization exhausted
- Validation: parity proven (implicit default == explicit fusion, ≠ hybrid), local ARM zero-config fast10 R@5 = 0.9667 / R@10 = 1.0

## Testing

- 520+ unit tests green (pre-existing suite)
- Parity test binary 0.16.0: default==fusion rankings identical; default≠hybrid
- fast10 zero-config local run: R@5=0.9667, R@10=1.0000, NDCG@5=0.9643
- 3-way sim cross-check: fts5-only R@5 sim 0.8211 vs harness 0.820 ✅
- Modal fts5 collection 500Q complete (10/10 shards, resume-safe via volume)
