### PR TITLE
fix(cli): default recall min_score 0.3 -> 0.0 (#1223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **Default recall `min_score` lowered 0.3 → 0.0 (#1223)** — since the fusion strategy (weighted RRF) became the recall default in 0.16.0, returned scores are rank-based (RRF contribution plus salience/recency boosts, typically ~0.0-0.2) rather than cosine similarity, so the CLI default threshold of 0.3 (a cosine-era value; HTTP/MCP already default 0.0) silently filtered out almost every result — measured on embeddinggemma-q4: all 20 paraphrase probes scored 0.169-0.186 rank-1 while a legacy-distribution 0.3 default expects ~0.5+, making default `uteke recall` return empty. Thresholds remain opt-in via `[recall] min_score`, `--min`, `--strict` (0.5), or HTTP `min_score`; docs now state the score scale per strategy.
 - **LongMemEval baseline mislabel** — RESULTS.md previously attributed the 0.854/0.885 (2026-08-13) full-500 baseline to "v0.15.0 hybrid"; those figures are the **vector-only** run (hybrid was validated at 50 questions only). Corrected, with both delta bases stated (+8.9pp full-500, +9.2pp 470-non-abstention).
 - **Full-dataset aggregates** — RESULTS.md now labels all three bases explicitly: Overall (470 non-abstention), Abstention (30), and Overall (full 500 = 0.982 recall_any@5 / 0.880 strict recall_all@5); no questions silently dropped from the aggregate rows.
 - Removed stale run logs and an outdated metrics snapshot from git tracking (values superseded by recomputation from committed raw artifacts).

--- a/crates/uteke-cli/src/config.rs
+++ b/crates/uteke-cli/src/config.rs
@@ -226,7 +226,11 @@ impl Default for AgingConfig {
 #[derive(serde::Deserialize, Clone)]
 #[serde(default)]
 pub struct RecallConfig {
-    /// Minimum cosine similarity score for recall results. Results below are filtered out.
+    /// Minimum similarity score for recall results. Results below are filtered out.
+    /// Default 0.0 (#1223): since fusion RRF became the default strategy (0.16.0),
+    /// returned scores are rank-based (~0.0-0.2), so a legacy cosine-era default of
+    /// 0.3 silently emptied default recalls. Threshold remains opt-in via config,
+    /// `--min`, or `--strict` (0.5).
     pub min_score: f64,
     /// Strict mode threshold (higher, for critical queries).
     pub min_score_strict: f64,
@@ -259,7 +263,7 @@ pub struct RecallConfig {
 impl Default for RecallConfig {
     fn default() -> Self {
         Self {
-            min_score: 0.3,
+            min_score: 0.0,
             min_score_strict: 0.5,
             // Fusion (weighted RRF: vector×1.7 + hybrid×1) is the default
             // strategy since 0.16.0 (#1123). Benchmark: fast50 R@5 0.98 vs
@@ -1035,7 +1039,7 @@ impl Config {
 # max_cold_count = 1000
 
 [recall]
-# min_score = 0.3
+# min_score = 0.0  # default since 0.17.x (#1223): fusion scores are rank-based; 0.3 is a legacy cosine-era threshold
 # min_score_strict = 0.5
 # default_strategy = "fusion"  # vector | fts5 | hybrid | graph | fusion
 # graph_density_weight = 0.1
@@ -1498,7 +1502,7 @@ namespace = "agent1"
     #[test]
     fn default_recall_config() {
         let cfg = RecallConfig::default();
-        assert!((cfg.min_score - 0.3).abs() < f64::EPSILON);
+        assert!((cfg.min_score - 0.0).abs() < f64::EPSILON);
         assert!((cfg.min_score_strict - 0.5).abs() < f64::EPSILON);
         // Fusion (vector×1.7 + hybrid×1 weighted RRF) is the default
         // strategy since 0.16.0 (#1123).
@@ -1837,7 +1841,7 @@ max_seq_length = 128
         assert_eq!(cfg.logging.level, "warn");
         assert_eq!(cfg.server.host, "127.0.0.1");
         assert_eq!(cfg.server.port, 8767);
-        assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
+        assert!((cfg.recall.min_score - 0.0).abs() < f64::EPSILON);
     }
 
     // ── #1078 P0 batch 3: score range guards, strategy validation, graph
@@ -1853,7 +1857,7 @@ max_seq_length = 128
         unsafe {
             std::env::remove_var("UTEKE_RECALL_MIN_SCORE");
         }
-        assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
+        assert!((cfg.recall.min_score - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -1866,7 +1870,7 @@ max_seq_length = 128
         unsafe {
             std::env::remove_var("UTEKE_RECALL_MIN_SCORE");
         }
-        assert!((cfg.recall.min_score - 0.3).abs() < f64::EPSILON);
+        assert!((cfg.recall.min_score - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -368,6 +368,7 @@ Additional flags not shown in the basic example above:
 # Minimum similarity score filter
 uteke recall "database config" --min 0.7
 uteke recall "database config" --strict    # uses min_score_strict (default 0.5)
+uteke recall "database config" --min 0.25  # opt-in similarity threshold (default 0.0 since #1223: fusion scores are rank-based)
 
 # Time-travel: query memories at specific point in time
 uteke recall "deployment process" --at 2026-06-01T12:00:00Z
@@ -415,6 +416,7 @@ uteke recall "api design" --context
 |------|-------------|
 | `--min <score>` | Minimum similarity score (0.0-1.0) |
 | `--strict` | Use strict threshold (`min_score_strict`, default 0.5) |
+| `--min <score>` | Minimum similarity score threshold (default 0.0 since 0.17.x, #1223 — fusion scores are rank-based, not cosine) |
 | `--at <timestamp>` | Query memories at point in time (RFC3339) |
 | `--related` | Follow relationship edges |
 | `--depth <n>` | Traversal depth for --related |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,7 +198,7 @@ Control minimum similarity score for recall results:
 [recall]
 # Minimum similarity score (0.0-1.0). Memories below this score are excluded.
 # Default: 0.3 (balanced). Use 0.0 to disable filtering.
-min_score = 0.3
+min_score = 0.0
 
 # Strict-mode threshold (used with `--strict` flag)
 min_score_strict = 0.5
@@ -223,7 +223,7 @@ graph_rerank_enabled = true   # master switch; false → graph acts like hybrid
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `min_score` | 0.3 | Minimum similarity score (0.0-1.0). **CLI only.** |
+| `min_score` | 0.0 | Minimum similarity score (0.0-1.0). **CLI only.** |
 | `min_score_strict` | 0.5 | Strict-mode threshold (used with `--strict`). **CLI only.** |
 | `default_strategy` | `fusion` | Default recall strategy (`vector\|fts5\|hybrid\|graph\|fusion`). Since 0.16.0 `fusion` (weighted RRF: vector×1.7 + hybrid×1, #1123) is the default — LongMemEval fast50 R@5 0.98 vs 0.9267 hybrid |
 | `graph_density_weight` | 0.1 | Edge-density boost weight (graph strategy only) |
@@ -234,8 +234,10 @@ graph_rerank_enabled = true   # master switch; false → graph acts like hybrid
 >
 > | Interface | Default `min_score` | Notes |
 > |-----------|---------------------|-------|
-> | **CLI** | `0.3` (from `[recall] min_score`) | Reads from `uteke.toml`. `--min 0.0` to disable. |
+> | **CLI** | `0.0` (from `[recall] min_score`) | Reads from `uteke.toml`. Set `--min` or `[recall] min_score` to enable. |
 > | **HTTP API / Server** | `0.0` (`DEFAULT_MIN_SCORE`) | Server has its own constant, ignores `[recall] min_score`. |
+>
+> **Note (since 0.17.x, #1223):** default recall scores under the fusion strategy are rank-based (RRF contribution + salience/recency boosts, typically ~0.0-0.2), not raw cosine similarity. A legacy cosine-era default threshold of 0.3 silently filtered out nearly all results, so the default is now 0.0 across every surface. Set a threshold explicitly (config `min_score`, `--min`, `--strict`, or HTTP `min_score`) only when you know the score scale of the active strategy.
 > | **MCP** | `0.0` | MCP server hardcodes 0.0. |
 >
 > This means a score of 0.25 is returned by API/MCP but **filtered out** by CLI.
@@ -278,7 +280,7 @@ Resolution order (highest priority first):
 | `UTEKE_VECTOR_BACKEND` | `[vector] backend` | compiled-in default | Vector engine when both are compiled in: `usearch`, `vecq`. Ignored (with a warning) on single-engine builds or unknown values. Switching engines on an existing store auto-rebuilds the index from SQLite |
 | `UTEKE_SERVER_HOST` | `[server] host` | `127.0.0.1` | Server bind address |
 | `UTEKE_SERVER_PORT` | `[server] port` | `8767` | Server port |
-| `UTEKE_RECALL_MIN_SCORE` | `[recall] min_score` | `0.3` | Default similarity threshold |
+| `UTEKE_RECALL_MIN_SCORE` | `[recall] min_score` | `0.0` | Default similarity threshold |
 | `UTEKE_RECALL_MIN_SCORE_STRICT` | `[recall] min_score_strict` | `0.5` | Strict threshold |
 | `UTEKE_RECALL_STRATEGY` | `[recall] default_strategy` | `fusion` | Default recall strategy (`vector\|fts5\|hybrid\|graph\|fusion`) |
 | `UTEKE_GRAPH_DENSITY_WEIGHT` | `[recall] graph_density_weight` | `0.1` | Edge-density boost weight |


### PR DESCRIPTION
## What

Lowers the default `[recall] min_score` from **0.3 to 0.0** (`crates/uteke-cli/src/config.rs`), updates the 4 tests asserting the old default, refreshes the sample-config comment, and updates `docs/configuration.md` + `docs/cli-reference.md` (including a new note stating the score scale per strategy). HTTP (`DEFAULT_MIN_SCORE`) and MCP already default to 0.0 — this aligns the CLI. Fixes #1223.

## Why

Since the fusion strategy (weighted RRF) became the recall default in 0.16.0, returned scores are **rank-based** (RRF contribution plus salience/recency boosts, typically ~0.0–0.2) rather than cosine similarity — the code itself documents that applying cosine thresholds to RRF scores "would incorrectly filter results" (`operations.rs`, hybrid arm). The 0.3 default is a cosine-era value, so default CLI recall now returns empty for almost every query.

Measured locally (uteke 0.17.0, embeddinggemma-q4): 20 paraphrase probes over a 40-memory store — every rank-1 similarity score fell in **0.169–0.186**; even the exact stored text scored 0.1875 (`explain`: raw vector cosine 0.738, final score 0.188). Under the legacy cosine-scale default of 0.3, all of these are filtered → `[]`.

Thresholds remain fully opt-in: `[recall] min_score`, `--min`, `--strict` (0.5), or HTTP `min_score`.

## Testing

- `cargo test -p uteke-cli config::` — 45 passed, 0 failed (incl. the 4 updated default assertions and the env-override range-guard tests).
- Manual E2E on the patched binary, fresh isolated store: default `recall` now returns the previously-invisible memory (score 0.174); `--min 0.25` still filters as expected; `--strict` unchanged (0.5).
- Behavioral note: results that previously showed by default remain visible; users with an explicit `min_score` in config are untouched (overlay logic unchanged).
