### PR TITLE
docs(contributing): require CLA + state contributions are unpaid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,4 +272,28 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 
-By contributing you agree your work is licensed under [Apache-2.0](LICENSE). No CLA required.
+By contributing you agree your work is licensed under [Apache-2.0](LICENSE).
+
+## CLA
+
+All contributions (code, docs, tests, configuration) require a signed
+Contributor License Agreement before a pull request can be merged:
+
+- 📋 **Individual?** → [Sign the Individual CLA](https://codecoradev.github.io/cla/?type=individual)
+- 🏢 **Contributing on behalf of a company?** → [Sign the Corporate CLA](https://codecoradev.github.io/cla/?type=corporate)
+
+The CLA is a license agreement, not a copyright assignment — you keep
+ownership of your work. Signing takes a couple of minutes and is stored
+in the [codecoradev/.github](https://github.com/codecoradev/.github)
+repository; a bot checks it automatically on every pull request.
+
+## Contributions are unpaid
+
+Contributing to this project is **voluntary and unpaid**. There is no
+compensation, payment, bounty, or financial reward of any kind for
+contributions — now or in the future. You contribute on your own time,
+at your own discretion, because you want to improve the project.
+
+If any paid-contribution program is ever introduced, it will be announced
+explicitly and this document will be updated. Until then, assume every
+contribution is volunteer work under the Apache-2.0 license terms above.


### PR DESCRIPTION
## What
- Fix contradiction in CONTRIBUTING.md: the License section said "No CLA required" while the active `cla-check.yml` workflow blocks every unsigned PR. Contributors were misled on their first PR and hit the CLA bot unprepared.
- Add a **CLA** section: what it is (license agreement, not copyright assignment), sign links for individual + corporate, and how the automated check works.
- Add a **Contributions are unpaid** section: all contributions are voluntary with no compensation, payment, bounty, or financial reward — now or in the future.

## Why
- Legal/UX hygiene: the docs must match the enforced contribution flow. The CLA gate is real (signatures checked via `codecoradev/.github/.cla/signatures.json`), so the docs claiming otherwise creates a bad first-contributor experience.
- Setting explicit expectations about volunteer status protects both sides — raised during review of the first external contributor issue (#1160).

## Testing
- Markdown-only change; no code touched.
- Verified the CLA bot workflow exists (`.github/workflows/cla-check.yml`) and the sign links match the ones the bot posts on unsigned PRs.