### PR TITLE
feat(build): dual-engine default — official binaries ship usearch + vecq

### DIFF
--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -14,9 +14,10 @@ name = "uteke"
 path = "src/main.rs"
 
 [features]
-default = ["usearch"]
-# Vector index backend forwarded to uteke-core. Exactly one must be enabled;
-# default is usearch (HNSW C++ FFI). vecq = pure-Rust 4-bit quantization (#1098).
+# Dual-engine default (#1168): ship BOTH engines, runtime-selectable via
+# UTEKE_VECTOR_BACKEND / [vector] backend. Slim builds: --no-default-features
+# --features vecq (mobile, pure Rust) or --features usearch (classic).
+default = ["usearch", "vecq"]
 usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 

--- a/crates/uteke-core/Cargo.toml
+++ b/crates/uteke-core/Cargo.toml
@@ -11,7 +11,11 @@ categories = ["science", "data-structures"]
 readme = "../../README.md"
 
 [features]
-default = ["onnx", "usearch"]
+# Dual-engine default (#1168): official binaries ship BOTH engines so
+# UTEKE_VECTOR_BACKEND / [vector] backend can switch at runtime.
+# Slim builds: --no-default-features --features "onnx,vecq" (mobile, no C++)
+# or --features "onnx,usearch" (classic single-engine desktop).
+default = ["onnx", "usearch", "vecq"]
 onnx = ["dep:ort", "dep:ndarray", "dep:tokenizers"]
 # Default vector search backend (HNSW, C++ FFI).
 usearch = ["dep:usearch"]

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -2754,8 +2754,6 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn vector_engine_switch_rebuilds_from_sqlite() {
-        use memory::vector::VectorBackend;
-
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("uteke.db");
 

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -21,9 +21,10 @@ name = "uteke_mcp"
 path = "src/lib.rs"
 
 [features]
-default = ["usearch"]
-# Vector index backend forwarded to uteke-core. Exactly one must be enabled;
-# default is usearch (HNSW C++ FFI). vecq = pure-Rust 4-bit quantization (#1098).
+# Dual-engine default (#1168): ship BOTH engines, runtime-selectable via
+# UTEKE_VECTOR_BACKEND / [vector] backend. Slim builds: --no-default-features
+# --features vecq (mobile, pure Rust) or --features usearch (classic).
+default = ["usearch", "vecq"]
 usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -10,10 +10,11 @@ keywords = ["server", "memory", "ai", "http", "embedding"]
 categories = ["web-programming::http-server", "development-tools"]
 
 [features]
-default = ["usearch"]
+# Dual-engine default (#1168): ship BOTH engines, runtime-selectable via
+# UTEKE_VECTOR_BACKEND / [vector] backend. Slim builds: --no-default-features
+# --features vecq (mobile, pure Rust) or --features usearch (classic).
+default = ["usearch", "vecq"]
 docgen = ["dep:schemars"]
-# Vector index backend forwarded to uteke-core. Exactly one must be enabled;
-# default is usearch (HNSW, C++ FFI). vecq = pure-Rust 4-bit quantization (#1098).
 usearch = ["uteke-core/usearch", "uteke-mcp/usearch"]
 vecq = ["uteke-core/vecq", "uteke-mcp/vecq"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     environment:
       # Auth (optional — set UTEKE_AUTH_TOKEN env var to enable)
       # - UTEKE_AUTH_TOKEN
+      # Vector engine (v0.17.0+): usearch (default) or vecq.
+      # Both engines ship in the image; switching rebuilds the index from
+      # SQLite on next start (data is never touched).
+      - UTEKE_VECTOR_BACKEND=${UTEKE_VECTOR_BACKEND:-usearch}
     restart: unless-stopped
     healthcheck:
       # curl is pre-installed in the uteke Docker image (Dockerfile runtime stage)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -101,9 +101,24 @@ docker run -v /path/to/uteke:/data ...
 
 The volume contains:
 - `uteke.db` — SQLite database (memories, metadata, FTS5)
-- `uteke_index.usearch` — HNSW vector index
+- `uteke_index.usearch` — HNSW vector index (default engine)
+- `uteke_index.vecq` — quantized index (created if you switch engines)
 - `uteke_index.keys` — Index key mapping
 - `models/embeddinggemma-q4/` — ONNX embedding model (~188MB)
+
+### Choosing the vector engine (v0.17.0+)
+
+Both engines ship in the image. Pick one via env var — switching leaves your
+data untouched; the new engine rebuilds its index from SQLite on the next start:
+
+```yaml
+environment:
+  - UTEKE_VECTOR_BACKEND=vecq   # or "usearch" (default)
+```
+
+`usearch` (HNSW) has the best query latency at scale; `vecq` (4-bit + residual,
+pure Rust) builds indexes ~16x faster with ~3x smaller files. See
+[configuration](configuration.md#environment-variables) for details.
 
 ## Multi-Architecture
 


### PR DESCRIPTION
## What
- Flip default features to `[onnx, usearch, vecq]` across uteke-core and the three forwarding crates (cli/server/mcp) — official binaries and the Docker image now ship **both** engines, so `UTEKE_VECTOR_BACKEND` / `[vector] backend` runtime selection (#1169) works out of the box.
- Slim builds unchanged: `--no-default-features --features vecq` (mobile, pure Rust, no C++) and `--features usearch` (classic single-engine).
- docker-compose.yml: expose `UTEKE_VECTOR_BACKEND` (default `usearch`).
- docs/docker.md: engine-choice section; volume layout documents `.usearch` + `.vecq` coexisting; switching rebuilds from SQLite, data untouched.

## Why
- Completes the #1168 story for the upcoming 0.17.0: without this, the runtime-switch feature only exists for source builders — official binaries would warn-fallback on any `vecq` preference. With this, release notes can honestly say: one binary, two engines, flip one env var.
- Binary size cost: ~+1 MB (11.86 MB vs ~10.9 MB usearch-only) — acceptable for desktop/server distribution.

## Testing
- `cargo test -p uteke-core --lib` (new dual-engine default): **537 passed, 0 failed**
- `cargo test -p uteke-cli config::`: **45 passed, 0 failed**
- Feature tables verified via TOML parse for all 3 crates
- **Release-binary end-to-end smoke test**: default run writes `uteke_index.usearch`; `UTEKE_VECTOR_BACKEND=vecq` rebuilds and hybrid recall finds the probe (score 1.13); switching back reuses the old `.usearch` file; `UTEKE_VECTOR_BACKEND=bogus` falls back cleanly (exit 0)
- CI will re-verify slim (vecq-check) and default build matrix

> Release 0.17.0 itself stays on hold pending maintainer approval (#1165).