### PR TITLE
chore(ci): bump actions/github-script from v7 to v9

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Comment on PR (unsigned only)
         if: steps.check.outputs.signed != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const author = '${{ github.event.pull_request.user.login }}';
@@ -97,7 +97,7 @@ jobs:
             }
 
       - name: Set commit status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const signed = '${{ steps.check.outputs.signed }}' === 'true';


### PR DESCRIPTION
## What (description of the change)

Bump `actions/github-script` from v7 to v9 in both steps of `cla-check.yml` (comment + commit-status steps).

## Why (reasoning and context)

v7 runs on deprecated Node 20 — deprecation warnings visible in recent cla-check run logs (e.g. PR #1097 run). v9 is the current major release (2026-04). No API changes needed: the inputs and `github.rest` surface used by both steps are unchanged.

## Testing (how the change was tested)

- YAML validated after edit
- The cla-check run on this PR itself is the live validation: both github-script steps execute on v9 and must post the CLA comment + commit status exactly as before