### PR TITLE
ci: dispatchable x86_64 snapshot build

### DIFF
--- a/.github/workflows/build-x86-dispatch.yml
+++ b/.github/workflows/build-x86-dispatch.yml
@@ -1,0 +1,31 @@
+name: Build x86_64 snapshot (dispatch)
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (default: develop)'
+        required: false
+        default: 'develop'
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || 'develop' }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add x86_64-unknown-linux-gnu
+      - name: Build release binary
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu -p uteke-cli
+      - name: Package bundle
+        run: |
+          cd target/x86_64-unknown-linux-gnu/release
+          tar czf /tmp/uteke-x86_64.tar.gz uteke
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: uteke-x86_64-snapshot
+          path: /tmp/uteke-x86_64.tar.gz


### PR DESCRIPTION
## What

- New workflow `build-x86-dispatch.yml`: manual dispatch, builds release x86_64 binary from any ref (default: develop), uploads as artifact
- No tag required — used for pre-release benchmark validation (pure-default 500Q run needs a 0.16.0 fusion-default binary on x86)

## Why

- Modal image currently bakes v0.15.0 (hybrid default). A `--strategy default` run today would silently evaluate hybrid, not fusion
- Release ritual (docs→tag→Release on main) must not be skipped, so a tagless dispatchable snapshot build is the clean path

## Testing

- Workflow syntax verified; dispatch target branch = this branch first run