### PR TITLE
fix(ci): make cla-check work for fork PRs

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# pull-requests:write is only effective for SAME-REPO PRs (bot comment).
+# Fork PRs run with a read-only GITHUB_TOKEN no matter what is declared here
+# — that is exactly why the old commit-status approach could never work on
+# forks (verified: PR #1221, run 34481899319, POST statuses → 403).
 permissions:
   pull-requests: write
   contents: read
-  statuses: write
 
 jobs:
   cla-check:
@@ -46,8 +49,16 @@ jobs:
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
-      - name: Comment on PR (unsigned only)
-        if: steps.check.outputs.signed != 'true'
+      # FORK-SAFE GATE: this job's own Actions check run carries the CLA gate.
+      # It is created by GitHub itself and is NOT subject to the fork token
+      # restriction: signed → job success; unsigned → annotated failure below.
+      #
+      # The PR comment is a courtesy for same-repo contributors only — forks
+      # cannot comment at all (also 403), so the step is conditioned and
+      # best-effort. It never affects the gate outcome.
+      - name: Comment on PR (same-repo, best effort)
+        if: steps.check.outputs.signed != 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |
@@ -64,6 +75,7 @@ jobs:
                   '- 📋 **Individual?** → [Sign CLA Individual](https://codecoradev.github.io/cla/?type=individual)',
                   '- 🏢 **Corporate?** → [Sign CLA Corporate](https://codecoradev.github.io/cla/?type=corporate)',
                   '',
+                  'After signing, this check turns green automatically (within ~1 hour, or ask a maintainer to re-run it).',
                   '---',
                   '<sub>By signing, you agree to the terms in [CLA_INDIVIDUAL.md](https://github.com/codecoradev/.github/blob/main/CLA_INDIVIDUAL.md) or [CLA_CORPORATE.md](https://github.com/codecoradev/.github/blob/main/CLA_CORPORATE.md).</sub>',
                 ].join('\n');
@@ -96,27 +108,9 @@ jobs:
               });
             }
 
-      - name: Set commit status
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const signed = '${{ steps.check.outputs.signed }}' === 'true';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ github.event.pull_request.head.sha }}',
-              state: signed ? 'success' : 'failure',
-              context: 'CLA Check',
-              description: signed
-                ? '✅ CLA signed'
-                : '❌ CLA not signed — sign at https://codecoradev.github.io/cla',
-              target_url: signed
-                ? 'https://github.com/codecoradev/.github/blob/main/.cla/signatures.json'
-                : 'https://codecoradev.github.io/cla',
-            });
-
       - name: Fail if not signed
         if: steps.check.outputs.signed != 'true'
         run: |
+          echo "::error title=CLA not signed::Sign the CodeCoraDev CLA at https://codecoradev.github.io/cla — once the signature PR is merged, this check turns green automatically (re-run it or wait ~1 hour)."
           echo "❌ CLA not signed by ${{ github.event.pull_request.user.login }}"
           exit 1


### PR DESCRIPTION
## What

- `cla-check.yml` no longer POSTs a commit status (context `CLA Check`); the CLA gate now rides on the job's own Actions check run (`cla-check`)
- Removes the `statuses: write` permission
- PR comment step becomes same-repo-only + `continue-on-error` (best effort)
- Unsigned path now emits a `::error` annotation with the portal link and auto-refresh info

## Why
Fork PRs always run workflows with a read-only `GITHUB_TOKEN`, regardless of declared `permissions`. The old design gated CLA on a manually POSTed commit status, so every external fork PR failed the status step with 403 — permanently red even with a signed CLA. Empirical evidence from today: PR #1221 (fork by @KazamiHazaki), run 34481899319: `signed='true'` yet `POST /repos/codecoradev/uteke/statuses/... -> 403 Resource not accessible by integration`; the comment step was skipped with zero bot comments on the PR (REST-verified).

The native Actions check run is created by GitHub itself and is not subject to the fork token restriction, making it the correct carrier for the gate. Semantics are unchanged: signed → green, unsigned → red with an explanatory annotation.

## Testing
- Structural asserts on the new YAML (no `createCommitStatus`, no `statuses: write`, comment step conditioned + `continue-on-error`, gate step untouched semantics)
- Functional test of the check script against live `signatures.json` from `.github@main`: `KazamiHazaki` → `signed=true`, unknown user → `signed=false`
- Full local validation: `cargo check`, `cargo clippy`, workspace tests, `cargo fmt --check` (pre-commit gates, all green; cora review passed)
- Post-merge (owner): ruleset `develop-protected` required context swaps `CLA Check` → `cla-check` (case-sensitive) via API, then an E2E synthetic PR validates the new gate

## Notes for reviewers
Until the ruleset swap lands, new PRs will show a red/pending `CLA Check` missing context — expected transitional state; this PR itself may show it. Sequence: merge this → ruleset swap → E2E validation.
