### PR TITLE
chore: release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [0.17.0] — 2026-09-06
 
-### Fixed
-
-- **Graph data returned stale nodes (#1189)** — `GET /graph` without a namespace returned every `graph_nodes` row raw, including nodes whose parent memory had been forgotten or deprecated; with soft-delete the store accumulated stale nodes on every conflict resolution. Memory-linked nodes are now filtered by liveness (memory exists and `deprecated = 0`) in every `graph_data` path, edges touching removed nodes are dropped, and `stats` counts the filtered graph.
-- **Memory graph nodes labeled with raw UUIDs (#1187)** — `ensure_node_for_memory` now labels new memory nodes with a readable content preview (first 60 chars of the memory) instead of the raw memory UUID, and upgrades legacy UUID-labeled rows in place on next access. Entity nodes are unaffected.
+Minor release. Theme: **inspectable, trustworthy memory** — explain recall on
+every surface, auditable conflict resolution with a measurable payoff, honest
+graphs, pagination metadata, and a dual-engine vector layer.
 
 ### Added
 
@@ -18,6 +17,11 @@
 - **Contradiction resolution ledger + undo (#1172, phase 2)** — supersessions are now a first-class, auditable ledger instead of a side effect: `Uteke::contradiction_resolutions(namespace, limit)` lists superseded-but-not-restored memories (winner, reason, timestamp via the deprecation row), `Uteke::undo_supersession(id)` restores a retired memory, removes the supersession edge pair, and records a `supersession_undone` event on both sides (only memories carrying a live `superseded_by` edge can be undone — the undo is itself auditable). Ledger membership is edge-driven (deprecated row + `superseded_by` edge), the same predicate undo resolves against, and re-superseding an already-deprecated memory refreshes the stored reason/timestamp so the ledger always names the current winner. Surfaces: `GET /contradictions?namespace=&limit=`, `POST /contradictions/undo` (`{id}`; 404 when nothing to undo), `uteke contradictions list|undo`, and MCP `uteke_contradictions` / `uteke_contradictions_undo`. Fixed in the process: the no-namespace ledger query bound its limit parameter to a nonexistent placeholder (`?2`) and failed at runtime — caught by the new MCP roundtrip test.
 
 - **Provenance data model (#1172, phase 1)** — schema v18 (additive): `memories.source_hash` records the SHA-256 of content at write time (tamper evidence — audits recompute it against live content), and `timeline_events.actor`/`evidence_json` record who performed an event and what evidence supports it. New `Uteke::provenance(id)` returns the full report (provenance fields, trust tier, hash comparison, event chain) — exposed as `GET /provenance?id=`, `uteke provenance <id>`, and the `uteke_provenance` MCP tool.
+
+### Fixed
+
+- **Graph data returned stale nodes (#1189)** — `GET /graph` without a namespace returned every `graph_nodes` row raw, including nodes whose parent memory had been forgotten or deprecated; with soft-delete the store accumulated stale nodes on every conflict resolution. Memory-linked nodes are now filtered by liveness (memory exists and `deprecated = 0`) in every `graph_data` path, edges touching removed nodes are dropped, and `stats` counts the filtered graph.
+- **Memory graph nodes labeled with raw UUIDs (#1187)** — `ensure_node_for_memory` now labels new memory nodes with a readable content preview (first 60 chars of the memory) instead of the raw memory UUID, and upgrades legacy UUID-labeled rows in place on next access. Entity nodes are unaffected.
 
 - **Namespace management API (#1181)** — namespaces are a derived view, now with sanctioned ops: `PUT /memory` accepts `namespace` (move a memory — plain column update, no re-embed), `POST /namespaces/rename` (`{from, to}`; existing target = merge, returns `{from, to, moved, target_existed}`), and `POST /namespaces/delete` with an explicit strategy for its memories: `refuse` (default — 409 while any memory references the name), `merge` (move all memories to `target`, the name vanishes), or `deprecate` (soft-delete — restorable via promote, never hard-deleted). `GET /namespaces?with_counts=true` now adds `active`/`deprecated` breakdown fields (`count` stays the total). CLI parity: `uteke namespace move|rename|delete` (delete requires `--confirm`). MCP parity: `uteke_namespace_rename`, `uteke_namespace_delete`, and `namespace` field on `uteke_update`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -22,7 +22,7 @@ usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.16.0", default-features = false, features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.17.0", default-features = false, features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -29,7 +29,7 @@ usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.16.0", default-features = false, features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.17.0", default-features = false, features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -27,8 +27,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.16.0", default-features = false, features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.16.0", default-features = false }
+uteke-core = { path = "../uteke-core", version = "0.17.0", default-features = false, features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.17.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,14 @@ host = "127.0.0.1"
 
 # Server port
 port = 8767
+
+[vector]
+# Vector search engine when the binary ships BOTH engines (official builds):
+# "usearch" (default — HNSW, C++ FFI, fastest) or "vecq" (training-free
+# quantization, zero C++ dep — mobile/slim builds). Switching engines on an
+# existing store auto-rebuilds the index from SQLite on next open (#1168).
+# Env override: UTEKE_VECTOR_BACKEND=usearch|vecq
+backend = "usearch"
 ```
 
 ## Server Mode


### PR DESCRIPTION
## What

Release prep for **0.17.0** — version bump across the workspace (0.16.0 → 0.17.0), internal dep requirements updated, CHANGELOG dated, and the dual-engine vector docs completed (`[vector] backend` section in configuration.md).

No code changes in this PR — all features below are already merged and individually CI-green on develop.

## Why

Cut the 0.17.0 minor release per #1165 (vecq-core 0.3 already pinned on develop and validated against crates.io).

## Contents of 0.17.0 (all merged to develop)

### Added
- **Explain recall (#1160, #1186)** — `--explain` / `explain: true` / MCP `explain` on every recall surface; per-result ranking signals (vector sim + rank, FTS rank, RRF contributions, boost deltas)
- **Contradiction resolution ledger + undo (#1172 F2, #1185)** — edge-driven ledger, atomic undo, `GET /contradictions`, `POST /contradictions/undo`, CLI `contradictions list|undo`, MCP tools
- **Contradiction benchmark segment (#1172 F3, #1192)** — `contradiction_segment.py` + published RESULTS.md section; fusion winner@1 0.850 → 1.000, stale@5 1.000 → 0.000 after supersede
- **`uteke supersede` CLI (#1192)** — surface parity (was MCP/HTTP only)
- **`/list` pagination metadata (#1188, #1191)** — opt-in `include_meta` envelope
- **Provenance data model (#1172 F1, #1184)** — schema v18, `source_hash`, actor/evidence chain, `GET /provenance`, CLI + MCP tools

### Fixed
- Graph excludes stale memory nodes; readable node labels (#1189 #1187, #1190)
- No-namespace ledger query bind bug (caught by new roundtrip test, #1185)

### Dual-engine vector (validation this release)
`UTEKE_VECTOR_BACKEND=usearch|vecq` env or `[vector] backend` in uteke.toml switches engines at runtime with automatic index rebuild from SQLite (#1168). Validated for 0.17.0: vecq-core 0.3.0 = main (crates.io), merge gate green (59 tests dbg+release, fmt, clippy -D warnings, real benchmark r@1 0.940 / r@10 0.974 / 4.78x = BENCHMARK.md baseline), uteke `vecq` feature builds + E2E store→index→recall green on both engines.

## Testing

- `cargo test --workspace` — 667 passed, 0 failed (release-commit build)
- fmt clean, clippy 0 warnings
- `cora review` pass (pre-commit + CI)
- QA sandbox (isolated UTEKE_HOME): 0.17.0 binary smoke on both engines — seed → recall (usearch), env-switch to vecq → recall, config-file switch → recall, explain output, empty ledger
- Production store backed up pre-release (integrity ok)