### PR TITLE
fix(install): copy bundled ORT libs on binary install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,6 +73,10 @@ Expand-Archive -Path uteke.zip -DestinationPath uteke
 # Move to a directory in PATH (e.g. C:\Users\you\AppData\Local\bin)
 mkdir -p C:\Users\you\AppData\Local\bin
 move uteke\uteke.exe C:\Users\you\AppData\Local\bin\
+move uteke\uteke-serve.exe C:\Users\you\AppData\Local\bin\
+move uteke\uteke-mcp.exe C:\Users\you\AppData\Local\bin\
+# Required for embeddings — release zip ships ONNX Runtime DLLs alongside the exes
+move uteke\onnxruntime*.dll C:\Users\you\AppData\Local\bin\
 
 # Add to PATH (current session)
 $env:PATH += ";C:\Users\you\AppData\Local\bin"
@@ -164,6 +168,9 @@ Check internet connection. Model downloaded from HuggingFace:
 ```
 https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX
 ```
+
+### `ONNX Runtime library not found` on `uteke remember` (notably Arch/CachyOS fresh installs)
+The release tarball/zip ships `libonnxruntime.so*` / `onnxruntime.dll` next to the binaries — keep them in the same directory as `uteke` (`~/.local/bin/` on Linux/macOS). The quick-install script does this automatically; manual tarball installs must copy the `.so`/`.dylib`/`.dll` too. Fallbacks searched: `/usr/local/lib /usr/lib /lib`, pip `onnxruntime/capi/`, `~/.cache/ort.pyke.io/`, or set `ORT_LIB_PATH=/path/to/libonnxruntime.so`. Then `uteke doctor` should report `Embedding model: embeddinggemma-q4`.
 
 Manual download:
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,21 +39,26 @@ This compiles uteke from source and installs it to Cargo's binary directory (typ
 Download from [GitHub Releases](https://github.com/codecoradev/uteke/releases):
 
 ```bash
-# Linux (x86_64)
+# Linux (x86_64) — tarball also contains libonnxruntime.so* (required for embeddings)
 curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-v0.17.0.tar.gz | tar xz
-mv uteke ~/.local/bin/
+mv uteke uteke-serve uteke-mcp ~/.local/bin/
+mv libonnxruntime.so* libonnxruntime_providers_shared.so* ~/.local/bin/
 
 # Linux (x86_64, legacy — no AVX2/SSE4.2)
 curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-x86_64-unknown-linux-gnu-legacy-v0.17.0.tar.gz | tar xz
-mv uteke ~/.local/bin/
+mv uteke uteke-serve uteke-mcp ~/.local/bin/
+mv libonnxruntime.so* ~/.local/bin/
+mkdir -p ~/.local/bin/ort-legacy && mv ort-legacy/libonnxruntime.so* ~/.local/bin/ort-legacy/
 
 # Linux (aarch64 / ARM)
 curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-unknown-linux-gnu-v0.17.0.tar.gz | tar xz
-mv uteke ~/.local/bin/
+mv uteke uteke-serve uteke-mcp ~/.local/bin/
+mv libonnxruntime.so* libonnxruntime_providers_shared.so* ~/.local/bin/
 
 # macOS (Apple Silicon)
 curl -sL https://github.com/codecoradev/uteke/releases/latest/download/uteke-aarch64-apple-darwin-v0.17.0.tar.gz | tar xz
-mv uteke ~/.local/bin/
+mv uteke uteke-serve uteke-mcp ~/.local/bin/
+mv libonnxruntime*.dylib ~/.local/bin/
 ```
 
 Supported platforms:
@@ -115,10 +120,13 @@ uteke upgrade --yes    # Skip confirmation
 
 ## What Gets Installed
 
-The install script deploys three binaries:
+The install script deploys three binaries plus the bundled ONNX Runtime shared library (required for local embeddings, no API keys needed):
 
 | Binary | Purpose |
 |--------|---------|
 | `uteke` | Core CLI — remember, recall, search, list, etc. |
 | `uteke-serve` | HTTP server for remote access and MCP over HTTP |
 | `uteke-mcp` | Standalone MCP server for AI agent integration |
+| `libonnxruntime.so*` (Linux) / `libonnxruntime*.dylib` (macOS) / `onnxruntime.dll` (Windows) | ONNX Runtime (currently v1.24.4, matches `ort` crate `2.0.0-rc.12`) — resolved via `<exe_dir>/libonnxruntime.so`, system paths, or `ORT_LIB_PATH` |
+
+> **Arch / CachyOS note:** there is no system `libonnxruntime.so` by default and `pip install onnxruntime` may have no wheel for newer Python (e.g. 3.14), so you must keep the bundled `.so` next to the binary in `~/.local/bin/`. If you see `ONNX Runtime library not found` on `uteke remember`, re-run the installer above or set `ORT_LIB_PATH=/path/to/libonnxruntime.so`. Then `uteke doctor` should show `Embedding model: embeddinggemma-q4`.

--- a/install.ps1
+++ b/install.ps1
@@ -144,6 +144,14 @@ function Install-Uteke {
             Write-Warn "$binary not found in archive"
         }
     }
+
+    # Install bundled ONNX Runtime DLLs (required for embeddings).
+    # Release zips ship onnxruntime.dll + providers DLLs alongside the exes.
+    # Without these, `uteke remember` fails with "ONNX Runtime library not found".
+    Get-ChildItem $extractDir -Filter "onnxruntime*.dll" -ErrorAction SilentlyContinue | ForEach-Object {
+        Copy-Item $_.FullName (Join-Path $InstallDir $_.Name) -Force
+        Write-Info ("Installed {0}" -f $_.Name)
+    }
     
     # Cleanup
     Remove-Item $archivePath -Force -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -145,6 +145,17 @@ install() {
         mv "${TEMP_DIR}/${MCP_BINARY_NAME}" "${INSTALL_DIR}/"
     fi
 
+    # Install bundled ONNX Runtime shared libs (required for embeddings).
+    # Release tarballs ship libonnxruntime.so* + providers_shared alongside the
+    # binaries (see release.yml Package step). Without these, `uteke remember`
+    # fails with "ONNX Runtime library not found" on distros with no system
+    # lib (e.g. Arch/CachyOS) — see resolve_ort_lib() in ort_init.rs which
+    # expects <exe_dir>/libonnxruntime.so on AVX2 CPUs.
+    # Mirrors build_from_source() which already copies ort-lib/*.so.
+    cp -a "${TEMP_DIR}"/libonnxruntime.so* "${INSTALL_DIR}/" 2>/dev/null || true
+    cp -a "${TEMP_DIR}"/libonnxruntime_providers_shared.so* "${INSTALL_DIR}/" 2>/dev/null || true
+    cp -a "${TEMP_DIR}"/libonnxruntime*.dylib "${INSTALL_DIR}/" 2>/dev/null || true
+
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
     if [ -f "${INSTALL_DIR}/${SERVER_BINARY_NAME}" ]; then
         chmod +x "${INSTALL_DIR}/${SERVER_BINARY_NAME}"


### PR DESCRIPTION
## What
Copy bundled ONNX Runtime libs on binary install. `install.sh` now `cp -a libonnxruntime.so*`, `libonnxruntime_providers_shared.so*`, and `libonnxruntime*.dylib` to `$INSTALL_DIR`; `install.ps1` copies `onnxruntime*.dll`; manual tarball snippets in `docs/install.md` / `INSTALL.md` updated to move the `.so`/`.dylib`/`.dll` alongside all three binaries.

## Why
Fresh `install.sh` installs on Arch/CachyOS (and any distro without a system ORT lib) leave `uteke remember` broken with `ONNX Runtime library not found`. The release tarball already contains `libonnxruntime.so*` (see `release.yml` Package step), but `install()` only moved the 3 binaries and discarded the libs. `build_from_source()` already copies them, so this mirrors that behavior. Closes #1220.

## How
- `install.sh`: add three `cp -a ... 2>/dev/null || true` lines after binary `mv`, preserving symlinks (`libonnxruntime.so -> .so.1 -> .so.1.24.4`).
- `install.ps1`: `Get-ChildItem onnxruntime*.dll` copy loop.
- Docs: update manual install snippets + `What Gets Installed` table (ORT v1.24.4, matches `ort 2.0.0-rc.12`) + Arch/CachyOS note.

## Testing
- [x] `sh -n install.sh` passes (syntax clean)
- [x] Simulated copy against `uteke-x86_64-unknown-linux-gnu-v0.17.0.tar.gz`: symlinks preserved in target dir
- [x] Manual repro from #1220 (CachyOS rolling, kernel 7.2.2-1-cachyos, x86_64 AVX2, uteke 0.17.0, `~/.local/bin` with no `.so`): after placing bundled `1.24.4` `.so` next to binary, `uteke remember "any context" --tags test` succeeds and `uteke doctor` passes (DB=2, Index=2, Embedding model: embeddinggemma-q4)
- [x] `cargo test --workspace` / `clippy` / `fmt` untouched — no Rust code changed (CI Run 34481899340 already green: Build, Test, Clippy, Format pass)

## Related Issues
Closes #1220

## Checklist
- [x] Branch name follows convention (`fix/`, `feat/`, `docs/`, `chore/`, `refactor/`, `test/`, `perf/`, `security/`)
- [x] Branch is from `develop`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials committed
- [x] One logical change per PR (no mixed concerns)
