### PR TITLE
build(core): bump vecq-core to 0.3.0 — adopt 4-bit + residual profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,9 +2882,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vecq-core"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07959c480b6d1d1d0d80eb92fa322271d6c2f1ae69529d6b0fbefc6dd4c88693"
+checksum = "543ddd2e748c26c39bd8ca5ab9c43eb01ba0ca13750a1428b08e8c7dc0d9def7"
 
 [[package]]
 name = "version_check"

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 usearch = { version = "2", optional = true }
-vecq-core = { version = "0.1", optional = true }
+vecq-core = { version = "0.3", optional = true }
 uuid = { version = "1", features = ["v4", "v7"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 thiserror = "2"

--- a/crates/uteke-core/src/memory/vector.rs
+++ b/crates/uteke-core/src/memory/vector.rs
@@ -569,7 +569,11 @@ impl VectorIndex {
 
     #[cfg(feature = "vecq")]
     fn create_index(dims: usize) -> Result<VecqIndex, Error> {
-        Ok(VecqIndex::new(dims, VECQ_SEED))
+        // 4-bit base quantization + residual refinement (issue #1161).
+        // `with_residual` pins bits=4 (residual requires the 4-bit width),
+        // improving recall on noise-dominated data at ~2x scan cost while
+        // keeping the same storage footprint as the legacy 0.1 profile.
+        Ok(VecqIndex::with_residual(dims, VECQ_SEED))
     }
 }
 


### PR DESCRIPTION
## What
- Bump `vecq-core` optional dep from `0.1` to `0.3` (`crates/uteke-core/Cargo.toml` + `Cargo.lock`).
- Switch the vecq backend's `create_index()` to `VecqIndex::with_residual(dims, VECQ_SEED)` — 4-bit base quantization + residual refinement. `with_residual` pins `bits=4` internally (residual requires the 4-bit width), so no explicit `set_bits` call is needed.

## Why
- Closes #1161. vecq-core 0.3.0 is live on crates.io and brings the keyed API, Matryoshka working_dim, cascade search, residual mode, configurable width, and zero-copy VecqView.
- **Profile decision (per #1161 discussion): 4-bit + residual** — same storage footprint as the legacy 0.1 profile, better recall on noise-dominated data at ~2x scan cost. Deliberately avoids the new 5-bit default.
- File-format forward lock-in is accepted: SQLite stays the source of truth; `uteke repair` rebuilds the index from stored embeddings if a rollback ever encounters a newer-format index file. 0.3.0 reads all older formats (v1–v1.5), so existing persisted indexes keep working.

## Testing
- `cargo test -p uteke-core --no-default-features --features "onnx,vecq" --lib` → **529 passed, 0 failed** (includes the 8 vector-module tests: roundtrip, save/load, top-k, eviction)
- `cargo test -p uteke-core --lib` (default usearch backend) → **528 passed, 0 failed** — regression-free
- `cargo build -p uteke-cli -p uteke-server -p uteke-mcp --no-default-features --features vecq` → green
- `cargo fmt --all -- --check` → clean
- CI `vecq-check` job will re-verify both feature builds

> Replaces #1163 (closed: `deps/` branch prefix not allowed by the Branch Naming check; `deps` is not a valid conventional-commit type).