### PR TITLE
docs: refresh documentation for 0.16.0 — fusion default, updated benchmarks, bundled skill bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The new `fusion` strategy — weighted Reciprocal Rank Fusion of the vector and 
 
 ### Validated
 
-- **Full-release validation: pure-default 500Q LongMemEval run (2026-08-29)** — zero-config `--strategy default` on the complete validation set: **R@5 0.946 / R@10 0.977** on 470 non-abstention questions (**+9.2 pts** R@5 vs 0.15.0 hybrid baseline 0.854). Binary built from the exact release SHA; raw per-question results committed under `benchmarks/longmemeval/results_modal_default/` for independent verification.
+- **Full-release validation: pure-default 500Q LongMemEval run (2026-08-29)** — zero-config `--strategy default` on the complete validation set: **R@5 0.946 / R@10 0.977** on 470 non-abstention questions (**+9.2 pts** R@5 vs 0.15.0 hybrid baseline 0.854). Binary built from the exact release SHA; aggregate results in `benchmarks/longmemeval/RESULTS.md`, raw per-question results on the benchmark Modal volume for independent verification.
 - **Public benchmark page + comparison chart (#1141)** — `docs/benchmarks.md` now publishes the dual-metric view from the same run: recall_any@5 **98.2%** (the metric competitor benchmarks publish) alongside the stricter recall_all family (recall_all@10 95.4%, strict recall_all@5 88.0% with mathematical ceiling 99.4%, coverage@5 94.3%). No other system in the comparison publicly reports the strict family.
 
 ## [0.15.0] — 2026-08-19

--- a/README.id.md
+++ b/README.id.md
@@ -108,7 +108,7 @@ Setiap AI tool lupa. Context window penuh, sesi berakhir, dan AI kamu start over
 | **Setup** | Satu binary | pip + Docker + Qdrant | npm + Docker (iii-engine) | pip + Docker + Postgres | pip + Docker + Neo4j | Satu binary (Go) |
 | **API key** | ❌ Nggak perlu | ✅ OpenAI/LLM | ✅ LLM key | ✅ LLM key | ✅ LLM key | ❌ Nggak perlu |
 | **Offline** | ✅ Full | ❌ Cloud embedding | ❌ Butuh LLM | ❌ Butuh LLM | ❌ Butuh LLM + vector DB | ✅ Full |
-| **Search** | **Hybrid** (Vector + FTS5 + RRF) | Vector + Graph | Vector + Graph | Vector | Temporal Graph | **FTS5 doang** |
+| **Search** | **Fusion** (weighted RRF vector + hybrid; hybrid = HNSW + FTS5 RRF) | Vector + Graph | Vector + Graph | Vector | Temporal Graph | **FTS5 doang** |
 | **Kecepatan recall** | ~45ms | Network round-trip | Network round-trip | Network round-trip | Network round-trip | ~Cepat (lokal) |
 | **Data kamu** | ✅ Nggak pernah keluar | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ✅ Lokal |
 | **Stars** | 🌱 Growing | ⭐ ~60K | ⭐ ~25K | ⭐ ~24K | ⭐ ~5K | ⭐ ~5K |
@@ -171,7 +171,7 @@ uteke recall "caching decision" --room engineering
 
 | Fitur | Apa fungsinya |
 |-------|---------------|
-| 🧠 **Hybrid Search** | Cari berdasarkan makna (vector) + kata kunci exact (FTS5). Digabung dengan Reciprocal Rank Fusion (RRF). |
+| 🧠 **Hybrid + Fusion Search** | Cari berdasarkan makna (vector) + kata kunci exact (FTS5). Digabung dengan Reciprocal Rank Fusion (RRF). Sejak v0.16.0, `fusion` — weighted RRF dari ranking vector dan hybrid — jadi default recall strategy. |
 | 🏠 **Rooms** | **Shared memory multi-agent.** Kelompokkan memori berdasarkan konteks (meeting, project, klien). Multiple agent baca/tulis ke room yang sama dengan atribusi author. Cross-agent recall tanpa sync manual. |
 | ⏳ **Time-travel** | Recall memori seperti adanya di titik waktu manapun. `uteke recall "deploy" --at 2025-01-15` |
 | 🏷️ **Metadata Kaya** | Tag, entity, kategori, key:value di setiap memori. |
@@ -210,7 +210,7 @@ uteke recall "caching decision" --room engineering
 | 🔥 **Tiered Memory** | Tracking Hot/Warm/Cold dengan auto-cleanup memori basi. |
 | 🔄 **Embed Fallback** | Degrade ke no-op embedder kalau local model gagal (nggak pernah crash). |
 | 👥 **Namespace Multi-Agent** | Memori terisolasi penuh per agent, tanpa overhead. |
-| 📊 **Benchmark** | `uteke bench` untuk perf testing. [Lihat hasil](docs/BENCHMARKS.md). |
+| 📊 **Benchmark** | `uteke bench` untuk perf testing. [Lihat hasil](docs/benchmarks.md). |
 
 <details>
 <summary>🔌 Konfigurasi MCP Server — connect ke Claude Code, Cursor, Hermes</summary>
@@ -299,7 +299,7 @@ Bisa. Uteke punya MCP server yang langsung pakai dengan Claude Code, Cursor, dan
 <details>
 <summary><strong>Sudah production-ready?</strong></summary>
 
-Uteke sekarang v0.14.3 dengan 530+ test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
+Uteke sekarang v0.16.0 dengan 200+ test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
 </details>
 
 ---
@@ -308,7 +308,7 @@ Uteke sekarang v0.14.3 dengan 530+ test, CI/CD di setiap commit, dan benchmark h
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (530+ test)
+cargo test --workspace         # Test (200+ test)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Every AI tool forgets. Context windows fill up, sessions end, and your AI starts
 | **Setup** | One binary (`curl \| sh`) | pip install + venv | pip + Docker + Qdrant | npm + iii-engine | npm (Node.js) | pip + Docker + Neo4j | Cloud or local binary | One binary |
 | **API keys** | ❌ None | ⚠️ For remote embeddings | ✅ OpenAI/LLM | ✅ LLM key | ✅ LLM key | ✅ LLM key | ⚠️ Cloud only | ❌ None |
 | **Works offline** | ✅ Fully | ⚠️ Optional | ❌ Cloud embedding | ❌ Needs LLM | ❌ Needs LLM | ❌ Needs LLM + vector DB | ✅ Local binary + Ollama | ✅ Fully |
-| **Search** | **Hybrid** (Vector + FTS5 + RRF) | sqlite-vec + FTS5 | Vector + Graph | Vector + Graph | Vector | Hybrid (semantic + keyword + graph) | Vector + rerank | **FTS5 only** |
+| **Search** | **Fusion** (weighted RRF of vector + hybrid; hybrid = HNSW + FTS5 RRF) | sqlite-vec + FTS5 | Vector + Graph | Vector + Graph | Vector | Hybrid (semantic + keyword + graph) | Vector + rerank | **FTS5 only** |
 | **Recall speed** | ~45ms | ~50ms+ | Network round-trip | Network round-trip | Network round-trip | Network round-trip | Network round-trip | ~Fast (local) |
 | **Multi-agent** | ✅ **Rooms** (shared memory, cross-agent recall, author attribution) | ✅ Multi-agent surface | ❌ | ✅ Shared server | ✅ Multi-agent groups | ❌ | ❌ | ⚠️ Shared via MCP |
 | **Time-travel** | ✅ Native point-in-time | ⚠️ Temporal triples | ❌ | ❌ | ❌ | ✅ Temporal graphs | ❌ | ❌ |
@@ -142,9 +142,9 @@ Every AI tool forgets. Context windows fill up, sessions end, and your AI starts
 | **Recall latency (10K memories)** | **42ms** P50, 50ms P95 | Flat from 100 to 10K memories (HNSW O(log N)) |
 | **Insert throughput** | 6-22 ops/s | CPU-bound (ONNX embedding inference) |
 | **Storage per memory** | ~10KB | SQLite + HNSW, scales linearly |
-| **LongMemEval Recall@5** | **0.958** | 12-question diverse sample, EmbeddingGemma Q4 |
+| **LongMemEval Recall@5** | **0.946** | Full 500Q validation, zero-config fusion default (R@10 0.977), EmbeddingGemma Q4 |
 
-Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark details](docs/benchmarks.md) · [LongMemEval results](benchmarks/longmemeval/RESULTS.md)
+Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark details](docs/benchmarks.md) · [LongMemEval results](benchmarks/longmemeval/RESULTS.md) — fusion default: R@5 0.946 / R@10 0.977 on the full 500Q validation set (v0.16.0)
 
 </details>
 
@@ -201,7 +201,7 @@ uteke recall "caching decision" --room engineering
 
 | Feature | What it does |
 |---------|-------------|
-| 🧠 **Hybrid Search** | Vector similarity + FTS5 full-text search, merged by Reciprocal Rank Fusion (RRF). Finds by meaning AND exact keywords. |
+| 🧠 **Hybrid + Fusion Search** | Vector similarity + FTS5 full-text search, merged by Reciprocal Rank Fusion (RRF). Since v0.16.0, `fusion` — a weighted RRF of the vector and hybrid rankings — is the default recall strategy. Finds by meaning AND exact keywords. |
 | 🏠 **Rooms** | **Multi-agent shared memory.** Group memories by context (meetings, projects, clients). Multiple agents read/write to the same room with author attribution. Cross-agent recall without manual sync. |
 | ⏳ **Time-travel** | Recall memories as they existed at any point in time. `uteke recall "deploy" --at 2025-01-15` |
 | 🏷️ **Rich Metadata** | Tags, entities, categories, key:value pairs on every memory. |
@@ -220,6 +220,7 @@ uteke recall "caching decision" --room engineering
 | 📈 **Salience + Recency** | Dual-axis recall boost by memory type and age. |
 | 🔍 **Orphan Detection** | Find disconnected, low-importance memories for cleanup. |
 | 🌙 **Dream Cycle** | One-command maintenance: lint → backlinks → dedup → orphans. |
+| 🧬 **Consolidation** | Merge near-duplicate room memories into fewer, denser records — segment-level planner, provenance trust policy, per-pair control. (0.16.0) |
 
 ### Integrations
 
@@ -231,6 +232,7 @@ uteke recall "caching decision" --room engineering
 | 📝 **Document Engine** | Wiki/knowledge base with `uteke doc create/get/list` and auto-chunking. |
 | 📥 **Import/Export** | JSONL-based backup and restore. |
 | 🔑 **View-Only API Keys** | Read-only tokens for safe GET-only access to the server. |
+| 👤 **Author Types** | `human` vs `agent` attribution on every memory, across CLI, HTTP, and MCP. (0.16.0) |
 
 ### Performance & Privacy
 
@@ -243,7 +245,7 @@ uteke recall "caching decision" --room engineering
 | 🔥 **Tiered Memory** | Hot/Warm/Cold tracking with auto-cleanup of stale memories. |
 | 🔄 **Embed Fallback** | Gracefully degrades to no-op embedder if local model fails (never crashes). |
 | 👥 **Multi-Agent Namespaces** | Fully isolated memory per agent, zero overhead. |
-| 📊 **Benchmarks** | Built-in `uteke bench` for perf testing. [See results](docs/BENCHMARKS.md). |
+| 📊 **Benchmarks** | Built-in `uteke bench` for perf testing. [See results](docs/benchmarks.md). |
 
 <details>
 <summary>🔌 MCP Server config: connect to Claude Code, Cursor, Hermes</summary>
@@ -376,7 +378,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.14.3 with 530+ tests, CI/CD on every commit, and benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x, so expect rough edges, but the core is stable.
+Uteke is at v0.16.0 with 200+ tests, CI/CD on every commit, and a benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x, so expect rough edges, but the core is stable.
 </details>
 
 ---
@@ -385,7 +387,7 @@ Uteke is at v0.14.3 with 530+ tests, CI/CD on every commit, and benchmark harnes
 
 ```bash
 cargo build --workspace        # Build
-cargo test --workspace         # Test (530+ tests)
+cargo test --workspace         # Test (200+ tests)
 cargo clippy -- -D warnings    # Lint
 cargo fmt                      # Format
 ```

--- a/crates/uteke-cli/assets/uteke-memory-skill.md
+++ b/crates/uteke-cli/assets/uteke-memory-skill.md
@@ -1,11 +1,11 @@
 ---
-description: "Persistent memory engine for AI agents via the uteke CLI — remember, recall, search, forget with semantic + FTS5 hybrid search, documents, knowledge graph, rooms, tiered memory, and multi-agent namespaces."
+description: "Persistent memory engine for AI agents via the uteke CLI — remember, recall, search, forget with hybrid + fusion semantic search (fusion default since 0.16.0), documents, knowledge graph, rooms, tiered memory, and multi-agent namespaces."
 ---
 
 # Uteke Memory Skill
 
 Persistent memory engine for AI agents via the `uteke` CLI.
-Version: **0.10.0** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Zero unsafe code.
+Version: **0.16.0** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60); `fusion` (weighted RRF of the vector and hybrid rankings) is the default recall strategy since 0.16.0. Zero unsafe code.
 
 > **Hermes integration:** Install the `uteke-memory` plugin for automatic recall
 > on every turn via the `pre_llm_call` hook. No shell hook or daemon needed.
@@ -29,7 +29,7 @@ Version: **0.10.0** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Z
 | Command | Description | Key Options |
 |---------|-------------|-------------|
 | `uteke remember <TEXT>` | Store a new memory | `--tags`, `--type`, `--entity`, `--category`, `--meta`, `--room`, `--author`, `--source`, `--source-type`, `--detect-contradiction` |
-| `uteke recall <QUERY>` | Hybrid search (vector + FTS5, RRF) | `--limit`, `--tags`, `--entity`, `--category`, `--min`, `--strategy` (vector/fts5/hybrid/graph), `--salience`, `--recency`, `--related`, `--depth`, `--context`, `--at` (time-travel), `--type` (all/memory/doc), `--where` (JSON field filter) |
+| `uteke recall <QUERY>` | Fusion search (default since 0.16.0 — weighted RRF of vector + hybrid rankings) | `--limit`, `--tags`, `--entity`, `--category`, `--min`, `--strategy` (fusion/vector/fts5/hybrid/graph), `--salience`, `--recency`, `--related`, `--depth`, `--context`, `--at` (time-travel), `--type` (all/memory/doc), `--where` (JSON field filter) |
 | `uteke search <QUERY>` | Keyword text search | `--limit`, `--tags` |
 | `uteke list` | List memories with filters | `--tag`, `--entity`, `--category`, `--limit`, `--offset`, `--at` |
 | `uteke get <ID>` | Get single memory by UUID | |
@@ -94,7 +94,8 @@ Version: **0.10.0** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Z
 
 | Command | Description | Key Options |
 |---------|-------------|-------------|
-| `uteke dream` | Full maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify | `--phases`, `--skip`, `--dry-run`, `--quiet` |
+| `uteke dream` | Full maintenance pipeline: lint → backlinks → dedup → orphans → compact → verify (dry-run first by default) | `--phases`, `--skip`, `--dry-run`, `--quiet` |
+| `uteke lifecycle <cycle\|promote\|status>` | Safe lifecycle: soft-deprecate aged memories, promote back, status | `--namespace` |
 | `uteke consolidate` | Merge near-duplicate memories | `--threshold` (default 0.90), `--dry-run` |
 | `uteke prune` | Remove deprecated/expired memories | `--ttl` (default 30), `--dry-run` |
 | `uteke timeline <ID>` | Show audit log events for a memory | `--limit` (default 20) |
@@ -139,12 +140,14 @@ Version: **0.10.0** — SQLite + usearch HNSW + FTS5 hybrid search (RRF k=60). Z
 | `uteke hook install <SHELL>` | Install shell hook (bash/zsh/fish) |
 | `uteke completions <SHELL>` | Generate shell completions (bash/zsh/fish/powershell) |
 | `uteke upgrade` | Check for updates and upgrade | `-y` (skip confirmation) |
+| `uteke onboard` | Interactive setup wizard: detect install, pick agent, toggle features, write config | `--yes --agent <TYPE>` |
 
 ## Architecture
 
 - **Storage:** SQLite (WAL mode) with namespace column + FTS5 virtual table
 - **Vector index:** usearch persistent HNSW (768d, cosine similarity)
 - **Hybrid search:** RRF (k=60) merges vector + FTS5 results; graph strategy adds graph-signal reranking
+- **Fusion (default since 0.16.0):** weighted RRF of the vector and hybrid rankings — LongMemEval 500Q R@5 0.946
 - **Embedding:** ONNX EmbeddingGemma Q4 (768d), auto-downloaded
 - **Tiered memory:** Hot (<7d, +0.1 boost), Warm (<30d), Cold (>30d)
 - **Schema versioning:** Integer counter, auto-migration on upgrade

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,7 @@ title: Architecture
 | Vector Index | usearch + RwLock | Persistent HNSW, concurrent reads via RwLock |
 | Full-Text Search | SQLite FTS5 | Built-in, auto-created, phrase + token-OR fallback |
 | Hybrid Search | RRF (k=60) | Merges vector + FTS5 via Reciprocal Rank Fusion |
+| Fusion (default) | weighted RRF | Since 0.16.0: fuses the vector and hybrid rankings (#1123) |
 | Storage | SQLite (rusqlite) | Embedded, zero-config, battle-tested |
 | Embedding | EmbeddingGemma Q4 ONNX | 768d vectors, multilingual, downloaded on first run |
 | Namespaces | SQLite column | Multi-agent isolation, zero overhead |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -114,7 +114,7 @@ the same data.
   published benchmark documents (accessed Aug 2026) and differ in embedding
   models and pipeline details.
 - The FTS5-only bar is an ablation of our own system, not a competitor.
-- Raw per-question results for the uteke run: `benchmarks/longmemeval/results_modal_default/` in this repo.
+- Aggregate metrics + per-type breakdown: `benchmarks/longmemeval/RESULTS.md` in this repo. Raw per-question results are kept on the benchmark Modal volume (`uteke-longmemeval`, `default/` prefix), not committed here.
 
 ## Environment
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,7 +108,7 @@ uteke remember "User prefers dark mode" --tags pref --namespace my-agent
 
 ## uteke recall
 
-Unified search combining vector similarity with FTS5 full-text search, ranked by Reciprocal Rank Fusion (RRF). Searches **both memories and documents** by default (unified mode). Hot memories (accessed within 7 days) get a score boost.
+Unified search combining vector similarity with FTS5 full-text search, ranked by Reciprocal Rank Fusion (RRF). Default strategy since v0.16.0: **fusion** — a weighted RRF of the vector and hybrid rankings. Searches **both memories and documents** by default (unified mode). Hot memories (accessed within 7 days) get a score boost.
 
 ```bash
 uteke recall "What framework does the API use?"
@@ -309,8 +309,9 @@ uteke recall "deployment process" --at 2026-06-01T12:00:00Z
 # Relationship graph traversal
 uteke recall "auth" --related --depth 2
 
-# Recall strategy (vector | fts5 | hybrid | graph)
-uteke recall "auth" --strategy hybrid   # default — vector + FTS5 (RRF fusion)
+# Recall strategy (fusion | vector | fts5 | hybrid | graph)
+uteke recall "auth" --strategy fusion   # default since 0.16.0 — weighted RRF of vector + hybrid rankings
+uteke recall "auth" --strategy hybrid   # vector + FTS5 fused via RRF (k=60)
 uteke recall "auth" --strategy vector   # vector similarity only
 uteke recall "auth" --strategy fts5     # full-text search only
 uteke recall "auth" --strategy graph    # hybrid + graph-signal reranking (#378)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,10 +196,12 @@ min_score = 0.3
 min_score_strict = 0.5
 
 # Default recall strategy for `uteke recall` when --strategy is not given.
-# One of: vector | fts5 | hybrid | graph.
+# One of: fusion | vector | fts5 | hybrid | graph.
+#   fusion — weighted RRF of the vector and hybrid rankings (default since 0.16.0;
+#            LongMemEval 500Q R@5 0.946 vs 0.854 hybrid, #1123)
 #   vector — vector similarity only (original behavior)
 #   fts5   — full-text search only
-#   hybrid — vector + FTS5 fused via Reciprocal Rank Fusion (default)
+#   hybrid — vector + FTS5 fused via Reciprocal Rank Fusion (k=60)
 #   graph  — hybrid + graph-signal reranking (#378): well-connected memories
 #            get a subtle log-scaled score boost
 default_strategy = "fusion"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ The wizard covers:
 uteke remember --tags project "My app uses SvelteKit 5 with Tailwind" \
   --entity my-app --category frontend
 
-# Hybrid search (vector + FTS5, ranked by RRF)
+# Fusion recall — weighted RRF of vector + hybrid rankings (default since 0.16.0)
 uteke recall "What frontend framework do I use?"
 
 # Filter by entity or category

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ hero:
 features:
   - icon: 🧠
     title: Semantic Memory
-    details: AI remembers by meaning, not keywords. Local ONNX embeddings (768d) with usearch persistent HNSW index. Hybrid search via FTS5 + RRF.
+    details: AI remembers by meaning, not keywords. Local ONNX embeddings (768d) with usearch persistent HNSW index. Hybrid search (FTS5 + RRF) with fusion as the default strategy since 0.16.0.
   - icon: 📦
     title: Single Binary
     details: Zero dependencies. No Docker, no database server, no Python, no API keys.

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Pin a specific version:
 
 ```bash
-UTEKE_VERSION=v0.14.3 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.16.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ## Install via Cargo
@@ -40,19 +40,19 @@ Download from [GitHub Releases](https://github.com/codecoradev/uteke/releases):
 
 ```bash
 # Linux (x86_64)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-v0.14.3.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-v0.16.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # Linux (x86_64, legacy — no AVX2/SSE4.2)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-legacy-v0.14.3.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-legacy-v0.16.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # Linux (aarch64 / ARM)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-unknown-linux-gnu-v0.14.3.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-unknown-linux-gnu-v0.16.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-apple-darwin-v0.14.3.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-apple-darwin-v0.16.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -137,7 +137,7 @@ Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 | Tool | Description |
 |------|-------------|
 | `uteke_remember` | Store a memory (supports type, room, author, tags) |
-| `uteke_recall` | Semantic search (supports tags filter, min_score, strategy: hybrid/vector/fts5/graph — default hybrid) |
+| `uteke_recall` | Semantic search (supports tags filter, min_score, strategy: fusion/vector/fts5/hybrid/graph — default `fusion` since 0.16.0) |
 | `uteke_search` | Text search with optional tag filter |
 | `uteke_list` | List memories (supports pagination via offset) |
 | `uteke_get` | Fetch a single memory's full record by id — no truncation (accepts UUID or unambiguous prefix) |

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -99,4 +99,4 @@ Some mutants produce identical behavior regardless of tests. These are documente
 
 5 chunker mutants cause **infinite loops** (progress guard mutations) — the test binary hangs and cargo-mutants reports TIMEOUT. These are counted as caught-in-spirit: no test can terminate an infinite loop.
 
-Last updated: v0.14.1
+Last updated: v0.16.0

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,22 @@ title: Roadmap
 
 Demand-gated — we build what people actually use. Track progress on [GitHub Issues](https://github.com/codecoradev/uteke/issues).
 
+## v0.16.0 — Fusion Default `✓ Released 2026-08-29`
+
+- **`fusion` is now the default recall strategy (#1123)** — weighted RRF of the vector and hybrid rankings; LongMemEval 500Q R@5 0.946 vs 0.854 hybrid (+9.2 pts), zero config needed
+- Public benchmark page: dual-metric view (recall_any + strict recall_all) with comparison chart (#1141)
+- Full-release validation: 500Q pure-default run, binary built from the exact release SHA
+- Post-release fixes: `repair --reembed` handles NULL-embedding rows (#1146), CLA check bot allowlist (#1132), repair report reflects final index state (#1149)
+
+## v0.15.0 — Trust Across Surfaces, Portable Store `✓ Released 2026-08-19`
+
+- **Supersession workflow (#1069)** — mark a stale decision as superseded by a newer one; recall flags superseded entries
+- **Structural export/import (#1068)** — full-store round-trip (rooms, graph, edges, documents, timeline) without loss
+- UUIDv7 IDs for new memories — time-ordered at the front
+- MCP `uteke_get` + `uteke_update` (#1067), richer MCP outputs (#1066)
+- `uteke_dream` runs dry-run first — destructive passes need explicit confirmation (#1065)
+- `/export` keeps namespace attribution (#1064); recall cache score parity (#1063)
+
 ## v0.14.0–v0.14.3 — Hybrid Default, Scene Extraction, Surface Parity `✓ Released 2026-08-14–15`
 
 - **Hybrid (RRF) is now the default recall strategy (#1005)** — recall@5 85.4% → 98.0%; revert via `strategy = "vector"` in `[recall]`


### PR DESCRIPTION
## What

Carry of #1156 (merged to develop) to `main` via `chore/release-*` branch per the Source Branch policy (PRs into main must come from develop or chore/release-*; precedent: #1042 `chore/carry-fix-1041-to-main`).

Post-release documentation refresh for v0.16.0 (released 2026-08-29):

- **README.md + README.id.md**: version claim v0.14.3 → v0.16.0; test count 530+ → 200+ (grep-verified); comparison Search column leads with **Fusion** (default); features add Consolidation + Author Types (0.16.0); benchmark teaser → full 500Q validation (R@5 0.946 / R@10 0.977); fixed broken `docs/BENCHMARKS.md` link
- **Bundled skill asset** (ships in binary via `include_str!`): 0.10.0 → 0.16.0, strategy enum includes `fusion` default, `lifecycle`/`onboard` rows added
- **install.md**: pinned examples v0.14.3 → v0.16.0 (all 4 asset URLs verified HTTP 200)
- **mcp.md / cli-reference.md / configuration.md / getting-started.md / index.md / architecture.md**: fusion documented as default since 0.16.0
- **roadmap.md**: v0.15.0 + v0.16.0 recorded as released
- **CHANGELOG.md + benchmarks.md**: corrected the "raw per-question results committed" claim — that path is gitignored and was never committed; aggregates live in `benchmarks/longmemeval/RESULTS.md`, raw results stay on the Modal benchmark volume. No numbers changed.

## Why

v0.16.0 made `fusion` the default recall strategy and shipped a full 500Q validation, but the public front page, the bundled skill asset (distributed inside every binary), install pins, and several doc pages still described pre-0.15 behavior. A user installing v0.16.0 today reads instructions for v0.14.3 — and the changelog pointed to raw results that were never actually committed, undermining the independent-verification promise. Meanwhile main cannot simply fast-forward to develop (it carries unreleased work), so the doc fix must land on main through the sanctioned chore/release-* carry path to be visible to users who install from main.

## Testing

- Docs-only: no Rust behavior touched; skill asset change is markdown text in an `include_str!` asset, no test asserts its literal content
- Identical content already green on develop via #1156 (all 16 checks passed, merged a0a400d)
- Supersedes #1157 (closed: branch-name policy)