### PR TITLE
docs(bench): independent reproduction results + surfaced headline numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,13 @@ Every AI tool forgets. Context windows fill up, sessions end, and your AI starts
 | **Recall latency (10K memories)** | **42ms** P50, 50ms P95 | Flat from 100 to 10K memories (HNSW O(log N)) |
 | **Insert throughput** | 6-22 ops/s | CPU-bound (ONNX embedding inference) |
 | **Storage per memory** | ~10KB | SQLite + HNSW, scales linearly |
-| **LongMemEval Recall@5** | **0.946** | Full 500Q validation, zero-config fusion default (R@10 0.977), EmbeddingGemma Q4 |
+| **LongMemEval-S recall_any@5** | **98.2%** | Full 500Q validation, zero-config fusion default (v0.16.0) — the metric competitor benchmarks publish |
+| LongMemEval-S recall_all@10 | 95.4% | Strict: every gold session in top-10 |
+| LongMemEval-S strict recall_all@5 | 88.0% | Every gold session in top-5 (mathematical ceiling 99.4%) |
+
+![uteke vs published systems on LongMemEval-S](docs/assets/longmemeval-comparison.jpg)
+
+> **Don't trust our benchmark — run your own.** We re-ran 108 of the 500 published questions on a 4-core ARM desktop (different CPU architecture from the published Modal x86 run, same v0.16.0 binary and harness): **107/108 produced identical per-question rankings**. The single difference was an adjacent-rank near-tie, both runs retrieved the identical top-10 session set, one gold session swapped ranks 5-6. Details in [RESULTS.md](benchmarks/longmemeval/RESULTS.md).
 
 Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark details](docs/benchmarks.md) · [LongMemEval results](benchmarks/longmemeval/RESULTS.md) — fusion default: R@5 0.946 / R@10 0.977 on the full 500Q validation set (v0.16.0)
 

--- a/benchmarks/longmemeval/RESULTS.md
+++ b/benchmarks/longmemeval/RESULTS.md
@@ -5,6 +5,28 @@
 
 ---
 
+## Independent Reproduction (2026-09-01)
+
+The published 500Q run was produced on Modal x86. To test whether the result depends on that infrastructure, a 108-question subset (pref: 30, kupd: 78) was re-run locally on a 4-core ARM desktop (Oracle Ampere A1, aarch64) — same v0.16.0 binary, same harness (`run_eval.py`), different CPU architecture.
+
+| Subset | Questions | Identical per-question rankings | R@5 published | R@5 re-run |
+|---|---|---|---|---|
+| pref | 30 | 30/30 | 96.7% | 96.7% |
+| kupd | 78 | 77/78 | 100.0% | 99.4% |
+| **Total** | **108** | **107/108** | — | — |
+
+**The one divergence** (question `0977f2af`, knowledge-update, 2 gold sessions): both runs retrieved the identical top-10 session set; one gold session sits at rank 5 (published) vs rank 6 (re-run), moving that question's recall_all@5 from 1.0 to 0.5. The harness persists rankings rather than raw scores, so the exact score gap cannot be shown, but the identical top-10 set identifies this as cross-architecture floating-point noise on an RRF near-tie, not a retrieval failure. R@10 = 1.0 in both runs.
+
+**Reproduce:**
+
+```bash
+python3 run_eval.py --data data/subset_kupd.json --output results_rerun --strategy default --resume
+```
+
+Raw artifacts are kept on the benchmark Modal volume (`uteke-longmemeval`, `default/` and rerun prefixes), consistent with the published run — datasets and result JSONL files are not committed to git (see `.gitignore` here; `download_data.sh` fetches the dataset).
+
+---
+
 ## Uteke Retrieval — Strategy Comparison
 
 ### Vector (semantic only)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -116,6 +116,10 @@ the same data.
 - The FTS5-only bar is an ablation of our own system, not a competitor.
 - Aggregate metrics + per-type breakdown: `benchmarks/longmemeval/RESULTS.md` in this repo. Raw per-question results are kept on the benchmark Modal volume (`uteke-longmemeval`, `default/` prefix), not committed here.
 
+### Reproducibility
+
+An independent local re-run (2026-09-01) of 108 of the 500 questions on a 4-core ARM desktop reproduced the published Modal x86 run: **107/108 questions produced identical per-question rankings**. The single difference was an adjacent-rank near-tie (identical top-10 set, one gold session swapped ranks 5-6) from cross-architecture floating-point noise. Aggregate R@5 on the subset: 96.7% / 99.4% (re-run) vs 96.7% / 100.0% (published). See the [Independent Reproduction section in RESULTS.md](../benchmarks/longmemeval/RESULTS.md) for the full table and reproduction command.
+
 ## Environment
 
 | Component | Details |


### PR DESCRIPTION
## What

Three documentation additions from this week's benchmark reproduction exercise:

1. **`benchmarks/longmemeval/RESULTS.md`** — new "Independent Reproduction" section at the top: the published 500Q run (Modal x86) was re-run as a 108-question subset on a 4-core ARM desktop (aarch64), same v0.16.0 binary, same harness. Result: **107/108 questions produced identical per-question rankings**. The single divergence is documented in detail (`0977f2af`: identical top-10 set, one gold session swapped ranks 5-6, RRF near-tie across CPU architectures). Includes the reproduction command.

2. **`README.md`** benchmark details block — surfaced the headline numbers that previously lived only in docs: recall_any@5 **98.2%** (500Q) plus the strict family (recall_all@10 95.4%, strict recall_all@5 88.0% with ceiling), the comparison chart embed, and a "don't trust our benchmark - run your own" callout linking to the reproduction section.

3. **`docs/benchmarks.md`** — new "Reproducibility" subsection under Honesty notes, linking to RESULTS.md for the full table.

## Why

The reproduction exercise (108Q subset, per-question diff vs the published Modal x86 run) is the strongest credibility evidence we have for the published 98.2% claim, and none of it was visible in the surfaces visitors actually read. The blog post published today links to the RESULTS.md reproduction section, so it needs to be live. Honest framing per the dual-metric policy: we report 107/108 and explain the one near-tie rather than claiming perfection.

## Testing

- Markdown link/chart path checks: `docs/assets/longmemeval-comparison.jpg` exists in repo; all relative links resolve (`RESULTS.md`, `docs/benchmarks.md`).
- Numbers cross-checked against `results_rerun_pref/`, `results_rerun_kupd/` local artifacts and the published `results_modal_default/` run (per-question diff script, 2026-09-01).
- No code changes; docs-only. Raw artifacts stay on the Modal volume per existing convention (`.gitignore` in benchmarks/longmemeval/), now stated explicitly in RESULTS.md.