### PR TITLE
fix(core): verify dedup candidates are live before skipping insert (#1210)

### DIFF
--- a/crates/uteke-core/src/operations.rs
+++ b/crates/uteke-core/src/operations.rs
@@ -274,7 +274,21 @@ impl crate::Uteke {
             }
             let sim = (1.0 - dist).clamp(0.0, 1.0);
             if sim >= DEDUP_THRESHOLD {
-                return Ok(Some(id.clone()));
+                // Verify against SQLite before trusting the index hit (#1210).
+                // A stale index can still hold vectors for rows that were
+                // soft-deleted (deprecated) or hard-deleted; deduplicating
+                // against them silently drops the write and can link rooms
+                // to invisible ghost rows. Treat them as absent and keep
+                // scanning remaining candidates.
+                match self.store.get_by_id(id) {
+                    // Live row — safe to dedup onto.
+                    Ok(Some(m)) if !m.deprecated => return Ok(Some(id.clone())),
+                    // Missing (hard-deleted) or deprecated row — stale index
+                    // entry; skip this candidate and keep scanning (#1210).
+                    Ok(_) => continue,
+                    // Store read failed — never dedup on an unreliable read.
+                    Err(_) => continue,
+                }
             }
         }
 
@@ -2542,6 +2556,40 @@ mod dedup_tests {
             .remember("Same content different namespace", &[], None, Some("ns2"))
             .unwrap();
         assert_ne!(id1, id2, "different namespace should not dedup");
+    }
+
+    #[test]
+    #[ignore = "requires ONNX embedder (model download) in CI"]
+    fn test_dedup_skips_deprecated_stale_index_entry() {
+        // #1210: a stale vector index on a long-running server can still hold
+        // the vector of a soft-deleted (deprecated) memory. Dedup must NOT
+        // match it — the rewrite must produce a NEW live memory instead of
+        // silently returning the deprecated ghost id (which also gets linked
+        // into rooms by remember_in_room, invisible in recall).
+        let uteke = Uteke::open(":memory:").unwrap();
+        let ns = "dedup-depr";
+        let content = "Ghost dedup regression content #1210";
+        let id1 = uteke.remember(content, &[], None, Some(ns)).unwrap();
+
+        // Healthy path: soft-delete removes the vector from the index.
+        uteke.soft_forget(&id1, "test: 1210 repro").unwrap();
+
+        // Simulate index/SQLite desync (missed repair / failed persistence):
+        // the deprecated row's vector re-enters the index.
+        let emb = uteke.store.get_by_id(&id1).unwrap().unwrap().embedding;
+        assert!(!emb.is_empty(), "precondition: first row must be embedded");
+        uteke.index.write().unwrap().insert(&id1, &emb).unwrap();
+
+        // The rewrite must NOT dedup onto the deprecated ghost.
+        let id2 = uteke.remember(content, &[], None, Some(ns)).unwrap();
+        assert_ne!(id2, id1, "deprecated row must not be a dedup target");
+
+        // The new row is live, holds the content, and the ghost stays hidden.
+        let live = uteke.store.get_by_id(&id2).unwrap().unwrap();
+        assert!(!live.deprecated);
+        assert_eq!(live.content, content);
+        let ghost = uteke.store.get_by_id(&id1).unwrap().unwrap();
+        assert!(ghost.deprecated);
     }
 
     #[test]


### PR DESCRIPTION
## What

`check_duplicate()` (the #442 semantic dedup, cosine ≥ 0.95) now verifies each candidate hit against SQLite before returning it: candidates whose row is missing (hard-deleted) or soft-deleted (`deprecated = 1`) are skipped, and dedup falls through to a normal insert. A store read error also skips the candidate — dedup never fires on an unreliable read.

Adds one regression test (`test_dedup_skips_deprecated_stale_index_entry`, ONNX-ignored per repo convention for embedder-dependent tests) that poisons the vector index with a deprecated row's embedding — simulating the index↔SQLite desync observed on a long-running server — and asserts the rewrite produces a fresh live row instead of the deprecated ghost id.

## Why

Fixes the production incident in #1210: on a long-running server whose vector index went stale relative to SQLite, `remember()` with near-identical content "succeeded" while writing **zero new rows** — it returned the deprecated row's id, and `remember_in_room()` then linked rooms to an invisible ghost row. Four write attempts in production all reported success and stored nothing.

Root cause: `check_duplicate()` filtered dedup candidates **only by namespace** — no `deprecated = 0` predicate, unlike every recall query in the codebase. A stale index entry for a soft-deleted row therefore still satisfied dedup. The verification happens at the point of acceptance (not in the namespace id-set query) so it also covers callers that dedup without a namespace filter.

Fixing at this layer protects both call sites (`remember()` and the import pipeline) and keeps behavior conservative: soft-deleted means forgotten, so a rewrite legitimately creates a new memory.

## Testing

- New regression test proven red→green: fails on unfixed code with exactly the production symptom (`assert_ne!` on ghost id, exit 101), passes with the fix.
- `cargo test -p uteke-core --lib dedup -- --include-ignored`: 12/12 pass (11 pre-existing dedup tests unchanged + the new one).
- `cargo test -p uteke-core --lib` (full suite, default profile): green — 560 passed, 0 failed, 33 ignored.
- `cargo clippy -p uteke-core --all-targets`: zero warnings. `cargo fmt --check`: clean.
- Manual E2E on an **isolated** store (`UTEKE_HOME=/tmp/...`, never prod): `remember → forget → remember` with identical content creates a second live row; the deprecated row stays `deprecated=1` (verified via read-only SQLite), matching the unit test at the CLI level.

Addresses #1210 (the issue stays open for post-merge validation before closing).
