### PR TITLE
fix: graph excludes stale memory nodes + readable node labels (#1189 #1187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Graph data returned stale nodes (#1189)** — `GET /graph` without a namespace returned every `graph_nodes` row raw, including nodes whose parent memory had been forgotten or deprecated; with soft-delete the store accumulated stale nodes on every conflict resolution. Memory-linked nodes are now filtered by liveness (memory exists and `deprecated = 0`) in every `graph_data` path, edges touching removed nodes are dropped, and `stats` counts the filtered graph.
+- **Memory graph nodes labeled with raw UUIDs (#1187)** — `ensure_node_for_memory` now labels new memory nodes with a readable content preview (first 60 chars of the memory) instead of the raw memory UUID, and upgrades legacy UUID-labeled rows in place on next access. Entity nodes are unaffected.
+
 ### Added
 
 - **Explain recall (#1160)** — `explain` mode on every recall surface shows WHY each memory ranked where it did: vector similarity and rank, FTS rank, RRF score with per-channel fusion contributions, and jaccard/salience/recency/graph boost deltas. Surfaces: `uteke recall "…" --explain` (human-readable, combine with `--json` for machine output), `POST /recall` with `"explain": true` (memory-only — combined with `search_type`/`at`/`before`/`after` returns 400), and the `explain` flag on the MCP `uteke_recall` tool. The explanation path replays the active strategy's exact pipeline (same channel depths, RRF constants, and boost order) while bypassing the recall cache, so the explanation always matches the returned results; fts5 explanation works without an embedder, other strategies embed the query once (~50 ms, same as a cold recall).

--- a/crates/uteke-core/src/graph.rs
+++ b/crates/uteke-core/src/graph.rs
@@ -330,11 +330,69 @@ impl<'a> GraphStore<'a> {
     /// work with plain memory IDs — `graph_edges.source_id/target_id` have
     /// FKs to `graph_nodes(id)`, so memory IDs must be mapped to nodes
     /// before insertion (#1180).
+    ///
+    /// #1187: newly created memory nodes carry a readable content preview
+    /// (first 60 chars) as their label instead of the raw memory UUID.
+    /// Legacy rows whose label is still the raw memory ID are upgraded
+    /// in place here.
     pub fn ensure_node_for_memory(&self, memory_id: &str) -> Result<String, Error> {
-        if let Some(id) = self.node_id_for_memory(memory_id)? {
-            return Ok(id);
+        let node_id = match self.node_id_for_memory(memory_id)? {
+            Some(id) => id,
+            None => {
+                let label = self.memory_node_label(memory_id)?;
+                return self.upsert_node(&label, Some("memory"), Some(memory_id));
+            }
+        };
+
+        // #1187 legacy upgrade: raw-UUID labels → readable preview labels.
+        // Entity nodes and non-UUID labels are untouched.
+        let label_is_memory_id: bool = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM graph_nodes WHERE id = ?1 AND label = ?2 AND memory_id = ?2 AND entity_type = 'memory'",
+                params![node_id, memory_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|c| c > 0)
+            .map_err(|e| Error::db("graph node label probe", e))?;
+        if label_is_memory_id {
+            let label = self.memory_node_label(memory_id)?;
+            self.conn
+                .execute(
+                    "UPDATE graph_nodes SET label = ?1 WHERE id = ?2",
+                    params![label, node_id],
+                )
+                .map_err(|e| Error::db("graph node label upgrade", e))?;
         }
-        self.upsert_node(memory_id, Some("memory"), Some(memory_id))
+        Ok(node_id)
+    }
+
+    /// Readable node label for a memory (#1187): `preview — <8-char id>`
+    /// so two memories with identical 60-char prefixes still get distinct
+    /// labels (upsert is label-keyed; a bare preview could collide or
+    /// hijack an existing entity node).
+    fn memory_node_label(&self, memory_id: &str) -> Result<String, Error> {
+        let preview = self.memory_label_preview(memory_id)?;
+        let short_id: String = memory_id.chars().take(8).collect();
+        Ok(match preview {
+            Some(p) => format!("{p} — {short_id}"),
+            None => memory_id.to_string(),
+        })
+    }
+
+    /// Content preview for a memory's node label (#1187): first 60 chars of
+    /// the memory content. `None` when the memory does not exist.
+    fn memory_label_preview(&self, memory_id: &str) -> Result<Option<String>, Error> {
+        let row: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT substr(content, 1, 60) FROM memories WHERE id = ?1",
+                params![memory_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::db("memory label preview", e))?;
+        Ok(row.filter(|s| !s.trim().is_empty()))
     }
 
     /// Create an edge between two nodes. Ignores if edge already exists (INSERT OR IGNORE).
@@ -693,9 +751,14 @@ mod tests {
     fn setup() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         // Don't enable foreign_keys in test — graph_nodes references memories(id)
-        // which doesn't exist in this minimal test setup.
+        // which doesn't exist in this minimal test setup. A minimal memories
+        // table IS present so #1187 label previews can resolve.
         conn.execute_batch(
             r#"
+            CREATE TABLE memories (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL DEFAULT ''
+            );
             CREATE TABLE graph_nodes (
                 id TEXT PRIMARY KEY,
                 label TEXT NOT NULL COLLATE NOCASE,
@@ -780,13 +843,19 @@ mod tests {
     #[test]
     fn test_ensure_node_for_memory_creates_linked_node_idempotently() {
         let conn = setup();
+        conn.execute(
+            "INSERT INTO memories (id, content) VALUES ('01890a5d-ac96-774b-bcce-b30220900001', 'Deploy uses Bun, never npm')",
+            [],
+        )
+        .unwrap();
         let g = GraphStore::new(&conn);
         let mid = "01890a5d-ac96-774b-bcce-b30220900001";
         let first = g.ensure_node_for_memory(mid).unwrap();
         let second = g.ensure_node_for_memory(mid).unwrap();
         assert_eq!(first, second, "ensure must be idempotent");
         let node = g.get_node(&first).unwrap().expect("node must exist");
-        assert_eq!(node.label, mid);
+        // #1187: label is a readable content preview + short id, not the UUID.
+        assert_eq!(node.label, "Deploy uses Bun, never npm — 01890a5d");
         assert_eq!(node.entity_type.as_deref(), Some("memory"));
         assert_eq!(node.memory_id.as_deref(), Some(mid));
     }
@@ -997,5 +1066,153 @@ mod tests {
         let nodes = g.all_nodes().unwrap();
         assert_eq!(nodes.len(), 3);
         assert_eq!(nodes[0].label, "Alice"); // sorted
+    }
+
+    // ── #1187 legacy label upgrade + #1189 graph liveness ──────────────
+
+    #[test]
+    fn test_ensure_node_for_memory_upgrades_legacy_uuid_label() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO memories (id, content) VALUES ('legacy-mem-1', 'Vector index uses usearch by default')",
+            [],
+        )
+        .unwrap();
+        let g = GraphStore::new(&conn);
+        // Legacy row: raw memory UUID as the label (pre-#1187 servers).
+        let legacy_id = g
+            .upsert_node("legacy-mem-1", Some("memory"), Some("legacy-mem-1"))
+            .unwrap();
+
+        let node = g.get_node(&legacy_id).unwrap().expect("node exists");
+        assert_eq!(
+            node.label, "legacy-mem-1",
+            "precondition: legacy UUID label"
+        );
+
+        // First ensure() must upgrade the label in place, keeping the ID.
+        let id = g.ensure_node_for_memory("legacy-mem-1").unwrap();
+        assert_eq!(id, legacy_id, "node id must be preserved");
+        let node = g.get_node(&id).unwrap().expect("node exists");
+        assert_eq!(
+            node.label, "Vector index uses usearch by default — legacy-m",
+            "label upgraded to readable preview"
+        );
+    }
+
+    #[test]
+    fn test_graph_data_filters_stale_memory_nodes() {
+        let uteke = crate::Uteke::open(":memory:").unwrap();
+        // Embedder-free seeding (CI has no ONNX runtime) — the graph layer
+        // under test is storage-only, vectors are opaque bytes here.
+        let embedding = vec![0.1_f32; 768];
+        let keep = uteke
+            .remember_precomputed(
+                "active memory about caching",
+                &[],
+                None,
+                Some("gns"),
+                "fact",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        let gone = uteke
+            .remember_precomputed(
+                "memory that will be forgotten",
+                &[],
+                None,
+                Some("gns"),
+                "fact",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        let dep = uteke
+            .remember_precomputed(
+                "memory that will be deprecated",
+                &[],
+                None,
+                Some("gns"),
+                "fact",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        uteke.forget(&gone).unwrap();
+        uteke.supersede(&dep, &keep, Some("pivot")).unwrap();
+
+        let gs = crate::GraphStore::new(uteke.graph_store());
+        // One node per live memory + the stale ones (the bug setup).
+        let n_keep = gs.ensure_node_for_memory(&keep).unwrap();
+        let n_gone = gs.ensure_node_for_memory(&gone).unwrap();
+        let n_dep = gs.ensure_node_for_memory(&dep).unwrap();
+        gs.add_edge(&n_keep, &n_dep, "related", 1.0).unwrap();
+        gs.add_edge(&n_dep, &n_gone, "related", 1.0).unwrap();
+
+        // No namespace: stale nodes (forgotten + deprecated) must vanish.
+        let data = uteke.graph_data(None).unwrap();
+        let ids: Vec<&str> = data.nodes.iter().map(|n| n.id.as_str()).collect();
+        assert!(
+            !ids.contains(&n_gone.as_str()),
+            "forgotten memory's node must be filtered (#1189)"
+        );
+        assert!(
+            !ids.contains(&n_dep.as_str()),
+            "deprecated memory's node must be filtered (#1189)"
+        );
+        assert!(
+            ids.contains(&n_keep.as_str()),
+            "live memory's node must stay"
+        );
+        // Edges touching removed nodes are gone too.
+        assert_eq!(
+            data.edges.len(),
+            0,
+            "all edges touched stale nodes: {:?}",
+            data.edges
+        );
+        // Stats reflect the filtered graph.
+        assert_eq!(data.stats.node_count, ids.len());
+    }
+
+    #[test]
+    fn test_graph_data_namespace_filter_still_excludes_other_ns() {
+        let uteke = crate::Uteke::open(":memory:").unwrap();
+        let embedding = vec![0.1_f32; 768];
+        let in_ns = uteke
+            .remember_precomputed(
+                "in target namespace",
+                &[],
+                None,
+                Some("ns-a"),
+                "fact",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        let other = uteke
+            .remember_precomputed(
+                "in another namespace",
+                &[],
+                None,
+                Some("ns-b"),
+                "fact",
+                "text",
+                &embedding,
+            )
+            .unwrap();
+        let gs = crate::GraphStore::new(uteke.graph_store());
+        let _ = gs.ensure_node_for_memory(&in_ns).unwrap();
+        let _ = gs.ensure_node_for_memory(&other).unwrap();
+
+        let data = uteke.graph_data(Some("ns-a")).unwrap();
+        let mids: Vec<&str> = data
+            .nodes
+            .iter()
+            .filter_map(|n| n.memory_id.as_deref())
+            .collect();
+        assert!(mids.contains(&in_ns.as_str()));
+        assert!(!mids.contains(&other.as_str()), "other ns must be excluded");
     }
 }

--- a/crates/uteke-core/src/lib.rs
+++ b/crates/uteke-core/src/lib.rs
@@ -1364,18 +1364,34 @@ impl Uteke {
     /// Get graph nodes + edges for visualization (#408).
     ///
     /// Returns all nodes and edges in the knowledge graph, optionally
-    /// limited by namespace.
+    /// limited by namespace. Stale memory nodes are excluded in every
+    /// path (#1189): the namespace path matches `namespace AND
+    /// deprecated = 0`; the no-namespace path drops nodes whose parent
+    /// memory is missing (hard-deleted) or deprecated — so the graph
+    /// does not grow stale nodes on every forget/deprecate.
     pub fn graph_data(&self, namespace: Option<&str>) -> Result<GraphData, Error> {
         let gs = GraphStore::new(&self.store.conn);
         let nodes = gs.all_nodes()?;
         let edges = gs.all_edges()?;
         let stats = gs.stats()?;
 
+        // Liveness set: memories that may appear in the graph — existing
+        // AND not deprecated (#1189). Legacy graph_rows whose memory was
+        // hard-deleted drop out here too (orphaned nodes).
+        let live_memory_ids: std::collections::HashSet<String> = self
+            .store
+            .conn
+            .prepare("SELECT id FROM memories WHERE deprecated = 0")
+            .map_err(|e| Error::db("Failed to prepare liveness query", e))?
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| Error::db("Failed to query live memories", e))?
+            .filter_map(|r| r.ok())
+            .collect();
+
         // Filter by namespace if specified.
         // Memory-linked nodes are filtered by their parent memory's namespace.
         // Entity nodes (no memory_id) are always included (shared across namespaces).
         let (nodes, edges) = if let Some(ns) = namespace {
-            // Build a set of memory IDs that belong to this namespace.
             let ns_memory_ids: std::collections::HashSet<String> = self
                 .store
                 .conn
@@ -1411,7 +1427,33 @@ impl Uteke {
 
             (filtered_nodes, filtered_edges)
         } else {
-            (nodes, edges)
+            // #1189: no namespace → still drop nodes whose memory is gone
+            // or deprecated (the bug: this path returned all_nodes() raw).
+            let filtered_nodes: Vec<GraphNode> = nodes
+                .into_iter()
+                .filter(|n| match &n.memory_id {
+                    None => true,
+                    Some(mid) => live_memory_ids.contains(mid),
+                })
+                .collect();
+            let node_ids: std::collections::HashSet<&str> =
+                filtered_nodes.iter().map(|n| n.id.as_str()).collect();
+            let filtered_edges: Vec<GraphEdge> = edges
+                .into_iter()
+                .filter(|e| {
+                    node_ids.contains(e.source_id.as_str())
+                        && node_ids.contains(e.target_id.as_str())
+                })
+                .collect();
+            (filtered_nodes, filtered_edges)
+        };
+
+        // Stats count the FILTERED graph, not the raw tables (#1189) —
+        // otherwise GET /graph reported node counts that included stale rows.
+        let stats = crate::graph::GraphStats {
+            node_count: nodes.len(),
+            edge_count: edges.len(),
+            relation_types: stats.relation_types,
         };
 
         Ok(GraphData {


### PR DESCRIPTION
## What

Two graph-quality fixes that share `graph_store`:

**#1189 — stale nodes excluded from `graph_data` in every path.** The no-namespace path of `GET /graph` returned `all_nodes()` raw: nodes whose parent memory had been forgotten (hard-deleted) or deprecated stayed in the graph forever, and soft-delete made the store accumulate stale nodes on every supersede. Memory-linked nodes are now filtered by liveness (memory exists AND `deprecated = 0`) in the no-namespace path too (the namespace path already matched `namespace AND deprecated = 0`), edges touching removed nodes are dropped, and `stats` counts the **filtered** graph so reported counts can't include stale rows.

**#1187 — readable labels for memory nodes.** `ensure_node_for_memory` labeled new nodes with the raw memory UUID, so every graph UI rendered UUID strings. New nodes get a readable label `<60-char content preview> — <8-char id>` (short-id suffix keeps labels unique — upsert is label-keyed, so a bare preview could collide or hijack an entity node). Legacy rows labeled with the raw UUID are upgraded **in place on next access** (node id and edges preserved, entity nodes untouched).

## Why

#1189 (bug) and #1187 (enhancement), both found during the Corin web audit. Corin currently works around both client-side (paginated /list resolution + client-side filtering), which is N+1 HTTP for server-side one-liners.

## Testing

- `cargo test --workspace` — 666 passed, 0 failed, including 3 new: legacy UUID label upgraded in place (id preserved, readable preview), stale-node filtering (forgotten + superseded nodes and their edges vanish, live node stays, stats parity), namespace filter still excludes other namespaces
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` 0 warnings
- `cora review --staged` — pass after fixing 2 findings from its first pass (preview-label collision → short-id suffix; misleading doc claim → corrected wording)
- Pre-commit hooks: fmt + clippy + cora all green