### PR TITLE
test(cli,core): env parsing guards + validate_input_with_limits boundary matrix (#1078 P0)

### DIFF
--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -1818,4 +1818,147 @@ max_seq_length = 128
         assert_eq!(cfg.server.port, 8767);
         assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
     }
+
+    // ── #1078 P0 batch 3: score range guards, strategy validation, graph
+    // weights, embed fallback — none previously covered. ─────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_min_score_out_of_range_ignored() {
+        unsafe {
+            std::env::set_var("UTEKE_RECALL_MIN_SCORE", "1.5");
+        }
+        let cfg = Config::default().apply_env_overrides();
+        unsafe {
+            std::env::remove_var("UTEKE_RECALL_MIN_SCORE");
+        }
+        assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_min_score_not_a_number_ignored() {
+        unsafe {
+            std::env::set_var("UTEKE_RECALL_MIN_SCORE", "banana");
+        }
+        let cfg = Config::default().apply_env_overrides();
+        unsafe {
+            std::env::remove_var("UTEKE_RECALL_MIN_SCORE");
+        }
+        assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_strategy_valid_values_accepted() {
+        for v in ["vector", "fts5", "hybrid", "graph", "fusion"] {
+            unsafe {
+                std::env::set_var("UTEKE_RECALL_STRATEGY", v);
+            }
+            let cfg = Config::default().apply_env_overrides();
+            assert_eq!(cfg.recall.default_strategy, v, "strategy {v} rejected");
+        }
+        unsafe {
+            std::env::remove_var("UTEKE_RECALL_STRATEGY");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_strategy_invalid_ignored() {
+        unsafe {
+            std::env::set_var("UTEKE_RECALL_STRATEGY", "quantum");
+        }
+        let cfg = Config::default().apply_env_overrides();
+        unsafe {
+            std::env::remove_var("UTEKE_RECALL_STRATEGY");
+        }
+        // Invalid strategy keeps the fusion default
+        assert_eq!(cfg.recall.default_strategy, "fusion");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_graph_weights_valid() {
+        unsafe {
+            std::env::set_var("UTEKE_GRAPH_DENSITY_WEIGHT", "0.5");
+            std::env::set_var("UTEKE_GRAPH_AUTHORITY_WEIGHT", "0.7");
+        }
+        let cfg = Config::default().apply_env_overrides();
+        unsafe {
+            std::env::remove_var("UTEKE_GRAPH_DENSITY_WEIGHT");
+            std::env::remove_var("UTEKE_GRAPH_AUTHORITY_WEIGHT");
+        }
+        assert!((cfg.recall.graph_density_weight - 0.5).abs() < f32::EPSILON);
+        assert!((cfg.recall.graph_authority_weight - 0.7).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_graph_weights_out_of_range_ignored() {
+        unsafe {
+            std::env::set_var("UTEKE_GRAPH_DENSITY_WEIGHT", "-1.0");
+            std::env::set_var("UTEKE_GRAPH_AUTHORITY_WEIGHT", "2.0");
+        }
+        let cfg = Config::default().apply_env_overrides();
+        unsafe {
+            std::env::remove_var("UTEKE_GRAPH_DENSITY_WEIGHT");
+            std::env::remove_var("UTEKE_GRAPH_AUTHORITY_WEIGHT");
+        }
+        assert!((cfg.recall.graph_density_weight - 0.1).abs() < f32::EPSILON);
+        assert!((cfg.recall.graph_authority_weight - 0.1).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_override_embed_fallback_all_fields() {
+        unsafe {
+            std::env::set_var("UTEKE_EMBED_FALLBACK_API_KEY", "fb-key");
+            std::env::set_var("UTEKE_EMBED_FALLBACK_BASE_URL", "https://fb.example");
+            std::env::set_var("UTEKE_EMBED_FALLBACK_ENDPOINT_PATH", "/v1/e");
+            std::env::set_var("UTEKE_EMBED_FALLBACK_MODEL", "fb-model");
+        }
+        let cfg = Config::default().apply_env_overrides();
+        unsafe {
+            std::env::remove_var("UTEKE_EMBED_FALLBACK_API_KEY");
+            std::env::remove_var("UTEKE_EMBED_FALLBACK_BASE_URL");
+            std::env::remove_var("UTEKE_EMBED_FALLBACK_ENDPOINT_PATH");
+            std::env::remove_var("UTEKE_EMBED_FALLBACK_MODEL");
+        }
+        assert_eq!(cfg.embed_fallback.api_key, "fb-key");
+        assert_eq!(cfg.embed_fallback.base_url, "https://fb.example");
+        assert_eq!(cfg.embed_fallback.endpoint_path, "/v1/e");
+        assert_eq!(cfg.embed_fallback.model, "fb-model");
+        assert!(cfg.embed_fallback.is_configured());
+    }
+
+    #[test]
+    fn embed_fallback_is_configured_matrix() {
+        // Nothing set — not configured
+        let none = EmbedFallbackConfig {
+            api_key: String::new(),
+            base_url: String::new(),
+            endpoint_path: String::new(),
+            model: String::new(),
+        };
+        assert!(!none.is_configured());
+
+        // Partial (2 of 3 required) — still not configured
+        let partial = EmbedFallbackConfig {
+            api_key: "k".into(),
+            base_url: "u".into(),
+            endpoint_path: String::new(),
+            model: String::new(),
+        };
+        assert!(!partial.is_configured());
+
+        // All three required set — configured (endpoint_path optional)
+        let full = EmbedFallbackConfig {
+            api_key: "k".into(),
+            base_url: "u".into(),
+            endpoint_path: String::new(),
+            model: "m".into(),
+        };
+        assert!(full.is_configured());
+    }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -2408,6 +2408,43 @@ fn resolve_db_path(db_path: &Path) -> Result<String, Error> {
 
 #[cfg(test)]
 mod tests {
+    /// #1078 P0 batch 4: validate_input_with_limits boundary matrix —
+    /// previously zero direct tests on the configurable-limit variant.
+    #[test]
+    fn validate_input_with_limits_matrix() {
+        use super::validate_input_with_limits;
+
+        // 1) happy path
+        assert!(validate_input_with_limits("hello", &["a"], 100, 10, 20).is_ok());
+        // 2) empty content (incl. whitespace-only)
+        assert!(validate_input_with_limits("", &["a"], 100, 10, 20).is_err());
+        assert!(validate_input_with_limits("   \n\t", &["a"], 100, 10, 20).is_err());
+        // 3) content exactly at limit → ok; over limit → err
+        let no_tags: &[&str] = &[];
+        let at = "x".repeat(100);
+        assert!(validate_input_with_limits(&at, no_tags, 100, 10, 20).is_ok());
+        let over = "x".repeat(101);
+        assert!(validate_input_with_limits(&over, no_tags, 100, 10, 20).is_err());
+        // 4) content length check disabled when limit = 0
+        let huge = "x".repeat(500);
+        assert!(validate_input_with_limits(&huge, no_tags, 0, 10, 20).is_ok());
+        // 5) tags exactly at count limit → ok; over → err
+        let ten: Vec<&str> = vec!["t"; 10];
+        assert!(validate_input_with_limits("c", &ten, 100, 10, 20).is_ok());
+        let eleven: Vec<&str> = vec!["t"; 11];
+        assert!(validate_input_with_limits("c", &eleven, 100, 10, 20).is_err());
+        // 6) empty tag string rejected
+        assert!(validate_input_with_limits("c", &[""], 100, 10, 20).is_err());
+        // 7) tag exactly at length limit → ok; over → err
+        let tag_at = "y".repeat(20);
+        assert!(validate_input_with_limits("c", &[&tag_at], 100, 10, 20).is_ok());
+        let tag_over = "y".repeat(21);
+        assert!(validate_input_with_limits("c", &[&tag_over], 100, 10, 20).is_err());
+        // 8) tag length check disabled when limit = 0
+        let tag_huge = "y".repeat(200);
+        assert!(validate_input_with_limits("c", &[&tag_huge], 100, 10, 0).is_ok());
+    }
+
     #[ignore = "requires ONNX embedder — index file extension follows active backend"]
     #[test]
     fn index_file_uses_backend_extension() {


### PR DESCRIPTION
## What
- 8 new tests in `crates/uteke-cli/src/config.rs` covering env override guards previously untested: recall min_score range guard (out-of-range / non-numeric ignored), strategy validation (5 valid values accepted, invalid keeps fusion default), graph weights (valid accepted, out-of-range ignored), embed fallback env overrides (all 4 fields + `is_configured` matrix none/partial/full)
- 1 boundary matrix test in `crates/uteke-core/src/lib.rs` for `validate_input_with_limits`: empty + whitespace content, content at/over limit, `limit=0` disables content check, tag count at/over, empty tag rejected, tag length at/over, `limit=0` disables tag length check

## Why
`apply_env_overrides` handles 37 env vars with validation guards and had zero tests on the guard branches; `validate_input_with_limits` is the public input-validation API (#404) with zero direct tests. Both listed P0 in the #1078 mutation-coverage audit — silent guard regressions (e.g. accepting out-of-range scores) are correctness risks.

## Testing
- `cargo test -p uteke-cli config::` — 38 passed (30 existing + 8 new)
- `cargo test -p uteke-core --lib validate_input` — 1 passed (555 filtered)
- Full CI on PR