### PR TITLE
docs: fusion weights = internal hasil tuning, bukan bagian kontrak publik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 Minor release. One theme: retrieval quality that ships by default.
 
-The new `fusion` strategy — weighted Reciprocal Rank Fusion of the vector ranking (×1.7) and the hybrid ranking (×1) — is now the default everywhere: CLI, HTTP API, and MCP. Vector and hybrid fail on different questions; fusing both captures each side's wins. Zero config needed.
+The new `fusion` strategy — weighted Reciprocal Rank Fusion of the vector and hybrid rankings — is now the default everywhere: CLI, HTTP API, and MCP. Vector and hybrid fail on different questions; fusing both captures each side's wins. Zero config needed.
 
 ### Added
 
-- **`fusion` recall strategy (#1123)** — runs vector and hybrid rankings and RRF-fuses them (k=60, weights 1.7/1.0 tuned on LongMemEval fast50 actual x86 rankings). LongMemEval fast50: R@5 0.98 vs 0.9267 hybrid, R@10 1.0. Available on every surface: `--strategy fusion`, HTTP `strategy: "fusion"`, MCP `strategy: "fusion"`.
+- **`fusion` recall strategy (#1123)** — runs vector and hybrid rankings and RRF-fuses them (k=60, weights tuned on LongMemEval fast50 actual x86 rankings). LongMemEval fast50: R@5 0.98 vs 0.9267 hybrid, R@10 1.0. Available on every surface: `--strategy fusion`, HTTP `strategy: "fusion"`, MCP `strategy: "fusion"`.
 
 ### Changed
 

--- a/benchmarks/longmemeval/RESULTS.md
+++ b/benchmarks/longmemeval/RESULTS.md
@@ -21,7 +21,7 @@
 
 **Improvement (Hybrid vs Vector): +12.6pp R@5**
 
-### Fusion (weighted RRF: vector×1.7 + hybrid×1, #1123) — default since 0.16.0
+### Fusion (weighted RRF of vector + hybrid rankings, #1123) — default since 0.16.0
 
 | Questions | R@5 | R@10 | NDCG@5 | NDCG@10 | Embedding | Date |
 |-----------|-----|------|--------|---------|-----------|------|
@@ -42,7 +42,7 @@ fast10 detail: 1 partial miss @5 (60472f9c multi-session, R@5 0.67 → R@10 1.0)
 
 **Why fusion works:** vector-only and hybrid-only fail on DISJOINT question sets (fast50: 7 questions vector wins, 5 hybrid wins, no overlap in failures). RRF fusing both rankings captures each side's wins.
 
-**Tuning evidence:** weight plateau [1.7, 1.9] → R@5 0.98 on actual x86 rankings; 1.7 chosen mid-plateau. wv=1.5 (ARM-local tuning) measured 0.9535 on x86 — arch drift of ±1 rank motivated re-tuning on the deployment arch (commit 47155af).
+**Tuning evidence:** weight grid sweep on actual x86 rankings; chosen value sits mid-plateau (stable across a range), not at an edge. Weights are internal implementation details (see core crate) rather than part of the public contract.
 
 ---
 
@@ -86,7 +86,7 @@ Simulation over saved rankings; fts5-only rankings collected on Modal x86
 (500Q, ~4.5h, resume-safe via volume). Cross-check: sim fts5-only R@5=0.8211
 vs harness-reported 0.820 — parsing validated.
 
-- 2-way shipped fusion (1.7/1.0) R@5 = 0.9800 (fast50)
+- 2-way shipped fusion (tuned weights) R@5 = 0.9800 (fast50)
 - best 3-way (2.0/1.0/0.1) R@5 = 0.9800 — delta +0.0000, **0 flipped questions**
 - adding fts5 as third arm changes nothing at any grid weight tried
 - fts5-only fails: temporal-reasoning (63) + multi-session (55) dominate —

--- a/benchmarks/longmemeval/RESULTS.md
+++ b/benchmarks/longmemeval/RESULTS.md
@@ -97,3 +97,21 @@ Remaining headroom is insert-side granularity (3 partial-recall fails) —
 separate project, uncertain payoff.
 
 Artifacts: sim3way_final.py, preview_scores.py, results_modal_fts5_partial/
+
+### Pure-default (zero-config fusion) 500Q — Modal x86_64, binary 0.16.0 from git bfbc296 (2026-08-29)
+
+Pre-release validation: `--strategy default` (no flag at all) against the full 500Q dataset.
+Binary built in-image from exact SHA bfbc296 (PR #1137/#1138), image build prints `uteke 0.16.0`.
+
+| Question Type | Count | Recall@5 | Recall@10 | NDCG@5 | NDCG@10 |
+|---|---|---|---|---|---|
+| **Overall** | 470 | **0.946** | 0.977 | 0.897 | 0.911 |
+| knowledge-update | 72 | 1.000 | 1.000 | 0.972 | 0.972 |
+| multi-session | 121 | 0.906 | 0.976 | 0.880 | 0.913 |
+| single-session-assistant | 56 | 0.982 | 1.000 | 0.959 | 0.965 |
+| single-session-preference | 30 | 0.967 | 0.967 | 0.839 | 0.839 |
+| single-session-user | 64 | 0.969 | 0.969 | 0.913 | 0.913 |
+| temporal-reasoning | 127 | 0.920 | 0.962 | 0.849 | 0.867 |
+
+Context: v0.15.0 hybrid baseline on the same dataset: Overall R@5 = 0.854 / R@10 = 0.885 (2026-08-13).
+Fusion default lifts full-500Q recall@5 by **+9.2 points** (0.854 → 0.946) with zero configuration.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -32,7 +32,7 @@ The full pipeline (fusion strategy, default since 0.16.0):
 1. Query → ONNX embedding generation
 2. HNSW vector search → vector ranking
 3. FTS5 full-text search + RRF (k=60) → hybrid ranking
-4. Weighted RRF fusion of the two rankings (vector×1.7 + hybrid×1, #1123)
+4. Weighted RRF fusion of the two rankings (#1123, tuned weights)
 
 Retrieval quality (LongMemEval fast50, session-level): fusion R@5 0.98
 vs hybrid 0.9267 vs vector-only 0.854. Vector and hybrid fail on


### PR DESCRIPTION
## What

- `RESULTS.md`, `CHANGELOG.md`, `docs/benchmarks.md`: nilai weight fusion yang eksplisit diganti deskripsi "benchmark-tuned weights"
- Body PR #1134/#1135 dan komentar close #1118 sudah di-scrub via API dengan redaksi yang sama

## Why

Weight fusion itu artefak tuning kompetitif — bukan hal yang perlu dipromosikan di permukaan publik. Kode tetap terbuka di core crate (sesuai filosofi open source repo ini), tapi prosa dokumentasi tidak perlu memasang resep tuningnya di depan pintu.

Redaksi pengganti tetap mempertahankan metodologi: "chosen value sits mid-plateau (stable across a range), not at an edge" — cara kerjanya jelas, angkanya tidak.

## Testing

- grep pola weight di seluruh docs → 0 remnant
- dist VitePress di-rebuild → bersih (3 temuan CHANGELOG = false positive: versi Rust 1.75/1.85 dan statistik 61.7%)
