### PR TITLE
fix(cli): repair --reembed report reflects final index state (#1149)

### DIFF
--- a/crates/uteke-cli/src/commands/maintenance.rs
+++ b/crates/uteke-cli/src/commands/maintenance.rs
@@ -63,19 +63,37 @@ pub(crate) fn run_repair(
         tracing::info!("Running repair");
     }
 
-    let report = uteke.repair().map_err(|e| format!("Repair failed: {e}"))?;
+    let mut report = uteke.repair().map_err(|e| format!("Repair failed: {e}"))?;
+
+    // Optional: re-embed memories with missing vectors.
+    // Runs BEFORE the Repair Report is printed so `index_after` and the
+    // "still differs" warning reflect the final state, not the intermediate
+    // rebuild that legitimately excludes NULL/empty-embedding rows (#1149).
+    let reembed_report = if reembed {
+        tracing::info!("Running repair --reembed (regenerating missing embeddings)");
+        match uteke.reembed_missing() {
+            Ok(r) => {
+                // Refresh the vector count to include newly appended vectors.
+                if let Ok(v) = uteke.verify() {
+                    report.index_after = v.index_count;
+                }
+                Some(Ok(r))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    } else {
+        None
+    };
+
+    // Repair itself succeeded — always print its report (even if reembed failed).
     if cli.json {
         output::print_json(&report);
     } else {
         output::print_repair_human(&report);
     }
 
-    // Optional: re-embed memories with missing vectors.
-    if reembed {
-        tracing::info!("Running repair --reembed (regenerating missing embeddings)");
-        let reembed_report = uteke
-            .reembed_missing()
-            .map_err(|e| format!("Re-embed failed: {e}"))?;
+    if let Some(result) = reembed_report {
+        let reembed_report = result.map_err(|e| format!("Re-embed failed: {e}"))?;
         if cli.json {
             output::print_json(&reembed_report);
         } else {


### PR DESCRIPTION
## What (description of the change)

`run_repair` now runs `reembed_missing()` **before** printing the Repair Report and refreshes `report.index_after` from `verify()` after the re-embed pass. The report (and its `⚠ Index count still differs` warning) now reflects the final index state instead of the intermediate rebuild that legitimately excludes NULL/empty-embedding rows. The repair report is still printed even when reembed fails, so operators always see the repair outcome.

## Why (reasoning and context)

Closes #1149. Found during the post-merge E2E retest of #1147: the Repair Report printed `Index after: 0 vectors` + `⚠ Index count still differs from DB` immediately above a successful "Re-embedded 2/2" summary — because `repair()`'s rebuild drops invalid-embedding rows by design, and the CLI printed that stale count before `reembed_missing()` appended the repaired vectors. Same stale-display pattern as #1117. Plain `repair` (no `--reembed`) keeps warning honestly when rows remain unrepaired.

## Testing (how the change was tested)

- E2E on an isolated store (`/tmp/uteke-t1149`, real ONNX embedder, no SQL workaround):
  - 2 rows corrupted (1× `embedding = NULL`, 1× `embedding = X''`) → `repair --reembed` → **`Index after: 2 vectors` + `✓ Index rebuilt successfully`**, no false warning; `doctor` green afterwards.
  - Plain `repair` on a 1-NULL-row store → `index_after=0` + `⚠ still differs` **kept** (rows genuinely unrepaired — operator is correctly told to run `--reembed`).
- `cargo test -p uteke-core --lib`: 524 passed, 0 failed.
- `cargo test -p uteke-cli`: 52 passed, 0 failed.
- `cargo check` clean; pre-push cora review: no issues.

Fixes #1149