### PR TITLE
feat(api): room rename, room update, memory room-move + CLI memory update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Room rename, room update, and memory room-move (#1202)** — rooms now have sanctioned lifecycle ops matching the namespace family: `Uteke::rename_room(old, new)` rewrites the registry row and every `room_memories`/`room_documents` reference in ONE transaction (FK-safe insert→repoint→delete order; no `ON UPDATE CASCADE` needed), preserving title/description/namespace; `Uteke::update_room(id, title?, description?)` edits room metadata (schema v19 adds the additive `rooms.description` column; structural export/import carry it and stay backward-compatible with 5-column exports); `Uteke::move_memory_to_room(id, from, to)` moves a memory between rooms preserving the link's `author`/`role`/`joined_at` provenance (`Ok(0)` when not a member of `from`). Surfaces: HTTP `POST /room/rename|/room/update|/room/memory/move` (404 on missing room/link), CLI `uteke room rename|update|move-memory`, MCP `uteke_room_rename|uteke_room_update|uteke_room_memory_move`.
+- **`uteke update <id>` CLI** — in-place memory edit (content/tags/importance/pinned/type), closing the CLI surface gap: HTTP `PUT /memory` and MCP `uteke_update` already existed (#1202 item 5).
+
 ## [0.17.0] — 2026-09-06
 
 Minor release. Theme: **inspectable, trustworthy memory** — explain recall on

--- a/crates/uteke-cli/src/cli.rs
+++ b/crates/uteke-cli/src/cli.rs
@@ -200,6 +200,26 @@ pub enum Commands {
         /// Memory ID (UUID)
         id: String,
     },
+    /// Update a memory in place (content/tags/importance/pinned/type) (#1202)
+    Update {
+        /// Memory ID (UUID)
+        id: String,
+        /// New content (omit to keep the current one)
+        #[arg(long)]
+        content: Option<String>,
+        /// New tags, comma-separated (replaces the current set)
+        #[arg(long)]
+        tags: Option<String>,
+        /// Importance override (0.0–1.0)
+        #[arg(long)]
+        importance: Option<f64>,
+        /// Pinned state (never decays, boosted in recall)
+        #[arg(long)]
+        pinned: Option<bool>,
+        /// Memory type: fact, procedure, preference, decision, context, note, insight, reference, event
+        #[arg(long = "type")]
+        r#type: Option<String>,
+    },
     /// Delete a memory by ID
     Forget {
         /// Memory ID (UUID)
@@ -772,6 +792,35 @@ pub enum RoomCommands {
         /// Optional title for the room
         #[arg(long)]
         title: Option<String>,
+    },
+    /// Rename a room — registry row and all member/document links move together (#1202)
+    Rename {
+        /// Current room ID
+        old_id: String,
+        /// New room ID
+        new_id: String,
+    },
+    /// Update a room's title and/or description (#1202)
+    Update {
+        /// Room ID
+        room_id: String,
+        /// New title (omit to keep the current one)
+        #[arg(long)]
+        title: Option<String>,
+        /// New description (omit to keep the current one)
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Move a memory from one room to another, preserving link provenance (#1202)
+    MoveMemory {
+        /// Memory ID
+        memory_id: String,
+        /// Source room ID (the memory must be a member)
+        #[arg(long = "from")]
+        from_room: String,
+        /// Target room ID (must exist)
+        #[arg(long = "to")]
+        to_room: String,
     },
     /// List all rooms
     List {

--- a/crates/uteke-cli/src/commands/mod.rs
+++ b/crates/uteke-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ mod room;
 mod server;
 mod tags;
 mod timeline;
+mod update;
 pub(crate) mod update_check;
 pub(crate) mod upgrade;
 
@@ -150,6 +151,24 @@ pub(crate) fn run_command(cli: &Cli, uteke: &mut Uteke, config: &Config) -> Resu
         ),
 
         Commands::Get { id } => list::run_get(cli, uteke, id),
+
+        Commands::Update {
+            id,
+            content,
+            tags,
+            importance,
+            pinned,
+            r#type,
+        } => update::run(
+            cli,
+            uteke,
+            id,
+            content.clone(),
+            tags.clone(),
+            *importance,
+            *pinned,
+            r#type.clone(),
+        ),
 
         Commands::Forget {
             id,

--- a/crates/uteke-cli/src/commands/room.rs
+++ b/crates/uteke-cli/src/commands/room.rs
@@ -28,6 +28,67 @@ pub(crate) fn run(
             }
             Ok(())
         }
+        RoomCommands::Rename { old_id, new_id } => {
+            let room = uteke
+                .rename_room(old_id, new_id)
+                .map_err(|e| format!("Failed to rename room: {e}"))?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({"renamed": old_id, "to": new_id, "room": room})
+                );
+            } else {
+                println!("✓ Room '{old_id}' renamed to '{new_id}'");
+            }
+            Ok(())
+        }
+        RoomCommands::Update {
+            room_id,
+            title,
+            description,
+        } => {
+            let room = uteke
+                .update_room(room_id, title.as_deref(), description.as_deref())
+                .map_err(|e| format!("Failed to update room: {e}"))?;
+            match room {
+                Some(room) => {
+                    if cli.json {
+                        println!("{}", serde_json::to_string_pretty(&room).unwrap());
+                    } else {
+                        println!("✓ Room '{room_id}' updated");
+                    }
+                }
+                None => return Err(format!("Room not found: {room_id}")),
+            }
+            Ok(())
+        }
+        RoomCommands::MoveMemory {
+            memory_id,
+            from_room,
+            to_room,
+        } => {
+            let moved = uteke
+                .move_memory_to_room(memory_id, from_room, to_room)
+                .map_err(|e| format!("Failed to move memory: {e}"))?;
+            if moved == 0 {
+                return Err(format!(
+                    "Memory '{memory_id}' has no link in room '{from_room}'"
+                ));
+            }
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "moved": memory_id,
+                        "from_room": from_room,
+                        "to_room": to_room
+                    })
+                );
+            } else {
+                println!("✓ Memory '{memory_id}' moved from '{from_room}' to '{to_room}'");
+            }
+            Ok(())
+        }
         RoomCommands::List { namespace } => {
             // Rooms are cross-namespace collaboration spaces (#392).
             // Only filter when --namespace is explicitly passed on the

--- a/crates/uteke-cli/src/commands/update.rs
+++ b/crates/uteke-cli/src/commands/update.rs
@@ -1,0 +1,51 @@
+//! `uteke update` — in-place memory edit (CLI surface for `Uteke::update_memory`,
+//! issue #1202). HTTP `PUT /memory` and MCP `uteke_update` already existed;
+//! this closes the CLI gap.
+
+use crate::Cli;
+use uteke_core::Uteke;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run(
+    cli: &Cli,
+    uteke: &Uteke,
+    id: &str,
+    content: Option<String>,
+    tags: Option<String>,
+    importance: Option<f64>,
+    pinned: Option<bool>,
+    memory_type: Option<String>,
+) -> Result<(), String> {
+    tracing::info!("Updating memory: {id}");
+    let tag_list: Option<Vec<String>> = tags.map(|t| {
+        t.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    });
+
+    let updated = uteke
+        .update_memory(
+            id,
+            content.as_deref(),
+            tag_list.as_deref(),
+            None,
+            importance,
+            pinned,
+            memory_type.as_deref(),
+        )
+        .map_err(|e| format!("Failed to update memory: {e}"))?;
+    if !updated {
+        return Err(format!("Memory not found: {id}"));
+    }
+
+    if cli.json {
+        let memory = uteke
+            .get(id)
+            .map_err(|e| format!("Failed to reload memory: {e}"))?;
+        println!("{}", serde_json::to_string_pretty(&memory).unwrap());
+    } else {
+        println!("✓ Memory '{id}' updated");
+    }
+    Ok(())
+}

--- a/crates/uteke-core/src/memory/rooms.rs
+++ b/crates/uteke-core/src/memory/rooms.rs
@@ -12,6 +12,8 @@ pub struct Room {
     pub namespace: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Free-text description (schema v19, #1202). `None` = not set.
+    pub description: Option<String>,
 }
 
 /// Statistics about a room.
@@ -155,7 +157,8 @@ impl super::Store {
     pub fn get_room(&self, room_id: &str) -> Result<Option<Room>, Error> {
         self.conn
             .query_row(
-                "SELECT id, title, namespace, created_at, updated_at FROM rooms WHERE id = ?1",
+                "SELECT id, title, namespace, created_at, updated_at, description \
+                 FROM rooms WHERE id = ?1",
                 params![room_id],
                 |row| {
                     Ok(Room {
@@ -164,6 +167,7 @@ impl super::Store {
                         namespace: row.get(2)?,
                         created_at: row.get(3)?,
                         updated_at: row.get(4)?,
+                        description: row.get(5)?,
                     })
                 },
             )
@@ -180,13 +184,14 @@ impl super::Store {
         // on the rooms table itself (#545).
         let sql = match namespace {
             Some(_) => {
-                "SELECT id, title, namespace, created_at, updated_at \
+                "SELECT id, title, namespace, created_at, updated_at, description \
                  FROM rooms \
                  WHERE namespace = ?1 \
                  ORDER BY updated_at DESC"
             }
             None => {
-                "SELECT id, title, namespace, created_at, updated_at FROM rooms \
+                "SELECT id, title, namespace, created_at, updated_at, description \
+                 FROM rooms \
                  ORDER BY updated_at DESC"
             }
         };
@@ -205,6 +210,7 @@ impl super::Store {
                         namespace: row.get(2)?,
                         created_at: row.get(3)?,
                         updated_at: row.get(4)?,
+                        description: row.get(5)?,
                     })
                 })
                 .map_err(|e| Error::db("list rooms", e))?
@@ -218,6 +224,7 @@ impl super::Store {
                         namespace: row.get(2)?,
                         created_at: row.get(3)?,
                         updated_at: row.get(4)?,
+                        description: row.get(5)?,
                     })
                 })
                 .map_err(|e| Error::db("list rooms", e))?
@@ -226,6 +233,181 @@ impl super::Store {
         };
 
         Ok(rows)
+    }
+
+    /// Rename a room: update the registry row and every reference in
+    /// `room_memories` / `room_documents` in ONE transaction (#1202).
+    ///
+    /// The FK on `room_memories.room_id` is `ON DELETE CASCADE` only (no
+    /// `ON UPDATE`), so a plain `UPDATE rooms SET id` would either fail or
+    /// orphan members — all three tables are rewritten together instead.
+    /// Author/role/joined_at metadata on links is preserved untouched.
+    ///
+    /// Returns the renamed `Room`. Errors when the room does not exist or
+    /// the target ID is already taken.
+    pub fn rename_room(&self, old_id: &str, new_id: &str) -> Result<Room, Error> {
+        if old_id == new_id {
+            return Err(Error::Validation(
+                "Rename source and target room IDs are identical".to_string(),
+            ));
+        }
+        let exists = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM rooms WHERE id = ?1)",
+                params![old_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|e| Error::db("rename room: check source", e))?;
+        if !exists {
+            return Err(Error::Validation(format!("Room not found: {old_id}")));
+        }
+        let taken = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM rooms WHERE id = ?1)",
+                params![new_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|e| Error::db("rename room: check target", e))?;
+        if taken {
+            return Err(Error::Validation(format!("Room already exists: {new_id}")));
+        }
+
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("rename room: begin tx", e))?;
+        // FK-safe order: insert the new registry row FIRST, then repoint the
+        // children, then drop the old row — every intermediate state keeps
+        // every room_memories/room_documents FK satisfied (no ON UPDATE
+        // CASCADE on these FKs).
+        let now = chrono::Utc::now().to_rfc3339();
+        tx.execute(
+            "INSERT INTO rooms (id, title, namespace, created_at, updated_at, description) \
+             SELECT ?1, title, namespace, created_at, ?2, description FROM rooms WHERE id = ?3",
+            params![new_id, now, old_id],
+        )
+        .map_err(|e| Error::db("rename room: insert new row", e))?;
+        tx.execute(
+            "UPDATE room_memories SET room_id = ?1 WHERE room_id = ?2",
+            params![new_id, old_id],
+        )
+        .map_err(|e| Error::db("rename room: move members", e))?;
+        tx.execute(
+            "UPDATE room_documents SET room_id = ?1 WHERE room_id = ?2",
+            params![new_id, old_id],
+        )
+        .map_err(|e| Error::db("rename room: move document links", e))?;
+        tx.execute("DELETE FROM rooms WHERE id = ?1", params![old_id])
+            .map_err(|e| Error::db("rename room: remove old row", e))?;
+        tx.commit()
+            .map_err(|e| Error::db("rename room: commit", e))?;
+
+        Ok(self
+            .get_room(new_id)?
+            .expect("room row must exist after rename"))
+    }
+
+    /// Update a room's title and/or description (#1202). `None` fields are
+    /// left unchanged; the room row itself is never recreated, so members,
+    /// documents, and timestamps of linked rows stay valid.
+    ///
+    /// Returns the updated `Room`, or `None` when the room does not exist.
+    pub fn update_room(
+        &self,
+        room_id: &str,
+        title: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<Option<Room>, Error> {
+        let room = match self.get_room(room_id)? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        let now = chrono::Utc::now().to_rfc3339();
+        let new_title = title.or(room.title.as_deref());
+        let new_description = description.or(room.description.as_deref());
+        self.conn
+            .execute(
+                "UPDATE rooms SET title = ?1, description = ?2, updated_at = ?3 WHERE id = ?4",
+                params![new_title, new_description, now, room_id],
+            )
+            .map_err(|e| Error::db("update room", e))?;
+        self.get_room(room_id)
+    }
+
+    /// Move a memory from one room to another (#1202).
+    ///
+    /// Rooms are many-to-many (`room_memories` PK `(room_id, memory_id)`), so
+    /// the move removes the `from` link and inserts the `to` link in ONE
+    /// transaction, preserving the link's `author`/`role`/`joined_at`
+    /// provenance. `to` must differ from `from`; the target room must exist.
+    ///
+    /// Returns the number of links moved: `Ok(0)` when the memory has no link
+    /// in `from` (or `from` does not exist), `Ok(1)` on success.
+    pub fn move_memory_to_room(
+        &self,
+        memory_id: &str,
+        from_room: &str,
+        to_room: &str,
+    ) -> Result<usize, Error> {
+        if from_room == to_room {
+            return Err(Error::Validation(
+                "Move source and target rooms are identical".to_string(),
+            ));
+        }
+        let target_exists = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM rooms WHERE id = ?1)",
+                params![to_room],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|e| Error::db("move memory to room: check target", e))?;
+        if !target_exists {
+            return Err(Error::Validation(format!("Room not found: {to_room}")));
+        }
+
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::db("move memory to room: begin tx", e))?;
+        // Read the link's provenance BEFORE removing it — membership history
+        // (author/role/joined_at) moves with the link.
+        let link: Option<(String, String, String)> = tx
+            .query_row(
+                "SELECT author, role, joined_at FROM room_memories \
+                 WHERE room_id = ?1 AND memory_id = ?2",
+                params![from_room, memory_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(|e| Error::db("move memory to room: read link", e))?;
+        let (author, role, joined_at) = match link {
+            Some(l) => l,
+            // Nothing linked in `from` — leave the store untouched (the tx
+            // is dropped uncommitted, which rolls back cleanly).
+            None => return Ok(0),
+        };
+        tx.execute(
+            "DELETE FROM room_memories WHERE room_id = ?1 AND memory_id = ?2",
+            params![from_room, memory_id],
+        )
+        .map_err(|e| Error::db("move memory to room: unlink source", e))?;
+        tx.execute(
+            "INSERT OR IGNORE INTO room_memories (room_id, memory_id, author, role, joined_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![to_room, memory_id, author, role, joined_at],
+        )
+        .map_err(|e| Error::db("move memory to room: link target", e))?;
+        tx.execute(
+            "UPDATE rooms SET updated_at = ?1 WHERE id IN (?2, ?3)",
+            params![chrono::Utc::now().to_rfc3339(), from_room, to_room],
+        )
+        .map_err(|e| Error::db("move memory to room: timestamps", e))?;
+        tx.commit()
+            .map_err(|e| Error::db("move memory to room: commit", e))?;
+        Ok(1)
     }
 
     /// Get statistics about a room.

--- a/crates/uteke-core/src/memory/schema.rs
+++ b/crates/uteke-core/src/memory/schema.rs
@@ -420,6 +420,8 @@ impl super::Store {
                 17 => self.migrate_v16_to_v17()?,
                 // v18: provenance chain — source_hash, actor, evidence_json (#1172)
                 18 => self.migrate_v17_to_v18()?,
+                // v19: room description column — room rename/update support (#1202)
+                19 => self.migrate_v18_to_v19()?,
                 _ => {
                     // No-op for future versions.
                 }
@@ -1178,6 +1180,23 @@ impl super::Store {
         }
 
         tracing::info!("Migration v17 to v18 complete: provenance chain columns added");
+        Ok(())
+    }
+
+    /// Schema v19 (#1202): `rooms.description` — free-text room description
+    /// for `room update`. Additive and NULL-safe: NULL = no description.
+    /// Fresh stores get the column directly in CREATE TABLE; this migration
+    /// only patches stores stamped at v18 or lower.
+    fn migrate_v18_to_v19(&self) -> Result<(), Error> {
+        tracing::info!("Applying schema migration v18 to v19: rooms.description (#1202)");
+
+        if !self.column_exists_in("rooms", "description") {
+            self.conn
+                .execute_batch("ALTER TABLE rooms ADD COLUMN description TEXT;")
+                .map_err(|e| Error::db("schema migration v18 to v19: rooms.description", e))?;
+        }
+
+        tracing::info!("Migration v18 to v19 complete: rooms.description added");
         Ok(())
     }
 }

--- a/crates/uteke-core/src/memory/store.rs
+++ b/crates/uteke-core/src/memory/store.rs
@@ -143,7 +143,8 @@ CREATE TABLE IF NOT EXISTS rooms (
     title TEXT,
     namespace TEXT NOT NULL DEFAULT 'default',
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    description TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_rooms_namespace ON rooms(namespace);
 
@@ -179,7 +180,7 @@ pub(super) const SCHEMA_INDEXES: &[&str] = &[
 ];
 
 /// Current schema version. Increment when adding migrations.
-pub(crate) const CURRENT_SCHEMA_VERSION: i32 = 18;
+pub(crate) const CURRENT_SCHEMA_VERSION: i32 = 19;
 
 /// Persistent SQLite store for memories.
 pub struct Store {
@@ -733,7 +734,7 @@ mod tests {
             .conn
             .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(version, 18, "schema should be upgraded to current (v18)");
+        assert_eq!(version, 19, "schema should be upgraded to current (v19)");
 
         // Legacy row backfilled to 'agent'.
         let at: String = store

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -480,9 +480,15 @@ mod tests {
 
     // ── Room rename / update / memory room-move (#1202) ─────────────
 
+    /// Embedder-less engine — these ops never touch embeddings, and CI has
+    /// no ONNX runtime (same pattern as operations::namespace_management_tests).
+    fn open_no_embedder() -> crate::Uteke {
+        crate::Uteke::open_with_backend(":memory:", None).unwrap()
+    }
+
     #[test]
     fn rename_room_moves_registry_and_links() {
-        let uteke = open_in_memory();
+        let uteke = open_no_embedder();
         uteke
             .create_room("old-room", Some("Old"), "default")
             .unwrap();
@@ -546,7 +552,7 @@ mod tests {
 
     #[test]
     fn rename_room_rejects_missing_source_and_taken_target() {
-        let uteke = open_in_memory();
+        let uteke = open_no_embedder();
         uteke.create_room("a", None, "default").unwrap();
         uteke.create_room("b", None, "default").unwrap();
 
@@ -562,7 +568,7 @@ mod tests {
 
     #[test]
     fn update_room_sets_title_and_description() {
-        let uteke = open_in_memory();
+        let uteke = open_no_embedder();
         uteke.create_room("r", Some("Title"), "default").unwrap();
 
         // Description only — title must survive.
@@ -592,7 +598,7 @@ mod tests {
 
     #[test]
     fn move_memory_between_rooms_preserves_link_provenance() {
-        let uteke = open_in_memory();
+        let uteke = open_no_embedder();
         uteke.create_room("src", None, "default").unwrap();
         uteke.create_room("dst", None, "default").unwrap();
         let mid = uteke
@@ -630,7 +636,7 @@ mod tests {
 
     #[test]
     fn move_memory_rejects_bad_targets() {
-        let uteke = open_in_memory();
+        let uteke = open_no_embedder();
         uteke.create_room("s", None, "default").unwrap();
         let mid = uteke.remember("x", &[], None, Some("default")).unwrap();
         uteke

--- a/crates/uteke-core/src/rooms.rs
+++ b/crates/uteke-core/src/rooms.rs
@@ -191,6 +191,39 @@ impl crate::Uteke {
         self.store.delete_room(room_id)
     }
 
+    /// Rename a room: the registry row and every member/document link move
+    /// in ONE transaction (#1202). Namespace, title, and description are
+    /// preserved. Errors when the room is missing or the target ID is taken.
+    pub fn rename_room(&self, old_id: &str, new_id: &str) -> Result<Room, Error> {
+        self.store.rename_room(old_id, new_id)
+    }
+
+    /// Update a room's title and/or description (#1202). `None` fields are
+    /// left unchanged. Returns the updated room, or `None` when the room
+    /// does not exist.
+    pub fn update_room(
+        &self,
+        room_id: &str,
+        title: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<Option<Room>, Error> {
+        self.store.update_room(room_id, title, description)
+    }
+
+    /// Move a memory from one room to another (#1202), preserving the link's
+    /// author/role/joined_at provenance. Returns `Ok(0)` when the memory is
+    /// not a member of `from_room`, `Ok(1)` on success. The target room must
+    /// exist; namespace stays untouched (no recall-cache impact).
+    pub fn move_memory_to_room(
+        &self,
+        memory_id: &str,
+        from_room: &str,
+        to_room: &str,
+    ) -> Result<usize, Error> {
+        self.store
+            .move_memory_to_room(memory_id, from_room, to_room)
+    }
+
     /// Generate a summary of room discussion (topic clustering, no LLM needed).
     /// Enriched with embedding-distance semantic segments (#1088) when
     /// embeddings exist — these are the batching units for future
@@ -443,6 +476,175 @@ mod tests {
             "small room must return semantic results (#894)"
         );
         assert!(results.iter().any(|r| r.memory.content.contains("Rust")));
+    }
+
+    // ── Room rename / update / memory room-move (#1202) ─────────────
+
+    #[test]
+    fn rename_room_moves_registry_and_links() {
+        let uteke = open_in_memory();
+        uteke
+            .create_room("old-room", Some("Old"), "default")
+            .unwrap();
+        let m1 = uteke.remember("m one", &[], None, Some("default")).unwrap();
+        let m2 = uteke.remember("m two", &[], None, Some("default")).unwrap();
+        uteke
+            .store
+            .link_memory_to_room("old-room", &m1, "alice", "participant")
+            .unwrap();
+        uteke
+            .store
+            .link_memory_to_room("old-room", &m2, "bob", "lead")
+            .unwrap();
+
+        let room = uteke.rename_room("old-room", "new-room").unwrap();
+        assert_eq!(room.id, "new-room");
+        assert_eq!(room.title, Some("Old".to_string()));
+        assert_eq!(room.namespace, "default");
+
+        // Old name is gone, members followed.
+        assert!(uteke.get_room("old-room").unwrap().is_none());
+        assert_eq!(uteke.recall_room("new-room", None, 0).unwrap().len(), 2);
+        // Cross-namespace room recall is author-filterable on the new ID.
+        assert_eq!(
+            uteke.recall_room("new-room", Some("bob"), 0).unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn rename_room_preserves_document_links() {
+        let store = crate::memory::Store::open(":memory:").unwrap();
+        store.create_room("r-old", None, "default").unwrap();
+        let doc = crate::memory::documents::Document {
+            id: "doc-1".to_string(),
+            slug: "doc-1".to_string(),
+            title: "Doc One".to_string(),
+            content: "# Doc One\nContent".to_string(),
+            namespace: None,
+            author: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+            version: 1,
+            content_type: "markdown".to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            parent_id: None,
+            path: "/doc-1/".to_string(),
+            depth: 0,
+            sort_order: 0,
+            has_children: false,
+        };
+        store.upsert_document(&doc).unwrap();
+        store.room_add_document("r-old", "doc-1").unwrap();
+
+        store.rename_room("r-old", "r-new").unwrap();
+
+        assert_eq!(store.room_list_documents("r-new").unwrap(), vec!["doc-1"]);
+        assert!(store.room_list_documents("r-old").unwrap().is_empty());
+    }
+
+    #[test]
+    fn rename_room_rejects_missing_source_and_taken_target() {
+        let uteke = open_in_memory();
+        uteke.create_room("a", None, "default").unwrap();
+        uteke.create_room("b", None, "default").unwrap();
+
+        let missing = uteke.rename_room("nope", "c");
+        assert!(matches!(missing, Err(crate::Error::Validation(_))));
+
+        let taken = uteke.rename_room("a", "b");
+        assert!(matches!(taken, Err(crate::Error::Validation(_))));
+
+        let same = uteke.rename_room("a", "a");
+        assert!(matches!(same, Err(crate::Error::Validation(_))));
+    }
+
+    #[test]
+    fn update_room_sets_title_and_description() {
+        let uteke = open_in_memory();
+        uteke.create_room("r", Some("Title"), "default").unwrap();
+
+        // Description only — title must survive.
+        let room = uteke
+            .update_room("r", None, Some("First description"))
+            .unwrap();
+        let room = room.expect("room exists");
+        assert_eq!(room.title, Some("Title".to_string()));
+        assert_eq!(room.description, Some("First description".to_string()));
+
+        // Overwrite both.
+        let room = uteke
+            .update_room("r", Some("New title"), Some("Updated desc"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(room.title, Some("New title".to_string()));
+        assert_eq!(room.description, Some("Updated desc".to_string()));
+
+        // Missing room → None.
+        assert!(
+            uteke
+                .update_room("ghost", Some("x"), None)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn move_memory_between_rooms_preserves_link_provenance() {
+        let uteke = open_in_memory();
+        uteke.create_room("src", None, "default").unwrap();
+        uteke.create_room("dst", None, "default").unwrap();
+        let mid = uteke
+            .remember("traveler", &[], None, Some("default"))
+            .unwrap();
+        uteke
+            .store
+            .link_memory_to_room("src", &mid, "carol", "moderator")
+            .unwrap();
+
+        let moved = uteke.move_memory_to_room(&mid, "src", "dst").unwrap();
+        assert_eq!(moved, 1);
+
+        // Out of source, present in target.
+        assert!(uteke.recall_room("src", None, 0).unwrap().is_empty());
+        let dst = uteke.recall_room("dst", None, 0).unwrap();
+        assert_eq!(dst.len(), 1);
+        assert_eq!(dst[0].id, mid);
+
+        // Link provenance (author/role) moved with the link.
+        let (author, role): (String, String) = uteke
+            .store()
+            .conn
+            .query_row(
+                "SELECT author, role FROM room_memories WHERE room_id = 'dst' AND memory_id = ?1",
+                [&mid],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((author.as_str(), role.as_str()), ("carol", "moderator"));
+
+        // Move again — nothing left in source → Ok(0), store untouched.
+        assert_eq!(uteke.move_memory_to_room(&mid, "src", "dst").unwrap(), 0);
+    }
+
+    #[test]
+    fn move_memory_rejects_bad_targets() {
+        let uteke = open_in_memory();
+        uteke.create_room("s", None, "default").unwrap();
+        let mid = uteke.remember("x", &[], None, Some("default")).unwrap();
+        uteke
+            .store
+            .link_memory_to_room("s", &mid, "a", "participant")
+            .unwrap();
+
+        // Target room missing.
+        let missing_target = uteke.move_memory_to_room(&mid, "s", "nope");
+        assert!(matches!(missing_target, Err(crate::Error::Validation(_))));
+
+        // Same room.
+        let same = uteke.move_memory_to_room(&mid, "s", "s");
+        assert!(matches!(same, Err(crate::Error::Validation(_))));
     }
 
     // ── Room ↔ Document junction ──────────────────────────────────

--- a/crates/uteke-core/src/structural_export.rs
+++ b/crates/uteke-core/src/structural_export.rs
@@ -140,7 +140,8 @@ impl crate::Uteke {
         let simple_tables: &[(&str, &str)] = &[
             (
                 "room",
-                "SELECT id, title, namespace, created_at, updated_at FROM rooms",
+                "SELECT id, title, namespace, created_at, updated_at, description \
+                 FROM rooms",
             ),
             (
                 "room_memory",
@@ -394,15 +395,20 @@ impl crate::Uteke {
             match tag {
                 "room" => {
                     let r = &v["row"];
+                    // Column-count aware: exports predating description
+                    // (#1202) carry 5 columns; new exports carry 6. Both
+                    // import cleanly (description defaults to NULL).
+                    let description = r.get(5).and_then(|v| v.as_str());
                     let n = conn
                         .execute(
-                            "INSERT OR IGNORE INTO rooms (id, title, namespace, created_at, updated_at) VALUES (?1,?2,?3,?4,?5)",
+                            "INSERT OR IGNORE INTO rooms (id, title, namespace, created_at, updated_at, description) VALUES (?1,?2,?3,?4,?5,?6)",
                             rusqlite::params![
                                 r[0].as_str().unwrap_or(""),
                                 r[1].as_str(),
                                 r[2].as_str().unwrap_or("default"),
                                 r[3].as_str().unwrap_or(""),
                                 r[4].as_str().unwrap_or(""),
+                                description,
                             ],
                         )
                         .map_err(|e| Error::db_msg(format!("import room: {e}")))?;

--- a/crates/uteke-mcp/src/lib.rs
+++ b/crates/uteke-mcp/src/lib.rs
@@ -166,6 +166,9 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 tool_room_create(),
                 tool_room_list(),
                 tool_room_delete(),
+                tool_room_rename(),
+                tool_room_update(),
+                tool_room_memory_move(),
                 tool_room_recall(),
                 tool_room_memories(),
                 tool_room_stats(),
@@ -221,6 +224,9 @@ fn handle_request(uteke: &Uteke, method: &str, params: Option<Value>) -> Result<
                 "uteke_room_create" => exec_room_create(uteke, &arguments)?,
                 "uteke_room_list" => exec_room_list(uteke, &arguments)?,
                 "uteke_room_delete" => exec_room_delete(uteke, &arguments)?,
+                "uteke_room_rename" => exec_room_rename(uteke, &arguments)?,
+                "uteke_room_update" => exec_room_update(uteke, &arguments)?,
+                "uteke_room_memory_move" => exec_room_memory_move(uteke, &arguments)?,
                 "uteke_room_recall" => exec_room_recall(uteke, &arguments)?,
                 "uteke_room_memories" => exec_room_memories(uteke, &arguments)?,
                 "uteke_room_stats" => exec_room_stats(uteke, &arguments)?,
@@ -732,6 +738,53 @@ fn tool_room_delete() -> Value {
                 "room_id": { "type": "string", "description": "Room identifier to delete" }
             },
             "required": ["room_id"]
+        }
+    })
+}
+
+fn tool_room_rename() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_rename",
+        "description": "Rename a room. The registry row and every member/document link move in one transaction; title, description, and namespace are preserved (#1202).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from": { "type": "string", "description": "Current room identifier" },
+                "to": { "type": "string", "description": "New room identifier (must not exist)" }
+            },
+            "required": ["from", "to"]
+        }
+    })
+}
+
+fn tool_room_update() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_update",
+        "description": "Update a room's title and/or description. Omitted fields stay unchanged (#1202).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "room_id": { "type": "string", "description": "Room identifier" },
+                "title": { "type": "string", "description": "New title (omit to keep current)" },
+                "description": { "type": "string", "description": "New description (omit to keep current)" }
+            },
+            "required": ["room_id"]
+        }
+    })
+}
+
+fn tool_room_memory_move() -> Value {
+    serde_json::json!({
+        "name": "uteke_room_memory_move",
+        "description": "Move a memory from one room to another, preserving the link's author/role/joined_at provenance (#1202).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "memory_id": { "type": "string", "description": "Memory identifier" },
+                "from_room": { "type": "string", "description": "Source room (memory must be a member)" },
+                "to_room": { "type": "string", "description": "Target room (must exist)" }
+            },
+            "required": ["memory_id", "from_room", "to_room"]
         }
     })
 }
@@ -2068,6 +2121,69 @@ fn exec_room_delete(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
         content: vec![McpContent::Text {
             r#type: "text".to_string(),
             text,
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_rename(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let from = args["from"].as_str().ok_or("Missing 'from'")?;
+    let to = args["to"].as_str().ok_or("Missing 'to'")?;
+
+    uteke
+        .rename_room(from, to)
+        .map_err(|e| format!("Failed to rename room: {e}"))?;
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("✓ Room '{from}' renamed to '{to}' — all links moved atomically"),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_update(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let room_id = args["room_id"].as_str().ok_or("Missing 'room_id'")?;
+    let title = args["title"].as_str();
+    let description = args["description"].as_str();
+
+    let room = uteke
+        .update_room(room_id, title, description)
+        .map_err(|e| format!("Failed to update room: {e}"))?
+        .ok_or_else(|| format!("Room not found: {room_id}"))?;
+
+    let title_out = room.title.as_deref().unwrap_or("(none)");
+    let desc_out = room.description.as_deref().unwrap_or("(none)");
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!(
+                "✓ Room '{room_id}' updated — title: {title_out}, description: {desc_out}"
+            ),
+        }],
+        is_error: false,
+    })
+}
+
+fn exec_room_memory_move(uteke: &Uteke, args: &Value) -> Result<ToolResult, String> {
+    let memory_id = args["memory_id"].as_str().ok_or("Missing 'memory_id'")?;
+    let from_room = args["from_room"].as_str().ok_or("Missing 'from_room'")?;
+    let to_room = args["to_room"].as_str().ok_or("Missing 'to_room'")?;
+
+    let moved = uteke
+        .move_memory_to_room(memory_id, from_room, to_room)
+        .map_err(|e| format!("Failed to move memory: {e}"))?;
+    if moved == 0 {
+        return Err(format!(
+            "Memory '{memory_id}' has no link in room '{from_room}'"
+        ));
+    }
+
+    Ok(ToolResult {
+        content: vec![McpContent::Text {
+            r#type: "text".to_string(),
+            text: format!("✓ Memory '{memory_id}' moved from '{from_room}' to '{to_room}'"),
         }],
         is_error: false,
     })

--- a/crates/uteke-server/src/api_registry.rs
+++ b/crates/uteke-server/src/api_registry.rs
@@ -338,6 +338,33 @@ pub const ENDPOINTS: &[Endpoint] = &[
         excludes_deprecated: false,
         issues: &[],
     },
+    Endpoint {
+        method: "POST",
+        path: "/room/rename",
+        description: "Rename a room: the registry row and every member/document link move in one transaction; title, description, and namespace are preserved (#1202). Accepts `{ from, to }`. Write op — blocked for read-only tokens.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#1202"],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/update",
+        description: "Update a room's title and/or description; omitted fields stay unchanged (#1202). Accepts `{ room_id, title?, description? }`; 404 when the room is missing. Write op — blocked for read-only tokens.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#1202"],
+    },
+    Endpoint {
+        method: "POST",
+        path: "/room/memory/move",
+        description: "Move a memory from one room to another, preserving the link's author/role/joined_at provenance (#1202). Accepts `{ memory_id, from_room, to_room }`; 404 when the memory has no link in `from_room`. Write op — blocked for read-only tokens.",
+        request_type: Some("serde_json::Value"),
+        response_type: None,
+        excludes_deprecated: false,
+        issues: &["#1202"],
+    },
     // ── Room Documents ──────────────────────────────────────────────────
     Endpoint {
         method: "POST",

--- a/crates/uteke-server/src/handlers.rs
+++ b/crates/uteke-server/src/handlers.rs
@@ -1649,6 +1649,120 @@ pub fn route(uteke: &Mutex<Uteke>, ctx: &ReqCtx, req: &mut Request) -> Response<
             }
         }
 
+        // POST /room/rename — rename a room, moving all member/document
+        // links in one transaction (#1202)
+        (Method::Post, "/room/rename") => {
+            #[derive(Deserialize)]
+            struct RoomRenameRequest {
+                from: String,
+                to: String,
+            }
+            match read_body::<RoomRenameRequest>(req.as_reader()) {
+                Ok(req_data) => match uteke.rename_room(&req_data.from, &req_data.to) {
+                    Ok(room) => ctx.ok_response_for(
+                        req,
+                        &serde_json::json!({
+                            "renamed": req_data.from,
+                            "to": req_data.to,
+                            "room": room,
+                        }),
+                    ),
+                    Err(e) => {
+                        let status = match e {
+                            uteke_core::Error::Validation(_) => 400,
+                            _ => 500,
+                        };
+                        ctx.error_response_for(req, status, e.to_string())
+                    }
+                },
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
+        // POST /room/update — update room title/description (#1202)
+        (Method::Post, "/room/update") => {
+            #[derive(Deserialize)]
+            struct RoomUpdateRequest {
+                room_id: String,
+                #[serde(default)]
+                title: Option<String>,
+                #[serde(default)]
+                description: Option<String>,
+            }
+            match read_body::<RoomUpdateRequest>(req.as_reader()) {
+                Ok(req_data) => {
+                    match uteke.update_room(
+                        &req_data.room_id,
+                        req_data.title.as_deref(),
+                        req_data.description.as_deref(),
+                    ) {
+                        Ok(Some(room)) => {
+                            ctx.ok_response_for(req, &serde_json::json!({ "room": room }))
+                        }
+                        Ok(None) => ctx.error_response_for(
+                            req,
+                            404,
+                            format!("Room not found: {}", req_data.room_id),
+                        ),
+                        Err(e) => {
+                            let status = match e {
+                                uteke_core::Error::Validation(_) => 400,
+                                _ => 500,
+                            };
+                            ctx.error_response_for(req, status, e.to_string())
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
+        // POST /room/memory/move — move a memory from one room to another,
+        // preserving link author/role/joined_at (#1202)
+        (Method::Post, "/room/memory/move") => {
+            #[derive(Deserialize)]
+            struct RoomMemoryMoveRequest {
+                memory_id: String,
+                from_room: String,
+                to_room: String,
+            }
+            match read_body::<RoomMemoryMoveRequest>(req.as_reader()) {
+                Ok(req_data) => {
+                    match uteke.move_memory_to_room(
+                        &req_data.memory_id,
+                        &req_data.from_room,
+                        &req_data.to_room,
+                    ) {
+                        Ok(1) => ctx.ok_response_for(
+                            req,
+                            &serde_json::json!({
+                                "moved": req_data.memory_id,
+                                "from_room": req_data.from_room,
+                                "to_room": req_data.to_room,
+                            }),
+                        ),
+                        Ok(0) => ctx.error_response_for(
+                            req,
+                            404,
+                            format!(
+                                "Memory {} has no link in room {}",
+                                req_data.memory_id, req_data.from_room
+                            ),
+                        ),
+                        Ok(_) => unreachable!("move returns 0 or 1"),
+                        Err(e) => {
+                            let status = match e {
+                                uteke_core::Error::Validation(_) => 400,
+                                _ => 500,
+                            };
+                            ctx.error_response_for(req, status, e.to_string())
+                        }
+                    }
+                }
+                Err(e) => ctx.error_response_for(req, 400, e),
+            }
+        }
+
         // POST /room/remember — store memory and link to room (#762)
         (Method::Post, "/room/remember") => {
             match read_body::<RoomRememberRequest>(req.as_reader()) {
@@ -3165,6 +3279,80 @@ mod room_recall_at_tests {
                 .to_lowercase()
                 .contains("refus")
         );
+    }
+
+    #[test]
+    fn room_rename_update_move_endpoints_roundtrip() {
+        let app = NamespaceApp::new();
+
+        // Create rooms + one room memory.
+        let body = serde_json::json!({ "room_id": "ws", "namespace": "default" }).to_string();
+        let (status, resp) = app.call(Method::Post, "/room/create", Some(body));
+        assert_eq!(status, 200, "{resp}");
+        let body = serde_json::json!({ "room_id": "ws-3", "namespace": "default" }).to_string();
+        let (status, resp) = app.call(Method::Post, "/room/create", Some(body));
+        assert_eq!(status, 200, "{resp}");
+
+        let body = serde_json::json!({
+            "content": "room note",
+            "tags": [],
+            "room_id": "ws",
+            "author": "tester"
+        })
+        .to_string();
+        let (status, resp) = app.call(Method::Post, "/room/remember", Some(body));
+        assert_eq!(status, 200, "{resp}");
+        let memory_id = resp["id"].as_str().expect("memory id").to_string();
+
+        // Rename ws → ws-2.
+        let body = serde_json::json!({ "from": "ws", "to": "ws-2" }).to_string();
+        let (status, resp) = app.call(Method::Post, "/room/rename", Some(body));
+        assert_eq!(status, 200, "{resp}");
+        assert_eq!(resp["renamed"], serde_json::json!("ws"));
+        assert_eq!(resp["room"]["id"], serde_json::json!("ws-2"));
+
+        // Update title/description on ws-2.
+        let body = serde_json::json!({
+            "room_id": "ws-2",
+            "title": "Workspace",
+            "description": "Renamed workspace"
+        })
+        .to_string();
+        let (status, resp) = app.call(Method::Post, "/room/update", Some(body));
+        assert_eq!(status, 200, "{resp}");
+        assert_eq!(
+            resp["room"]["description"],
+            serde_json::json!("Renamed workspace")
+        );
+
+        // Move the memory ws-2 → ws-3.
+        let body = serde_json::json!({
+            "memory_id": memory_id,
+            "from_room": "ws-2",
+            "to_room": "ws-3"
+        })
+        .to_string();
+        let (status, resp) = app.call(Method::Post, "/room/memory/move", Some(body.clone()));
+        assert_eq!(status, 200, "{resp}");
+        assert_eq!(resp["moved"], serde_json::json!(memory_id));
+
+        // Moving again → 404 (no link left in source).
+        let (status, resp) = app.call(Method::Post, "/room/memory/move", Some(body));
+        assert_eq!(status, 404, "{resp}");
+        assert!(
+            resp["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no link")
+        );
+    }
+
+    #[test]
+    fn room_update_missing_room_returns_404() {
+        let app = NamespaceApp::new();
+        let body = serde_json::json!({ "room_id": "ghost", "title": "x" }).to_string();
+        let (status, resp) = app.call(Method::Post, "/room/update", Some(body));
+        assert_eq!(status, 404, "{resp}");
     }
 
     #[test]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -411,6 +411,30 @@ List all memories in a room (chronological). Accepts `?room_id=...` query param.
 
 Delete a room (unlink-only): room links are removed, memories and documents are preserved. Response: `{ deleted, unlinked_memories }`. Accepts `?room_id=...` query param.
 
+#### 🟡 `POST` `/room/rename`
+
+Rename a room: the registry row and every member/document link move in one transaction; title, description, and namespace are preserved (#1202). Accepts `{ from, to }`. Write op — blocked for read-only tokens.
+
+**Request body**: JSON object (see handler source for fields)
+
+*Related: `#1202`*
+
+#### 🟡 `POST` `/room/update`
+
+Update a room's title and/or description; omitted fields stay unchanged (#1202). Accepts `{ room_id, title?, description? }`; 404 when the room is missing. Write op — blocked for read-only tokens.
+
+**Request body**: JSON object (see handler source for fields)
+
+*Related: `#1202`*
+
+#### 🟡 `POST` `/room/memory/move`
+
+Move a memory from one room to another, preserving the link's author/role/joined_at provenance (#1202). Accepts `{ memory_id, from_room, to_room }`; 404 when the memory has no link in `from_room`. Write op — blocked for read-only tokens.
+
+**Request body**: JSON object (see handler source for fields)
+
+*Related: `#1202`*
+
 #### 🟡 `POST` `/room/document`
 
 Store a reference document in a room (large content >500 chars).


### PR DESCRIPTION
## What

Implements the remaining gaps from #1202 (audited against code first — items 4 and the API side of item 5 already existed):

- **Room rename** (`Uteke::rename_room(old, new)`): rewrites the registry row and every `room_memories` / `room_documents` reference in ONE transaction. The FKs are `ON DELETE CASCADE` only (no `ON UPDATE`), so the implementation uses an FK-safe insert-new-row → repoint-children → delete-old-row order. Title, description, and namespace are preserved; errors on missing source or taken target (`Error::Validation`).
- **Room update** (`Uteke::update_room(id, title?, description?)`): edits title and/or description, `None` = keep current. Adds the additive `rooms.description` column via **schema v19** (fresh stores get it in CREATE TABLE; existing stores migrate with a guarded `ALTER TABLE`). Structural export now carries the 6th column and import accepts both 5- and 6-column exports.
- **Memory room-move** (`Uteke::move_memory_to_room(id, from, to)`): rooms are many-to-many (`room_memories` PK `(room_id, memory_id)`), so the move reads the link's provenance, then delete+insert in one transaction — `author`/`role`/`joined_at` travel with the link. `Ok(0)` when the memory is not a member of `from`; target room must exist; same-room moves rejected.
- **`uteke update <id>` CLI**: in-place memory edit (content/tags/importance/pinned/type). The facade (`Uteke::update_memory`), HTTP (`PUT /memory`), and MCP (`uteke_update`) surfaces already existed — this closes the CLI-only gap (#1202 item 5).

Surfaces per op (mirrors the #1183 pattern): HTTP `POST /room/rename` (`{from, to}`), `POST /room/update` (`{room_id, title?, description?}`; 404 when room missing), `POST /room/memory/move` (`{memory_id, from_room, to_room}`; 404 when the link is absent); CLI `uteke room rename <old> <new>`, `uteke room update <id> [--title ...] [--description ...]`, `uteke room move-memory <id> --from <room> --to <room>`, `uteke update <id> [--content ...] [--tags ...] [--importance ...] [--pinned ...] [--type ...]`; MCP `uteke_room_rename`, `uteke_room_update`, `uteke_room_memory_move`.

## Why

Fleet ops across many agents/projects need room lifecycle management: renaming a room today means create-new + re-remember everything, which breaks anything referencing the room name (agent routing config, memory hooks, channel-mirror conventions). `link_memory_to_room` had no reverse, so consolidating rooms was impossible without losing link provenance. `rooms` had no description column and no metadata edit path. Closes #1202 (items 1, 2, 3, 5-CLI).

## Testing

- 8 new unit tests in `uteke-core` (`rooms::tests`): rename moves registry + member links (author-filterable recall on the new ID), rename preserves document links, rename rejects missing source / taken target / same-ID, update sets title+description independently (and `None` for missing room), move preserves link provenance (verified via direct SQL on `room_memories`), move rejects missing target room / same-room. Schema-migration test updated: `MAX(version)` now asserts **19**.
- 2 new HTTP roundtrip tests in `uteke-server`: `room_rename_update_move_endpoints_roundtrip` (full flow: create → room/remember → rename → update → move → 404 on double-move) and `room_update_missing_room_returns_404`.
- Local CI replication: `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; full `cargo test --workspace` green.
