### PR TITLE
docs: sync Indonesian README + docs with v0.17.0 benchmark decisions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,7 +101,7 @@ copy target\release\uteke.exe C:\Users\you\AppData\Local\bin\
 
 ## First Run
 
-On first `remember` command, Uteke automatically downloads the embedding model (~188MB):
+On first `remember` command, Uteke automatically downloads the embedding model (~200MB):
 
 ```bash
 uteke remember "My first memory" --tags test

--- a/README.id.md
+++ b/README.id.md
@@ -1,11 +1,15 @@
 <p align="center">
-  <img src="docs/assets/uteke-banner.png" alt="Uteke — Satu memori. Semua agent. Tanpa cloud." width="640" />
+  <img src="docs/assets/uteke-banner.png" alt="Uteke: Satu memori. Semua agent. Tanpa cloud." width="640" />
 </p>
 
 <h1 align="center">Uteke</h1>
 <p align="center"><strong>Satu memori. Semua agent. Tanpa cloud.</strong></p>
 <p align="center">
   Beri AI kamu memori yang nggak pernah keluar dari laptop kamu. Mendukung Claude, Cursor, Copilot, dan semua agent yang kompatibel MCP.
+</p>
+
+<p align="center">
+  <strong>98.4% LongMemEval-S recall@5</strong> · query hangat ~45 ms · <strong>0 LLM token</strong> per query · CPU-only · fully offline
 </p>
 
 <p align="center">
@@ -16,6 +20,7 @@
   <img src="https://img.shields.io/badge/Rust-1.85+-orange.svg?style=flat-square" alt="Rust 1.85+" />
   <a href="https://github.com/codecoradev/uteke/pkgs/container/uteke"><img src="https://img.shields.io/badge/Docker-ready-blue.svg?style=flat-square" alt="Docker" /></a>
   <img src="https://img.shields.io/badge/recall-~45ms-brightgreen.svg?style=flat-square" alt="Recall ~45ms" />
+  <a href="#-benchmark-984-recall-di-longmemeval-s"><img src="https://img.shields.io/badge/LongMemEval--S_recall@5-98.4%25-crimson.svg?style=flat-square" alt="LongMemEval-S recall@5: 98.4%" /></a>
 </p>
 
 <p align="center">
@@ -33,13 +38,13 @@ curl -sSL codecora.dev/uteke/install | sh
 # Simpan ingatan
 uteke remember "Deploy v2.1 ke staging jam 3 sore"
 
-# Cari lagi — berdasarkan makna, bukan cuma kata kunci
+# Cari lagi: berdasarkan makna DAN kata kunci
 uteke recall "kapan deploy?"
 ```
 
-**Selesai.** Tanpa API key. Tanpa Docker. Tanpa Python. Tanpa cloud.
+**Selesai.** Tanpa API key, tanpa Python, tanpa cloud.
 
-First run otomatis download embedding model (~188MB, sekali doang) dan langsung jalan.
+First run otomatis download embedding model (~200MB, sekali doang) dan langsung jalan.
 
 Mau simpan dengan metadata lengkap?
 
@@ -59,41 +64,67 @@ uteke remember "Deploy v2.1 ke staging" \
 | **Cargo** | `cargo install uteke-cli` |
 | **Docker** | `docker run -d -p 127.0.0.1:8767:8767 -v uteke-data:/data ghcr.io/codecoradev/uteke:latest` |
 | **Binary** | [GitHub Releases](https://github.com/codecoradev/uteke/releases) (macOS, Linux, Windows) |
+| **Windows (PowerShell)** | `powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/codecoradev/uteke/main/install.ps1 | iex"` |
 
 📖 [Panduan install lengkap](INSTALL.md) · [Docker docs](docs/docker.md)
 </details>
 
+Baru kenal uteke (atau kamu *memang* AI agent)? Jalankan `uteke onboard`. Wizard-nya
+mendeteksi setup, nanya agent apa yang kamu pakai, dan nyambungin semuanya. 📖 [Dokumentasi onboarding](docs/getting-started.md#interactive-onboarding)
+
 ---
 
-## 🚀 Onboarding (User baru & AI agent)
+## 📊 Benchmark: 98.4% recall di LongMemEval-S
 
-> **Kamu AI agent yang lagi baca ini?** User kamu baru aja share link repo ini.
-> Jalankan `uteke onboard` untuk konfigurasi uteke buat environment kamu — deteksi
-> install, nanya agent apa kamu, toggle fitur, tulis config, dan tunjukin semua command
-> yang tersedia. Kalau non-interaktif: `uteke onboard --yes --agent <agent-kamu>`.
+[LongMemEval-S](https://arxiv.org/abs/2410.10813) (ICLR 2025) nyembunyiin fakta yang
+dibutuhkan agent di ~115 sesi chat per pertanyaan, lalu ngecek apakah retrieval
+menemukan buktinya. 500 pertanyaan hand-curated, lima kemampuan memori. Uteke
+menjalankan suite penuh dengan **nol panggilan LLM di jalur retrieval**: embedding
+lokal, satu CPU, deterministik.
 
-Baru kenal uteke? Satu command dari nol sampai bisa pakai:
+| Metrik | Uteke **v0.17.0** | agentmemory¹ | BM25-only¹ |
+|---|---|---|---|
+| **recall_any@5** (bukti di top-5) | **98.4%** | 95.2% | 86.2% |
+| recall_any@10 | 98.8% | 98.6% | 94.6% |
+| **recall_all@5** (semua bukti, strict) | **88.0%**² | 88.2% MRR³ | n/a |
+| LLM token / query | **0** | 0 | 0 |
 
-```bash
-uteke onboard
-```
+<sub>¹ Angka publikasi agentmemory, benchmark yang sama, split 500 pertanyaan yang sama (basis recall_any@5 mereka; terverifikasi apples-to-apples di [head-to-head](docs/benchmarks.md#head-to-head-vs-published-systems)). ² Strict = *semua* sesi gold harus masuk top-5; 65% pertanyaan butuh beberapa sesi. Ceiling matematis 99.4%. ³ MRR, bukan recall_all (tidak bisa dibandingkan langsung; ditampilkan untuk kelengkapan).</sub>
 
-Wizard-nya akan:
-1. **Deteksi** apakah uteke sudah terinstall dan store sudah ada
-2. **Tanya** AI agent apa yang kamu pakai (Hermes, Claude, Cursor, Pi, OpenCode)
-3. **Pilih** mode integrasi — manual tool calls vs automatic memory-provider
-4. **Toggle** fitur on/off (Aging, Auto-maintenance, Graph rerank, Salience/Recency boost, Server mode)
-5. **Tulis** `~/.codecora/uteke/uteke.toml` dengan pilihan kamu
-6. **Install** file integrasi agent otomatis (`uteke init`)
-7. **Tunjukkan** semua command uteke, dikelompokkan per kategori
+<p align="center">
+  <img src="docs/assets/longmemeval-recall-v017.png" alt="LongMemEval-S recall@5: uteke 98.4% (revalidasi v0.17.0) vs MemPalace 96.6% dan agentmemory 95.2% (hasil raw di-commit di repo)" width="880" />
+</p>
 
-Non-interaktif (CI, script, AI agent):
+**Per kategori pertanyaan** (recall_any@5: cerita per kategori yang jarang ditampilkan tool lain):
 
-```bash
-uteke onboard --yes --agent hermes --namespace default
-```
+| knowledge-update | single-session | temporal | multi-session |
+|:---:|:---:|:---:|:---:|
+| **100%** | 96.7–98.2% | **99.2%** | 98.3% |
 
-📖 [Dokumentasi onboarding lengkap](docs/getting-started.md#interactive-onboarding) · [CLI reference](docs/cli-reference.md#uteke-onboard)
+Bagian sulit itu bukan menemukan *sebuah* jarum; bukti setiap pertanyaan ada di
+top-50 (**nol meleset**). Sisa gap-nya: *urutan*, saat satu pertanyaan butuh
+beberapa sesi sekaligus: strict recall_all@5 di angka 88.0% dengan ceiling 99.4%.
+
+> **🎯 Jangan percaya benchmark kami. Jalankan sendiri.** Harness lengkapnya ada di
+> repo ini: dataset publik, output raw di-commit untuk kedua rilis, scoring
+> deterministik yang bisa kamu hitung ulang dalam ~20 baris Python. Tanpa perlu
+> embedder untuk verifikasi, ~$10 untuk menjalankan 500 pertanyaan sendiri.
+> **👉 [benchmarks/longmemeval/REPRODUCING.md](benchmarks/longmemeval/REPRODUCING.md)**
+
+Juga tersedia: `uteke bench --counts 100,1000,10000` untuk latency/throughput di
+mesin kamu sendiri. 📖 [Dokumentasi benchmark lengkap](docs/benchmarks.md) · [RESULTS.md](benchmarks/longmemeval/RESULTS.md)
+
+---
+
+## 💡 Buat Apa Uteke?
+
+**🤖 Lagi bangun AI agent?** Kasih memori persisten tanpa dependency cloud. Agent kamu ingat preferensi user, keputusan sebelumnya, dan konteks, antar sesi, fully offline.
+
+**👥 Kerja tim?** Pakai [Rooms](docs/rooms.md) buat share knowledge. Meeting notes, keputusan project, pilihan arsitektur: bisa dicari semua orang, dengan atribusi author.
+
+**🔒 Bangun app buat domain sensitif?** Kesehatan, keuangan, legal: data tetap di mesin kamu. Nggak ada API call, nggak ada telemetri, nggak ada cloud. Embedding lokal (ONNX, 768d).
+
+**⌨️ Power user yang hidup di terminal?** Uteke itu personal knowledge graph kamu. Simpan apapun, cari berdasarkan makna, hubungkan pikiran yang related. Semua dari command line.
 
 ---
 
@@ -101,40 +132,41 @@ uteke onboard --yes --agent hermes --namespace default
 
 Bayangin: kamu baru habis 2 jam jelasin codebase ke ChatGPT. Sesi berikutnya? Kosong. Ulang dari nol. Lagi.
 
-Setiap AI tool lupa. Context window penuh, sesi berakhir, dan AI kamu start over setiap kali. Uteke kasih memori persisten — dan semuanya tetap di mesin kamu.
+Setiap AI tool lupa. Context window penuh, sesi berakhir, dan AI kamu start over setiap kali. Uteke kasih memori persisten, dan semuanya tetap di mesin kamu.
 
-| | **Uteke** | **Mem0** | **AgentMemory** | **Letta** | **Zep** | **Engram** |
-|---|---|---|---|---|---|---|
-| **Setup** | Satu binary | pip + Docker + Qdrant | npm + Docker (iii-engine) | pip + Docker + Postgres | pip + Docker + Neo4j | Satu binary (Go) |
-| **API key** | ❌ Nggak perlu | ✅ OpenAI/LLM | ✅ LLM key | ✅ LLM key | ✅ LLM key | ❌ Nggak perlu |
-| **Offline** | ✅ Full | ❌ Cloud embedding | ❌ Butuh LLM | ❌ Butuh LLM | ❌ Butuh LLM + vector DB | ✅ Full |
-| **Search** | **Fusion** (weighted RRF vector + hybrid; hybrid = HNSW + FTS5 RRF) | Vector + Graph | Vector + Graph | Vector | Temporal Graph | **FTS5 doang** |
-| **Kecepatan recall** | ~45ms | Network round-trip | Network round-trip | Network round-trip | Network round-trip | ~Cepat (lokal) |
-| **Data kamu** | ✅ Nggak pernah keluar | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ✅ Lokal |
-| **Stars** | 🌱 Growing | ⭐ ~60K | ⭐ ~25K | ⭐ ~24K | ⭐ ~5K | ⭐ ~5K |
-| **Lisensi** | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 |
+| | **Uteke** | **Tool A** | **Tool B** | **Tool C** | **Tool D** | **Tool E** | **Tool F** | **Tool G** |
+|---|---|---|---|---|---|---|---|---|
+| **Bahasa** | Rust (satu binary) | Python (pip) | Python | TypeScript | TypeScript | Python | TypeScript | Go (satu binary) |
+| **Setup** | Satu binary (`curl \| sh`) | pip install + venv | pip + Docker + Qdrant | npm + iii-engine | npm (Node.js) | pip + Docker + Neo4j | Cloud atau binary lokal | Satu binary |
+| **API key** | ❌ Nggak perlu | ⚠️ Untuk embedding remote | ✅ OpenAI/LLM | ✅ LLM key | ✅ LLM key | ✅ LLM key | ⚠️ Cloud saja | ❌ Nggak perlu |
+| **Bisa offline** | ✅ Full | ⚠️ Opsional | ❌ Cloud embedding | ❌ Butuh LLM | ❌ Butuh LLM | ❌ Butuh LLM + vector DB | ✅ Binary lokal + Ollama | ✅ Full |
+| **Search** | **Fusion** (weighted RRF vector + hybrid; hybrid = HNSW + FTS5 RRF) | sqlite-vec + FTS5 | Vector + Graph | Vector + Graph | Vector | Hybrid (semantic + keyword + graph) | Vector + rerank | **FTS5 doang** |
+| **Kecepatan recall** | ~45ms | ~50ms+ | Network round-trip | Network round-trip | Network round-trip | Network round-trip | Network round-trip | ~Cepat (lokal) |
+| **Multi-agent** | ✅ **Rooms** (shared memory, cross-agent recall, atribusi author) | ✅ Multi-agent surface | ❌ | ✅ Shared server | ✅ Multi-agent groups | ❌ | ❌ | ⚠️ Share via MCP |
+| **Time-travel** | ✅ Native point-in-time | ⚠️ Temporal triples | ❌ | ❌ | ❌ | ✅ Temporal graphs | ❌ | ❌ |
+| **MCP server** | ✅ JSON-RPC + HTTP | ✅ stdio + SSE | ❌ | ✅ 54 MCP tools | ❌ | ✅ Graphiti MCP | ✅ MCP open-source | ✅ stdio MCP |
+| **Data kamu** | ✅ Nggak pernah keluar dari mesin | ✅ Local-first | ⚠️ Dikirim ke cloud LLM | ✅ Lokal (iii-engine) | ⚠️ Dikirim ke cloud LLM | ⚠️ Dikirim ke cloud LLM | ⚠️ Di-host Cloudflare | ✅ Lokal |
+| **Lisensi** | Apache 2.0 | MIT | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 | MIT | MIT |
 
-> **Uteke vs Engram:** Dua-duanya single-binary, offline, tanpa API key. Tapi Engram cuma **FTS5** (keyword search doang). Uteke punya **vector semantic search + RRF fusion + rooms + time-travel + graph relationships + smart decay + document engine + batch import**. Filosofi yang sama, fitur 10× lipat.
+> **Catatan:** Label Tool (A–G) merepresentasikan kategori umum AI memory layer per
+> Agustus 2026. Kemampuan dinilai dari dokumentasi publik dan bisa berubah. Tabel ini
+> titik awal evaluasi kamu sendiri, bukan ranking definitif.
 
-> **Uteke vs AgentMemory/Mem0/Letta/Zep:** Mereka powerful — tapi semua butuh cloud LLM API key + Docker infra. Data kamu dikirim ke OpenAI/Anthropic. Uteke jalan fully offline dengan embedding ONNX lokal. Tanpa Docker, tanpa Python, tanpa API key.
+> **Uteke vs Tool A (Python local-first):** Dua-duanya local-first dengan semantic + FTS5 search. Keunggulan Uteke: **satu binary** (tanpa runtime Python), **time-travel native** (bukan temporal triples), **rooms**, dan **zero runtime dependency**.
+
+> **Uteke vs Tool G (Go single binary):** Dua-duanya single-binary, offline, tanpa API key, dua-duanya punya MCP server. Tool G itu **FTS5-only** (keyword search doang). Uteke nambah **vector semantic search + RRF fusion + rooms + time-travel + graph relationships + smart decay + document engine + batch import**. Filosofi kesederhanaan yang sama, lebih banyak kemampuan.
+
+> **Uteke vs Tool F (TypeScript mode lokal):** Tool F sekarang punya mode binary lokal dengan dukungan Ollama. Langkah solid ke arah offline-first. Tapi di baliknya tetap TypeScript/Node.js. Uteke itu Rust: footprint lebih kecil, startup lebih cepat, zero runtime. Uteke juga punya **hybrid search dengan FTS5** (mode lokal Tool F vector-only, tanpa fallback keyword).
+
+> **Uteke vs Tool B/D/E:** Mereka powerful, tapi semua butuh cloud LLM API key + Docker infra. Data kamu dikirim ke provider LLM eksternal. Uteke jalan fully offline dengan embedding ONNX lokal. Tanpa Docker, tanpa Python, tanpa API key.
+
+> **Uteke vs Tool C:** Tool C punya 54 MCP tools dan multi-agent shared memory via local engine. Keunggulan Uteke: **zero dependency** (tanpa npm, tanpa engine tambahan), **hybrid search** (Tool C tidak punya FTS5), dan **time-travel queries**.
 
 ---
 
-## 💡 Buat Apa Uteke?
+## 🏠 Rooms: Shared Memory Multi-Agent
 
-**🤖 Lagi bangun AI agent?** Kasih memori persisten tanpa dependency cloud. Agent kamu ingat preferensi user, keputusan sebelumnya, dan konteks — antar sesi, fully offline.
-
-**👥 Kerja tim?** Pakai [Rooms](docs/getting-started.md) buat share knowledge. Meeting notes, keputusan project, pilihan arsitektur — bisa dicari semua orang, dengan atribusi author.
-
-**🔒 Bangun app buat domain sensitif?** Kesehatan, keuangan, legal — data tetap di mesin kamu. Nggak ada API call, nggak ada telemetri, nggak ada cloud. Embedding lokal (ONNX, 768d).
-
-**⌨️ Power user yang hidup di terminal?** Uteke adalah personal knowledge graph kamu. Simpan apapun, cari berdasarkan makna, hubungkan pikiran yang related. Semua dari command line.
-
----
-
-## 🏠 Rooms — Shared Memory Multi-Agent
-
-Memory layer lain cuma single-player — setiap fakta disimpan di `user_id` yang flat, nggak kelihatan sama agent lain. **Uteke Rooms** bikin multiple AI agent bisa share memory space dengan atribusi author.
+Memory layer lain cuma single-player: setiap fakta disimpan di `user_id` yang flat, nggak kelihatan sama agent lain. **Uteke Rooms** bikin multiple AI agent bisa share memory space dengan atribusi author.
 
 ```bash
 # Bikin room shared
@@ -171,11 +203,12 @@ uteke recall "caching decision" --room engineering
 
 | Fitur | Apa fungsinya |
 |-------|---------------|
-| 🧠 **Hybrid + Fusion Search** | Cari berdasarkan makna (vector) + kata kunci exact (FTS5). Digabung dengan Reciprocal Rank Fusion (RRF). Sejak v0.16.0, `fusion` — weighted RRF dari ranking vector dan hybrid — jadi default recall strategy. |
+| 🧠 **Hybrid + Fusion Search** | Cari berdasarkan makna (vector) + kata kunci exact (FTS5). Digabung dengan Reciprocal Rank Fusion (RRF). Sejak v0.16.0, `fusion` (weighted RRF dari ranking vector dan hybrid) jadi default recall strategy. |
 | 🏠 **Rooms** | **Shared memory multi-agent.** Kelompokkan memori berdasarkan konteks (meeting, project, klien). Multiple agent baca/tulis ke room yang sama dengan atribusi author. Cross-agent recall tanpa sync manual. |
 | ⏳ **Time-travel** | Recall memori seperti adanya di titik waktu manapun. `uteke recall "deploy" --at 2025-01-15` |
 | 🏷️ **Metadata Kaya** | Tag, entity, kategori, key:value di setiap memori. |
 | 🧩 **Tipe Memori** | Kategori bertipe (fact, procedure, decision, dll.) dengan auto-inferensi. |
+| ✏️ **Partial Updates** | Ubah isi, tags, metadata, importance, atau type tanpa rewrite penuh. |
 | 📎 **Citations** | Atribusi sumber di setiap memori (URL, file, user, batch import). |
 
 ### Search & Intelligence
@@ -183,51 +216,42 @@ uteke recall "caching decision" --room engineering
 | Fitur | Apa fungsinya |
 |-------|---------------|
 | 🔗 **Relationship Graph** | Hubungkan memori dengan edge bertipe (supersedes, contradicts, references). Auto-backlink. |
+| 🔗 **Cross-Entity Linking** | Referensi dua arah memori↔dokumen via wikilink `[[doc-slug]]`. |
 | 🤖 **Cosine Auto-Linking** | Otomatis bikin edge `similar_to` antar memori yang related. |
 | 📉 **Smart Decay** | Skor importance komposit. Pin yang penting, biarkan yang basi memudar. |
 | 📈 **Salience + Recency** | Boost recall dual-axis berdasarkan tipe dan usia memori. |
 | 🔍 **Orphan Detection** | Cari memori terputus dengan importance rendah untuk dibersihkan. |
 | 🌙 **Dream Cycle** | Maintenance satu perintah: lint → backlinks → dedup → orphans. |
+| 🧬 **Consolidation** | Gabungkan memori room yang mirip jadi lebih sedikit dan lebih padat: planner level-segmen, kebijakan trust provenance, kontrol per-pasangan. |
 
 ### Integrasi
 
 | Fitur | Apa fungsinya |
 |-------|---------------|
 | 🔌 **MCP Server** | JSON-RPC via stdio + Streamable HTTP. Langsung pakai dengan Claude Code, Cursor, Hermes. |
-| 🖥️ **Mode Server** | Daemon persisten — eliminates cold-start embedding load di setiap call. |
+| 🖥️ **Mode Server** | Daemon persisten: eliminates cold-start embedding load di setiap call. |
 | 📂 **Batch Import** | Import seluruh direktori dengan routing strategi otomatis (dokumen vs. memori). |
 | 📝 **Document Engine** | Wiki/knowledge base dengan `uteke doc create/get/list` + auto-chunking. |
 | 📥 **Import/Export** | Backup dan restore berbasis JSONL. |
 | 🔑 **View-Only API Keys** | Token read-only untuk akses GET saja ke server. |
+| 👤 **Tipe Author** | Atribusi `human` vs `agent` di setiap memori, konsisten di CLI, HTTP, dan MCP. |
 
 ### Performa & Privasi
 
 | Fitur | Apa fungsinya |
 |-------|---------------|
-| 📦 **Single Binary** | Zero dependency. Tanpa Docker, tanpa database server, tanpa Python, tanpa API key. |
+| 📦 **Single Binary** | Zero dependency. Tanpa Python, tanpa API key. Local-first secara default. |
+| 🐳 **Docker Ready** | Image resmi di GHCR. Jalankan sebagai shared service untuk tim atau deployment cloud. |
 | 🔒 **Fully Offline** | Embedding ONNX lokal (EmbeddingGemma Q4, 768d). Tanpa telemetri, tanpa cloud. |
 | ⚡ **Recall Cache** | Cache LRU yang eliminate redundant embedding untuk query berulang. |
 | 🔥 **Tiered Memory** | Tracking Hot/Warm/Cold dengan auto-cleanup memori basi. |
 | 🔄 **Embed Fallback** | Degrade ke no-op embedder kalau local model gagal (nggak pernah crash). |
 | 👥 **Namespace Multi-Agent** | Memori terisolasi penuh per agent, tanpa overhead. |
-| 📊 **Benchmark** | `uteke bench` untuk perf testing. [Lihat hasil](docs/benchmarks.md). |
-
-<details>
-<summary>🔌 Konfigurasi MCP Server — connect ke Claude Code, Cursor, Hermes</summary>
-
-```jsonc
-// .mcp.json (Claude Code, Cursor)
-{ "mcpServers": { "uteke": { "command": "uteke-mcp" } } }
-```
-
-Untuk Claude Desktop, Hermes, dan HTTP transport, lihat [MCP docs](docs/mcp.md).
-</details>
-
-📖 [Dokumentasi lengkap](docs/getting-started.md) · [Referensi CLI](docs/cli-reference.md) · [Konfigurasi](docs/configuration.md)
+| 📊 **Benchmark** | `uteke bench` bawaan untuk perf testing. [Lihat hasil](docs/benchmarks.md). |
 
 ---
 
-## 🏗️ Arsitektur
+## 🚀 Cara Kerja
 
 ```mermaid
 graph LR
@@ -244,50 +268,111 @@ graph LR
 ```
 
 **Cara kerja hybrid search:**
-1. **HNSW** (usearch) — cari berdasarkan makna ("deploy" cocok dengan "rollout")
-2. **FTS5** (SQLite) — cari berdasarkan kata exact ("deploy" cocok dengan "deploy")
-3. **RRF** (k=60) — gabungkan dua ranked lists → terbaik dari keduanya
+1. **HNSW** (usearch): cari berdasarkan makna ("deploy" cocok dengan "rollout")
+2. **FTS5** (SQLite): cari berdasarkan kata exact ("deploy" cocok dengan "deploy")
+3. **RRF** (k=60): gabungkan dua ranked lists → terbaik dari keduanya
 
 Semua jalan in-process. Tanpa network. Tanpa cloud. Tanpa server (kecuali mau pakai mode server).
+
+<details>
+<summary>🐳 Mode deployment (local-first secara default, Docker/server kalau perlu)</summary>
+
+**Local-first (default)**: satu binary, zero infrastruktur.
+
+```bash
+curl -sSL codecora.dev/uteke/install | sh
+uteke remember "memori pertama"
+```
+
+Data kamu tersimpan di `~/.codecora/uteke/`.
+
+**Docker / mode server**: untuk tim atau agent remote.
+
+```bash
+docker run -d -p 127.0.0.1:8767:8767 -v uteke-data:/data ghcr.io/codecoradev/uteke:latest
+# atau: uteke serve --host 0.0.0.0 --port 8767
+```
+
+📖 [Panduan Docker](docs/docker.md) · [Dokumentasi server mode](docs/configuration.md#server-mode)
+</details>
+
+<details>
+<summary>🏠 Rooms: contoh shared memory multi-agent</summary>
+
+```bash
+# Bikin room shared
+uteke room create "engineering" --description "Keputusan tim"
+
+# Agent Alice simpan keputusan
+uteke remember "Kita pilih Redis buat caching, bukan Memcached" \
+  --room engineering --author alice
+
+# Agent Bob tambah konteks
+uteke remember "Redis cluster: 3 node, 2 replica tiap node" \
+  --room engineering --author bob
+
+# Agent manapun bisa recall history shared
+uteke recall "caching decision" --room engineering
+```
+
+Atribusi author di setiap memori; cross-agent recall tanpa sync manual.
+📖 [Dokumentasi Rooms lengkap →](docs/rooms.md)
+</details>
+
+<details>
+<summary>🔌 Konfigurasi MCP: connect ke Claude Code, Cursor, Hermes</summary>
+
+```jsonc
+// .mcp.json (Claude Code, Cursor)
+{ "mcpServers": { "uteke": { "command": "uteke-mcp" } } }
+```
+
+Untuk Claude Desktop, Hermes, dan HTTP transport, lihat [MCP docs](docs/mcp.md).
+</details>
+
+---
+
+## 📚 Dokumentasi
+
+| | |
+|---|---|
+| **Mulai** | [Installation](INSTALL.md) · [Getting started](docs/getting-started.md) · [Onboarding](docs/getting-started.md#interactive-onboarding) |
+| **Referensi** | [CLI reference](docs/cli-reference.md) · [Konfigurasi](docs/configuration.md) · [Docker](docs/docker.md) |
+| **Integrasi** | [Setup MCP](docs/mcp.md) · Claude Code · Cursor · Hermes |
+| **Benchmark** | [docs/benchmarks.md](docs/benchmarks.md) · [RESULTS.md](benchmarks/longmemeval/RESULTS.md) · [Reproduksi sendiri](benchmarks/longmemeval/REPRODUCING.md) |
 
 ---
 
 ## ❓ FAQ
 
 <details>
-<summary><strong>Bedanya Uteke sama Mem0 atau Letta apa?</strong></summary>
+<summary><strong>Bedanya Uteke sama memory tool yang cloud-dependent apa?</strong></summary>
 
-Mem0 dan Letta bagus — tapi mereka butuh API key cloud (OpenAI/LLM) dan infrastruktur eksternal (Docker, Postgres, Qdrant). Data kamu dikirim ke cloud LLM provider. Uteke itu satu binary tanpa API key sama sekali. Semua embedding jalan lokal via ONNX. Data kamu nggak pernah keluar dari mesin kamu. [Lihat tabel perbandingan](#-kenapa-uteke).
+Banyak memory layer (basis Python atau TypeScript) butuh API key cloud (OpenAI/LLM) dan infrastruktur eksternal (Docker, Postgres, Qdrant). Data kamu dikirim ke cloud LLM provider. Uteke itu satu binary tanpa API key sama sekali. Semua embedding jalan lokal via ONNX. Data kamu nggak pernah keluar dari mesin kamu. [Lihat tabel perbandingan](#-kenapa-uteke).
 </details>
 
 <details>
-<summary><strong>Bedanya sama AgentMemory?</strong></summary>
+<summary><strong>Bedanya sama platform MCP multi-tool?</strong></summary>
 
-AgentMemory (25K stars) itu platform TypeScript/Node.js dengan 53 MCP tools dan 12 auto-hooks. Feature-rich tapi butuh Docker + iii-engine + LLM API key. Uteke itu Rust, zero dependency, dan jalan fully offline. Kalau mau integrasi maksimum dan nggak masalah cloud dependency → AgentMemory. Kalau mau privasi, kecepatan, dan zero setup → Uteke.
+Beberapa platform menawarkan lusinan MCP tools dan multi-agent shared memory via local engine. Kaya integrasi, tapi butuh npm, runtime terpisah, dan LLM API key untuk embedding. Uteke itu Rust, zero dependency, dan jalan fully offline dengan embedding ONNX lokal. Mau integrasi maksimum → platform itu. Mau privasi, kecepatan, zero setup, dan hybrid search → Uteke.
 </details>
 
 <details>
-<summary><strong>Bedanya sama Engram?</strong></summary>
+<summary><strong>Bedanya sama single-binary memory tool lain?</strong></summary>
 
-Engram (2.4K stars, Go) punya filosofi yang sama: single binary, zero deps, MCP server, local-first. Bedanya di **search**: Engram cuma pakai **FTS5** (keyword matching). Uteke pakai **hybrid search** (HNSW vector similarity + FTS5 + Reciprocal Rank Fusion) — artinya kamu bisa cari berdasarkan *makna*, bukan cuma kata exact. Uteke juga punya rooms, time-travel, graph relationships, smart decay, document engine, dan batch import.
-</details>
-
-<details>
-<summary><strong>Uteke bisa ingat apa aja?</strong></summary>
-
-Apapun yang text-based: keputusan, meeting notes, code snippet, konteks project, catatan personal, state agent. Bisa di-tag, di-kategorikan, dan di-link antar memori. Flag `--batch-dir` bisa import seluruh direktori dokumen sekaligus.
+Beberapa single-binary tool share filosofi kami: satu binary, zero deps, MCP server, local-first. Beda kuncinya di **search**: kebanyakan **FTS5-only** (keyword matching). Uteke pakai **hybrid search** (HNSW vector similarity + FTS5 + Reciprocal Rank Fusion), jadi kamu bisa cari berdasarkan *makna*, bukan cuma kata exact. Uteke juga punya rooms, time-travel, graph relationships, smart decay, document engine, dan batch import.
 </details>
 
 <details>
 <summary><strong>Beneran bisa offline?</strong></summary>
 
-Ya. Embedding model (EmbeddingGemma Q4, 768d) download sekali (~188MB) saat first run. Setelah itu, zero network call. Tanpa telemetri. Kalau local model gagal, Uteke degrade ke no-op embedder — nggak pernah crash dan nggak pernah manggil cloud API.
+Ya. Embedding model (EmbeddingGemma Q4, 768d) download sekali (~200MB) saat first run. Setelah itu, zero network call. Tanpa telemetri. Kalau local model gagal, Uteke degrade ke no-op embedder, jadi nggak pernah crash dan nggak pernah manggil cloud API.
 </details>
 
 <details>
 <summary><strong>Cepetan recall-nya?</strong></summary>
 
-~45ms sebagai library (diukur di 100–10K memori). Nggak ada network round-trip karena semuanya lokal. Recall cache LRU menghilangkan komputasi embedding berulang untuk query yang sama.
+~45ms sebagai CLI (pengukuran: rata-rata 31ms @10K di bench host yang dipublikasikan) (diukur di 100–10K memori, flat mengikuti ukuran store). Nggak ada network round-trip karena semuanya lokal. Recall cache LRU menghilangkan komputasi embedding berulang untuk query yang sama.
 </details>
 
 <details>
@@ -299,8 +384,23 @@ Bisa. Uteke punya MCP server yang langsung pakai dengan Claude Code, Cursor, dan
 <details>
 <summary><strong>Sudah production-ready?</strong></summary>
 
-Uteke sekarang v0.16.0 dengan 200+ test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x — mungkin ada rough edges, tapi core-nya udah stabil.
+Uteke sekarang v0.17.0 dengan 200+ test, CI/CD di setiap commit, dan benchmark harness. Dipakai production oleh tim CodeCora dan early adopter lain. Masih di versi 0.x, jadi mungkin ada rough edges, tapi core-nya udah stabil.
 </details>
+
+---
+
+## 🗺️ Roadmap & Editions
+
+| | **Uteke OSS** (repo ini) | **Uteke Cloud** |
+|---|---|---|
+| Kualitas retrieval | ✅ Full (engine identik) | ✅ Identik (parity-benchmarked) |
+| Lisensi | Apache-2.0, self-host | Layanan managed |
+| Jawaban berbasis LLM (resolusi fakta recency-aware, abstention) | BYOK | Termasuk |
+| Multi-workspace, dashboard, backup | DIY | ✅ Termasuk |
+| Harga | Gratis | *Segera* |
+
+Engine open-source tetap full-capability. Tidak ada bagian dari hasil benchmark di
+ atas yang dipagari paywall. Cloud menambahkan kenyamanan hosted di atasnya.
 
 ---
 
@@ -319,24 +419,20 @@ Kontribusi diterima! Baca [CONTRIBUTING.md](CONTRIBUTING.md) untuk panduan lengk
 
 ## 📄 Lisensi
 
-[Apache License 2.0](LICENSE) — pakai, fork, ship.
+[Apache License 2.0](LICENSE). Pakai, fork, ship.
 
 ---
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/?repos=codecoradev%2Futeke&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=codecoradev/uteke&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=codecoradev/uteke&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=codecoradev/uteke&type=date&legend=top-left" />
- </picture>
-</a>
+<p align="center">
+  <img src="https://s3.ajianaz.dev/hermes/codecoradev/uteke/star-history.png" alt="Uteke Star History" width="720" />
+</p>
 
 ---
 
 <p align="center">
-  <strong>Berguna?</strong> ⭐ Star repo ini — bantu orang lain nemuin Uteke.
+  <strong>Berguna?</strong> ⭐ Star repo ini. Bantu orang lain nemuin Uteke.
 </p>
 <p align="center">
   <a href="https://github.com/codecoradev/uteke/stargazers">

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ one CPU, deterministic.
 | Metric | uteke **v0.17.0** | agentmemory¹ | BM25-only¹ |
 |---|---|---|---|
 | **recall_any@5** (evidence in top-5) | **98.4%** | 95.2% | 86.2% |
-| recall_any@10 | 98.9% | 98.6% | 94.6% |
-| **recall_all@5** (all evidence, strict) | **88.3%**² | 88.2% MRR³ | n/a |
+| recall_any@10 | 98.8% | 98.6% | 94.6% |
+| **recall_all@5** (all evidence, strict) | **88.0%**² | 88.2% MRR³ | n/a |
 | LLM tokens / query | **0** | 0 | 0 |
 
-<sub>¹ agentmemory's published numbers, same benchmark, same 500-question split (their recall_any@5 basis; verified apples-to-apples in our [head-to-head](docs/benchmarks.md#head-to-head-vs-published-systems)). ² Strict = *every* gold session in top-5; 43% of questions need multiple sessions. Mathematical ceiling 99.4%. ³ MRR, not recall_all (not directly comparable; shown for completeness).</sub>
+<sub>¹ agentmemory's published numbers, same benchmark, same 500-question split (their recall_any@5 basis; verified apples-to-apples in our [head-to-head](docs/benchmarks.md#head-to-head-vs-published-systems)). ² Strict = *every* gold session in top-5; 65% of questions have multiple gold sessions. Mathematical ceiling 99.4%. ³ MRR, not recall_all (not directly comparable; shown for completeness).</sub>
 
 <p align="center">
-  <img src="docs/assets/longmemeval-recall-v017.png" alt="LongMemEval-S recall@5: uteke 98.4% (revalidated v0.17.0) vs MemPalace 96.6% and agentmemory 95.2% — raw results committed in-repo" width="880" />
+  <img src="docs/assets/longmemeval-recall-v017.png" alt="LongMemEval-S recall@5: uteke 98.4% (revalidated v0.17.0) vs MemPalace 96.6% and agentmemory 95.2% (raw results committed in-repo)" width="880" />
 </p>
 
 **By question category** (recall_any@5: the category-level story most tools don't show):
@@ -99,7 +99,7 @@ one CPU, deterministic.
 
 The hard part isn't finding *a* needle; every question's evidence lands in the
 top-50 (**zero misses**). The residual gap is *ordering* when a question needs
-several sessions at once: strict recall_all@5 is 88.3% against a 99.4% ceiling.
+several sessions at once: strict recall_all@5 is 88.0% against a 99.4% ceiling.
 
 > **🎯 Don't trust our benchmark. Run it yourself.** The full harness is in this
 > repo: public dataset, committed raw outputs for both releases, deterministic
@@ -333,7 +333,7 @@ Yes. The embedding model (EmbeddingGemma Q4, 768d) downloads once (~200MB) on fi
 <details>
 <summary><strong>How fast is recall?</strong></summary>
 
-~45ms as a CLI (measurements: 31ms avg @10K on the published bench host) (measured at 100–10K memories, flat with store size). No network round-trip because everything is local. The LRU recall cache eliminates redundant embedding computation for repeated queries.
+~45ms as a CLI (measurements: 31ms avg @10K on the published bench host, 100–10K memories, flat with store size). No network round-trip because everything is local. The LRU recall cache eliminates redundant embedding computation for repeated queries.
 </details>
 
 <details>

--- a/benchmarks/longmemeval/REPRODUCING.md
+++ b/benchmarks/longmemeval/REPRODUCING.md
@@ -11,13 +11,15 @@ the computer tell you the truth yourself. Three budgets, pick one:
 | ~$10 | [Full 500-question run](#3-full-500-question-run-modal-or-any-linux-box) | ~3 h | ~$5-10 Modal credits |
 
 **What you need:** a machine with `cargo` (Rust 1.85+), Python 3.10+, and ~4 GB free
-disk. The embedding model (~188 MB) downloads once on first run. Everything else is
+disk. The embedding model (~200 MB) downloads once on first run. Everything else is
 in this repo.
 
 > **Published numbers (v0.17.0, 500 questions, LongMemEval-S):**
-> recall_any@5 **98.4%** · recall_any@10 98.8% · strict recall_all@5 88.3% ·
-> coverage R@5 94.7% (470 non-abstention questions; the 30 `_abs` abstention
-> questions are reported separately — they measure answering, not retrieval).
+> recall_any@5 **98.4%** · recall_any@10 98.8% · strict recall_all@5 88.0% ·
+> coverage@5 94.4% — all on the full 500-question basis. On the 470
+> non-abstention questions (the 30 `_abs` questions are reported separately:
+> they measure answering, not retrieval), strict recall_all@5 is 88.3% and
+> coverage@5 is 94.7%.
 > What these metric names mean: [docs/benchmarks.md](../../docs/benchmarks.md) and
 > [`RESULTS.md`](RESULTS.md#reading-the-metrics).
 
@@ -94,7 +96,7 @@ pip install -r scripts/requirements.txt
 #    never a uteke from your PATH)
 cd ../.. && cargo build --release -p uteke-cli && cd benchmarks/longmemeval
 
-# 4. Run 50 questions (first run downloads the 188 MB embedding model once)
+# 4. Run 50 questions (first run downloads the ~200 MB embedding model once)
 python3 scripts/run_eval.py \
     --data data/longmemeval_oracle.json \
     --output results_mine \
@@ -153,10 +155,12 @@ different questions:
   gold session in top-K). This is the metric competitor benchmarks publish;
   ours: **98.4% @ 5** (full 500-question set).
 - **recall_all@K (strict)** — "did it get *all* of them?" (every gold session in
-  top-K; 43% of questions need multiple sessions). The honest ceiling-capable
-  number: **88.3% @ 5** — mathematical ceiling is 99.4% (3 questions have 6 gold
+  top-K; 65% of the 500 questions have multiple gold sessions). The honest
+  ceiling-capable number: **88.0% @ 5** on the full 500 (88.3% on the 470
+  non-abstention) — mathematical ceiling is 99.4% (3 questions have 6 gold
   sessions; top-5 physically can't hold all).
-- **coverage R@K** — partial credit (fraction of gold sessions found). 94.7%.
+- **coverage R@K** — partial credit (fraction of gold sessions found). 94.4%
+  full-500 (94.7% on the 470 non-abstention).
 
 Per-category breakdown, the 30 abstention questions, contradiction segment, and
 the full v0.16.0 → v0.17.0 comparison: [`RESULTS.md`](RESULTS.md),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,7 +269,7 @@ Benchmarked on Oracle Cloud ARM (Ampere Altra), CPU-only, no GPU.
 ├── uteke.db                    # SQLite (memories + metadata + FTS5)
 ├── uteke_index.usearch         # Persistent HNSW vector index
 ├── uteke_index.keys            # Index key mapping (atomic save)
-├── embeddinggemma-q4/           # Local ONNX embedding model (~188MB)
+├── embeddinggemma-q4/           # Local ONNX embedding model (~200MB)
 │   └── onnx/                    # model_q4.onnx + model_q4.onnx_data
 └── logs/
     ├── uteke.log               # Current log

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,24 +9,40 @@ Embedding model: EmbeddingGemma Q4 (768d, ONNX Runtime, CPU-only).
 
 ## Results
 
+Re-verified on the v0.17.0 release binary (2026-09-09, native aarch64 build,
+[full run](../benchmarks/internal/RESULTS.md)):
+
+| Scale | Insert ops/s | Insert Total | Recall Avg | Recall P95 | DB Size | Index Size |
+|-------|-------------|-------------|------------|------------|---------|------------|
+| 100 memories | 17.3/s | 5.8s | **31ms** | 47ms | 0.7MB | 0.31MB |
+| 1,000 memories | 17.5/s | 57s | **42ms** | 62ms | 5.2MB | 3.10MB |
+| 10,000 memories | 5.0/s | 33.4 min | **31ms** | 38ms | 80.7MB | 30.2MB |
+
+<details>
+<summary>Historical table (2026-08 run, v0.12.0-era, as originally published)</summary>
+
 | Scale | Insert ops/s | Insert Total | Recall Avg | Recall P95 | DB Size | Index Size |
 |-------|-------------|-------------|------------|------------|---------|------------|
 | 100 memories | 18.5/s | 5.4s | **40ms** | 46ms | 708KB | 319KB |
 | 1,000 memories | 21.8/s | 45.9s | **45ms** | 51ms | 5.3MB | 3.2MB |
 | 10,000 memories | 6.0/s | 28.0 min | **42ms** | 50ms | 81.3MB | 30.3MB |
 
+Storage matches the v0.17.0 run within a fraction of a percent.
+</details>
+
 ## Key Takeaways
 
-### Recall Latency: Flat ~40-45ms from 100 to 10K memories
+### Recall Latency: Flat ~30-45ms from 100 to 10K memories
 
 The killer stat: recall latency barely changes as the store grows.
 
-- 100 memories → **40ms**
-- 1,000 memories → **45ms**
-- 10,000 memories → **42ms** ← actually *faster* than 1K (warm ONNX cache)
+- 100 memories → **31ms**
+- 1,000 memories → **42ms**
+- 10,000 memories → **31ms** ← actually *faster* than 1K (warm ONNX cache)
 
 HNSW search is O(log N), so even at 10K memories, the vector index adds <1ms.
-The ~40ms floor is dominated by ONNX embedding inference, not search.
+The floor is dominated by ONNX embedding inference, not search. We quote ~45ms
+in the headline as a conservative upper bound.
 
 The full pipeline (fusion strategy, default since 0.16.0):
 1. Query → ONNX embedding generation
@@ -44,17 +60,17 @@ No network round-trip. No API call. Everything in-process.
 
 Each insert requires an ONNX embedding pass (CPU inference). Throughput drops at scale because HNSW graph traversal grows as the index expands:
 
-- 100 memories → **18.5 ops/s**
-- 1,000 memories → **21.8 ops/s**
-- 10,000 memories → **6.0 ops/s**
+- 100 memories → **17.3 ops/s**
+- 1,000 memories → **17.5 ops/s**
+- 10,000 memories → **5.0 ops/s** (within run-to-run noise of the earlier 6.0)
 
-At 6 ops/s, inserting 10K memories takes ~28 minutes. For bulk ingestion, use `uteke import` (batch mode) which pipelines embeddings.
+At 5 ops/s, inserting 10K memories takes ~33 minutes. For bulk ingestion, use `uteke import` (batch mode) which pipelines embeddings.
 
 ### Storage Efficiency
 
-- 100 memories → 708KB DB + 319KB index = **~10KB per memory**
-- 1,000 memories → 5.3MB DB + 3.2MB index = **~8.5KB per memory**
-- 10,000 memories → 81.3MB DB + 30.3MB index = **~11.2KB per memory**
+- 100 memories → 0.7MB DB + 0.31MB index = **~10KB per memory**
+- 1,000 memories → 5.2MB DB + 3.1MB index = **~8.3KB per memory**
+- 10,000 memories → 80.7MB DB + 30.2MB index = **~11.1KB per memory**
 
 Storage scales linearly (~10KB/memory). SQLite + HNSW both grow predictably.
 
@@ -76,26 +92,34 @@ See [LongMemEval retrieval harness](https://github.com/codecoradev/uteke/tree/de
 
 ## LongMemEval-S — Retrieval Accuracy (500 questions)
 
-Full validation run of uteke v0.16.0 default strategy (fusion, zero-config) on
+Full-validation runs of the default strategy (fusion, zero-config) on
 LongMemEval-S: 500 questions, session-level retrieval, ~115 haystack sessions per
 question (2,415 unique sessions), EmbeddingGemma Q4 CPU-only, deterministic — no
-LLM anywhere in the retrieval path.
+LLM anywhere in the retrieval path. Originally validated on v0.16.0 and
+re-validated end-to-end on the v0.17.0 release binary (2026-09-09).
 
-![uteke vs published systems on LongMemEval-S](assets/longmemeval-comparison.jpg)
+![uteke vs published systems on LongMemEval-S, revalidated on v0.17.0](assets/longmemeval-recall-v017.png)
 
 ### Headline numbers
 
-| Metric | Value | What it means |
-|---|---|---|
-| **recall_any@5** | **98.2%** | At least one gold session in top-5 — the metric competitor benchmarks publish |
-| recall_any@10 | 98.8% | |
-| recall_all@10 | 95.4% | **Strict:** every gold session must appear in top-10 |
-| strict recall_all@5 | 88.0% | Every gold session in top-5 (mathematical ceiling 99.4% — 3 questions have 6 gold sessions) |
-| coverage@5 | 94.3% | Partial credit per question (the harness's default aggregate) |
+Full 500-question basis, v0.17.0 re-validation (v0.16.0 original run alongside):
+
+| Metric | v0.17.0 | v0.16.0 | What it means |
+|---|---|---|---|
+| **recall_any@5** | **98.4%** | 98.2% | At least one gold session in top-5 — the metric competitor benchmarks publish |
+| recall_any@10 | 98.8% | 98.8% | |
+| strict recall_all@5 | 88.0% | 88.0% | **Strict:** every gold session in top-5 (mathematical ceiling 99.4% — 3 questions have 6 gold sessions) |
+| strict recall_all@10 | 95.4% | 95.4% | Every gold session in top-10 |
+| coverage@5 | 94.4% | 94.3% | Partial credit per question |
+
+On the 470 non-abstention questions (the 30 `_abs` abstention questions are
+reported separately), strict recall_all@5 is 88.3% and coverage@5 is 94.7%.
+Per-type breakdown, ablations, and the contradiction segment:
+[benchmarks/longmemeval/RESULTS.md](../benchmarks/longmemeval/RESULTS.md).
 
 Gold-session distribution across the 500 questions: 1 gold ×176, 2 ×250, 3 ×41,
-4 ×19, 5 ×11, 6 ×3. 43% of questions are multi-session — which is why we report
-the strict family at all.
+4 ×19, 5 ×11, 6 ×3. 65% of questions have multiple gold sessions — which is why
+we report the strict family at all.
 
 ### Why two metric families
 
@@ -106,6 +130,15 @@ only truly solved when **all 3** are retrieved. `recall_all@K` measures exactly
 that. It is harder, bounded below recall_any, and to our knowledge no other
 system in the comparison publishes it. We report both, from the same run, with
 the same data.
+
+### Head-to-head vs published systems
+
+The agentmemory numbers quoted in the [README](../README.md#-benchmarks-984-recall-on-longmemeval-s)
+are their published figures on the same benchmark and the same 500-question
+split, on their own recall_any@5 basis — verified apples-to-apples before
+quoting (their harness, their split, their metric definition). The BM25-only
+column is their published lexical baseline, not our system. Our own FTS5
+ablation on this dataset scores 91.4% any@5 ([RESULTS.md](../benchmarks/longmemeval/RESULTS.md)).
 
 ### Honesty notes
 
@@ -128,7 +161,7 @@ An independent local re-run (2026-09-01) of 108 of the 500 questions on a 4-core
 | OS | Linux 6.8.0 (aarch64) |
 | Rust | 1.85+ |
 | Embedding | EmbeddingGemma Q4, 768d, ONNX Runtime CPU |
-| Uteke | v0.16.0 for LongMemEval-S validation; perf table re-verified on v0.17.0 (2026-09-09) |
+| Uteke | v0.16.0 validation + v0.17.0 re-validation (2026-09-09), both full 500 questions; perf table re-verified on v0.17.0 |
 
 ## Methodology
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ title: Docker
 
 # Docker
 
-Uteke ships as a lightweight multi-arch Docker image (~10MB). The embedding model (~188MB) downloads automatically on first run and is cached in the volume — subsequent updates are instant.
+Uteke ships as a lightweight multi-arch Docker image (~10MB). The embedding model (~200MB) downloads automatically on first run and is cached in the volume, so subsequent updates are instant.
 
 ## Quick Start
 
@@ -104,7 +104,7 @@ The volume contains:
 - `uteke_index.usearch` — HNSW vector index (default engine)
 - `uteke_index.vecq` — quantized index (created if you switch engines)
 - `uteke_index.keys` — Index key mapping
-- `models/embeddinggemma-q4/` — ONNX embedding model (~188MB)
+- `models/embeddinggemma-q4/` — ONNX embedding model (~200MB)
 
 ### Choosing the vector engine (v0.17.0+)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh |
 
 See the [Installation guide](/install) for all methods (Cargo, binary, Docker).
 
-> 💡 First run downloads the embedding model (~188MB). No API keys needed.
+> 💡 First run downloads the embedding model (~200MB). No API keys needed.
 
 ## Interactive Onboarding
 
@@ -168,7 +168,7 @@ All data lives in `~/.codecora/uteke/`:
 ├── uteke.db                    # SQLite (memories + metadata + FTS5)
 ├── uteke_index.usearch         # Persistent HNSW vector index
 ├── uteke_index.keys            # Index key mapping
-├── embeddinggemma-q4/          # Local ONNX embedding model (~188MB)
+├── embeddinggemma-q4/          # Local ONNX embedding model (~200MB)
 │   └── onnx/                   # model_q4.onnx + model_q4.onnx_data
 └── logs/
     ├── uteke.log               # Current log

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Pin a specific version:
 
 ```bash
-UTEKE_VERSION=v0.16.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+UTEKE_VERSION=v0.17.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 ```
 
 ## Install via Cargo
@@ -40,19 +40,19 @@ Download from [GitHub Releases](https://github.com/codecoradev/uteke/releases):
 
 ```bash
 # Linux (x86_64)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-v0.16.0.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-v0.17.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # Linux (x86_64, legacy — no AVX2/SSE4.2)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-legacy-v0.16.0.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-legacy-v0.17.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # Linux (aarch64 / ARM)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-unknown-linux-gnu-v0.16.0.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-unknown-linux-gnu-v0.17.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-apple-darwin-v0.16.0.tar.gz | tar xz
+curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-apple-darwin-v0.17.0.tar.gz | tar xz
 mv uteke ~/.local/bin/
 ```
 
@@ -86,7 +86,7 @@ docker pull ghcr.io/codecoradev/uteke:latest
 
 ## First Run
 
-On first run, uteke downloads the embedding model (~188MB). No API keys needed — fully offline.
+On first run, uteke downloads the embedding model (~200MB). No API keys needed — fully offline.
 
 ```bash
 uteke doctor   # Verify installation

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -323,6 +323,6 @@ See [Docker guide — MCP](/docker#mcp-model-context-protocol) for full Docker-s
 | `Permission denied` | `chmod +x $(which uteke-mcp)` or ensure the binary is on your `PATH` |
 | `Connection refused` (HTTP) | Ensure `uteke-serve` is running: `uteke-serve` |
 | Client can't see tools | Verify the MCP config JSON is valid and the client has been restarted |
-| Slow first query | The embedding model (~188MB) downloads on first use — subsequent calls are ~45ms |
+| Slow first query | The embedding model (~200MB) downloads on first use — subsequent calls are ~45ms |
 
 See also: [Architecture — MCP Transport](/architecture#mcp-transport-381)


### PR DESCRIPTION
## What

Sync the Indonesian README and stale docs with the v0.17.0 benchmark state that #1208/#1209/#1212–#1217 established on the EN side.

**README.id.md** (main rewrite, was still pre-restructure from Sep 6):
- Benchmark-first structure mirroring the EN README: 98.4% LongMemEval-S recall@5 headline, v0.17.0 numbers table, per-category strip, revalidation chart, "run it yourself" callout with REPRODUCING.md link
- ~45ms warm / conservative latency claim (per owner decision, not 23ms)
- Competitor table migrated from real names + star counts to anonymized Tool A–G labels with the assessment disclaimer, matching the EN README's positioning
- New "Roadmap & Editions" section (OSS vs Cloud), docs table with RESULTS.md + REPRODUCING.md, Cloud row uses "managed" framing only
- 188MB → ~200MB model size, v0.16.0 → v0.17.0 production-ready FAQ, zero prose em dashes (en dashes kept only in numeric ranges)

**Claim fixes across docs** (each recomputed from the committed raw artifacts before editing):
- README.md + REPRODUCING.md: strict recall_all@5 rows/quotes now label their basis: 88.0% full-500 vs 88.3% on the 470 non-abstention; recall_any@10 98.9% → 98.8% (full-500); "43% of questions need multiple sessions" → 65% have multiple gold sessions (324/500 counted from the committed dataset)
- docs/benchmarks.md: perf table replaced with the v0.17.0 re-verification run (17.3/17.5/5.0 ops/s, 31/42/31ms), 2026-08 table kept as a collapsed historical block; LongMemEval section now shows the v0.16.0 → v0.17.0 revalidation columns; "Head-to-head vs published systems" section added so the README footnote anchor resolves
- docs/install.md: pinned download URLs bumped v0.16.0 → v0.17.0 (asset names verified against the published release)
- INSTALL.md, docs/{docker,getting-started,architecture,mcp}.md: 188MB → ~200MB

## Why

The user asked for the Indonesian README to be updated and the rest of the docs swept for anything else needing the same. The EN side went through #1214–#1217 (restructure, owner-decision alignment, humanizer pass, chart embed) but README.id.md still carried the pre-benchmark structure, old claims (23ms-adjacent, 188MB, named competitors, no benchmark section at all), and the docs sweep surfaced mixed-basis strict numbers and a 43% multi-session claim that does not match the committed dataset.

## Testing

- Every benchmark number recomputed from `benchmarks/longmemeval/results/*.jsonl` + the committed dataset before editing (any@5 98.4/98.8, strict@5 88.0 full-500 / 88.3 on 470, coverage 94.4/94.7, fts5 ablation 91.4, zero misses @50 on v017 raw)
- Humanizer/copywriting mechanical gate on final text: both READMEs at 0 em dashes, 0 banned phrases, Indonesian tells cleaned (0 "adalah", no summary headings)
- Badge/FAQ anchors derived from the new headings and grep-verified; CI branch-naming whitelist checked before push (`docs/` prefix)
