### PR TITLE
ci: temporary CLA gate E2E probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ mutants*.out.old/
 # embedder cache artifact from local test runs
 crates/uteke-core/embed_cache.db
 embed_cache.db
+
+# cla-e2e-probe: temporary marker for CLA gate validation (PR will be closed, never merged)


### PR DESCRIPTION
## What
One comment line in `.gitignore`. No functional change.

## Why
Synthetic probe to validate the CLA gate mechanism transition end-to-end (commit-status `CLA Check` → native check run `cla-check`). This PR will be **closed without merging** once validation completes.

## Testing
Not applicable — probe PR, closed before merge. Serves as the empirical test bed for the ruleset swap.
