### PR TITLE
fix(ci): CLA check skips bot PRs with exact allowlist (#1132)

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   cla-check:
     runs-on: ubuntu-latest
-    if: "!contains(fromJSON('[\"app/dependabot\", \"app/renovate\", \"github-actions[bot]\"]'), github.event.pull_request.user.login)"
+    if: "!contains(fromJSON('[\"dependabot[bot]\", \"renovate[bot]\", \"github-actions[bot]\", \"app/dependabot\", \"app/renovate\"]'), github.event.pull_request.user.login)"
     steps:
       - name: Fetch & check CLA signature
         id: check


### PR DESCRIPTION
## What (description of the change)

One-line change to the `cla-check` job condition in `.github/workflows/cla-check.yml`:

```diff
-    if: "!contains(fromJSON('[\"app/dependabot\", \"app/renovate\", \"github-actions[bot]\"]'), github.event.pull_request.user.login)"
+    if: "!contains(fromJSON('[\"dependabot[bot]\", \"renovate[bot]\", \"github-actions[bot]\", \"app/dependabot\", \"app/renovate\"]'), github.event.pull_request.user.login)"
```

## Why (context, problem solved, alternatives considered)

Fixes #1132.

Dependabot PRs are authored by **`dependabot[bot]`**, not `app/dependabot`, so the exemption condition never matched. The CLA job ran on every dependabot PR, failed, and left a "please sign the CLA" comment on each one — demonstrated in `codecoradev/vecq` PRs #2 and #3, which failed `CLA Check` with this exact condition while CI itself was green. Fixed there in vecq#14 with an exact allowlist; this PR mirrors that fix.

Exact allowlist only — deliberately **not** a `[bot]` substring match: any third-party GitHub App can author PRs as `their-app[bot]`, and a substring match would exempt arbitrary apps from the CLA (flagged by cora review in vecq#14). The legacy `app/dependabot` / `app/renovate` forms are kept as fallbacks.

## Testing

- [x] Condition shape verified identical to the merged, production-proven vecq#14 allowlist (diffed directly against `vecq/.github/workflows/cla-check.yml:20`)
- [x] YAML syntactically valid (parser accepted the edit; workflow unchanged elsewhere)
- [x] Human PRs unaffected: `ajianaz` not in allowlist → job still runs for human authors
- [x] cora review: no findings
- [ ] CI green on this PR (CLA Check should pass — author is a signed CLA contributor)