### PR TITLE
fix(ci): skip branch naming and PR description checks for bot PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,6 +9,7 @@ jobs:
   branch-naming:
     name: Branch Naming
     runs-on: ubuntu-latest
+    if: "!contains(fromJSON('[\"dependabot[bot]\", \"renovate[bot]\", \"github-actions[bot]\", \"app/dependabot\", \"app/renovate\"]'), github.event.pull_request.user.login)"
     steps:
       - name: Check branch name
         env:
@@ -38,6 +39,7 @@ jobs:
   pr-template:
     name: PR Description
     runs-on: ubuntu-latest
+    if: "!contains(fromJSON('[\"dependabot[bot]\", \"renovate[bot]\", \"github-actions[bot]\", \"app/dependabot\", \"app/renovate\"]'), github.event.pull_request.user.login)"
     steps:
       - name: Check PR body
         env:


### PR DESCRIPTION
## What

Adds a job-level `if:` condition to the `branch-naming` and `pr-template` jobs in `pr-checks.yml` so they are skipped for pull requests opened by bots (`dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, plus legacy `app/*` forms). The condition is copied verbatim from the proven allowlist already shipped in `cla-check.yml` (#1148), so the bot list stays consistent across workflows.

## Why

Every dependabot PR currently fails exactly two required checks:

- **Branch Naming**: dependabot branches (`dependabot/cargo/...`) cannot follow the `type/topic` convention by design.
- **PR Description**: dependabot PR bodies do not follow our What/Why/Testing template by design.

These failures are structural (impossible for the bot to fix), not code problems — they turn every routine dependency PR `UNSTABLE`/`BLOCKED` and add merge friction. #1205 additionally sat `BLOCKED` after a transient Cora Review infra error. Real examples: #1204, #1205, #1206, #1207 (all merged today with these cosmetic reds).

## Testing

- Validated with the 4-layer workflow linter (actionlint + per-step syntax checks): ALL CLEAN.
- The `if:` expression is byte-identical to the one merged in `cla-check.yml` (#1148), which is proven in production on every dependabot PR since 2026-08-29 (cla-check SKIPPED for bots, as intended).
- Natural E2E: the 4 currently-open dependabot PRs will re-run this workflow on their next synchronize/rebase; jobs should flip to SKIPPED. The two dependabot PRs merged today (#1204, #1206, #1207) document the before-state (Branch Naming + PR Description FAILURE, all real checks SUCCESS).
- No change to behavior for human PRs: condition is exact-match on bot logins only.

