### PR TITLE
docs: document namespace management (#1181) and sync MCP tool table with the actual server surface

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -849,6 +849,9 @@ uteke timeline <memory-id> --json
 | `uteke namespace list` | List all namespaces with memory counts |
 | `uteke namespace stats <name>` | Show stats for a namespace |
 | `uteke namespace switch <name>` | Set default namespace in config |
+| `uteke namespace move <id> <ns>` | Move a memory to another namespace, no re-embed (#1181) |
+| `uteke namespace rename <old> <new>` | Rename a namespace; existing target = merge (#1181) |
+| `uteke namespace delete <ns> --confirm` | Delete a namespace (`--strategy refuse\|merge\|deprecate`, #1181) |
 | `uteke hook <shell>` | Print shell hook script (bash/zsh/fish) |
 | `uteke init --agent <type>` | Initialize integration (opencode, pi, claude, cursor, hermes) |
 | `uteke init --agent hermes --memory-provider` | Install uteke as Hermes's default memory provider (auto recall + extraction). See [Hermes integration, Mode B](integrations/hermes.md). **Note:** Hermes Mode B deprecated — see [integrations/hermes.md](integrations/hermes.md) for migration. |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,17 +132,20 @@ uteke init --agent hermes  # Installs pre_llm_call hook
 
 ## Available Tools
 
-Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
+Both transports expose the same 46 tools (MCP protocol version `2025-06-18`):
 
 | Tool | Description |
 |------|-------------|
 | `uteke_remember` | Store a memory (supports type, room, author, tags) |
-| `uteke_recall` | Semantic search (supports tags filter, min_score, strategy: fusion/vector/fts5/hybrid/graph — default `fusion` since 0.16.0) |
+| `uteke_recall` | Semantic search (supports tags filter, min_score, strategy: fusion/vector/fts5/hybrid/graph — default `fusion` since 0.16.0, and the `explain` flag showing why each result ranked where it did, #1160) |
 | `uteke_search` | Text search with optional tag filter |
-| `uteke_list` | List memories (supports pagination via offset) |
+| `uteke_list` | List memories (supports pagination via offset, or `include_meta: true` for the `{memories, total, has_more, next_offset}` envelope, #1188) |
 | `uteke_get` | Fetch a single memory's full record by id — no truncation (accepts UUID or unambiguous prefix) |
-| `uteke_update` | Partial update — only provided fields change; content changes re-embed |
+| `uteke_update` | Partial update — only provided fields change; content changes re-embed; accepts `namespace` to move a memory (#1181) |
 | `uteke_supersede` | Mark a memory superseded by a newer one — wires the edge pair, soft-deprecates the old row; recall flags stale results (⚠ superseded by …) |
+| `uteke_provenance` | Full provenance report for a memory (#1172): author/source fields, trust tier, source hash at write vs live-recomputed content hash, and the timeline event chain with actor + evidence |
+| `uteke_contradictions` | List the contradiction resolution ledger (#1172): superseded-but-not-restored memories with winner, reason, and timestamp |
+| `uteke_contradictions_undo` | Undo a contradiction resolution (#1172): restore the retired memory, remove the supersession edge pair, record `supersession_undone` events |
 | `uteke_forget` | Delete a memory (accepts UUID or unambiguous prefix) |
 | `uteke_stats` | Memory store statistics |
 | `uteke_context` | AI-optimized context output for prompts |
@@ -161,6 +164,12 @@ Both transports expose the same 35 tools (MCP protocol version `2025-06-18`):
 | `uteke_room_memories` | List memories in a room (#569) |
 | `uteke_room_create` | Create a room |
 | `uteke_room_delete` | Delete a room |
+| `uteke_room_rename` | Rename a room; rewrites the registry row and every reference in one transaction (#1202) |
+| `uteke_room_update` | Update a room's title/description (#1202) |
+| `uteke_room_memory_move` | Move a memory to another room, preserving link provenance (#1202) |
+| `uteke_room_list` | List all rooms |
+| `uteke_namespace_rename` | Rename a namespace (#1181); when the target exists this is a merge, returns `{from, to, moved, target_existed}` |
+| `uteke_namespace_delete` | Delete a namespace with an explicit strategy for its memories (#1181): `refuse` (default, 409 while referenced), `merge` into `target`, or `deprecate` (soft-delete, restorable) |
 | `uteke_room_stats` | Room statistics |
 | `uteke_room_summary` | Room topic summary (tag clustering, no LLM) |
 | `uteke_room_summary_document` | Generate summary document from room (→ `POST /room/summary-document`) |

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -63,6 +63,35 @@ uteke recall "context"
 
 Resolution order: `--namespace` flag → `UTEKE_NAMESPACE` env → `uteke.toml` → `"default"`
 
+## Managing Namespaces (#1181)
+
+Namespaces are a derived view of where memories live, and v0.17.0 adds sanctioned
+ops to manage them directly:
+
+```bash
+# Move one memory to another namespace (plain column update, no re-embed)
+uteke namespace move <memory-id> other-ns
+
+# Rename a namespace. If the target already exists, this MERGES into it
+# (all memories move, the old name vanishes)
+uteke namespace rename old-ns new-ns
+
+# Delete a namespace with an explicit strategy for its memories:
+#   refuse    (default) refuses with 409 while any memory references the name
+#   merge     moves all memories to --target, the name vanishes
+#   deprecate soft-deletes them; restorable via promote, never hard-deleted
+uteke namespace delete temp-ns --strategy merge --target archive --confirm
+uteke namespace delete ghost-ns --strategy deprecate --confirm
+```
+
+The same operations are available over HTTP (`PUT /memory` with a `namespace`
+field, `POST /namespaces/rename`, `POST /namespaces/delete`) and MCP
+(`uteke_namespace_rename`, `uteke_namespace_delete`, plus the `namespace` field
+on `uteke_update`). `GET /namespaces?with_counts=true` reports `active` and
+`deprecated` breakdowns alongside the total count. Deleting a namespace never
+hard-deletes memories: `refuse` is the safe default, and `deprecate` keeps them
+recoverable.
+
 ## All Commands Are Scoped
 
 The `--namespace` flag works on every command:


### PR DESCRIPTION
## What

Bring the VitePress docs up to date with the namespace management feature (#1181, shipped in v0.17.0) and fix the MCP tool table, which had drifted from the actual server surface.

**docs/mcp.md**
- Tool count corrected: the page claimed "the same 35 tools" with a 37-row table, but the server registers **46** tools. Count and table verified programmatically against the dispatch arms and tool schemas in `crates/uteke-mcp/src/lib.rs` (distinct tool names only; `uteke_room_document` is a dispatch alias of `uteke_room_summary_document`, not a separate tool).
- Added the 9 missing rows: `uteke_namespace_rename`, `uteke_namespace_delete` (#1181); `uteke_room_rename`, `uteke_room_update`, `uteke_room_memory_move`, `uteke_room_list` (#1202); `uteke_provenance`, `uteke_contradictions`, `uteke_contradictions_undo` (#1172).
- Refreshed existing rows for recent features: `uteke_recall` explain flag (#1160), `uteke_list` `include_meta` pagination envelope (#1188), `uteke_update` `namespace` move field (#1181).

**docs/multi-agent.md**
- New "Managing Namespaces (#1181)" section: `uteke namespace move/rename/delete` with the `refuse`/`merge`/`deprecate` strategies, the HTTP equivalents (`PUT /memory` namespace field, `POST /namespaces/rename`, `POST /namespaces/delete`), the MCP tools, and the `with_counts=true` active/deprecated breakdown.

**docs/cli-reference.md**
- `uteke namespace move/rename/delete` added to the quick command table.

## Why

The namespace management API (#1181) landed in v0.17.0 with full API/CLI reference coverage (already correct in docs/api-reference.md and docs/cli-reference.md), but the guide-level docs were never updated: multi-agent.md still stopped at namespace switching, and mcp.md predates both #1181 and the #1172/#1202 tool additions. The stale "35 tools" claim also contradicted the actual server, which an agent integrating via MCP would notice immediately.

## Testing

- Tool table diffed against source: 46 dispatch arms = 46 schemas = 46 doc rows, zero missing, zero extra (scripted check, not eyeballed).
- `vitepress build` completes clean.
- New prose follows the zero-em-dash docs convention.
