### PR TITLE
feat(core): provenance data model — source hash, event actor/evidence chain (#1172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Provenance data model (#1172, phase 1)** — schema v18 (additive): `memories.source_hash` records the SHA-256 of content at write time (tamper evidence — audits recompute it against live content), and `timeline_events.actor`/`evidence_json` record who performed an event and what evidence supports it. New `Uteke::provenance(id)` returns the full report (provenance fields, trust tier, hash comparison, event chain) — exposed as `GET /provenance?id=`, `uteke provenance <id>`, and the `uteke_provenance` MCP tool.
+
 - **Namespace management API (#1181)** — namespaces are a derived view, now with sanctioned ops: `PUT /memory` accepts `namespace` (move a memory — plain column update, no re-embed), `POST /namespaces/rename` (`{from, to}`; existing target = merge, returns `{from, to, moved, target_existed}`), and `POST /namespaces/delete` with an explicit strategy for its memories: `refuse` (default — 409 while any memory references the name), `merge` (move all memories to `target`, the name vanishes), or `deprecate` (soft-delete — restorable via promote, never hard-deleted). `GET /namespaces?with_counts=true` now adds `active`/`deprecated` breakdown fields (`count` stays the total). CLI parity: `uteke namespace move|rename|delete` (delete requires `--confirm`). MCP parity: `uteke_namespace_rename`, `uteke_namespace_delete`, and `namespace` field on `uteke_update`.
 
 ### Fixed

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -460,6 +460,11 @@ pub enum Commands {
         #[arg(long, default_value = "20")]
         limit: usize,
     },
+    /// Show the full provenance report for a memory (#1172)
+    Provenance {
+        /// Memory ID (UUID)
+        id: String,
+    },
     /// Document operations — wiki/knowledge base (#406, #411)
     Doc {
         #[command(subcommand)]

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -384,6 +384,59 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
 
         Commands::Timeline { id, limit } => timeline::run(cli, uteke, id, *limit),
 
+        Commands::Provenance { id } => {
+            let report = uteke
+                .provenance(id)
+                .map_err(|e| format!("Failed to read provenance: {e}"))?;
+            match report {
+                Some(report) if cli.json => crate::output::print_json(&report),
+                Some(report) => {
+                    println!("Provenance for memory {id}");
+                    println!("  Namespace:    {}", report.namespace);
+                    println!("  Author type:  {}", report.author_type);
+                    println!(
+                        "  Source:       {} ({})",
+                        report.source.as_deref().unwrap_or("—"),
+                        report.source_type
+                    );
+                    println!("  Trust tier:   {:?}", report.trust_tier);
+                    println!("  Created:      {}", report.created_at);
+                    println!("  Updated:      {}", report.updated_at);
+                    println!("  Deprecated:   {}", report.deprecated);
+                    match report.source_hash.as_deref() {
+                        Some(h) if h == report.content_hash_now => {
+                            println!("  Content hash: {h} ✓ (matches write-time hash)");
+                        }
+                        Some(h) => {
+                            println!(
+                                "  Content hash: {h} ✗ MISMATCH — content changed after write (now {})",
+                                report.content_hash_now
+                            );
+                        }
+                        None => {
+                            println!(
+                                "  Content hash: — (pre-v18 row; now {})",
+                                report.content_hash_now
+                            );
+                        }
+                    }
+                    println!("\n  Event chain ({} events):", report.events.len());
+                    for event in &report.events {
+                        let actor = event.actor.as_deref().unwrap_or("—");
+                        println!(
+                            "    • [{}] {} (actor: {actor})",
+                            event.created_at, event.event_type
+                        );
+                        if let Some(evidence) = &event.evidence {
+                            println!("      evidence: {evidence}");
+                        }
+                    }
+                }
+                None => return Err(format!("Memory not found: {id}")),
+            }
+            Ok(())
+        }
+
         Commands::Doc { command } => crate::commands::doc::run(cli, uteke, command, config),
 
         Commands::Upgrade { yes } => upgrade::run(*yes),

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -64,6 +64,7 @@ pub use memory::{
     documents::{Document, DocumentChunk, DocumentSearchResult, DocumentSummary},
 };
 pub use orphans::{DEFAULT_ORPHAN_THRESHOLD, OrphanMemory, compute_orphan_score};
+pub use provenance::{ProvenanceReport, TrustTier};
 pub use salience_recency::{
     SalienceRecencyConfig, apply_boosts, recency_score, salience_score, type_half_life_days,
 };
@@ -1327,6 +1328,15 @@ impl Uteke {
         source_type: &str,
     ) -> Result<bool, Error> {
         self.store.set_source(id, source, source_type)
+    }
+
+    /// Set the content hash recorded at write time (#1172 Fase 1).
+    ///
+    /// Normally set automatically by `remember*`/import paths; public so
+    /// repair/backfill tooling can populate legacy rows. Pass `None` to
+    /// clear.
+    pub fn set_source_hash(&self, id: &str, source_hash: Option<&str>) -> Result<bool, Error> {
+        self.store.set_source_hash(id, source_hash)
     }
 
     /// Set author type on a memory (#1083): "human" | "agent".

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -418,6 +418,8 @@ impl super::Store {
                 16 => self.migrate_v15_to_v16()?,
                 // v17: deprecated_at column — time-travel deprecation predicate (#1086)
                 17 => self.migrate_v16_to_v17()?,
+                // v18: provenance chain — source_hash, actor, evidence_json (#1172)
+                18 => self.migrate_v17_to_v18()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -604,6 +606,7 @@ impl super::Store {
             "memory_feedback",
             "memory_doc_refs",
             "doc_mem_refs",
+            "timeline_events",
         ];
         if !ALLOWED_TABLES.contains(&table) {
             return false;
@@ -1127,6 +1130,54 @@ impl super::Store {
         }
 
         tracing::info!("Migration v16 to v17 complete: deprecated_at column added");
+        Ok(())
+    }
+
+    /// v18: Provenance chain fields (#1172 Fase 1).
+    ///
+    /// Additive, zero data loss:
+    /// - `memories.source_hash` — SHA-256 of the content at write time
+    ///   (tamper-evidence for audits).
+    /// - `timeline_events.actor` — who performed the event (agent id, "user",
+    ///   "system").
+    /// - `timeline_events.evidence_json` — JSON array of related memory IDs /
+    ///   scores supporting the event (e.g. contradiction resolution evidence).
+    fn migrate_v17_to_v18(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v17 to v18: provenance chain (#1172)");
+
+        if !self.column_exists("source_hash") {
+            self.conn
+                .execute_batch("ALTER TABLE memories ADD COLUMN source_hash TEXT;")
+                .map_err(|e| Error::db("schema migration v17 to v18: source_hash", e))?;
+        }
+        // Guard for stores missing the v9 table entirely (defensive — a
+        // stamped v17 store should have it, but test fixtures / repaired
+        // databases may not). Fresh shape includes the new columns.
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS timeline_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                    event_type TEXT NOT NULL,
+                    event_data TEXT,
+                    created_at TEXT NOT NULL,
+                    actor TEXT,
+                    evidence_json TEXT
+                );",
+            )
+            .map_err(|e| Error::db("schema migration v17 to v18: timeline_events", e))?;
+        if !self.column_exists_in("timeline_events", "actor") {
+            self.conn
+                .execute_batch("ALTER TABLE timeline_events ADD COLUMN actor TEXT;")
+                .map_err(|e| Error::db("schema migration v17 to v18: actor", e))?;
+        }
+        if !self.column_exists_in("timeline_events", "evidence_json") {
+            self.conn
+                .execute_batch("ALTER TABLE timeline_events ADD COLUMN evidence_json TEXT;")
+                .map_err(|e| Error::db("schema migration v17 to v18: evidence_json", e))?;
+        }
+
+        tracing::info!("Migration v17 to v18 complete: provenance chain columns added");
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS memories (
     slug TEXT,
     source TEXT,
     source_type TEXT NOT NULL DEFAULT 'user',
-    author_type TEXT NOT NULL DEFAULT 'agent'
+    author_type TEXT NOT NULL DEFAULT 'agent',
+    source_hash TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
 CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
@@ -83,7 +84,9 @@ CREATE TABLE IF NOT EXISTS timeline_events (
     memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
     event_type TEXT NOT NULL,
     event_data TEXT,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    actor TEXT,
+    evidence_json TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_timeline_memory ON timeline_events(memory_id);
 CREATE INDEX IF NOT EXISTS idx_timeline_type ON timeline_events(event_type);
@@ -176,7 +179,7 @@ pub(super) const SCHEMA_INDEXES: &[&str] = &[
 ];
 
 /// Current schema version. Increment when adding migrations.
-pub(crate) const CURRENT_SCHEMA_VERSION: i32 = 17;
+pub(crate) const CURRENT_SCHEMA_VERSION: i32 = 18;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -270,6 +273,34 @@ impl Store {
             )
             .map_err(|e| Error::db("set source", e))?;
         Ok(rows > 0)
+    }
+
+    /// Set the provenance content hash for a memory (#1172 Fase 1).
+    ///
+    /// `None` clears the hash (used by repair/backfill tooling). Returns
+    /// `false` when the memory does not exist.
+    pub fn set_source_hash(&self, id: &str, source_hash: Option<&str>) -> Result<bool, Error> {
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE memories SET source_hash = ?1 WHERE id = ?2",
+                rusqlite::params![source_hash, id],
+            )
+            .map_err(|e| Error::db("set source hash", e))?;
+        Ok(rows > 0)
+    }
+
+    /// Read the provenance content hash for a memory (#1172 Fase 1).
+    pub fn get_source_hash(&self, id: &str) -> Result<Option<String>, Error> {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "SELECT source_hash FROM memories WHERE id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("get source hash", e))
     }
 
     /// Set author type on a memory (#1083): "human" or "agent".
@@ -702,7 +733,7 @@ mod tests {
             .conn
             .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(version, 17, "schema should be upgraded to v17");
+        assert_eq!(version, 18, "schema should be upgraded to current (v18)");
 
         // Legacy row backfilled to 'agent'.
         let at: String = store

--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -330,6 +330,17 @@ impl crate::Uteke {
 
         self.store.insert(&memory)?;
 
+        // Provenance: record the content hash at write time (#1172 Fase 1).
+        // Best-effort — audits recompute this to detect post-write tampering.
+        use sha2::Digest;
+        let source_hash: String = sha2::Sha256::digest(content.as_bytes())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        if let Err(e) = self.store.set_source_hash(&id, Some(source_hash.as_str())) {
+            tracing::warn!("source_hash write failed for {id}: {e}");
+        }
+
         // Timeline: record creation (#347). This hook lives in the single
         // shared creation path so every remember() / remember_typed() /
         // remember_precomputed() / consolidate() call records a Created
@@ -2724,5 +2735,91 @@ mod namespace_management_tests {
 
         // Unknown strategy is rejected.
         assert!(u.delete_namespace("ghost-ns", "hard-delete", None).is_err());
+    }
+
+    /// #1172 Fase 1: remember records a SHA-256 source hash; provenance()
+    /// returns the full chain (fields + tier + timeline) and detects content
+    /// modified after write via hash mismatch.
+    #[test]
+    fn provenance_chain_and_source_hash() {
+        use sha2::Digest;
+
+        let u = Uteke::open_with_backend(":memory:", None).expect("open without embedder");
+        let id = u
+            .remember("the deploy window is 09:00 WIB", &[], None, Some("ops"))
+            .expect("remember");
+
+        let report = u.provenance(&id).expect("provenance").expect("exists");
+        assert_eq!(report.id, id);
+        assert_eq!(report.namespace, "ops");
+        assert_eq!(report.author_type, "agent");
+        // Hash at write time must match a live recomputation.
+        let expected: String = sha2::Sha256::digest(report.content.as_bytes())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(report.source_hash.as_deref(), Some(expected.as_str()));
+        assert_eq!(report.content_hash_now, expected);
+        assert!(!report.events.is_empty(), "Created event must be recorded");
+        assert!(report.events.iter().any(|e| e.event_type == "created"));
+
+        // Update content without touching source_hash → mismatch detected
+        // (this is the tamper-evidence property).
+        u.store
+            .conn
+            .execute(
+                "UPDATE memories SET content = 'tampered' WHERE id = ?1",
+                rusqlite::params![id],
+            )
+            .expect("tamper");
+        let after = u.provenance(&id).expect("provenance").expect("exists");
+        assert_eq!(after.content, "tampered");
+        assert_ne!(
+            after.source_hash.as_deref(),
+            Some(after.content_hash_now.as_str()),
+            "post-write modification must break the hash match"
+        );
+
+        // Unknown ID → Ok(None).
+        assert!(
+            u.provenance("00000000-0000-4000-8000-000000000000")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// #1172 Fase 1: timeline events carry actor + evidence when written via
+    /// the provenance-aware API, and old callers (no provenance) stay working.
+    #[test]
+    fn timeline_events_carry_provenance() {
+        let u = Uteke::open_with_backend(":memory:", None).expect("open without embedder");
+        let id = u
+            .remember("evidence chain probe", &[], None, None)
+            .expect("remember");
+
+        u.store
+            .add_timeline_event_with_provenance(
+                &id,
+                crate::timeline::TimelineEventType::Updated,
+                Some(&serde_json::json!({"field": "importance"})),
+                Some("agent:cto"),
+                Some(&serde_json::json!([{"memory": "other-id", "score": 0.82}])),
+            )
+            .expect("append provenance event");
+
+        let events = u.timeline(&id, 0).expect("timeline");
+        assert_eq!(events.len(), 2, "created + updated");
+        let provenance_event = events
+            .iter()
+            .find(|e| e.event_type == "updated")
+            .expect("updated event");
+        assert_eq!(provenance_event.actor.as_deref(), Some("agent:cto"));
+        let evidence = provenance_event.evidence.as_ref().expect("evidence");
+        assert_eq!(evidence[0]["memory"], serde_json::json!("other-id"));
+
+        // Plain events (Created) have no actor — backward compatible shape.
+        let created = events.iter().find(|e| e.event_type == "created").unwrap();
+        assert!(created.actor.is_none());
+        assert!(created.evidence.is_none());
     }
 }

--- a/crates/uteke-core/src/provenance.rs
+++ b/crates/uteke-core/src/provenance.rs
@@ -131,6 +131,70 @@ fn contains_hedge(lower: &str) -> bool {
     HEDGE_MARKERS.iter().any(|h| lower.contains(h))
 }
 
+// ── Provenance chain query (#1172 Fase 1) ──────────────────────────────────
+
+/// Full provenance view of a memory (#1172 Fase 1): identity + provenance
+/// fields + trust tier + content hash + the auditable event chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProvenanceReport {
+    pub id: String,
+    pub namespace: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub author_type: String,
+    pub source: Option<String>,
+    pub source_type: String,
+    /// SHA-256 of the content at the last write (schema v18+). `None` for
+    /// memories written before the column existed.
+    pub source_hash: Option<String>,
+    /// Content currently stored — lets an auditor recompute the hash and
+    /// verify tamper-evidence.
+    pub content: String,
+    /// Hash of the current content (computed live) — compare against
+    /// `source_hash` to detect post-write modifications.
+    pub content_hash_now: String,
+    pub trust_tier: TrustTier,
+    pub deprecated: bool,
+    /// Event chain, newest first, with actor + evidence when recorded.
+    pub events: Vec<crate::timeline::TimelineEvent>,
+}
+
+impl crate::Uteke {
+    /// Build the full provenance report for a memory (#1172 Fase 1).
+    ///
+    /// Returns `Ok(None)` when the memory does not exist.
+    pub fn provenance(&self, id: &str) -> Result<Option<ProvenanceReport>, crate::Error> {
+        use sha2::Digest;
+
+        let memory = match self.store.get_by_id(id)? {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+        let source_hash = self.store.get_source_hash(id)?;
+        let content_hash_now: String = sha2::Sha256::digest(memory.content.as_bytes())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        let events = self.store.list_timeline_events(id, 0)?;
+        let trust_tier = TrustTier::of(&memory);
+        Ok(Some(ProvenanceReport {
+            id: memory.id.clone(),
+            namespace: memory.namespace.clone(),
+            created_at: memory.created_at.to_rfc3339(),
+            updated_at: memory.updated_at.to_rfc3339(),
+            author_type: memory.author_type.clone(),
+            source: memory.source.clone(),
+            source_type: memory.source_type.clone(),
+            source_hash,
+            content: memory.content,
+            content_hash_now,
+            trust_tier,
+            deprecated: memory.deprecated,
+            events,
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/uteke-core/src/timeline.rs
+++ b/crates/uteke-core/src/timeline.rs
@@ -71,6 +71,15 @@ pub struct TimelineEvent {
     /// Optional JSON payload describing what changed.
     pub event_data: Option<String>,
     pub created_at: String,
+    /// Who performed the event (#1172): agent id, "user", or "system".
+    /// `None` for events written before schema v18.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+    /// JSON array of related memory IDs / scores supporting the event
+    /// (#1172) — e.g. contradiction-resolution evidence. `None` for events
+    /// written before schema v18.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<serde_json::Value>,
 }
 
 impl Store {
@@ -82,6 +91,23 @@ impl Store {
         event_type: TimelineEventType,
         event_data: Option<&serde_json::Value>,
     ) -> Result<(), Error> {
+        self.add_timeline_event_with_provenance(memory_id, event_type, event_data, None, None)
+    }
+
+    /// Append a timeline event with provenance attribution (#1172 Fase 1).
+    ///
+    /// `actor` = who performed the event (agent id, "user", "system");
+    /// `evidence` = JSON array of related memory IDs / scores supporting the
+    /// event. Both optional; stored as `NULL` when absent. Best-effort like
+    /// [`Self::add_timeline_event`].
+    pub fn add_timeline_event_with_provenance(
+        &self,
+        memory_id: &str,
+        event_type: TimelineEventType,
+        event_data: Option<&serde_json::Value>,
+        actor: Option<&str>,
+        evidence: Option<&serde_json::Value>,
+    ) -> Result<(), Error> {
         let data_str = event_data.map(|v| match serde_json::to_string(v) {
             Ok(s) => s,
             Err(e) => {
@@ -91,15 +117,24 @@ impl Store {
                 "null".to_string()
             }
         });
+        let evidence_str = evidence.map(|v| match serde_json::to_string(v) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("timeline: failed to serialize event evidence: {e}");
+                "null".to_string()
+            }
+        });
         self.conn
             .execute(
-                "INSERT INTO timeline_events (memory_id, event_type, event_data, created_at)
-                 VALUES (?1, ?2, ?3, ?4)",
+                "INSERT INTO timeline_events (memory_id, event_type, event_data, created_at, actor, evidence_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 params![
                     memory_id,
                     event_type.as_str(),
                     data_str,
                     chrono::Utc::now().to_rfc3339(),
+                    actor,
+                    evidence_str,
                 ],
             )
             .map_err(|e| Error::db("add timeline event", e))?;
@@ -115,10 +150,12 @@ impl Store {
         limit: usize,
     ) -> Result<Vec<TimelineEvent>, Error> {
         let sql = if limit == 0 {
-            "SELECT id, memory_id, event_type, event_data, created_at FROM timeline_events
+            "SELECT id, memory_id, event_type, event_data, created_at, actor, evidence_json
+             FROM timeline_events
              WHERE memory_id = ?1 ORDER BY created_at DESC, id DESC"
         } else {
-            "SELECT id, memory_id, event_type, event_data, created_at FROM timeline_events
+            "SELECT id, memory_id, event_type, event_data, created_at, actor, evidence_json
+             FROM timeline_events
              WHERE memory_id = ?1 ORDER BY created_at DESC, id DESC LIMIT ?2"
         };
         let mut stmt = self
@@ -154,12 +191,25 @@ impl Store {
 }
 
 fn map_timeline_row(r: &rusqlite::Row) -> rusqlite::Result<TimelineEvent> {
+    let evidence_str: Option<String> = r.get(6)?;
+    let evidence =
+        evidence_str
+            .as_deref()
+            .and_then(|s| match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    tracing::warn!("timeline: corrupted evidence JSON (will use null): {e}");
+                    None
+                }
+            });
     Ok(TimelineEvent {
         id: r.get(0)?,
         memory_id: r.get(1)?,
         event_type: r.get(2)?,
         event_data: r.get(3)?,
         created_at: r.get(4)?,
+        actor: r.get(5)?,
+        evidence,
     })
 }
 

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -144,6 +144,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_search(),
                 tool_list(),
                 tool_get(),
+                tool_provenance(),
                 tool_supersede(),
                 tool_update(),
                 tool_forget(),
@@ -196,6 +197,7 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_search" => exec_search(uteke, &arguments)?,
                 "uteke_list" => exec_list(uteke, &arguments)?,
                 "uteke_get" => exec_get(uteke, &arguments)?,
+                "uteke_provenance" => exec_provenance(uteke, &arguments)?,
                 "uteke_supersede" => exec_supersede(uteke, &arguments)?,
                 "uteke_update" => exec_update(uteke, &arguments)?,
                 "uteke_forget" => exec_forget(uteke, &arguments)?,
@@ -313,6 +315,40 @@ fn tool_get() -> Value {
             },
             "required": ["id"]
         }
+    })
+}
+
+fn tool_provenance() -> Value {
+    serde_json::json!({
+        "name": "uteke_provenance",
+        "description": "Full provenance report for a memory (#1172): author/source fields, trust tier, source hash at write vs live content hash (tamper evidence), and the full timeline event chain with actor + evidence. Use when auditing why a memory exists, who wrote it, and whether it changed after write.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "Full UUID or unambiguous prefix" }
+            },
+            "required": ["id"]
+        }
+    })
+}
+
+/// Full provenance report for a memory (#1172 Fase 1).
+fn exec_provenance(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let id_arg = args["id"].as_str().ok_or("Missing 'id'")?;
+    let id = resolve_id(uteke, id_arg)?;
+
+    let report = uteke
+        .provenance(&id)
+        .map_err(|e| format!("Failed: {e}"))?
+        .ok_or_else(|| format!("Memory not found: {id}"))?;
+
+    let text = serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".to_string());
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text,
+        }],
+        is_error: false,
     })
 }
 

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -497,6 +497,15 @@ pub const ENDPOINTS: &[Endpoint] = &[
     // ── Timeline ─────────────────────────────────────────────────────────
     Endpoint {
         method: "GET",
+        path: "/provenance",
+        description: "Full provenance report for a memory (#1172): author/source fields, trust tier, source hash at write vs live-recomputed content hash (tamper evidence), and the full timeline event chain with actor + evidence. Accepts `?id=...` query param.",
+        request_type: None,
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["1172"],
+    },
+    Endpoint {
+        method: "GET",
         path: "/timeline",
         description: "Get timeline of memory events for a memory. Accepts `?id=...` query param.",
         request_type: None,

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -2185,6 +2185,23 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             Err(e) => ctx.error_response_for(req, 400, e),
         },
 
+        // ── Provenance chain (#1172) ─────────────────────────────────────
+        (Method::Get, "/provenance") => {
+            let query = path.split('?').nth(1).unwrap_or("");
+            let id = match parse_query_param(query, "id") {
+                Some(id) => id,
+                None => return ctx.error_response_for(req, 400, "Missing 'id' query parameter"),
+            };
+            match uteke.provenance(&id) {
+                Ok(Some(report)) => ctx.ok_response_for(req, &report),
+                Ok(None) => ctx.error_response_for(req, 404, format!("Memory not found: {id}")),
+                Err(e) => {
+                    error!("Provenance error: {e}");
+                    ctx.error_response_for(req, 500, "Internal server error")
+                }
+            }
+        }
+
         // ── Timeline ─────────────────────────────────────────────────────
         (Method::Get, "/timeline") => {
             let query = path.split('?').nth(1).unwrap_or("");
@@ -3081,5 +3098,41 @@ mod room_recall_at_tests {
         assert_eq!(ghost["active"], serde_json::json!(0));
         assert_eq!(ghost["deprecated"], serde_json::json!(1));
         assert_eq!(ghost["count"], serde_json::json!(1));
+    }
+
+    // ── Provenance API (#1172) ─────────────────────────────────────────
+
+    #[test]
+    fn provenance_endpoint_reports_chain_and_hash() {
+        let app = NamespaceApp::new();
+        let id = app.remember_in("provenance surface probe", "audit");
+
+        let get_url = format!("/provenance?id={id}");
+        let (status, report) = app.call(Method::Get, &get_url, None);
+        assert_eq!(status, 200, "{report}");
+        assert_eq!(report["id"], serde_json::json!(id));
+        assert_eq!(report["namespace"], serde_json::json!("audit"));
+        assert_eq!(report["author_type"], serde_json::json!("agent"));
+        assert_eq!(report["trust_tier"], serde_json::json!("agent"));
+        assert_eq!(report["source_hash"], report["content_hash_now"]);
+        let events = report["events"].as_array().expect("events array");
+        assert!(
+            events
+                .iter()
+                .any(|e| e["event_type"] == serde_json::json!("created")),
+            "created event must be in the chain: {report}"
+        );
+
+        // Unknown ID → 404.
+        let (status, _) = app.call(
+            Method::Get,
+            "/provenance?id=00000000-0000-4000-8000-000000000000",
+            None,
+        );
+        assert_eq!(status, 404);
+
+        // Missing param → 400.
+        let (status, _) = app.call(Method::Get, "/provenance", None);
+        assert_eq!(status, 400);
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -100,6 +100,12 @@ Update an existing memory's content and/or metadata.
 
 Get graph edges for a memory. Accepts `?id=...` query param.
 
+#### 🟢 `GET` `/provenance`
+
+Full provenance report for a memory (#1172): author/source fields, trust tier, source hash at write vs live-recomputed content hash (tamper evidence), and the full timeline event chain with actor + evidence. Accepts `?id=...` query param.
+
+*Related: `1172`*
+
 #### 🟡 `POST` `/lifecycle/cycle`
 
 Run lifecycle aging cycle: deprecate old memories, optionally prune expired ones.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -262,6 +262,25 @@ uteke lifecycle restore <memory-id>
 
 See [Configuration → Memory Lifecycle](/configuration#memory-lifecycle) for lifecycle config options.
 
+## uteke provenance
+
+Show the full provenance report for a memory (#1172) — who wrote it, from
+what source, its trust tier, whether the content still matches the hash
+recorded at write time, and the complete event chain with actor +
+evidence.
+
+```bash
+# Human-readable audit report
+uteke provenance <memory-id>
+
+# JSON (for tooling)
+uteke provenance <memory-id> --json
+```
+
+Hash verdicts: `✓ matches` (content unchanged since write), `✗ MISMATCH`
+(content modified after write — investigate), `—` (memory predates
+schema v18; hash will be recorded on next content update).
+
 ## uteke namespace
 
 Manage namespaces — list, inspect, switch defaults, and manage members (#1181).


### PR DESCRIPTION
## What

Phase 1 of the memory evolution plan (#1172): the provenance **data model**, additive schema v17 → v18, zero data loss.

- `memories.source_hash` (TEXT, nullable) — SHA-256 of the content, recorded automatically in the single shared creation path (`remember_precomputed`, which backs `remember`/`remember_typed`/consolidation). Auditors recompute the hash of current content to detect post-write tampering.
- `timeline_events.actor` (TEXT) + `timeline_events.evidence_json` (TEXT, JSON array) — who performed an event and what evidence supports it. Written via `Store::add_timeline_event_with_provenance`; existing `add_timeline_event` callers are untouched (NULL actor/evidence).
- `Uteke::provenance(id)` → `ProvenanceReport` (exported): provenance fields (`author_type`, `source`, `source_type`, timestamps), `TrustTier` classification, `source_hash` (at write) vs `content_hash_now` (live-recomputed), `deprecated`, and the full event chain newest-first.
- `Uteke::set_source_hash(id, Option<&str>)` — public for repair/backfill tooling on legacy rows.
- Bug fixed en route: `column_exists_in` allowlist did not include `timeline_events`, so the helper silently returned false for that table — the v18 migration would have double-ALTERed. Allowlist now includes it, and the migration additionally ensures the table exists with the fresh shape (defensive for partially-repaired stores).

Surfaces (HTTP / CLI / MCP for `provenance`) land in the follow-up PR — this PR is the schema + core API layer.

## Why

#1172 item 1 (per the OSS/cloud triage decision): provenance is the correctness primitive everything else builds on. Fase 2 (contradiction evidence chain + undo) writes its resolution rationale as provenance-bearing timeline events; the audit surfaces read them through this model.

## Testing

- New (embedder-free per CI constraint): `provenance_chain_and_source_hash` — hash recorded at write matches live recomputation; direct DB content tampering breaks the match (tamper-evidence property); event chain contains `created`; unknown ID → `Ok(None)`.
- New: `timeline_events_carry_provenance` — provenance-bearing event stores actor + evidence (readable back via `Uteke::timeline`), plain events keep the old shape (backward compat).
- Migration: existing `test_author_type_migration_v15_to_v16` (legacy v15 DB → v18) and `test_migration_v11_to_v12_from_v04x_db` (fixture without timeline_events) both pass after the defensive CREATE + allowlist fix; fresh-store version stamping asserted at 18.
- `cargo fmt --all` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo test -p uteke-core --lib` 548 passed / 0 failed · server handler suite 23/23 ✓ · `cora review --staged` ✓ (No issues found).
