### PR TITLE
fix(core): repair --reembed can now repair NULL-embedding rows (#1146)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/crates/uteke-core/src/maintenance.rs
+++ b/crates/uteke-core/src/maintenance.rs
@@ -182,17 +182,16 @@ impl crate::Uteke {
 
     /// Re-embed memories that have missing or empty embedding vectors.
     ///
-    /// Scans all non-deprecated memories, finds those with empty embeddings,
-    /// generates new embeddings, updates the database, and adds them to the index.
+    /// Scans active memories with NULL/empty embeddings via a dedicated SQL
+    /// query (`load_missing_embeddings`), generates new embeddings, updates
+    /// the database, and adds them to the index.
     pub fn reembed_missing(&self) -> Result<ReembedReport, Error> {
-        let all_memories = self.store.load_all(None)?;
-        let total_scanned = all_memories.len();
-
-        // Filter to memories with empty embeddings, excluding deprecated.
-        let missing: Vec<&Memory> = all_memories
-            .iter()
-            .filter(|m| !m.deprecated && m.embedding.is_empty())
-            .collect();
+        // Scan directly for NULL/empty embeddings (#1146). This must NOT go
+        // through load_all(): its `embedding IS NOT NULL` guard (kept for
+        // index.build() safety, #992) filtered out exactly the rows this
+        // function exists to repair, making NULL rows permanently invisible.
+        let missing: Vec<Memory> = self.store.load_missing_embeddings(None)?;
+        let total_scanned = self.store.load_all(None)?.len();
 
         let missing_count = missing.len();
         if missing_count == 0 {
@@ -655,6 +654,91 @@ mod tests {
         let restored: PruneResult = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.pruned, 5);
         assert_eq!(restored.deprecated, 3);
+    }
+
+    #[ignore = "requires ONNX embedder — validates reembed repairs NULL-embedding rows (#1146)"]
+    #[test]
+    fn test_reembed_repairs_null_embedding_rows() {
+        // Regression test for #1146: `repair --reembed` used to scan through
+        // load_all(), whose `embedding IS NOT NULL` guard (#992) filtered out
+        // exactly the rows needing repair. NULL-embedding rows (write-path
+        // crash artifacts) were permanently invisible to reembed and doctor
+        // reported an unresolvable MISMATCH.
+        let dir = tempfile::tempdir().unwrap();
+        let uteke = crate::Uteke::open(dir.path().join("uteke.db")).unwrap();
+
+        // Create one healthy memory (gets a real embedding).
+        let id = uteke
+            .remember("raft consensus requires a majority quorum", &[], None, None)
+            .unwrap();
+
+        // Simulate a write-path crash artifact: NULL embedding.
+        let id_null = uteke
+            .remember("vector quantization compresses embeddings", &[], None, None)
+            .unwrap();
+        uteke
+            .graph_store()
+            .execute(
+                "UPDATE memories SET embedding = NULL WHERE id = ?1",
+                rusqlite::params![id_null],
+            )
+            .unwrap();
+
+        // And the empty-blob variant (what the old code could only see).
+        let id_empty = uteke
+            .remember(
+                "hybrid search blends keyword and vector signals",
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        uteke
+            .graph_store()
+            .execute(
+                "UPDATE memories SET embedding = X'' WHERE id = ?1",
+                rusqlite::params![id_empty],
+            )
+            .unwrap();
+
+        // Scan finds both NULL and empty-blob rows.
+        let scanned = uteke.store.load_missing_embeddings(None).unwrap();
+        assert_eq!(
+            scanned.len(),
+            2,
+            "scan must see NULL-embedding rows, not just empty-blob ones"
+        );
+
+        // Reembed repairs both; the healthy row is untouched.
+        let report = uteke.reembed_missing().unwrap();
+        assert_eq!(report.missing_count, 2);
+        assert_eq!(report.reembedded, 2, "both rows must be re-embedded");
+        assert_eq!(report.failed, 0);
+
+        // DB no longer has NULL/empty embeddings among active memories.
+        let remaining: i64 = uteke
+            .graph_store()
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE (embedding IS NULL OR length(embedding) = 0) AND deprecated = 0",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0);
+
+        // End-to-end: verify() reports a consistent store after repair.
+        let v = uteke.verify().unwrap();
+        assert!(
+            v.consistent,
+            "store must be consistent after reembed, got db={} index={}",
+            v.db_count, v.index_count
+        );
+
+        // Reembed is now a no-op.
+        let again = uteke.reembed_missing().unwrap();
+        assert_eq!(again.missing_count, 0);
+        assert_eq!(again.reembedded, 0);
+        let _ = (id, id_null, id_empty);
     }
 
     #[test]

--- a/crates/uteke-core/src/memory/crud.rs
+++ b/crates/uteke-core/src/memory/crud.rs
@@ -634,6 +634,55 @@ impl super::Store {
         Ok(memories)
     }
 
+    /// Load active memories whose embedding is missing (SQL NULL or empty blob).
+    ///
+    /// Unlike [`load_all`], this deliberately includes NULL-embedding rows: it is
+    /// the scan source for `repair --reembed` (#1146). The NULL guard in
+    /// `load_all` exists to keep such rows out of `index.build()` (#992), but
+    /// reusing it as the reembed scan made NULL rows permanently invisible to
+    /// the one tool designed to fix them.
+    pub fn load_missing_embeddings(&self, namespace: Option<&str>) -> Result<Vec<Memory>, Error> {
+        let sql = match namespace {
+            Some(_) => {
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug, source, source_type, author_type, deprecated_at FROM memories WHERE namespace = ?1 AND (embedding IS NULL OR length(embedding) = 0) AND deprecated = 0 ORDER BY created_at"
+            }
+            None => {
+                "SELECT id, content, embedding, tags, metadata, created_at, updated_at, namespace, access_count, last_accessed, deprecated, valid_from, valid_until, memory_type, importance, pinned, content_type, slug, source, source_type, author_type, deprecated_at FROM memories WHERE (embedding IS NULL OR length(embedding) = 0) AND deprecated = 0 ORDER BY created_at"
+            }
+        };
+
+        let mut memories = Vec::new();
+        match namespace {
+            Some(ns) => {
+                let mut stmt = self
+                    .conn
+                    .prepare(sql)
+                    .map_err(|e| Error::db("database operation", e))?;
+                let rows = stmt
+                    .query_map(params![ns], row_to_memory)
+                    .map_err(|e| Error::db("database store operation", e))?;
+                for row in rows {
+                    let m = row.map_err(|e| Error::db("database operation", e))?;
+                    memories.push(m);
+                }
+            }
+            None => {
+                let mut stmt = self
+                    .conn
+                    .prepare(sql)
+                    .map_err(|e| Error::db("database operation", e))?;
+                let rows = stmt
+                    .query_map([], row_to_memory)
+                    .map_err(|e| Error::db("database operation", e))?;
+                for row in rows {
+                    let m = row.map_err(|e| Error::db("database operation", e))?;
+                    memories.push(m);
+                }
+            }
+        }
+        Ok(memories)
+    }
+
     /// Count total memories, optionally filtered by namespace.
     /// Count ACTIVE (non-deprecated) memories, optionally filtered by namespace.
     ///


### PR DESCRIPTION
## What (description of the change)

- Adds `Store::load_missing_embeddings(namespace)` — a dedicated SQL scan (`WHERE embedding IS NULL OR length(embedding) = 0 AND deprecated = 0`) that, unlike `load_all()`, deliberately includes NULL-embedding rows.
- Rewires `reembed_missing()` to scan via the new method instead of `load_all()`. `load_all()` itself is unchanged.
- Regression test `test_reembed_repairs_null_embedding_rows` (ignored, requires ONNX embedder) covering: NULL row + empty-blob row → scan sees both → reembed repairs 2/2 → `verify()` consistent → reembed is a no-op afterwards.

## Why (context, problem solved, alternatives considered)

Fixes #1146.

`reembed_missing()` previously scanned through `load_all()`, whose `embedding IS NOT NULL` guard (added for #992 — NULL vectors must not enter `index.build()`) filtered out **exactly the rows reembed exists to repair**. NULL-embedding rows (write-path crash artifacts) were permanently invisible: doctor reported an unresolvable MISMATCH and `repair --reembed` printed "nothing to re-embed".

Found on a production store with 36 such rows (created 2026-07-10..2026-08-13). The workaround used there was manual `NULL → X''` SQL followed by reembed — with this fix, the same store reaches "All checks passed" using official commands alone.

Alternatives considered (see issue): splitting `load_all()` into two variants, or making the write path write `X''` instead of NULL. The dedicated scan has the smallest blast radius and keeps `load_all()`'s #992 guarantee intact.

## Testing

- [x] `cargo test -p uteke-core --lib -- --ignored reembed` → **1 passed** (real ONNX embedder, 32s)
- [x] Adjacent regression tests still pass: `test_verify_counts_doc_chunks` (#1111), `test_repair_preserves_doc_chunk_vectors` (#1110) → **2 passed**
- [x] Full suite: `cargo test -p uteke-core --lib` → **524 passed, 0 failed, 31 ignored**
- [x] `cargo fmt` + `cargo clippy` clean (pre-commit verified)
- [x] cora review: no findings
- [x] Production store replication (pre-PR, on 0.16.0 release binary + SQL workaround): 36/36 re-embedded, doctor green