### PR TITLE
chore(benchmarks): preserve AMB (agent-memory-benchmark) run kit (#1226)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,6 +8,7 @@ how, and what the numbers are.
 | [`internal/`](internal/) | Performance | Insert throughput, recall latency, storage footprint (`uteke bench`) | ✅ Maintained — re-verified on v0.17.0 (2026-09-09) |
 | [`longmemeval/`](longmemeval/) | External #1 | Retrieval quality on [LongMemEval-S](https://arxiv.org/abs/2410.10813) (500 questions, session-level) | ✅ Validated on v0.16.0 (pure-default run); -M variant **not** measured (transparent) |
 | [`locomo/`](locomo/) | External #2 | Retrieval quality on [LoCoMo](https://github.com/snap-research/locomo) (very long multi-session conversations) | 🚧 Planned — adapter + pilot |
+| [`amb/`](amb/) | External #3 | Retrieval + temporal QA on [AMB](https://github.com/vectorize-io/agent-memory-benchmark) (run kit: patches + provenance) | 🚧 Run in progress — RESULTS pending (#1226) |
 
 Friendly overview page: [docs/benchmarks.md](../docs/benchmarks.md).
 
@@ -23,7 +24,8 @@ benchmarks/
 │   ├── results/       ← canonical raw artifacts (committed — audit them!)
 │   ├── scripts/       ← harness, metrics, Modal fan-out infra
 │   └── data/          ← dataset (gitignored; scripts/download_data.sh)
-└── locomo/            ← LoCoMo (planned)
+├── locomo/            ← LoCoMo (planned)
+└── amb/               ← AMB run kit (patch series + provenance, no vendored code)
 ```
 
 ## Reproduce

--- a/benchmarks/amb/README.md
+++ b/benchmarks/amb/README.md
@@ -1,0 +1,77 @@
+# AMB — Agent Memory Benchmark run kit
+
+Reproduction kit for running [AMB](https://github.com/vectorize-io/agent-memory-benchmark)
+(external benchmark #3) against uteke. The upstream harness has no license file, so
+this directory ships **patches against upstream** rather than a vendored copy.
+
+Status: 🚧 run in progress — RESULTS pending (full-1540 run + Gemini re-judge).
+
+## Provenance
+
+| Artifact | Value |
+|---|---|
+| Upstream repo | `vectorize-io/agent-memory-benchmark` |
+| Upstream base commit | `347f551b1014d8f8d5fab9eb38175f457a6ed195` |
+| Local branch | `feat/uteke-provider-and-compat` (4 commits, `16f940e`..`7b76a0e`) |
+| Uncommitted work | session-date ingest anchors + harness fixes → `patches/0005-*.patch` |
+| Snapshot date | 2026-09-11 (issue #1226: the only copy lived in a throwaway clone) |
+
+## Contents
+
+```
+amb/
+├── README.md                          ← you are here: provenance + run notes
+├── patches/
+│   ├── 0001-…  uteke memory provider + OpenAI-compat fixes
+│   ├── 0002-…  ingest via temp file + `uteke import`, not argv
+│   ├── 0003-…  unique temp file per ingest item (concurrency)
+│   ├── 0004-…  retry on missing required keys in LLM JSON responses
+│   └── 0005-…  UNCOMMITTED upstream work: session-date ingest anchors,
+│               raw-response full-payload fix, system-role JSON contract,
+│               repair-retry, graceful per-query degrade, AMB_TEMPERATURE,
+│               AMB_DEBUG_DUMP (see "Load-bearing fixes" below)
+└── scripts/
+    └── apply_patches.sh               ← clone upstream + apply all patches
+```
+
+## Reproduce
+
+```bash
+# 1. Clone upstream and apply the uteke provider patches
+./scripts/apply_patches.sh /path/to/amb-uteke
+
+# 2. Configure (see "Run notes" for exact env)
+export AMB_PROVIDER=uteke
+export OPENAI_BASE_URL=https://api.z.ai/api/coding/paas/v4   # GLM via Z.AI coding endpoint
+export OPENAI_MODEL=glm-5.3
+export AMB_THINKING_DISABLED=1          # thinking eats the token budget on GLM
+export AMB_TEMPERATURE=0                # deterministic runs
+# export AMB_DEBUG_DUMP=/tmp/amb-debug.jsonl   # capture full message payloads
+
+# 3. Run the harness per upstream README (locomo dataset), then judge.
+```
+
+## Load-bearing fixes (why the patches matter)
+
+Measured on conv-30 (LoCoMo), uteke 0.17.0, embeddinggemma-q4, GLM-5.3 judge:
+
+1. **Raw response must be the FULL recall payload** — locomo's prompt template
+   `json.dumps()`es the provider's raw response INSTEAD of the assembled context.
+   A hit-count stub silently produces empty-context prompts.
+   Artifact: 8.6% accuracy on the full run; canary fix trajectory
+   4.9% / 11.1% (empty context) → 69.1% (rich context, no dates) → **93.8%** (dated).
+2. **Session dates must be prepended at ingest** (`[Session date/time: …]` header) —
+   LoCoMo temporal QA demands absolute-date anchors; without them conv-30 temporal
+   = 15%, with them = 100% (26/26).
+3. **JSON contract via SYSTEM role, not a user-message prefix** — with thinking
+   disabled, GLM-5.3 (z.ai coding endpoint) degenerates on the combined single
+   user message: echoes the schema or mass-abstains even when the answer is in
+   the context.
+4. **Repair-retry conversation** after repeated format failures beats blind re-rolls.
+5. **Graceful per-query degrade** — one unparseable response must not kill a
+   multi-hour run; a sentinel-marked row still lands in the output.
+
+## RESULTS
+
+Pending — will be filled after the full-1540 run completes and the Gemini
+flash-lite re-judge (judge uniformity with other benchmark entries) is done.

--- a/benchmarks/amb/patches/0001-feat-uteke-memory-provider-compat-fixes-for-OpenAI-c.patch
+++ b/benchmarks/amb/patches/0001-feat-uteke-memory-provider-compat-fixes-for-OpenAI-c.patch
@@ -1,0 +1,256 @@
+From 16f940e1ccf02332afa830d286612657a1f9d272 Mon Sep 17 00:00:00 2001
+From: ajianaz <ajianaz@users.noreply.github.com>
+Date: Thu, 10 Sep 2026 23:22:18 +0700
+Subject: [PATCH 1/4] feat: uteke memory provider + compat fixes for
+ OpenAI-compatible backends
+
+- memory/uteke.py: uteke provider (CLI-backed ingest/recall, scratch store,
+  namespace per isolation unit, doc-id via tags, UTEKE_BIN/UTEKE_AMB_STORE env)
+- dataset/locomo.py: load_documents now honors the base-class user_ids
+  contract (filtered runner paths crashed with TypeError before)
+- llm/openai.py: AMB_OPENAI_STRICT_JSON=0 falls back to json_object with
+  schema-in-prompt for backends that ignore json_schema (GLM via gateways),
+  fence/brace extraction, AMB_MAX_TOKENS cap
+---
+ src/memory_bench/dataset/locomo.py  |   3 +
+ src/memory_bench/llm/openai.py      |  41 +++++++--
+ src/memory_bench/memory/__init__.py |   2 +
+ src/memory_bench/memory/uteke.py    | 125 ++++++++++++++++++++++++++++
+ 4 files changed, 165 insertions(+), 6 deletions(-)
+ create mode 100644 src/memory_bench/memory/uteke.py
+
+diff --git a/src/memory_bench/dataset/locomo.py b/src/memory_bench/dataset/locomo.py
+index 535985d..a2403a3 100644
+--- a/src/memory_bench/dataset/locomo.py
++++ b/src/memory_bench/dataset/locomo.py
+@@ -284,6 +284,7 @@ If it's correct, set correct=true.
+         category: str | None = None,
+         limit: int | None = None,
+         ids: set[str] | None = None,
++        user_ids: set[str] | None = None,
+     ) -> list[Document]:
+         data = self._load_raw()
+         documents: list[Document] = []
+@@ -295,6 +296,8 @@ If it's correct, set correct=true.
+             sample_id = item["sample_id"]
+             if conv_filter is not None and sample_id != conv_filter:
+                 continue
++            if user_ids is not None and sample_id not in user_ids:
++                continue
+             conv = item["conversation"]
+             speaker_a = conv.get("speaker_a", "A")
+             speaker_b = conv.get("speaker_b", "B")
+diff --git a/src/memory_bench/llm/openai.py b/src/memory_bench/llm/openai.py
+index 44d14b4..0beb667 100644
+--- a/src/memory_bench/llm/openai.py
++++ b/src/memory_bench/llm/openai.py
+@@ -25,6 +25,24 @@ class OpenAILLM(LLM):
+             "required": schema.required,
+             "additionalProperties": False,
+         }
++        strict_mode = os.environ.get("AMB_OPENAI_STRICT_JSON") != "0"
++        max_tokens_env = os.environ.get("AMB_MAX_TOKENS")
++        max_tokens = int(max_tokens_env) if max_tokens_env else None
++        if strict_mode:
++            response_format: dict = {
++                "type": "json_schema",
++                "json_schema": {"name": "response", "schema": schema_json, "strict": True},
++            }
++        else:
++            # Some OpenAI-compatible backends (e.g. GLM via Bifrost) ignore json_schema
++            # and thinking-disable flags; they DO honor json_object + instructions.
++            schema_desc = json.dumps(schema_json, ensure_ascii=False)
++            prompt = (
++                "You must respond with ONLY a JSON object — no markdown fences, no extra "
++                "text — with EXACTLY this shape:\n"
++                f"{schema_desc}\n\n{prompt}"
++            )
++            response_format = {"type": "json_object"}
+         delay = _RETRY_BASE_DELAY
+         last_exc = None
+         for attempt in range(_MAX_RETRIES):
+@@ -32,13 +50,24 @@ class OpenAILLM(LLM):
+                 response = self._client.chat.completions.create(
+                     model=self._model,
+                     messages=[{"role": "user", "content": prompt}],
+-                    response_format={
+-                        "type": "json_schema",
+-                        "json_schema": {"name": "response", "schema": schema_json, "strict": True},
+-                    },
++                    response_format=response_format,
++                    **({"max_tokens": max_tokens} if max_tokens else {}),
+                 )
+-                text = response.choices[0].message.content
+-                return json.loads(text)
++                text = response.choices[0].message.content or ""
++                # tolerate ```json fences some backends add despite instructions
++                stripped = text.strip()
++                if stripped.startswith("```"):
++                    stripped = stripped.strip("`")
++                    if stripped.lower().startswith("json"):
++                        stripped = stripped[4:]
++                try:
++                    return json.loads(stripped)
++                except json.JSONDecodeError:
++                    # last resort: extract the outermost {...} substring
++                    lo, hi = stripped.find("{"), stripped.rfind("}")
++                    if lo != -1 and hi > lo:
++                        return json.loads(stripped[lo:hi + 1])
++                    raise
+             except Exception as e:
+                 last_exc = e
+                 msg = str(e)
+diff --git a/src/memory_bench/memory/__init__.py b/src/memory_bench/memory/__init__.py
+index 2b7e5e0..d203999 100644
+--- a/src/memory_bench/memory/__init__.py
++++ b/src/memory_bench/memory/__init__.py
+@@ -11,6 +11,7 @@ from .ogham import OghamMemoryProvider
+ from .supermemory import SupermemoryMemoryProvider
+ from .none import NoMemoryProvider
+ from .hscoding import HsCodingProvider
++from .uteke import UtekeMemoryProvider
+ 
+ REGISTRY: dict[str, type[MemoryProvider]] = {
+     "vanilla": NoMemoryProvider,
+@@ -28,6 +29,7 @@ REGISTRY: dict[str, type[MemoryProvider]] = {
+     "ogham": OghamMemoryProvider,
+     "qdrant": HybridSearchMemoryProvider,
+     "supermemory": SupermemoryMemoryProvider,
++    "uteke": UtekeMemoryProvider,
+ }
+ # legacy aliases (docs/scripts used these); canonical names above
+ REGISTRY["none"] = NoMemoryProvider
+diff --git a/src/memory_bench/memory/uteke.py b/src/memory_bench/memory/uteke.py
+new file mode 100644
+index 0000000..b176e5d
+--- /dev/null
++++ b/src/memory_bench/memory/uteke.py
+@@ -0,0 +1,125 @@
++"""Uteke memory provider for the Agent Memory Benchmark harness (internal runs).
++
++Bridges the harness MemoryProvider interface to the uteke CLI:
++
++- ingest(): one `uteke remember` per document, into a dedicated scratch store
++  (UTEKE_AMB_STORE, default /opt/data/tmp/uteke-amb-bench), namespaced by
++  user_id (the dataset isolation unit) and tagged with the document id so
++  retrieved docs map back to AMB Document ids deterministically.
++- retrieve(): `uteke recall --min 0 --json --limit k` in the caller's namespace;
++  scores are ranking-only, so the default 0.3 relevance threshold is disabled.
++
++Document content: sessions arrive as JSON-dumped turn lists ({"speaker","text"}
++or {"role","content"}); they are re-serialized as plain "Speaker: text" dialogue
++lines, which embed far better than raw JSON for the embeddinggemma channel.
++
++Install: drop this file into src/memory_bench/memory/ and register "uteke" in
++memory/__init__.py REGISTRY. Requires the uteke binary on PATH (>= 0.17).
++"""
++
++from __future__ import annotations
++
++import json
++import os
++import shutil
++import subprocess
++from pathlib import Path
++
++from ..models import Document
++from .base import MemoryProvider
++
++
++def _session_dialogue(content: str) -> str:
++    """Turn AMB session content (JSON-dumped turns) into plain dialogue text."""
++    try:
++        turns = json.loads(content)
++    except (json.JSONDecodeError, TypeError):
++        return content
++    if not isinstance(turns, list):
++        return content
++    lines = []
++    for t in turns:
++        if not isinstance(t, dict):
++            lines.append(str(t))
++            continue
++        who = t.get("speaker") or t.get("role") or "unknown"
++        text = t.get("text") or t.get("content") or ""
++        lines.append(f"{who}: {text}")
++    return "\n".join(lines)
++
++
++class UtekeMemoryProvider(MemoryProvider):
++    name = "uteke"
++    description = (
++        "Uteke local-first memory engine (fusion hybrid retrieval, CPU-only, "
++        "no LLM in the retrieval path)."
++    )
++    kind = "local"
++    concurrency = 4
++
++    def __init__(self):
++        self._store = Path(
++            os.environ.get("UTEKE_AMB_STORE", "/opt/data/tmp/uteke-amb-bench")
++        )
++        # Explicit override matters on machines with several installed builds
++        # (e.g. an x86_64 binary left in ~/.cargo/bin on an aarch64 host).
++        self._bin = os.environ.get("UTEKE_BIN") or shutil.which("uteke") or "uteke"
++
++    # -- lifecycle ---------------------------------------------------------
++    def prepare(self, store_dir: Path, unit_ids: set[str] | None = None, reset: bool = True) -> None:
++        if reset and self._store.exists():
++            shutil.rmtree(self._store)
++        self._store.mkdir(parents=True, exist_ok=True)
++
++    def cleanup(self) -> None:
++        # keep the store for post-run inspection; harness outputs are the record
++        pass
++
++    # -- helpers -----------------------------------------------------------
++    def _run(self, args: list[str]) -> dict | list:
++        proc = subprocess.run(
++            [self._bin, *args, "--store", str(self._store), "--json"],
++            capture_output=True, text=True, timeout=300,
++        )
++        if proc.returncode != 0:
++            raise RuntimeError(f"uteke {' '.join(args[:2])} failed: {proc.stderr[:400]}")
++        try:
++            return json.loads(proc.stdout)
++        except json.JSONDecodeError:
++            return []
++
++    # -- interface ---------------------------------------------------------
++    def ingest(self, documents: list[Document]) -> None:
++        for doc in documents:
++            content = _session_dialogue(doc.content)
++            self._run([
++                "remember", content,
++                "--namespace", doc.user_id or "default",
++                "--tags", f"amb,doc-{doc.id}",
++            ])
++
++    def retrieve(
++        self,
++        query: str,
++        k: int = 10,
++        user_id: str | None = None,
++        query_timestamp: str | None = None,
++        filters: dict | None = None,
++    ) -> tuple[list[Document], dict | None]:
++        out = self._run([
++            "recall", query,
++            "--namespace", user_id or "default",
++            "--limit", str(k),
++            "--min", "0",
++        ])
++        docs: list[Document] = []
++        for hit in out:
++            tags = hit.get("tags") or []
++            doc_id = next((t[4:] for t in tags if t.startswith("doc-")), hit.get("memory_id", ""))
++            docs.append(Document(
++                id=doc_id,
++                content=hit.get("content", ""),
++                user_id=user_id,
++                source_ids=[doc_id],
++            ))
++        return docs, {"raw_hits": len(out)}
+-- 
+2.47.3
+

--- a/benchmarks/amb/patches/0002-fix-benchmarks-ingest-via-temp-file-uteke-import-not.patch
+++ b/benchmarks/amb/patches/0002-fix-benchmarks-ingest-via-temp-file-uteke-import-not.patch
@@ -1,0 +1,51 @@
+From 920f4edc87fd5794932eb3fe8b758544293ba64a Mon Sep 17 00:00:00 2001
+From: ajianaz <ajianaz@users.noreply.github.com>
+Date: Thu, 10 Sep 2026 23:28:09 +0700
+Subject: [PATCH 2/4] fix(benchmarks): ingest via temp file + uteke import, not
+ argv
+
+Sessions can exceed the OS per-argument limit when passed as argv to
+`uteke remember` (E2BIG on long contexts; BEAM/LongMemEval-scale corpora).
+`import` accepts a file path and applies the same namespace/tags options,
+so content now routes through a per-item temp file. Round-trip verified:
+tags survive recall and doc-id mapping is unchanged.
+---
+ src/memory_bench/memory/uteke.py | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/src/memory_bench/memory/uteke.py b/src/memory_bench/memory/uteke.py
+index b176e5d..ffcc859 100644
+--- a/src/memory_bench/memory/uteke.py
++++ b/src/memory_bench/memory/uteke.py
+@@ -90,13 +90,21 @@ class UtekeMemoryProvider(MemoryProvider):
+ 
+     # -- interface ---------------------------------------------------------
+     def ingest(self, documents: list[Document]) -> None:
+-        for doc in documents:
+-            content = _session_dialogue(doc.content)
+-            self._run([
+-                "remember", content,
+-                "--namespace", doc.user_id or "default",
+-                "--tags", f"amb,doc-{doc.id}",
+-            ])
++        # Route content through a temp file + `uteke import` instead of argv:
++        # sessions can exceed the OS per-argument limit (E2BIG), and the CLI
++        # takes file paths, not stdin, for `remember`.
++        tmp = self._store / ".ingest-item.txt"
++        try:
++            for doc in documents:
++                content = _session_dialogue(doc.content)
++                tmp.write_text(content, encoding="utf-8")
++                self._run([
++                    "import", str(tmp), "--format", "text",
++                    "--namespace", doc.user_id or "default",
++                    "--tags", f"amb,doc-{doc.id}",
++                ])
++        finally:
++            tmp.unlink(missing_ok=True)
+ 
+     def retrieve(
+         self,
+-- 
+2.47.3
+

--- a/benchmarks/amb/patches/0003-fix-benchmarks-unique-temp-file-per-ingest-item.patch
+++ b/benchmarks/amb/patches/0003-fix-benchmarks-unique-temp-file-per-ingest-item.patch
@@ -1,0 +1,58 @@
+From 007511ea79defe9a193071d15a726c80f32f3b31 Mon Sep 17 00:00:00 2001
+From: ajianaz <ajianaz@users.noreply.github.com>
+Date: Thu, 10 Sep 2026 23:34:18 +0700
+Subject: [PATCH 3/4] fix(benchmarks): unique temp file per ingest item
+
+The fixed .ingest-item.txt path raced when ingest ran concurrently
+(async_ingest wraps sync ingest in a thread). Use tempfile.mkstemp inside
+the store dir instead; adapter test re-passed.
+---
+ src/memory_bench/memory/uteke.py | 21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/src/memory_bench/memory/uteke.py b/src/memory_bench/memory/uteke.py
+index ffcc859..86a7ed0 100644
+--- a/src/memory_bench/memory/uteke.py
++++ b/src/memory_bench/memory/uteke.py
+@@ -23,6 +23,7 @@ import json
+ import os
+ import shutil
+ import subprocess
++import tempfile
+ from pathlib import Path
+ 
+ from ..models import Document
+@@ -92,19 +93,21 @@ class UtekeMemoryProvider(MemoryProvider):
+     def ingest(self, documents: list[Document]) -> None:
+         # Route content through a temp file + `uteke import` instead of argv:
+         # sessions can exceed the OS per-argument limit (E2BIG), and the CLI
+-        # takes file paths, not stdin, for `remember`.
+-        tmp = self._store / ".ingest-item.txt"
+-        try:
+-            for doc in documents:
+-                content = _session_dialogue(doc.content)
+-                tmp.write_text(content, encoding="utf-8")
++        # takes file paths, not stdin, for `remember`. Unique per call so
++        # concurrent ingests (async_ingest runs in threads) never collide.
++        for doc in documents:
++            content = _session_dialogue(doc.content)
++            fd, tmp_path = tempfile.mkstemp(prefix="amb-ingest-", suffix=".txt", dir=str(self._store))
++            try:
++                with os.fdopen(fd, "w", encoding="utf-8") as f:
++                    f.write(content)
+                 self._run([
+-                    "import", str(tmp), "--format", "text",
++                    "import", tmp_path, "--format", "text",
+                     "--namespace", doc.user_id or "default",
+                     "--tags", f"amb,doc-{doc.id}",
+                 ])
+-        finally:
+-            tmp.unlink(missing_ok=True)
++            finally:
++                os.unlink(tmp_path)
+ 
+     def retrieve(
+         self,
+-- 
+2.47.3
+

--- a/benchmarks/amb/patches/0004-fix-benchmarks-retry-on-missing-required-keys-in-LLM.patch
+++ b/benchmarks/amb/patches/0004-fix-benchmarks-retry-on-missing-required-keys-in-LLM.patch
@@ -1,0 +1,63 @@
+From 7b76a0e47424158fda9de93512d0ea6c821b85dd Mon Sep 17 00:00:00 2001
+From: ajianaz <ajianaz@users.noreply.github.com>
+Date: Thu, 10 Sep 2026 23:38:11 +0700
+Subject: [PATCH 4/4] fix(benchmarks): retry on missing required keys in LLM
+ JSON responses
+
+Reasoning models occasionally rename or drop required schema keys even in
+json_object mode; treat a shape-valid dict with missing keys as a malformed
+generation and retry instead of crashing the run downstream (KeyError on
+data['answer'] in rag mode).
+---
+ src/memory_bench/llm/openai.py | 29 +++++++++++++++++++++--------
+ 1 file changed, 21 insertions(+), 8 deletions(-)
+
+diff --git a/src/memory_bench/llm/openai.py b/src/memory_bench/llm/openai.py
+index 0beb667..a430e92 100644
+--- a/src/memory_bench/llm/openai.py
++++ b/src/memory_bench/llm/openai.py
+@@ -61,20 +61,33 @@ class OpenAILLM(LLM):
+                     if stripped.lower().startswith("json"):
+                         stripped = stripped[4:]
+                 try:
+-                    return json.loads(stripped)
++                    parsed = json.loads(stripped)
+                 except json.JSONDecodeError:
+                     # last resort: extract the outermost {...} substring
+                     lo, hi = stripped.find("{"), stripped.rfind("}")
+                     if lo != -1 and hi > lo:
+-                        return json.loads(stripped[lo:hi + 1])
+-                    raise
++                        parsed = json.loads(stripped[lo:hi + 1])
++                    else:
++                        raise
++                if not isinstance(parsed, dict):
++                    # some backends emit a bare JSON string/number; treat as a
++                    # malformed generation and retry (cheap, content-side only)
++                    raise ValueError(f"non-object JSON response: {type(parsed).__name__}")
++                missing = [k for k in schema.required if k not in parsed]
++                if missing:
++                    # models sometimes rename/drop keys; retry usually fixes it
++                    raise ValueError(f"missing required keys {missing}")
++                return parsed
+             except Exception as e:
+                 last_exc = e
+                 msg = str(e)
+-                if "429" in msg or "rate" in msg.lower():
+-                    if attempt < _MAX_RETRIES - 1:
+-                        time.sleep(delay)
+-                        delay *= 2
+-                        continue
++                retryable = (
++                    isinstance(e, (json.JSONDecodeError, ValueError))
++                    or "429" in msg
++                    or "rate" in msg.lower()
++                )
++                if retryable and attempt < _MAX_RETRIES - 1:
++                    time.sleep(_RETRY_BASE_DELAY if "429" in msg or "rate" in msg.lower() else 2)
++                    continue
+                 raise
+         raise RuntimeError(f"OpenAI request failed after {_MAX_RETRIES} retries: {last_exc}")
+-- 
+2.47.3
+

--- a/benchmarks/amb/patches/0005-uncommitted-session-dates-and-harness-fixes.patch
+++ b/benchmarks/amb/patches/0005-uncommitted-session-dates-and-harness-fixes.patch
@@ -1,0 +1,132 @@
+diff --git a/src/memory_bench/llm/openai.py b/src/memory_bench/llm/openai.py
+index a430e92..91e350c 100644
+--- a/src/memory_bench/llm/openai.py
++++ b/src/memory_bench/llm/openai.py
+@@ -1,6 +1,7 @@
+ import json
+ import os
+ import time
++from typing import Any, cast
+ 
+ from .base import LLM, Schema
+ 
+@@ -28,32 +29,71 @@ class OpenAILLM(LLM):
+         strict_mode = os.environ.get("AMB_OPENAI_STRICT_JSON") != "0"
+         max_tokens_env = os.environ.get("AMB_MAX_TOKENS")
+         max_tokens = int(max_tokens_env) if max_tokens_env else None
++        # GLM-family via Z.AI direct: thinking defaults ON and eats the token
++        # budget first; the flag works on the direct endpoint (unlike some
++        # gateways that silently drop it). Env-gated so other backends are
++        # unaffected.
++        extra: dict = {}
++        if os.environ.get("AMB_THINKING_DISABLED") == "1":
++            extra["extra_body"] = {"thinking": {"type": "disabled"}}
+         if strict_mode:
+             response_format: dict = {
+                 "type": "json_schema",
+                 "json_schema": {"name": "response", "schema": schema_json, "strict": True},
+             }
++            messages = [{"role": "user", "content": prompt}]
+         else:
+             # Some OpenAI-compatible backends (e.g. GLM via Bifrost) ignore json_schema
+             # and thinking-disable flags; they DO honor json_object + instructions.
++            # The JSON contract goes into a SYSTEM message, NOT prepended to the user
++            # content: with thinking disabled, GLM-5.3 (z.ai coding endpoint) degenerates
++            # on the combined single-user-message form — echoing the schema or mass-
++            # abstaining ("context does not contain ...") even when the answer is
++            # literally in the context (observed 2026-09-11: 8.6% full run, repro'd by
++            # canary; system-role form + thinking-off answers correctly).
+             schema_desc = json.dumps(schema_json, ensure_ascii=False)
+-            prompt = (
++            json_contract = (
+                 "You must respond with ONLY a JSON object — no markdown fences, no extra "
+                 "text — with EXACTLY this shape:\n"
+-                f"{schema_desc}\n\n{prompt}"
++                f"{schema_desc}"
+             )
+             response_format = {"type": "json_object"}
++            messages = [
++                {"role": "system", "content": json_contract},
++                {"role": "user", "content": prompt},
++            ]
+         delay = _RETRY_BASE_DELAY
+         last_exc = None
++        last_bad_text = ""
++        dump_path = os.environ.get("AMB_DEBUG_DUMP")
++        if dump_path:
++            with open(dump_path, "a", encoding="utf-8") as f:
++                f.write(json.dumps({"model": self._model, "messages": messages}) + "\n")
+         for attempt in range(_MAX_RETRIES):
++            if attempt >= 2 and len(messages) == 2:
++                # Still failing after two plain attempts: show the model its own
++                # bad output and ask for a repaired object — self-repair beats
++                # blind re-rolls against a degenerating generation pattern.
++                messages = [
++                    *messages,
++                    {"role": "assistant", "content": last_bad_text[:2000] or "(empty response)"},
++                    {"role": "user", "content": (
++                        "Your previous response was not the required JSON object. Respond again "
++                        f"with ONLY the JSON object with keys {schema.required} and string "
++                        "values — no other text."
++                    )},
++                ]
+             try:
+                 response = self._client.chat.completions.create(
+                     model=self._model,
+-                    messages=[{"role": "user", "content": prompt}],
++                    messages=cast(Any, messages),
+                     response_format=response_format,
++                    temperature=float(os.environ.get("AMB_TEMPERATURE", "0")),
+                     **({"max_tokens": max_tokens} if max_tokens else {}),
++                    **extra,
+                 )
+                 text = response.choices[0].message.content or ""
++                last_bad_text = text
+                 # tolerate ```json fences some backends add despite instructions
+                 stripped = text.strip()
+                 if stripped.startswith("```"):
+@@ -89,5 +129,14 @@ class OpenAILLM(LLM):
+                 if retryable and attempt < _MAX_RETRIES - 1:
+                     time.sleep(_RETRY_BASE_DELAY if "429" in msg or "rate" in msg.lower() else 2)
+                     continue
++                # Graceful degrade: one broken query must not kill a multi-hour
++                # benchmark run. Return a sentinel marked answer — the judge
++                # will score it incorrect, the row still lands in the output.
++                if isinstance(e, (json.JSONDecodeError, ValueError)):
++                    return {
++                        **{k: "" for k in schema.required},
++                        "reasoning": f"[format-error after {_MAX_RETRIES} retries] {last_exc}",
++                        "answer": "[unparseable model response]",
++                    }
+                 raise
+         raise RuntimeError(f"OpenAI request failed after {_MAX_RETRIES} retries: {last_exc}")
+diff --git a/src/memory_bench/memory/uteke.py b/src/memory_bench/memory/uteke.py
+index 86a7ed0..ca01b5f 100644
+--- a/src/memory_bench/memory/uteke.py
++++ b/src/memory_bench/memory/uteke.py
+@@ -96,7 +96,13 @@ class UtekeMemoryProvider(MemoryProvider):
+         # takes file paths, not stdin, for `remember`. Unique per call so
+         # concurrent ingests (async_ingest runs in threads) never collide.
+         for doc in documents:
+-            content = _session_dialogue(doc.content)
++            # LoCoMo's QA demands absolute dates ("convert relative time to
++            # specific dates") but session dates ride on Document.timestamp —
++            # dropping them makes temporal QA unanswerable (conv-30 temporal
++            # = 15% without the header). Prepend it so both the embedding and
++            # the answerer see the anchor.
++            header = f"[Session date/time: {doc.timestamp}]\n" if getattr(doc, "timestamp", None) else ""
++            content = header + _session_dialogue(doc.content)
+             fd, tmp_path = tempfile.mkstemp(prefix="amb-ingest-", suffix=".txt", dir=str(self._store))
+             try:
+                 with os.fdopen(fd, "w", encoding="utf-8") as f:
+@@ -133,4 +139,9 @@ class UtekeMemoryProvider(MemoryProvider):
+                 user_id=user_id,
+                 source_ids=[doc_id],
+             ))
+-        return docs, {"raw_hits": len(out)}
++        # Full recall payload (hits with content + metadata) as the raw response:
++        # locomo's prompt template json.dumps()es this INSTEAD of the assembled
++        # context ("matching the reference impl" = hindsight's full API dump).
++        # Returning only a hit-count stub here silently produced prompts whose
++        # entire context was {"raw_hits": N} (2026-09-11: 8.6% full run).
++        return docs, {"hits": out}

--- a/benchmarks/amb/scripts/apply_patches.sh
+++ b/benchmarks/amb/scripts/apply_patches.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Clone the AMB upstream repo and apply the uteke provider patch series.
+# Usage: ./apply_patches.sh <target-dir>
+set -euo pipefail
+
+TARGET="${1:?usage: apply_patches.sh <target-dir>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="347f551b1014d8f8d5fab9eb38175f457a6ed195"  # upstream commit this series is based on
+
+if [ -d "$TARGET/.git" ]; then
+  echo "Reusing existing clone at $TARGET"
+else
+  git clone https://github.com/vectorize-io/agent-memory-benchmark.git "$TARGET"
+fi
+
+cd "$TARGET"
+git checkout "$BASE" 2>/dev/null || {
+  echo "WARNING: base commit $BASE not found (upstream rebased?)."
+  echo "Patches may not apply cleanly — check with --3way."
+  git checkout main
+}
+
+echo "Applying patch series..."
+git apply --3way "$SCRIPT_DIR"/../patches/*.patch
+
+echo
+echo "Done. Verify:"
+git diff --stat
+echo
+echo "Sanity check: src/memory_bench/memory/uteke.py must exist and"
+echo "src/memory_bench/llm/openai.py must contain AMB_THINKING_DISABLED."
+grep -q "AMB_THINKING_DISABLED" src/memory_bench/llm/openai.py && echo "OK: harness patches present"
+test -f src/memory_bench/memory/uteke.py && echo "OK: uteke provider present"


### PR DESCRIPTION
## What

Adds `benchmarks/amb/` — a reproduction run kit for the Agent Memory Benchmark (AMB, vectorize-io/agent-memory-benchmark), same pattern as `benchmarks/locomo`. Upstream AMB has **no license file**, so this ships a **patch series against upstream** (with base-commit provenance) instead of a vendored copy: 4 committed patches + 1 patch capturing previously-uncommitted work (session-date ingest anchors, full raw-response fix, system-role JSON contract, repair-retry, graceful degrade, `AMB_TEMPERATURE`, `AMB_DEBUG_DUMP`).

Contents: `patches/0001–0005` (format-patch series, applied via `scripts/apply_patches.sh <dir>`), `README.md` (provenance table, run notes incl. GLM-5.3/Z.AI coding-endpoint env, load-bearing-fix explanations with measured canary trajectory, RESULTS placeholder). `benchmarks/README.md` index gains an AMB row.

## Why

The entire uteke AMB integration (adapter + harness patches, 4 local commits on `feat/uteke-provider-and-compat` + uncommitted fixes) lived ONLY in a throwaway clone at `/opt/data/tmp/amb` — a single `rm -rf` away from losing the reproducibility of the conv-30 QA result (4.9% → 93.8% trajectory documented in #1226). Closes #1226.

## Testing

- Patch series verified end-to-end: fresh clone of the local repo → `git checkout 347f551b` (recorded base) → `git apply --3way patches/*.patch` → all hunks applied cleanly; markers verified (`AMB_THINKING_DISABLED` in `openai.py`, `Session date` in `uteke.py`).
- `apply_patches.sh` follows exactly the verified sequence (clone → checkout base → apply --3way → marker sanity checks).
- Docs-only + patch-text change; no Rust code touched (cargo build unaffected; CI runs the standard gates).
