### PR TITLE
fix(room): honest room_delete reporting across CLI/HTTP/MCP

### DIFF
--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -160,14 +160,22 @@ pub(crate) fn run(
                 return Err("Operation not confirmed".to_string());
             }
 
-            uteke
+            let unlinked = uteke
                 .delete_room(room_id)
                 .map_err(|e| format!("Failed to delete room: {e}"))?;
 
             if cli.json {
-                println!("{}", serde_json::json!({"deleted": room_id}));
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "deleted": room_id,
+                        "unlinked_memories": unlinked,
+                    })
+                );
             } else {
-                println!("Room {room_id} deleted. Memories are preserved in their namespaces.");
+                println!(
+                    "Room {room_id} deleted. {unlinked} memory link(s) removed; memories are preserved in their namespaces."
+                );
             }
             Ok(())
         }

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -755,8 +755,19 @@ impl super::Store {
         Ok(Some(enriched))
     }
 
-    /// Delete a room and all its memory links (CASCADE).
-    pub fn delete_room(&self, room_id: &str) -> Result<(), Error> {
+    /// Delete a room (unlink-only).
+    ///
+    /// Removes the room row; the `room_memories` and `room_documents` links
+    /// are removed by `ON DELETE CASCADE`. The linked memories and documents
+    /// themselves are NOT deleted — they remain in their namespaces, now
+    /// orphaned from any room.
+    ///
+    /// Returns the number of memory links that were removed.
+    pub fn delete_room(&self, room_id: &str) -> Result<usize, Error> {
+        let memory_links = self
+            .get_room_memory_ids(room_id, None)
+            .map_err(|e| Error::db_msg(format!("failed to count room memories: {e}")))?
+            .len();
         let rows = self
             .conn
             .execute("DELETE FROM rooms WHERE id = ?1", params![room_id])
@@ -764,7 +775,7 @@ impl super::Store {
         if rows == 0 {
             return Err(Error::db_msg(format!("Room not found: {room_id}")));
         }
-        Ok(())
+        Ok(memory_links)
     }
 
     /// Generate a structured document from room memories, grouped by memory_type.
@@ -1160,7 +1171,8 @@ mod tests {
     fn delete_room_success() {
         let store = Store::open(":memory:").unwrap();
         store.create_room("del-me", None, "default").unwrap();
-        store.delete_room("del-me").unwrap();
+        let unlinked = store.delete_room("del-me").unwrap();
+        assert_eq!(unlinked, 0);
         assert!(store.get_room("del-me").unwrap().is_none());
     }
 
@@ -1186,7 +1198,8 @@ mod tests {
         let ids = store.get_room_memory_ids("cascade-room", None).unwrap();
         assert_eq!(ids.len(), 1);
 
-        store.delete_room("cascade-room").unwrap();
+        let unlinked = store.delete_room("cascade-room").unwrap();
+        assert_eq!(unlinked, 1);
         // Memory itself survives — only the room_memories link is cascade-deleted
         assert!(store.get_by_id("mem-1").unwrap().is_some());
         // Room is gone, so recall_room should return empty (room doesn't exist)

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -184,9 +184,10 @@ impl crate::Uteke {
         Ok(results)
     }
 
-    /// Delete a room and all its memory links.
-    /// Note: memories themselves are NOT deleted — they remain in their namespaces.
-    pub fn delete_room(&self, room_id: &str) -> Result<(), Error> {
+    /// Delete a room (unlink-only).
+    /// Returns the number of memory links removed; memories and documents
+    /// themselves are NOT deleted — they remain in their namespaces.
+    pub fn delete_room(&self, room_id: &str) -> Result<usize, Error> {
         self.store.delete_room(room_id)
     }
 

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -1856,14 +1856,18 @@ fn exec_room_list(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
 fn exec_room_delete(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
     let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
 
-    uteke
+    let unlinked = uteke
         .delete_room(room_id)
         .map_err(|e| format!("Failed to delete room: {e}"))?;
+
+    let text = format!(
+        "Room '{room_id}' deleted. {unlinked} memory link(s) removed; the memories themselves are preserved in their namespaces (no longer linked to any room)."
+    );
 
     Ok(ToolResult {
         content: vec![McpContent::Text {
             r#type: "text".to_string(),
-            text: format!("Room deleted: {room_id}"),
+            text,
         }],
         is_error: false,
     })

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -314,7 +314,7 @@ pub const ENDPOINTS: &[Endpoint] = &[
     Endpoint {
         method: "DELETE",
         path: "/room/delete",
-        description: "Delete a room and all its memories. Accepts `?room_id=...` query param.",
+        description: "Delete a room (unlink-only): room links are removed, memories and documents are preserved. Response: `{ deleted, unlinked_memories }`. Accepts `?room_id=...` query param.",
         request_type: None,
         response_type: None,
         excludes_deprecated: false,

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -1641,7 +1641,14 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
                 }
             };
             match uteke.delete_room(&room_id) {
-                Ok(()) => ctx.ok_response_for(req, &serde_json::json!({"deleted": room_id})),
+                Ok(unlinked) => ctx.ok_response_for(
+                    req,
+                    &serde_json::json!({
+                        "deleted": room_id,
+                        "unlinked_memories": unlinked,
+                        "note": "memories and documents are preserved in their namespaces, no longer linked to any room"
+                    }),
+                ),
                 Err(e) => {
                     let msg = format!("{e}");
                     if msg.contains("not found") {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -367,7 +367,7 @@ List all memories in a room (chronological). Accepts `?room_id=...` query param.
 
 #### 🔴 `DELETE` `/room/delete`
 
-Delete a room and all its memories. Accepts `?room_id=...` query param.
+Delete a room (unlink-only): room links are removed, memories and documents are preserved. Response: `{ deleted, unlinked_memories }`. Accepts `?room_id=...` query param.
 
 #### 🟡 `POST` `/room/document`
 


### PR DESCRIPTION
## What

- `delete_room()` (store + facade) now returns the number of memory links removed by the cascade, instead of `()`
- `DELETE /room/delete` response becomes `{ deleted, unlinked_memories, note }`
- MCP `uteke_room_delete` reports the actual link count instead of a fixed claim
- CLI `room delete` prints the count; `--json` output includes `unlinked_memories`
- Fixed misleading registry description ("Delete a room **and all its memories**") and regenerated `docs/api-reference.md` via docgen

## Why

Closes #1173. Incident on 2026-08-31 (room `codecora-product`): the Hermes tool called room_delete, all room memory links were removed by cascade, yet the tool replied "memories preserved" — while the API registry claimed the opposite ("and all its memories"). Both messages were wrong; the room-scoped memories became unreachable from any room path even though rows survive in the store. Forensics show core semantics were already unlink-only at HEAD and v0.13.x; the defect is reporting/documentation, not data handling.

## Testing

- `cargo fmt` + `cargo clippy --workspace --all-targets` clean
- `cargo test --workspace`: 629 passed, 0 failed (incl. updated `delete_room_success` / `delete_room_cascades_room_memories`)
- Live CLI smoke (scratch store): room with 2 memories → delete → reply "2 memory link(s) removed; memories are preserved"; all 3 test memories still searchable in store; room recall empty
- Live HTTP smoke (`uteke-serve`, scratch store): `DELETE /room/delete?room_id=...` → `{"deleted":"http-demo","unlinked_memories":1,"note":"..."}`; memory still retrievable via `POST /search`
- docgen regenerated and idempotent (no CI staleness)