### PR TITLE
chore: bump version 0.17.0 -> 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "uteke-server"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/codecoradev/uteke"

--- a/crates/uteke-cli/Cargo.toml
+++ b/crates/uteke-cli/Cargo.toml
@@ -22,7 +22,7 @@ usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.17.0", default-features = false, features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.18.0", default-features = false, features = ["onnx"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/uteke-mcp/Cargo.toml
+++ b/crates/uteke-mcp/Cargo.toml
@@ -29,7 +29,7 @@ usearch = ["uteke-core/usearch"]
 vecq = ["uteke-core/vecq"]
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.17.0", default-features = false, features = ["onnx"] }
+uteke-core = { path = "../uteke-core", version = "0.18.0", default-features = false, features = ["onnx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "7"

--- a/crates/uteke-server/Cargo.toml
+++ b/crates/uteke-server/Cargo.toml
@@ -27,8 +27,8 @@ name = "uteke-serve"
 path = "src/main.rs"
 
 [dependencies]
-uteke-core = { path = "../uteke-core", version = "0.17.0", default-features = false, features = ["onnx"] }
-uteke-mcp = { path = "../uteke-mcp", version = "0.17.0", default-features = false }
+uteke-core = { path = "../uteke-core", version = "0.18.0", default-features = false, features = ["onnx"] }
+uteke-mcp = { path = "../uteke-mcp", version = "0.18.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", optional = true }


### PR DESCRIPTION
## What

Bump workspace version 0.17.0 -> 0.18.0: root `Cargo.toml`, internal version requirements (`uteke-core` in cli/mcp/server, `uteke-mcp` in server), and `Cargo.lock`.

## Why

Pre-release alignment for the 0.18.0 line: the full-500 LongMemEval experiment (date anchors + query decomposition, #1232/#1237) validates against a binary that reports 0.18.0, so a green run can proceed straight to release without an extra version-churn commit afterwards.

## Testing

- `cargo update -w` resolves cleanly; `Cargo.lock` moves the four `uteke-*` packages 0.17.0 -> 0.18.0
- No functional code change; standard CI gates (build, tests, `--locked` resolution) cover this diff.