### PR TITLE
docs: AGENTS.md — point workflow SOT to codecora-workflow-standard room

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,10 @@ When develop→main conflicts, do NOT hand-resolve server-side (protected branch
 rejects direct pushes). Instead: branch from the release commit, `git merge main`,
 resolve keeping develop's side (unless main carries unique content — verify), push
 the branch as `chore/release-*`, and open the release PR from it.
+
+## Source of truth for workflow standards
+
+The canonical workflow SOP (merge gate, release flow, governance) lives in the
+uteke room `codecora-workflow-standard` (namespace `codecora`) on the shared
+store. This file is the repo-enforced subset — when rules disagree, the room
+wins, and this file gets updated in the same commit that changes the rule.


### PR DESCRIPTION
## What

Adds a short 'Source of truth for workflow standards' section to AGENTS.md: the canonical workflow SOP (merge gate, release flow, governance) lives in the uteke room `codecora-workflow-standard` (namespace `codecora`); AGENTS.md is the repo-enforced subset — when rules disagree, the room wins, and this file is updated in the same commit as any rule change.

Follow-up to #1198 (which added AGENTS.md with the mandatory post-release sync rule).

## Why

Keeps one source of truth — the room already holds the merge-gate HUB and the adopted release-flow standard (validated on 0.17.0); AGENTS.md previously didn't reference it, risking divergence between repo docs and the room SOP.

## Testing

Docs-only change; content mirrors the room entries added today (release flow ADOPTED — Opsi A + C validated on uteke 0.17.0). cora review pass on commit; no code touched.