### PR TITLE
docs(benchmarks): surface benchmark proof in README, fix stale versions and contradiction numbers

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@
 **Uteke** is a local-first semantic memory engine for AI agents. Single Rust binary, fully offline, ~30ms recall. No API key, Docker, or cloud service needed.
 
 - **Repo:** `codecoradev/uteke` (remote GitHub), local clone
-- **Version:** 0.14.3
+- **Version:** 0.17.0
 - **License:** Apache 2.0
 - **Main branches:** `develop` (default branch, all PRs go here), `main` (release mirror)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ graphs, pagination metadata, and a dual-engine vector layer.
 
 ### Added
 
-- **Contradiction benchmark segment (#1172, phase 3)** — `benchmarks/longmemeval/contradiction_segment.py`: 40-topic active-store segment measuring conflict-resolution quality end-to-end. Baseline (both facts active) vs resolved (superseded): fusion winner@1 0.975 → 1.000, stale@5 0.825 → 0.000. Published in `benchmarks/longmemeval/RESULTS.md`. Also adds `uteke supersede <old> <new> [--reason]` — CLI surface parity for supersession (previously MCP/HTTP only).
+- **Contradiction benchmark segment (#1172, phase 3)** — `benchmarks/longmemeval/contradiction_segment.py`: 40-topic active-store segment measuring conflict-resolution quality end-to-end. Baseline (both facts active) vs resolved (superseded): fusion winner@1 0.850 → 1.000, stale@5 1.000 → 0.000. Published in `benchmarks/longmemeval/RESULTS.md`. Also adds `uteke supersede <old> <new> [--reason]` — CLI surface parity for supersession (previously MCP/HTTP only).
 
 - **`/list` pagination metadata (#1188)** — `POST /list` accepts `"include_meta": true` to respond with an envelope `{memories, total, has_more, next_offset}` (`next_offset` is `null` on the last page) so clients no longer blind-paginate with 100-row guesses. The default response is unchanged (bare array) — existing clients are untouched; `include_meta` is ignored in `at` (point-in-time) mode, which stays a bare array.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <img src="https://img.shields.io/badge/Rust-1.85+-orange.svg?style=flat-square" alt="Rust 1.85+" />
   <a href="https://github.com/codecoradev/uteke/pkgs/container/uteke"><img src="https://img.shields.io/badge/Docker-ready-blue.svg?style=flat-square" alt="Docker" /></a>
   <img src="https://img.shields.io/badge/recall-~45ms-brightgreen.svg?style=flat-square" alt="Recall ~45ms" />
+  <a href="docs/benchmarks.md#longmemeval-s--retrieval-accuracy-500-questions"><img src="https://img.shields.io/badge/LongMemEval--S_recall@5-98.2%25-crimson.svg?style=flat-square" alt="LongMemEval-S recall@5: 98.2%" /></a>
 </p>
 
 <p align="center">
@@ -134,8 +135,10 @@ Every AI tool forgets. Context windows fill up, sessions end, and your AI starts
 >
 > **Uteke vs Tool C:** Tool C has 54 MCP tools and multi-agent shared memory via a local engine. Uteke's edge: **zero dependencies** (no npm, no extra engine), **hybrid search** (Tool C lacks FTS5), and **time-travel queries**.
 
-<details>
-<summary>📊 Benchmark numbers</summary>
+## 📊 Benchmarks — 98.2% recall on LongMemEval-S
+
+Fusion retrieval answers "what does the agent know *now*": after `supersede`, the
+contradiction segment goes from 85% → **100% winner@1 with zero stale facts** in top-5.
 
 | Metric | Result | Notes |
 |--------|--------|-------|
@@ -145,14 +148,13 @@ Every AI tool forgets. Context windows fill up, sessions end, and your AI starts
 | **LongMemEval-S recall_any@5** | **98.2%** | Full 500Q validation, zero-config fusion default (v0.16.0) — the metric competitor benchmarks publish |
 | LongMemEval-S recall_all@10 | 95.4% | Strict: every gold session in top-10 |
 | LongMemEval-S strict recall_all@5 | 88.0% | Every gold session in top-5 (mathematical ceiling 99.4%) |
+| Contradiction segment: winner@1 after supersede | **100%** | Stale facts drop from top-5 entirely (85% → 100% winner@1) — see [RESULTS.md](benchmarks/longmemeval/RESULTS.md) |
 
 ![uteke vs published systems on LongMemEval-S](docs/assets/longmemeval-comparison.jpg)
 
 > **Don't trust our benchmark — run your own.** We re-ran 108 of the 500 published questions on a 4-core ARM desktop (different CPU architecture from the published Modal x86 run, same v0.16.0 binary and harness): **107/108 produced identical per-question rankings**. The single difference was an adjacent-rank near-tie, both runs retrieved the identical top-10 session set, one gold session swapped ranks 5-6. Details in [RESULTS.md](benchmarks/longmemeval/RESULTS.md).
 
-Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark details](docs/benchmarks.md) · [LongMemEval results](benchmarks/longmemeval/RESULTS.md) — fusion default: R@5 0.946 / R@10 0.977 on the full 500Q validation set (v0.16.0)
-
-</details>
+Full benchmarks: `uteke bench --counts 100,1000,10000 --json` · [Benchmark details](docs/benchmarks.md) · [LongMemEval results](benchmarks/longmemeval/RESULTS.md) — full 500Q validation (v0.16.0): recall_any@5 0.982 / strict recall_all@5 0.880
 
 ---
 
@@ -384,7 +386,7 @@ Yes. Uteke ships with an MCP server that works with Claude Code, Cursor, and Her
 <details>
 <summary><strong>Is it production-ready?</strong></summary>
 
-Uteke is at v0.16.0 with 200+ tests, CI/CD on every commit, and a benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x, so expect rough edges, but the core is stable.
+Uteke is at v0.17.0 with 200+ tests, CI/CD on every commit, and a benchmark harness. It's used in production by the CodeCora team and other early adopters. Still in 0.x, so expect rough edges, but the core is stable.
 </details>
 
 ---

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -128,7 +128,7 @@ An independent local re-run (2026-09-01) of 108 of the 500 questions on a 4-core
 | OS | Linux 6.8.0 (aarch64) |
 | Rust | 1.85+ |
 | Embedding | EmbeddingGemma Q4, 768d, ONNX Runtime CPU |
-| Uteke | v0.12.0 |
+| Uteke | v0.16.0 for LongMemEval-S validation; perf table re-verified on v0.17.0 (2026-09-09) |
 
 ## Methodology
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,14 @@ title: Roadmap
 
 Demand-gated — we build what people actually use. Track progress on [GitHub Issues](https://github.com/codecoradev/uteke/issues).
 
+## v0.17.0 — Inspectable, Trustworthy Memory `✓ Released 2026-09-06`
+
+- **Explain recall (#1160)** — see why each memory ranked where it did, on every recall surface (CLI `--explain`, HTTP `explain`, MCP flag)
+- **Contradiction resolution as an auditable ledger (#1172)** — supersede/list/undo with provenance; contradiction benchmark segment: fusion winner@1 0.850 → 1.000 after supersede, stale@5 1.000 → 0.000
+- **Provenance data model (#1172, schema v18)** — `source_hash` tamper evidence, actor/evidence timeline events, `provenance(id)` report
+- **Dual-engine vector layer** — runtime-switchable vector engine (#1169/#1171)
+- **Namespace management API (#1181)** — rename/merge/delete with explicit memory strategy; `/list` pagination metadata (#1188)
+
 ## v0.16.0 — Fusion Default `✓ Released 2026-08-29`
 
 - **`fusion` is now the default recall strategy (#1123)** — weighted RRF of the vector and hybrid rankings; LongMemEval 500Q R@5 0.946 vs 0.854 hybrid (+9.2 pts), zero config needed


### PR DESCRIPTION
## What

Docs-only accuracy + visibility pass on benchmark materials (no code changes):

- **README**: promote the benchmark block out of the collapsed `<details>` into a full `## 📊 Benchmarks` section — headline chart + table visible on first scroll. Adds a crimson `LongMemEval-S recall@5 98.2%` badge and a contradiction-resolution hook line.
- **README**: contradiction segment row added to the benchmark table (from RESULTS.md, shipped in 0.17.0) + FAQ status line v0.16.0 → v0.17.0.
- **README**: closing benchmark line now cites full-500Q numbers verified against the committed raw artifact (`results_modal_default/retrieval_results.jsonl`): recall_any@5 0.982 / strict recall_all@5 0.880 (the previous "R@5 0.946 on the full 500Q" figure came from a 470-question aggregate, not the full set).
- **docs/benchmarks.md**: Environment table said `Uteke | v0.12.0` — stale since the 0.16 docs refresh. Now states v0.16.0 for the LongMemEval-S validation and notes the perf table was re-verified on v0.17.0 (2026-09-09, same host class: Oracle ARM A1, 4 vCPU / 24 GB, native aarch64 build).
- **CHANGELOG (Unreleased)**: contradiction segment numbers corrected 0.975 → 0.850 (winner@1 baseline) and 0.825 → 1.000 (stale@5 baseline) to match `results_contradiction_f3/metrics.json`.
- **AGENT.md**: Version 0.14.3 → 0.17.0. **docs/roadmap.md**: adds the released v0.17.0 section.

## Why

- `docs/benchmarks.md` contradicted itself: Environment row said v0.12.0 while the same document describes fusion as "default since 0.16.0" and carries the v0.16.0 LongMemEval-S validation section.
- The headline benchmark chart was hidden behind a collapsed `<details>` in the README — invisible without a click.
- CHANGELOG's contradiction numbers (0.975/0.825) appear nowhere in the committed raw metrics; `metrics.json` says fusion baseline winner@1 = 0.85, stale@5 = 1.0 (RESULTS.md agrees). The corrected story is also the stronger one: before resolution, the stale fact ranks in the top-5 for **every** query; supersede removes it entirely.

## Testing

- Docs-only diff (6 files, all `.md`), no code touched.
- Every cited number re-verified against committed raw artifacts:
  - recall_any@5 0.9820, strict recall_all@5 0.8800, strict@10 0.9540, coverage@5 0.9433 recomputed from `results_modal_default/` (500 questions)
  - FTS5 ablation bar 0.9140 recomputed from `results_modal_fts5_partial/` (10 shards, 500 questions)
  - contradiction numbers recomputed from `results_contradiction_f3/metrics.json`
- Perf table re-verified on v0.17.0 native aarch64 build, same host class (Oracle A1 4 vCPU/24GB), 2026-09-09:

  | Scale | Insert | Recall avg | Recall P95 | DB | Index |
  |---|---|---|---|---|---|
  | 100 | 17.3 ops/s | 31 ms | 47 ms | 0.7 MB | 0.31 MB |
  | 1,000 | 17.5 ops/s | 42 ms | 62 ms | 5.2 MB | 3.10 MB |
  | 10,000 | 5.0 ops/s | 31 ms | 38 ms | 80.7 MB | 30.2 MB |

  Storage matches the published table; recall latency equal or better; throughput within run-to-run noise. Published LongMemEval-S accuracy numbers remain attributed to the v0.16.0 run (retrieval scoring path unchanged in 0.17.0).
- Reproduce: `uteke bench --counts 100,1000,10000 --json` · contradiction segment: `benchmarks/longmemeval/contradiction_segment.py`.
