### PR TITLE
fix(bench): install build-essential for git-ref image build

### DIFF
--- a/benchmarks/longmemeval/modal_fanout.py
+++ b/benchmarks/longmemeval/modal_fanout.py
@@ -72,7 +72,8 @@ if UTEKE_GIT_REF:
     # but reuse the official ORT 1.24.4 x86_64 (SSE4.2) shared lib from the
     # latest release tarball — ort is load-dynamic, so the lib is decoupled
     # from the binary and versioned identically to official releases.
-    image = image.run_commands(
+    # build-essential: cargo needs a native linker (cc) on the base image.
+    image = image.apt_install("build-essential", "pkg-config").run_commands(
         "curl -sL https://github.com/codecoradev/uteke/releases/download/"
         f"{UTEKE_VERSION}/uteke-x86_64-unknown-linux-gnu-legacy-{UTEKE_VERSION}.tar.gz"
         " | tar xz -C /tmp && "


### PR DESCRIPTION
## What

- Add `build-essential` + `pkg-config` apt packages to the UTEKE_GIT_REF image path

## Why

- First validation run failed at image build: `error: linker cc not found` — ubuntu:24.04 base has no compiler toolchain, cargo needs a native linker
- Log evidence: image build im-H4V5GG0lomhwLVCia3LPea, container exit 101

## Testing

- Rerun of the actual validation run (500Q pure-default) after merge — image build step compiles and prints `uteke --version`