### PR TITLE
feat(benchmarks): LMEVAL_DATE_ANCHOR env for LongMemEval ingest

### DIFF
--- a/benchmarks/longmemeval/scripts/run_eval.py
+++ b/benchmarks/longmemeval/scripts/run_eval.py
@@ -48,14 +48,17 @@ except ImportError:
         return x
 
 
-def session_to_text(session):
+def session_to_text(session, date=None):
     """Convert a chat session (list of turns) into plain text."""
     lines = []
+    anchor = ""
+    if date and os.environ.get("LMEVAL_DATE_ANCHOR") == "1":
+        anchor = f"[Session date/time: {date}]\n"
     for turn in session:
         role = turn.get("role", "unknown")
         content = turn.get("content", "")
         lines.append(f"{role}: {content}")
-    return "\n".join(lines)
+    return anchor + "\n".join(lines)
 
 
 def chunk_session_text(text, max_chars=2000):
@@ -158,8 +161,8 @@ def insert_sessions(args, store_path, entry):
     jsonl_lines = []
     sid_order = []  # track session_ids in import order for counting
     for i, (sid, session) in enumerate(zip(session_ids, sessions)):
-        text = session_to_text(session)
         date = dates[i] if i < len(dates) else None
+        text = session_to_text(session, date=date)
 
         # Chunk long sessions to reduce embedding dilution (#1009).
         if args.chunk_sessions:


### PR DESCRIPTION
## What

Adds `LMEVAL_DATE_ANCHOR=1` env option to the LongMemEval retrieval benchmark ingest: when set, `session_to_text()` prepends a `[Session date/time: ...]` header (from `haystack_dates`) to each session text before chunking/import.

Default behavior is **unchanged** (no anchor) when the env is unset.

## Why

Companion to #1232 (the `--timestamp` CLI flag). During LongMemEval validation runs, ingest dates only land in metadata - invisible to vector/FTS recall. Anchoring the date into the content makes temporal-reasoning questions answerable by the existing retrieval paths. Partial validation (21 questions, all single-session-user): 0.905 -> 0.952 recall_all@5, 0 regressions. Full-500 run pending (blocked by a separate pre-existing ingest timeout on large haystacks).

## Testing

- [x] `LMEVAL_DATE_ANCHOR=1 python3 scripts/run_eval.py ... --limit 50` - anchored ingest works end-to-end (21 questions evaluated before an unrelated timeout)
- [x] Default path (env unset) - unchanged output
- [ ] Full-500 anchor run (parked, see note above)

Related: #1232, #1237
